### PR TITLE
fix: notification metadata 타입 통일

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentEventService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentEventService.kt
@@ -1,9 +1,9 @@
 package com.hoppingmall.mall.payment.service
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.hoppingmall.mall.payment.domain.Payment
 import com.hoppingmall.mall.payment.dto.event.PaymentCompletedEvent
 import com.hoppingmall.mall.payment.dto.event.PointEarnRequestEvent
-import com.hoppingmall.mall.notification.dto.event.NotificationEvent
 import com.hoppingmall.mall.notification.enum.NotificationType
 import com.hoppingmall.mall.point.service.PointPolicyService
 import com.hoppingmall.mall.global.common.service.TransactionalEventPublisher
@@ -15,7 +15,8 @@ import java.time.LocalDateTime
 class PaymentEventService(
     private val paymentEventPublisher: PaymentEventPublisher,
     private val transactionalEventPublisher: TransactionalEventPublisher,
-    private val pointPolicyService: PointPolicyService
+    private val pointPolicyService: PointPolicyService,
+    private val objectMapper: ObjectMapper
 ) {
     
     fun publishPaymentCompletedEvent(payment: Payment) {
@@ -47,12 +48,14 @@ class PaymentEventService(
     }
     
     fun publishPaymentCompletedNotification(payment: Payment) {
-        val metadata = mapOf(
+        val metadata = objectMapper.writeValueAsString(
+            mapOf(
             "orderId" to payment.orderId,
             "paymentId" to payment.id!!,
             "amount" to payment.amount.toString(),
             "method" to payment.method.toString(),
             "transactionId" to payment.transactionId
+            )
         )
         
         transactionalEventPublisher.publishEvent(

--- a/src/main/kotlin/com/hoppingmall/mall/point/service/PointEventConsumer.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/service/PointEventConsumer.kt
@@ -1,7 +1,7 @@
 package com.hoppingmall.mall.point.service
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.hoppingmall.mall.payment.dto.event.PointEarnRequestEvent
-import com.hoppingmall.mall.notification.dto.event.NotificationEvent
 import com.hoppingmall.mall.notification.enum.NotificationType
 import com.hoppingmall.mall.point.domain.Point
 import com.hoppingmall.mall.point.domain.PointHistory
@@ -23,7 +23,8 @@ import java.util.concurrent.ConcurrentHashMap
 class PointEventConsumer(
     private val pointRepository: PointRepository,
     private val pointHistoryRepository: PointHistoryRepository,
-    private val transactionalEventPublisher: TransactionalEventPublisher
+    private val transactionalEventPublisher: TransactionalEventPublisher,
+    private val objectMapper: ObjectMapper
 ) {
 
     @KafkaListener(topics = ["point-earn-request"], groupId = "point-service")
@@ -49,12 +50,14 @@ class PointEventConsumer(
                 )
             )
 
-            val metadata = mapOf(
-                "orderId" to event.orderId,
-                "paymentId" to event.paymentId,
-                "earnAmount" to event.earnAmount.toString(),
-                "reason" to (event.reason ?: "포인트 적립"),
-                "currentBalance" to savedPoint.balance.toString()
+            val metadata = objectMapper.writeValueAsString(
+                mapOf(
+                    "orderId" to event.orderId,
+                    "paymentId" to event.paymentId,
+                    "earnAmount" to event.earnAmount.toString(),
+                    "reason" to (event.reason ?: "포인트 적립"),
+                    "currentBalance" to savedPoint.balance.toString()
+                )
             )
 
             transactionalEventPublisher.publishEvent(

--- a/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentEventServiceTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentEventServiceTest.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.mall.payment.service
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.hoppingmall.mall.payment.domain.Payment
 import com.hoppingmall.mall.payment.dto.event.PointEarnRequestEvent
 import com.hoppingmall.mall.point.service.PointPolicyService
@@ -17,7 +18,13 @@ class PaymentEventServiceTest {
     private val paymentEventPublisher: PaymentEventPublisher = mock()
     private val transactionalEventPublisher: TransactionalEventPublisher = mock()
     private val pointPolicyService: PointPolicyService = mock()
-    private val paymentEventService = PaymentEventService(paymentEventPublisher, transactionalEventPublisher, pointPolicyService)
+    private val objectMapper = ObjectMapper()
+    private val paymentEventService = PaymentEventService(
+        paymentEventPublisher,
+        transactionalEventPublisher,
+        pointPolicyService,
+        objectMapper
+    )
     
     @Test
     fun `결제 완료 이벤트를 발행한다`() {
@@ -104,7 +111,11 @@ class PaymentEventServiceTest {
             eventType = eq("PaymentCompletedNotificationRequested"),
             eventData = argThat { eventData ->
                 val data = eventData as Map<String, Any>
-                data["content"] == "주문번호 1의 결제가 성공적으로 완료되었습니다. 결제 금액: 50000원"
+                val metadata = data["metadata"] as String
+                val metadataMap = objectMapper.readValue(metadata, Map::class.java)
+                data["content"] == "주문번호 1의 결제가 성공적으로 완료되었습니다. 결제 금액: 50000원" &&
+                    metadataMap["orderId"].toString() == "1" &&
+                    metadataMap["paymentId"].toString() == "1"
             },
             topic = eq("notification"),
             partitionKey = eq("1")

--- a/src/test/kotlin/com/hoppingmall/mall/point/service/PointEventConsumerIntegrationTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/point/service/PointEventConsumerIntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.mall.point.service
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.hoppingmall.mall.global.common.service.TransactionalEventPublisher
 import com.hoppingmall.mall.payment.dto.event.PointEarnRequestEvent
 import com.hoppingmall.mall.point.domain.Point
@@ -17,10 +18,9 @@ import org.mockito.kotlin.*
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Spy
 import org.mockito.junit.jupiter.MockitoExtension
 import java.math.BigDecimal
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 @ExtendWith(MockitoExtension::class)
 @DisplayName("PointEventConsumer 단위 테스트")
@@ -35,6 +35,9 @@ class PointEventConsumerIntegrationTest {
     
     @Mock
     private lateinit var transactionalEventPublisher: TransactionalEventPublisher
+    
+    @Spy
+    private val objectMapper = ObjectMapper()
     
     @InjectMocks
     private lateinit var pointEventConsumer: PointEventConsumer
@@ -78,7 +81,13 @@ class PointEventConsumerIntegrationTest {
             eq("Point"),
             eq("1"),
             eq("PointEarnedNotificationRequested"),
-            any(),
+            argThat { eventData ->
+                val data = eventData as Map<String, Any>
+                val metadata = data["metadata"] as String
+                val metadataMap = objectMapper.readValue(metadata, Map::class.java)
+                metadataMap["orderId"].toString() == "123" &&
+                    metadataMap["paymentId"].toString() == "456"
+            },
             eq("notification"),
             eq(userId.toString())
         )


### PR DESCRIPTION
Closes #25

## 🔧 작업 개요

NotificationEvent.metadata 타입 불일치를 해소하기 위해 발행부에서 JSON 문자열로 통일하고, 관련 테스트를 갱신했습니다.

---

## ✅ 주요 변경 사항

### payment.service
- `PaymentEventService`: 알림 이벤트 metadata를 JSON 문자열로 직렬화하여 발행

### point.service
- `PointEventConsumer`: 포인트 적립 알림 metadata를 JSON 문자열로 직렬화하여 발행

### notification.dto.event / notification.domain
- NotificationEvent/Notification metadata 타입(String)과 발행 데이터 정합성 유지

---

## ✅ 테스트

- `./gradlew clean test jacocoTestCoverageVerification`

---

## 📎 관련 이슈

- #25
