### PR TITLE
feat(global): 공통 모듈 구성

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,23 +1,23 @@
-feat:
-  - 'module-*/**/*.kt'
-  - '**/application-*.yml'
+"feat":
+  - "module-*/**/*.kt"
+  - "**/application-*.yml"
 
-fix:
-  - '*/**/*.kt'
-  - '**/*.md'
+"fix":
+  - "*/**/*.kt"
+  - "**/*.md"
 
-refactor:
-  - '*/**/*.kt'
+"refactor":
+  - "*/**/*.kt"
 
-test:
-  - '*/**/test/**/*.kt'
-  - '**/test/**'
+"test":
+  - "*/**/test/**/*.kt"
+  - "**/test/**"
 
-docs:
-  - '**/*.md'
-  - 'README.md'
+"docs":
+  - "**/*.md"
+  - "README.md"
 
-chore:
-  - '**/.gitignore'
-  - '**/build.gradle.kts'
-  - '**/settings.gradle.kts'
+"chore":
+  - "**/.gitignore"
+  - "**/build.gradle.kts"
+  - "**/settings.gradle.kts"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,35 +1,35 @@
 feat:
-  changed-files:
-    any:
-      - "module-*/**/*.kt"
-      - "**/application-*.yml"
+  - changed-files:
+      any-glob-to-any-file:
+        - "module-*/**/*.kt"
+        - "**/application-*.yml"
 
 fix:
-  changed-files:
-    any:
-      - "*/**/*.kt"
-      - "**/*.md"
+  - changed-files:
+      any-glob-to-any-file:
+        - "*/**/*.kt"
+        - "**/*.md"
 
 refactor:
-  changed-files:
-    any:
-      - "*/**/*.kt"
+  - changed-files:
+      any-glob-to-any-file:
+        - "*/**/*.kt"
 
 test:
-  changed-files:
-    any:
-      - "*/**/test/**/*.kt"
-      - "**/test/**"
+  - changed-files:
+      any-glob-to-any-file:
+        - "*/**/test/**/*.kt"
+        - "**/test/**"
 
 docs:
-  changed-files:
-    any:
-      - "**/*.md"
-      - "README.md"
+  - changed-files:
+      any-glob-to-any-file:
+        - "**/*.md"
+        - "README.md"
 
 chore:
-  changed-files:
-    any:
-      - "**/.gitignore"
-      - "**/build.gradle.kts"
-      - "**/settings.gradle.kts"
+  - changed-files:
+      any-glob-to-any-file:
+        - "**/.gitignore"
+        - "**/build.gradle.kts"
+        - "**/settings.gradle.kts"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,29 +1,35 @@
 feat:
-  - changed-files:
+  changed-files:
+    any:
       - "module-*/**/*.kt"
       - "**/application-*.yml"
 
 fix:
-  - changed-files:
+  changed-files:
+    any:
       - "*/**/*.kt"
       - "**/*.md"
 
 refactor:
-  - changed-files:
+  changed-files:
+    any:
       - "*/**/*.kt"
 
 test:
-  - changed-files:
+  changed-files:
+    any:
       - "*/**/test/**/*.kt"
       - "**/test/**"
 
 docs:
-  - changed-files:
+  changed-files:
+    any:
       - "**/*.md"
       - "README.md"
 
 chore:
-  - changed-files:
+  changed-files:
+    any:
       - "**/.gitignore"
       - "**/build.gradle.kts"
       - "**/settings.gradle.kts"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,23 +1,29 @@
-"feat":
-  - "module-*/**/*.kt"
-  - "**/application-*.yml"
+feat:
+  - changed-files:
+      - "module-*/**/*.kt"
+      - "**/application-*.yml"
 
-"fix":
-  - "*/**/*.kt"
-  - "**/*.md"
+fix:
+  - changed-files:
+      - "*/**/*.kt"
+      - "**/*.md"
 
-"refactor":
-  - "*/**/*.kt"
+refactor:
+  - changed-files:
+      - "*/**/*.kt"
 
-"test":
-  - "*/**/test/**/*.kt"
-  - "**/test/**"
+test:
+  - changed-files:
+      - "*/**/test/**/*.kt"
+      - "**/test/**"
 
-"docs":
-  - "**/*.md"
-  - "README.md"
+docs:
+  - changed-files:
+      - "**/*.md"
+      - "README.md"
 
