### PR TITLE
fix: kafka 설정 강화

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/KafkaConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/KafkaConfig.kt
@@ -16,6 +16,10 @@ import org.springframework.util.backoff.FixedBackOff
 import com.hoppingmall.mall.global.common.service.DLQService
 import org.apache.kafka.clients.consumer.ConsumerConfig.ISOLATION_LEVEL_CONFIG
 import org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG
+import org.springframework.messaging.converter.MessageConversionException
+import org.apache.kafka.common.errors.SerializationException
+import org.springframework.kafka.support.serializer.DeserializationException
+import java.util.UUID
 @Configuration
 class KafkaConfig {
 
@@ -30,6 +34,12 @@ class KafkaConfig {
 
     @Value("\${spring.kafka.listener.concurrency:1}")
     private var concurrency: Int = 4
+    
+    private val instanceId: String = UUID.randomUUID().toString()
+    private val trustedPackages: String = listOf(
+        "com.hoppingmall.mall.payment.dto.event",
+        "com.hoppingmall.mall.notification.dto.event"
+    ).joinToString(",")
 
     @Bean
     fun producerFactory(): ProducerFactory<String, Any> {
@@ -43,20 +53,22 @@ class KafkaConfig {
         configProps[ProducerConfig.ACKS_CONFIG] = "all"
         configProps[ProducerConfig.RETRIES_CONFIG] = Int.MAX_VALUE
         configProps[ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION] = 5
-        configProps[ProducerConfig.TRANSACTIONAL_ID_CONFIG] = "hoppingmall-tx-"
+        configProps[ProducerConfig.TRANSACTIONAL_ID_CONFIG] = "hoppingmall-tx-$instanceId"
         
         // 성능 최적화
         configProps[ProducerConfig.BATCH_SIZE_CONFIG] = 16384
         configProps[ProducerConfig.LINGER_MS_CONFIG] = 10
         configProps[ProducerConfig.COMPRESSION_TYPE_CONFIG] = "lz4"
         
-        return DefaultKafkaProducerFactory(configProps)
+        val producerFactory = DefaultKafkaProducerFactory<String, Any>(configProps)
+        producerFactory.setTransactionIdPrefix("hoppingmall-tx-$instanceId-")
+        return producerFactory
     }
 
     @Bean
     fun kafkaTemplate(): KafkaTemplate<String, Any> {
         val template = KafkaTemplate(producerFactory())
-        template.setTransactionIdPrefix("hoppingmall-tx-")
+        template.setTransactionIdPrefix("hoppingmall-tx-$instanceId-")
         return template
     }
 
@@ -74,7 +86,7 @@ class KafkaConfig {
         configProps[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = autoOffsetReset
         configProps[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
         configProps[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = JsonDeserializer::class.java
-        configProps[JsonDeserializer.TRUSTED_PACKAGES] = "*"
+        configProps[JsonDeserializer.TRUSTED_PACKAGES] = trustedPackages
         
         // Consumer 설정 - EOS를 위한 read_committed 유지
         configProps[ENABLE_AUTO_COMMIT_CONFIG] = false
@@ -96,6 +108,11 @@ class KafkaConfig {
                 sendToDLQ(record, exception, dlqService)
             },
             FixedBackOff(1000L, 3) // 1초 간격으로 3번 재시도
+        )
+        errorHandler.addNotRetryableExceptions(
+            DeserializationException::class.java,
+            SerializationException::class.java,
+            MessageConversionException::class.java
         )
         factory.setCommonErrorHandler(errorHandler)
         

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/config/KafkaConfigTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/config/KafkaConfigTest.kt
@@ -1,0 +1,91 @@
+package com.hoppingmall.mall.global.common.config
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.support.serializer.JsonDeserializer
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@DisplayName("KafkaConfig 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class KafkaConfigTest {
+
+    @Test
+    fun 트랜잭션_아이디는_인스턴스별로_유니크하다() {
+        val config1 = createConfig()
+        val config2 = createConfig()
+
+        val producerFactory1 = config1.producerFactory() as DefaultKafkaProducerFactory<String, Any>
+        val producerFactory2 = config2.producerFactory() as DefaultKafkaProducerFactory<String, Any>
+
+        val prefix1 = readField(producerFactory1, "transactionIdPrefix")
+        val prefix2 = readField(producerFactory2, "transactionIdPrefix")
+
+        assertNotNull(prefix1)
+        assertNotNull(prefix2)
+
+        assertTrue(prefix1.startsWith("hoppingmall-tx-"))
+        assertTrue(prefix2.startsWith("hoppingmall-tx-"))
+        assertNotEquals(prefix1, prefix2)
+    }
+
+    @Test
+    fun JsonDeserializer는_신뢰_패키지를_제한한다() {
+        val config = createConfig()
+        val consumerFactory = config.consumerFactory() as DefaultKafkaConsumerFactory<String, Any>
+
+        val configs = readConfigs(consumerFactory)
+        val trusted = configs[JsonDeserializer.TRUSTED_PACKAGES]?.toString()
+
+        assertNotNull(trusted)
+
+        assertEquals(
+            "com.hoppingmall.mall.payment.dto.event,com.hoppingmall.mall.notification.dto.event",
+            trusted
+        )
+        assertNotEquals("*", trusted)
+    }
+
+    private fun createConfig(): KafkaConfig {
+        val config = KafkaConfig()
+        setField(config, "bootstrapServers", "localhost:9092")
+        setField(config, "groupId", "test-group")
+        setField(config, "autoOffsetReset", "earliest")
+        setField(config, "concurrency", 1)
+        return config
+    }
+
+    private fun setField(target: Any, fieldName: String, value: Any) {
+        val field = target.javaClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.set(target, value)
+    }
+
+    private fun readField(target: Any, fieldName: String): String? {
+        val field = target.javaClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field.get(target)?.toString()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun readConfigs(factory: Any): Map<String, Any> {
+        val field = runCatching { factory.javaClass.getDeclaredField("configs") }.getOrNull()
+        if (field != null) {
+            field.isAccessible = true
+            return field.get(factory) as Map<String, Any>
+        }
+        val method = factory.javaClass.methods.firstOrNull {
+            it.name == "getConfigurationProperties" && it.parameterCount == 0
+        }
+        if (method != null) {
+            return method.invoke(factory) as Map<String, Any>
+        }
+        return emptyMap()
+    }
+}


### PR DESCRIPTION
Closes #26

## 🔧 작업 개요

Kafka 트랜잭션 ID 충돌과 역직렬화 보안 리스크를 줄이기 위해 producer/consumer 설정을 강화하고 관련 테스트를 추가했습니다.

---

## ✅ 주요 변경 사항

### global.common.config
- `KafkaConfig`: transactional.id/transactionIdPrefix를 인스턴스별 UUID로 생성
- `KafkaConfig`: JsonDeserializer trusted packages를 DTO 패키지로 제한
- `KafkaConfig`: 역직렬화/메시지 변환 예외를 재시도 제외 처리

### global.common.config (test)
- `KafkaConfigTest`: 트랜잭션 ID 유니크/신뢰 패키지 제한 테스트 추가

---

## ✅ 테스트

- `./gradlew test --tests com.hoppingmall.mall.global.common.config.KafkaConfigTest`

---

## 📎 관련 이슈

- #26
