### PR TITLE
fix: OutBox 단일 발행 보장

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/domain/OutboxEvent.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/domain/OutboxEvent.kt
@@ -69,6 +69,12 @@ class OutboxEvent(
         this.retryCount++
         this.updatedAt = LocalDateTime.now()
     }
+
+    fun markAsFailedPermanently(errorMessage: String) {
+        markAsFailed(errorMessage)
+        this.processed = true
+        this.processedAt = LocalDateTime.now()
+    }
     
     fun markAsRetrying() {
         this.status = OutboxStatus.RETRYING

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/repository/OutboxEventRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/repository/OutboxEventRepository.kt
@@ -23,6 +23,22 @@ interface OutboxEventRepository : JpaRepository<OutboxEvent, Long> {
         @Param("maxRetries") maxRetries: Int = 3,
         @Param("limit") limit: Int = 100
     ): List<OutboxEvent>
+
+    @Query("""
+        SELECT COUNT(o) > 0 FROM OutboxEvent o
+        WHERE o.aggregateType = :aggregateType
+        AND o.aggregateId = :aggregateId
+        AND o.eventType = :eventType
+        AND o.eventData = :eventData
+        AND o.status IN :statuses
+    """)
+    fun existsDuplicateEvent(
+        @Param("aggregateType") aggregateType: String,
+        @Param("aggregateId") aggregateId: String,
+        @Param("eventType") eventType: String,
+        @Param("eventData") eventData: String,
+        @Param("statuses") statuses: List<OutboxStatus>
+    ): Boolean
     
     @Query("""
         SELECT o FROM OutboxEvent o 
@@ -43,6 +59,27 @@ interface OutboxEventRepository : JpaRepository<OutboxEvent, Long> {
         AND o.processedAt < :cutoffDate
     """)
     fun deleteProcessedEventsBefore(@Param("cutoffDate") cutoffDate: LocalDateTime): Int
+
+    @Modifying
+    @Query("""
+        UPDATE OutboxEvent o
+        SET o.status = :nextStatus,
+            o.updatedAt = :updatedAt
+        WHERE o.id = :id
+        AND o.processed = false
+        AND (
+            o.status = :pendingStatus
+            OR (o.status = :failedStatus AND o.retryCount < :maxRetries)
+        )
+    """)
+    fun claimEventForPublish(
+        @Param("id") id: Long,
+        @Param("nextStatus") nextStatus: OutboxStatus,
+        @Param("updatedAt") updatedAt: LocalDateTime,
+        @Param("pendingStatus") pendingStatus: OutboxStatus,
+        @Param("failedStatus") failedStatus: OutboxStatus,
+        @Param("maxRetries") maxRetries: Int
+    ): Int
     
     @Query("""
         SELECT COUNT(o) FROM OutboxEvent o 
@@ -53,7 +90,7 @@ interface OutboxEventRepository : JpaRepository<OutboxEvent, Long> {
     @Query("""
         SELECT o FROM OutboxEvent o 
         WHERE o.processed = false 
-        AND o.createdAt < :cutoffDate
+        AND o.updatedAt < :cutoffDate
         ORDER BY o.createdAt ASC
         LIMIT :limit
     """)
@@ -61,4 +98,24 @@ interface OutboxEventRepository : JpaRepository<OutboxEvent, Long> {
         @Param("cutoffDate") cutoffDate: LocalDateTime,
         @Param("limit") limit: Int = 100
     ): List<OutboxEvent>
-}
+
+    @Modifying
+    @Query("""
+        UPDATE OutboxEvent o
+        SET o.status = :nextStatus,
+            o.updatedAt = :updatedAt
+        WHERE o.id = :id
+        AND o.processed = false
+        AND o.updatedAt < :cutoffDate
+        AND o.retryCount < :maxRetries
+        AND o.status IN :statuses
+    """)
+    fun claimStaleEvent(
+        @Param("id") id: Long,
+        @Param("nextStatus") nextStatus: OutboxStatus,
+        @Param("updatedAt") updatedAt: LocalDateTime,
+        @Param("cutoffDate") cutoffDate: LocalDateTime,
+        @Param("maxRetries") maxRetries: Int,
+        @Param("statuses") statuses: List<OutboxStatus>
+    ): Int
+} 

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/service/OutboxEventService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/service/OutboxEventService.kt
@@ -35,6 +35,18 @@ class OutboxEventService(
         partitionKey: String? = null
     ) {
         val serializedData = objectMapper.writeValueAsString(eventData)
+        val duplicated = outboxEventRepository.existsDuplicateEvent(
+            aggregateType = aggregateType,
+            aggregateId = aggregateId,
+            eventType = eventType,
+            eventData = serializedData,
+            statuses = listOf(OutboxStatus.PENDING, OutboxStatus.RETRYING, OutboxStatus.PUBLISHED)
+        )
+        
+        if (duplicated) {
+            logger.warn("Duplicate outbox event skipped: aggregateId=$aggregateId, eventType=$eventType")
+            return
+        }
         
         val outboxEvent = OutboxEvent(
             aggregateType = aggregateType,
@@ -63,17 +75,31 @@ class OutboxEventService(
             logger.info("Processing ${pendingEvents.size} pending outbox events")
             
             pendingEvents.forEach { event ->
-                publishEvent(event)
+                val eventId = event.id ?: return@forEach
+                val claimed = outboxEventRepository.claimEventForPublish(
+                    id = eventId,
+                    nextStatus = OutboxStatus.RETRYING,
+                    updatedAt = LocalDateTime.now(),
+                    pendingStatus = OutboxStatus.PENDING,
+                    failedStatus = OutboxStatus.FAILED,
+                    maxRetries = maxRetries
+                )
+                if (claimed > 0) {
+                    publishEvent(eventId)
+                }
             }
         }
     }
     
     @Async
     @Transactional
-    fun publishEvent(event: OutboxEvent) {
+    fun publishEvent(eventId: Long) {
+        var event: OutboxEvent? = null
         try {
-            event.markAsRetrying()
-            outboxEventRepository.save(event)
+            event = outboxEventRepository.findById(eventId).orElse(null) ?: return
+            if (event.processed || event.status != OutboxStatus.RETRYING) {
+                return
+            }
             
             val eventData = objectMapper.readValue(event.eventData, Map::class.java)
             
@@ -97,8 +123,13 @@ class OutboxEventService(
             }
             
         } catch (e: Exception) {
-            logger.error("Failed to publish outbox event: ${event.id}", e)
-            handlePublishFailure(event, e)
+            val failedEvent = event
+            if (failedEvent != null) {
+                logger.error("Failed to publish outbox event: ${failedEvent.id}", e)
+                handlePublishFailure(failedEvent, e)
+            } else {
+                logger.error("Failed to publish outbox event: $eventId", e)
+            }
         }
     }
     
@@ -113,9 +144,10 @@ class OutboxEventService(
     
     private fun handlePublishFailure(event: OutboxEvent, throwable: Throwable) {
         val errorMessage = throwable.message ?: "Unknown error"
-        
-        if (event.retryCount >= maxRetries) {
-            event.markAsFailed("Max retries exceeded: $errorMessage")
+        val willExceedMaxRetry = event.retryCount + 1 >= maxRetries
+
+        if (willExceedMaxRetry) {
+            event.markAsFailedPermanently("Max retries exceeded: $errorMessage")
             logger.error("Outbox event failed after max retries: eventId=${event.id}, error=$errorMessage")
         } else {
             event.markAsFailed(errorMessage)
@@ -147,11 +179,22 @@ class OutboxEventService(
             logger.warn("Found ${staleEvents.size} stale outbox events, retrying...")
             
             staleEvents.forEach { event ->
-                if (event.retryCount < maxRetries) {
-                    publishEvent(event)
-                } else {
-                    event.markAsFailed("Stale event - max retries exceeded")
+                val eventId = event.id ?: return@forEach
+                if (event.retryCount >= maxRetries) {
+                    event.markAsFailedPermanently("Stale event - max retries exceeded")
                     outboxEventRepository.save(event)
+                    return@forEach
+                }
+                val claimed = outboxEventRepository.claimStaleEvent(
+                    id = eventId,
+                    nextStatus = OutboxStatus.RETRYING,
+                    updatedAt = LocalDateTime.now(),
+                    cutoffDate = cutoffDate,
+                    maxRetries = maxRetries,
+                    statuses = listOf(OutboxStatus.PENDING, OutboxStatus.FAILED, OutboxStatus.RETRYING)
+                )
+                if (claimed > 0) {
+                    publishEvent(eventId)
                 }
             }
         }

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/service/OutboxEventServiceIntegrationTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/service/OutboxEventServiceIntegrationTest.kt
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -24,8 +26,6 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import java.util.concurrent.CompletableFuture
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 @ExtendWith(MockitoExtension::class)
 @DisplayName("OutboxEventService 통합 테스트")
@@ -55,6 +55,7 @@ class OutboxEventServiceIntegrationTest {
             callback(kafkaTemplate)
         }
         lenient().`when`(objectMapper.writeValueAsString(any())).thenReturn("\"{\"test\": \"data\"}\"")
+        lenient().`when`(objectMapper.readValue(any<String>(), eq(Map::class.java))).thenReturn(mapOf("test" to "data"))
     }
 
     private fun mockSendResult(): SendResult<String, Any> {
@@ -78,6 +79,13 @@ class OutboxEventServiceIntegrationTest {
             eventData = "\"{\"test\": \"data\"}\"",
             topic = "payment"
         )
+        doReturn(false).whenever(outboxEventRepository).existsDuplicateEvent(
+            aggregateType = "Payment",
+            aggregateId = "123",
+            eventType = "PaymentCompleted",
+            eventData = "\"{\"test\": \"data\"}\"",
+            statuses = listOf(OutboxStatus.PENDING, OutboxStatus.RETRYING, OutboxStatus.PUBLISHED)
+        )
         whenever(outboxEventRepository.save(any<OutboxEvent>())).thenReturn(savedEvent)
         
         outboxEventService.saveEvent(
@@ -90,6 +98,84 @@ class OutboxEventServiceIntegrationTest {
         
         verify(outboxEventRepository).save(any<OutboxEvent>())
         verify(objectMapper).writeValueAsString(eventData)
+    }
+
+    @Test
+    fun saveEvent_중복_이벤트는_저장하지_않는다() {
+        val eventData = mapOf("orderId" to 123, "amount" to 50000)
+        doReturn(true).whenever(outboxEventRepository).existsDuplicateEvent(
+            aggregateType = "Payment",
+            aggregateId = "123",
+            eventType = "PaymentCompleted",
+            eventData = "\"{\"test\": \"data\"}\"",
+            statuses = listOf(OutboxStatus.PENDING, OutboxStatus.RETRYING, OutboxStatus.PUBLISHED)
+        )
+
+        outboxEventService.saveEvent(
+            aggregateType = "Payment",
+            aggregateId = "123",
+            eventType = "PaymentCompleted",
+            eventData = eventData,
+            topic = "payment"
+        )
+
+        verify(outboxEventRepository, never()).save(any<OutboxEvent>())
+    }
+
+    @Test
+    fun publishPendingEvents_클레임_성공시_발행한다() {
+        val event = OutboxEvent(
+            aggregateType = "Payment",
+            aggregateId = "123",
+            eventType = "PaymentCompleted",
+            eventData = "\"{\"test\": \"data\"}\"",
+            topic = "payment",
+            partitionKey = "order-123"
+        ).apply { id = 1L }
+
+        whenever(outboxEventRepository.findUnprocessedEvents(any(), any(), any(), any()))
+            .thenReturn(listOf(event))
+        doReturn(1).whenever(outboxEventRepository).claimEventForPublish(
+            eq(1L),
+            eq(OutboxStatus.RETRYING),
+            any(),
+            eq(OutboxStatus.PENDING),
+            eq(OutboxStatus.FAILED),
+            eq(3)
+        )
+        event.status = OutboxStatus.RETRYING
+        whenever(outboxEventRepository.findById(1L)).thenReturn(java.util.Optional.of(event))
+
+        outboxEventService.publishPendingEvents()
+
+        verify(kafkaTemplate).executeInTransaction<Any>(any())
+    }
+
+    @Test
+    fun publishPendingEvents_클레임_실패시_발행하지_않는다() {
+        val event = OutboxEvent(
+            aggregateType = "Payment",
+            aggregateId = "123",
+            eventType = "PaymentCompleted",
+            eventData = "\"{\"test\": \"data\"}\"",
+            topic = "payment",
+            partitionKey = "order-123"
+        ).apply { id = 1L }
+
+        whenever(outboxEventRepository.findUnprocessedEvents(any(), any(), any(), any()))
+            .thenReturn(listOf(event))
+        doReturn(0).whenever(outboxEventRepository).claimEventForPublish(
+            eq(1L),
+            eq(OutboxStatus.RETRYING),
+            any(),
+            eq(OutboxStatus.PENDING),
+            eq(OutboxStatus.FAILED),
+            eq(3)
+        )
+
+        outboxEventService.publishPendingEvents()
+
+        verify(kafkaTemplate, never()).send(any<String>(), any<String>(), any<Any>())
     }
 
     @Test


### PR DESCRIPTION
Closes #27

## 🔧 작업 개요

Outbox 발행의 중복/경쟁 문제를 줄이기 위해 클레임 기반 상태 전환과 중복 저장 차단을 추가하고, 스테일 이벤트 처리 로직을 보강했습니다.

---

## ✅ 주요 변경 사항

### global.common.domain
- `OutboxEvent`: 영구 실패 처리 메서드 추가

### global.common.repository
- `OutboxEventRepository`: 중복 이벤트 검증/클레임 쿼리 추가
- `OutboxEventRepository`: 스테일 이벤트 클레임 및 기준 updatedAt으로 변경

### global.common.service
- `OutboxEventService`: 중복 저장 차단, 클레임 기반 단일 발행, 스테일 이벤트 재처리 보강

---

## ✅ 테스트

- `./gradlew test --tests com.hoppingmall.mall.global.common.service.OutboxEventServiceIntegrationTest`

---

## 📎 관련 이슈

- #27