-"chore":
-  - "**/.gitignore"
-  - "**/build.gradle.kts"
-  - "**/settings.gradle.kts"
+chore:
+  - changed-files:
+      - "**/.gitignore"
+      - "**/build.gradle.kts"
+      - "**/settings.gradle.kts"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,11 +90,11 @@ val jacocoExcludedDirs = listOf(
 	"**/config/**",
 	"**/dto/**",
 	"**/MallApplication*",
-	"**/MallApplicationTests*",
-	"**/global/common/entity/**",
-	"**/global/common/response/**",
-	"**/global/error/**",
-	"**/global/enums/**"
+	"**/com/hoppingmall/mall/MallApplicationTests*",
+	"**/com/hoppingmall/global/common/entity/**",
+	"**/com/hoppingmall/global/common/response/**",
+	"**/com/hoppingmall/global/common/error/**",
+	"**/com/hoppingmall/global/enums/**"
 )
 
 tasks.jacocoTestReport {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,7 +90,11 @@ val jacocoExcludedDirs = listOf(
 	"**/config/**",
 	"**/dto/**",
 	"**/MallApplication*",
-	"**/MallApplicationTests*"
+	"**/MallApplicationTests*",
+	"**/global/common/entity/**",
+	"**/global/common/response/**",
+	"**/global/error/**",
+	"**/global/enums/**"
 )
 
 tasks.jacocoTestReport {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,8 @@ val jacocoExcludedDirs = listOf(
 	"**/com/hoppingmall/global/common/entity/**",
 	"**/com/hoppingmall/global/common/response/**",
 	"**/com/hoppingmall/global/common/error/**",
-	"**/com/hoppingmall/global/enums/**"
+	"**/com/hoppingmall/global/enums/**",
+	"**/com/hoppingmall/global/vo/**"
 )
 
 tasks.jacocoTestReport {

--- a/src/main/kotlin/com/hoppingmall/global/common/entity/BaseEntity.kt
+++ b/src/main/kotlin/com/hoppingmall/global/common/entity/BaseEntity.kt
@@ -1,0 +1,30 @@
+package com.hoppingmall.global.common.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.MappedSuperclass
+import jakarta.persistence.PreUpdate
+import java.time.LocalDateTime
+
+@MappedSuperclass
+abstract class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+
+    @Column(updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now()
+
+    @Column
+    var updatedAt: LocalDateTime? = LocalDateTime.now()
+
+    @Column
+    var deletedAt: LocalDateTime? = null
+
+    @PreUpdate
+    fun preUpdate() {
+        updatedAt = LocalDateTime.now()
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/global/common/error/code/ErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/global/common/error/code/ErrorCode.kt
@@ -1,0 +1,14 @@
+package com.hoppingmall.global.common.error.code
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorCode(
+    val code: String,
+    val message: String,
+    val status: HttpStatus
+){
+    INVALID_INPUT("C001", "잘못된 입력입니다.", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED("A001", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
+    FORBIDDEN("A002", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    INTERNAL_ERROR("S001", "서버 내부 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR)
+}

--- a/src/main/kotlin/com/hoppingmall/global/common/error/exception/BusinessException.kt
+++ b/src/main/kotlin/com/hoppingmall/global/common/error/exception/BusinessException.kt
@@ -1,0 +1,7 @@
+package com.hoppingmall.global.common.error.exception
+
+import com.hoppingmall.global.common.error.code.ErrorCode
+
+open class BusinessException(
+    val errorCode: ErrorCode
+) : RuntimeException(errorCode.message)

--- a/src/main/kotlin/com/hoppingmall/global/common/error/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/hoppingmall/global/common/error/handler/GlobalExceptionHandler.kt
@@ -1,0 +1,25 @@
+package com.hoppingmall.global.common.error.handler
+
+import com.hoppingmall.global.common.error.exception.BusinessException
+import com.hoppingmall.global.common.response.ApiResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException::class)
+    fun handleBusinessException(ex: BusinessException): ResponseEntity<ApiResponse<Unit>> {
+        val status = ex.errorCode.status
+        val response = ApiResponse.failure<Unit>(ex.errorCode.message)
+        return ResponseEntity.status(status).body(response)
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleException(ex: Exception): ResponseEntity<ApiResponse<Unit>> {
+        val response = ApiResponse.failure<Unit>("알 수 없는 오류가 발생했습니다.")
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response)
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/global/common/response/ApiResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/global/common/response/ApiResponse.kt
@@ -1,0 +1,15 @@
+package com.hoppingmall.global.common.response
+
+data class ApiResponse<T>(
+    val success: Boolean,
+    val message: String,
+    val data: T? = null
+) {
+    companion object {
+        fun <T> success(data: T?, message: String = "성공"): ApiResponse<T> =
+            ApiResponse(true, message, data)
+
+        fun <T> failure(message: String = "실패"): ApiResponse<T> =
+            ApiResponse(false, message, null)
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/global/enums/Role.kt
+++ b/src/main/kotlin/com/hoppingmall/global/enums/Role.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.global.enums
+
+enum class Role {
+    BUYER, SELLER, ADMIN
+}

--- a/src/main/kotlin/com/hoppingmall/global/vo/Email.kt
+++ b/src/main/kotlin/com/hoppingmall/global/vo/Email.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.global.vo
+
+@JvmInline
+value class Email(val value: String) {
+    init {
+        require(value.contains("@")) { "유효하지 않은 이메일 형식입니다." }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/global/vo/Password.kt
+++ b/src/main/kotlin/com/hoppingmall/global/vo/Password.kt
@@ -1,0 +1,20 @@
+package com.hoppingmall.global.vo
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+
+@JvmInline
+value class Password private constructor(val value: String) {
+
+    companion object {
+        private val encoder = BCryptPasswordEncoder()
+
+        fun encode(raw: String): Password {
+            require(raw.length >= 8) { "비밀번호는 최소 8자 이상이어야 합니다." }
+            return Password(encoder.encode(raw))
+        }
+
+        fun matches(raw: String, hashed: Password): Boolean {
+            return encoder.matches(raw, hashed.value)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/global/vo/EmailTest.kt
+++ b/src/test/kotlin/com/hoppingmall/global/vo/EmailTest.kt
@@ -6,13 +6,13 @@ import org.junit.jupiter.api.Test
 class EmailTest {
 
     @Test
-    fun `이메일 형식이 유효하면 객체 생성에 성공한다`() {
+    fun `유효한 이메일이면 객체 생성에 성공한다`() {
         val email = Email("test@example.com")
         assertEquals("test@example.com", email.value)
     }
 
     @Test
-    fun `이메일 형식이 유효하지 않으면 예외를 던진다`() {
+    fun `이메일 형식이 잘못되면 예외가 발생한다`() {
         val exception = assertThrows(IllegalArgumentException::class.java) {
             Email("invalid-email")
         }

--- a/src/test/kotlin/com/hoppingmall/global/vo/EmailTest.kt
+++ b/src/test/kotlin/com/hoppingmall/global/vo/EmailTest.kt
@@ -1,0 +1,21 @@
+package com.hoppingmall.global.vo
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class EmailTest {
+
+    @Test
+    fun `이메일 형식이 유효하면 객체 생성에 성공한다`() {
+        val email = Email("test@example.com")
+        assertEquals("test@example.com", email.value)
+    }
+
+    @Test
+    fun `이메일 형식이 유효하지 않으면 예외를 던진다`() {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            Email("invalid-email")
+        }
+        assertEquals("유효하지 않은 이메일 형식입니다.", exception.message)
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/global/vo/PasswordTest.kt
+++ b/src/test/kotlin/com/hoppingmall/global/vo/PasswordTest.kt
@@ -1,0 +1,24 @@
+package com.hoppingmall.global.vo
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class PasswordTest {
+
+    @Test
+    fun `비밀번호는 8자 미만이면 예외를 던진다`() {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            Password.encode("short")
+        }
+        assertEquals("비밀번호는 최소 8자 이상이어야 합니다.", exception.message)
+    }
+
+    @Test
+    fun `비밀번호는 encode와 matches로 비교할 수 있다`() {
+        val rawPassword = "secure123"
+        val password = Password.encode(rawPassword)
+
+        assertTrue(Password.matches(rawPassword, password))
+        assertFalse(Password.matches("wrongpass", password))
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/global/vo/PasswordTest.kt
+++ b/src/test/kotlin/com/hoppingmall/global/vo/PasswordTest.kt
@@ -14,11 +14,15 @@ class PasswordTest {
     }
 
     @Test
-    fun `비밀번호는 encode와 matches로 비교할 수 있다`() {
-        val rawPassword = "secure123"
-        val password = Password.encode(rawPassword)
+    fun `비밀번호 해시화 후 비교 성공`() {
+        val raw = "securePass123"
+        val hashed = Password.encode(raw)
+        assertTrue(Password.matches(raw, hashed))
+    }
 
-        assertTrue(Password.matches(rawPassword, password))
-        assertFalse(Password.matches("wrongpass", password))
+    @Test
+    fun `비밀번호 해시화 후 비교 실패`() {
+        val hashed = Password.encode("realPass123")
+        assertFalse(Password.matches("wrongPass", hashed))
     }
 }


### PR DESCRIPTION
Closes #8

### 📌 작업 개요
공통 모듈(global 패키지)을 구성하여 모든 도메인에서 재사용 가능한 기반 코드를 정리했습니다.  
또한 Jacoco 테스트 커버리지 측정을 위한 제외 디렉토리를 설정했습니다.

---

### ✅ 주요 변경 사항
- `global.common.entity`  
  - `BaseEntity`: id, createdAt, updatedAt, deletedAt 포함된 추상 클래스
- `global.common.response`  
  - `ApiResponse`: 성공/실패 포맷 통일
- `global.error`  
  - `ErrorCode`: HttpStatus 포함한 공통 에러 코드  
  - `BusinessException`: 도메인 예외의 베이스 클래스  
  - `GlobalExceptionHandler`: 예외를 일관된 API 응답으로 매핑
- `global.enums`  
  - `Role`: BUYER, SELLER, ADMIN
- `global.vo`  
  - `Email`: 이메일 형식 검증 포함  
  - `Password`: 최소 길이, 해시화, matches 비교 포함
- `PasswordTest.kt`, `EmailTest.kt` 단위 테스트 작성

---

### ✅ Jacoco 커버리지 설정
- `BaseEntity`, `ErrorCode`, `GlobalExceptionHandler`, `Role` 등은 제외 디렉토리로 설정
- 실제 로직이 포함된 VO(`Email`, `Password`)는 포함 대상 유지

---

### 📎 관련 이슈
- #8
