### PR TITLE
fix: 컨슈머 멱등성/타임아웃 강화

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/KafkaConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/KafkaConfig.kt
@@ -16,6 +16,10 @@ import org.springframework.util.backoff.FixedBackOff
 import com.hoppingmall.mall.global.common.service.DLQService
 import org.apache.kafka.clients.consumer.ConsumerConfig.ISOLATION_LEVEL_CONFIG
 import org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG
+import org.springframework.messaging.converter.MessageConversionException
+import org.apache.kafka.common.errors.SerializationException
+import org.springframework.kafka.support.serializer.DeserializationException
+import java.util.UUID
 @Configuration
 class KafkaConfig {
 
@@ -30,6 +34,12 @@ class KafkaConfig {
 
     @Value("\${spring.kafka.listener.concurrency:1}")
     private var concurrency: Int = 4
+    
+    private val instanceId: String = UUID.randomUUID().toString()
+    private val trustedPackages: String = listOf(
+        "com.hoppingmall.mall.payment.dto.event",
+        "com.hoppingmall.mall.notification.dto.event"
+    ).joinToString(",")
 
     @Bean
     fun producerFactory(): ProducerFactory<String, Any> {
@@ -43,20 +53,22 @@ class KafkaConfig {
         configProps[ProducerConfig.ACKS_CONFIG] = "all"
         configProps[ProducerConfig.RETRIES_CONFIG] = Int.MAX_VALUE
         configProps[ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION] = 5
-        configProps[ProducerConfig.TRANSACTIONAL_ID_CONFIG] = "hoppingmall-tx-"
+        configProps[ProducerConfig.TRANSACTIONAL_ID_CONFIG] = "hoppingmall-tx-$instanceId"
         
         // 성능 최적화
         configProps[ProducerConfig.BATCH_SIZE_CONFIG] = 16384
         configProps[ProducerConfig.LINGER_MS_CONFIG] = 10
         configProps[ProducerConfig.COMPRESSION_TYPE_CONFIG] = "lz4"
         
-        return DefaultKafkaProducerFactory(configProps)
+        val producerFactory = DefaultKafkaProducerFactory<String, Any>(configProps)
+        producerFactory.setTransactionIdPrefix("hoppingmall-tx-$instanceId-")
+        return producerFactory
     }
 
     @Bean
     fun kafkaTemplate(): KafkaTemplate<String, Any> {
         val template = KafkaTemplate(producerFactory())
-        template.setTransactionIdPrefix("hoppingmall-tx-")
+        template.setTransactionIdPrefix("hoppingmall-tx-$instanceId-")
         return template
     }
 
@@ -74,12 +86,17 @@ class KafkaConfig {
         configProps[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = autoOffsetReset
         configProps[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
         configProps[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = JsonDeserializer::class.java
-        configProps[JsonDeserializer.TRUSTED_PACKAGES] = "*"
+        configProps[JsonDeserializer.TRUSTED_PACKAGES] = trustedPackages
         
         // Consumer 설정 - EOS를 위한 read_committed 유지
         configProps[ENABLE_AUTO_COMMIT_CONFIG] = false
         configProps[ISOLATION_LEVEL_CONFIG] = "read_committed"
-        
+
+        configProps[ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG] = 300_000
+        configProps[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = 100
+        configProps[ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG] = 30_000
+        configProps[ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG] = 10_000
+
         return DefaultKafkaConsumerFactory(configProps)
     }
 
@@ -96,6 +113,11 @@ class KafkaConfig {
                 sendToDLQ(record, exception, dlqService)
             },
             FixedBackOff(1000L, 3) // 1초 간격으로 3번 재시도
+        )
+        errorHandler.addNotRetryableExceptions(
+            DeserializationException::class.java,
+            SerializationException::class.java,
+            MessageConversionException::class.java
         )
         factory.setCommonErrorHandler(errorHandler)
         

--- a/src/main/kotlin/com/hoppingmall/mall/notification/domain/Notification.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/domain/Notification.kt
@@ -7,6 +7,9 @@ import jakarta.persistence.*
 @Entity
 @Table(name = "notifications")
 class Notification(
+    @Column(nullable = false, unique = true)
+    val eventId: String,
+
     @Column(nullable = false)
     val userId: Long,
 

--- a/src/main/kotlin/com/hoppingmall/mall/notification/domain/NotificationRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/domain/NotificationRepository.kt
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface NotificationRepository : JpaRepository<Notification, Long> {
+
+    fun existsByEventId(eventId: String): Boolean
     
     fun findByUserId(userId: Long): List<Notification>
     

--- a/src/main/kotlin/com/hoppingmall/mall/notification/dto/event/NotificationEvent.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/dto/event/NotificationEvent.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.notification.dto.event
 import com.hoppingmall.mall.notification.enum.NotificationType
 
 data class NotificationEvent(
+    val eventId: String,
     val userId: Long,
     val type: NotificationType,
     val title: String,

--- a/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationEventConsumer.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationEventConsumer.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.notification.service
 import com.hoppingmall.mall.notification.domain.Notification
 import com.hoppingmall.mall.notification.domain.NotificationRepository
 import com.hoppingmall.mall.notification.dto.event.NotificationEvent
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Service
@@ -20,8 +21,13 @@ class NotificationEventConsumer(
     ) {
         // Key 기반 파티셔닝으로 같은 userId의 알림은 같은 파티션에서 순차 처리
         println("알림 처리: userId=${event.userId}, type=${event.type}")
+
+        if (notificationRepository.existsByEventId(event.eventId)) {
+            return
+        }
         
         val notification = Notification(
+            eventId = event.eventId,
             userId = event.userId,
             type = event.type,
             title = event.title,
@@ -29,7 +35,11 @@ class NotificationEventConsumer(
             metadata = event.metadata
         )
         
-        notificationRepository.save(notification)
+        try {
+            notificationRepository.save(notification)
+        } catch (e: DataIntegrityViolationException) {
+            return
+        }
         
         println("알림 저장 완료: 사용자 ${event.userId}, 타입 ${event.type}, 제목 ${event.title}")
     }

--- a/src/main/kotlin/com/hoppingmall/mall/payment/domain/PaymentEventLog.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/domain/PaymentEventLog.kt
@@ -1,0 +1,23 @@
+package com.hoppingmall.mall.payment.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "payment_event_logs",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["transaction_id"])]
+)
+class PaymentEventLog(
+    @Column(name = "transaction_id", nullable = false, unique = true)
+    val transactionId: String,
+
+    @Column(nullable = false)
+    val paymentId: Long,
+
+    @Column(nullable = false)
+    val orderId: Long
+) : BaseEntity()

--- a/src/main/kotlin/com/hoppingmall/mall/payment/domain/repository/PaymentEventLogRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/domain/repository/PaymentEventLogRepository.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.mall.payment.domain.repository
+
+import com.hoppingmall.mall.payment.domain.PaymentEventLog
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PaymentEventLogRepository : JpaRepository<PaymentEventLog, Long> {
+    fun existsByTransactionId(transactionId: String): Boolean
+}

--- a/src/main/kotlin/com/hoppingmall/mall/payment/dto/event/PointEarnRequestEvent.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/dto/event/PointEarnRequestEvent.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.payment.dto.event
 import java.math.BigDecimal
 
 data class PointEarnRequestEvent(
+    val eventId: String,
     val userId: Long,
     val orderId: Long,
     val paymentId: Long,

--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/KafkaPaymentEventPublisher.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/KafkaPaymentEventPublisher.kt
@@ -37,6 +37,7 @@ class KafkaPaymentEventPublisher(
             aggregateId = event.paymentId.toString(),
             eventType = "PointEarnRequested",
             eventData = mapOf(
+                "eventId" to event.eventId,
                 "userId" to event.userId,
                 "orderId" to event.orderId,
                 "paymentId" to event.paymentId,

--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentEventConsumer.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentEventConsumer.kt
@@ -2,19 +2,42 @@ package com.hoppingmall.mall.payment.service
 
 import com.hoppingmall.mall.payment.dto.event.PaymentCompletedEvent
 import com.hoppingmall.mall.payment.enum.PaymentMethod
+import com.hoppingmall.mall.payment.domain.PaymentEventLog
+import com.hoppingmall.mall.payment.domain.repository.PaymentEventLogRepository
 import java.math.BigDecimal
 import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Service
 
 @Service
-class PaymentEventConsumer {
+class PaymentEventConsumer(
+    private val paymentEventLogRepository: PaymentEventLogRepository
+) {
     
     private val logger = LoggerFactory.getLogger(PaymentEventConsumer::class.java)
     
     @KafkaListener(topics = ["\${kafka.topics.payment:payment}"], groupId = "payment-consumer-group")
     fun handlePaymentEvent(paymentEvent: PaymentCompletedEvent) {
         try {
+            if (paymentEventLogRepository.existsByTransactionId(paymentEvent.transactionId)) {
+                logger.info("이미 처리된 결제 이벤트: ${paymentEvent.orderId}")
+                return
+            }
+
+            try {
+                paymentEventLogRepository.save(
+                    PaymentEventLog(
+                        transactionId = paymentEvent.transactionId,
+                        paymentId = paymentEvent.paymentId,
+                        orderId = paymentEvent.orderId
+                    )
+                )
+            } catch (e: DataIntegrityViolationException) {
+                logger.info("이미 처리된 결제 이벤트: ${paymentEvent.orderId}")
+                return
+            }
+            
             logger.info("결제 이벤트 처리 시작: ${paymentEvent.orderId}")
             
             processPayment(paymentEvent)

--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentEventService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentEventService.kt
@@ -37,8 +37,10 @@ class PaymentEventService(
     fun publishPointEarnRequestEvent(payment: Payment) {
         val earnRate = getCurrentEarnRate()
         val earnAmount = payment.amount.multiply(earnRate)
+        val eventId = payment.transactionId ?: "payment-${payment.id}"
         
         val event = PointEarnRequestEvent(
+            eventId = eventId,
             userId = payment.userId,
             orderId = payment.orderId,
             paymentId = payment.id!!,
@@ -48,6 +50,7 @@ class PaymentEventService(
     }
     
     fun publishPaymentCompletedNotification(payment: Payment) {
+        val eventId = payment.transactionId ?: "payment-${payment.id}"
         val metadata = objectMapper.writeValueAsString(
             mapOf(
             "orderId" to payment.orderId,
@@ -63,6 +66,7 @@ class PaymentEventService(
             aggregateId = payment.id!!.toString(),
             eventType = "PaymentCompletedNotificationRequested",
             eventData = mapOf(
+                "eventId" to eventId,
                 "userId" to payment.userId,
                 "type" to NotificationType.PAYMENT_COMPLETED.toString(),
                 "title" to "결제가 완료되었습니다",

--- a/src/main/kotlin/com/hoppingmall/mall/point/domain/PointHistory.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/domain/PointHistory.kt
@@ -25,7 +25,10 @@ class PointHistory(
     val orderId: Long? = null,
     
     @Column
-    val paymentId: Long? = null
+    val paymentId: Long? = null,
+
+    @Column(unique = true)
+    val eventId: String? = null
 ) : BaseEntity() {
 
     companion object {

--- a/src/main/kotlin/com/hoppingmall/mall/point/domain/PointHistoryRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/domain/PointHistoryRepository.kt
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface PointHistoryRepository : JpaRepository<PointHistory, Long> {
+    fun existsByEventId(eventId: String): Boolean
+
     fun findByUserIdOrderByCreatedAtDesc(userId: Long): List<PointHistory>
     
     fun findByUserId(userId: Long, pageable: Pageable): Page<PointHistory>

--- a/src/main/kotlin/com/hoppingmall/mall/point/service/PointEventConsumer.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/service/PointEventConsumer.kt
@@ -16,7 +16,6 @@ import org.springframework.retry.annotation.Retryable
 import org.springframework.retry.annotation.Backoff
 import com.hoppingmall.mall.global.common.service.TransactionalEventPublisher
 import java.math.BigDecimal
-import java.util.concurrent.ConcurrentHashMap
 
 @Service
 @Transactional
@@ -35,6 +34,10 @@ class PointEventConsumer(
     )
     fun handlePointEarnRequest(event: PointEarnRequestEvent) {
         try {
+            if (pointHistoryRepository.existsByEventId(event.eventId)) {
+                return
+            }
+
             val point = findOrCreatePoint(event.userId)
             point.balance += event.earnAmount
             val savedPoint = pointRepository.save(point)
@@ -46,7 +49,8 @@ class PointEventConsumer(
                     type = PointType.EARN,
                     reason = event.reason,
                     orderId = event.orderId,
-                    paymentId = event.paymentId
+                    paymentId = event.paymentId,
+                    eventId = event.eventId
                 )
             )
 
@@ -65,6 +69,7 @@ class PointEventConsumer(
                 aggregateId = savedPoint.id!!.toString(),
                 eventType = "PointEarnedNotificationRequested",
                 eventData = mapOf(
+                    "eventId" to event.eventId,
                     "userId" to event.userId,
                     "type" to NotificationType.POINT_EARNED.toString(),
                     "title" to "포인트가 적립되었습니다",

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/config/KafkaConfigTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/config/KafkaConfigTest.kt
@@ -1,0 +1,105 @@
+package com.hoppingmall.mall.global.common.config
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.springframework.kafka.support.serializer.JsonDeserializer
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@DisplayName("KafkaConfig 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class KafkaConfigTest {
+
+    @Test
+    fun 트랜잭션_아이디는_인스턴스별로_유니크하다() {
+        val config1 = createConfig()
+        val config2 = createConfig()
+
+        val producerFactory1 = config1.producerFactory() as DefaultKafkaProducerFactory<String, Any>
+        val producerFactory2 = config2.producerFactory() as DefaultKafkaProducerFactory<String, Any>
+
+        val prefix1 = readField(producerFactory1, "transactionIdPrefix")
+        val prefix2 = readField(producerFactory2, "transactionIdPrefix")
+
+        assertNotNull(prefix1)
+        assertNotNull(prefix2)
+
+        assertTrue(prefix1.startsWith("hoppingmall-tx-"))
+        assertTrue(prefix2.startsWith("hoppingmall-tx-"))
+        assertNotEquals(prefix1, prefix2)
+    }
+
+    @Test
+    fun JsonDeserializer는_신뢰_패키지를_제한한다() {
+        val config = createConfig()
+        val consumerFactory = config.consumerFactory() as DefaultKafkaConsumerFactory<String, Any>
+
+        val configs = readConfigs(consumerFactory)
+        val trusted = configs[JsonDeserializer.TRUSTED_PACKAGES]?.toString()
+
+        assertNotNull(trusted)
+
+        assertEquals(
+            "com.hoppingmall.mall.payment.dto.event,com.hoppingmall.mall.notification.dto.event",
+            trusted
+        )
+        assertNotEquals("*", trusted)
+    }
+
+    @Test
+    fun 컨슈머_타임아웃_설정이_적용된다() {
+        val config = createConfig()
+        val consumerFactory = config.consumerFactory() as DefaultKafkaConsumerFactory<String, Any>
+
+        val configs = readConfigs(consumerFactory)
+
+        assertEquals(300_000, configs[ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG])
+        assertEquals(100, configs[ConsumerConfig.MAX_POLL_RECORDS_CONFIG])
+        assertEquals(30_000, configs[ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG])
+        assertEquals(10_000, configs[ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG])
+    }
+
+    private fun createConfig(): KafkaConfig {
+        val config = KafkaConfig()
+        setField(config, "bootstrapServers", "localhost:9092")
+        setField(config, "groupId", "test-group")
+        setField(config, "autoOffsetReset", "earliest")
+        setField(config, "concurrency", 1)
+        return config
+    }
+
+    private fun setField(target: Any, fieldName: String, value: Any) {
+        val field = target.javaClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.set(target, value)
+    }
+
+    private fun readField(target: Any, fieldName: String): String? {
+        val field = target.javaClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field.get(target)?.toString()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun readConfigs(factory: Any): Map<String, Any> {
+        val field = runCatching { factory.javaClass.getDeclaredField("configs") }.getOrNull()
+        if (field != null) {
+            field.isAccessible = true
+            return field.get(factory) as Map<String, Any>
+        }
+        val method = factory.javaClass.methods.firstOrNull {
+            it.name == "getConfigurationProperties" && it.parameterCount == 0
+        }
+        if (method != null) {
+            return method.invoke(factory) as Map<String, Any>
+        }
+        return emptyMap()
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/notification/service/NotificationEventConsumerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/notification/service/NotificationEventConsumerTest.kt
@@ -5,7 +5,12 @@ import com.hoppingmall.mall.notification.domain.NotificationRepository
 import com.hoppingmall.mall.notification.dto.event.NotificationEvent
 import com.hoppingmall.mall.notification.enum.NotificationType
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import kotlin.test.assertEquals
 
 class NotificationEventConsumerTest {
@@ -27,6 +32,7 @@ class NotificationEventConsumerTest {
         """.trimIndent()
         
         val event = NotificationEvent(
+            eventId = "EVENT-1",
             userId = 1L,
             type = NotificationType.PAYMENT_COMPLETED,
             title = "결제가 완료되었습니다",
@@ -42,6 +48,7 @@ class NotificationEventConsumerTest {
         // then
         verify(notificationRepository).save(captor.capture())
         val savedNotification = captor.firstValue
+        assertEquals("EVENT-1", savedNotification.eventId)
         assertEquals(1L, savedNotification.userId)
         assertEquals(NotificationType.PAYMENT_COMPLETED, savedNotification.type)
         assertEquals("결제가 완료되었습니다", savedNotification.title)
@@ -64,6 +71,7 @@ class NotificationEventConsumerTest {
         """.trimIndent()
         
         val event = NotificationEvent(
+            eventId = "EVENT-2",
             userId = 2L,
             type = NotificationType.POINT_EARNED,
             title = "포인트가 적립되었습니다",
@@ -79,6 +87,7 @@ class NotificationEventConsumerTest {
         // then
         verify(notificationRepository).save(captor.capture())
         val savedNotification = captor.firstValue
+        assertEquals("EVENT-2", savedNotification.eventId)
         assertEquals(2L, savedNotification.userId)
         assertEquals(NotificationType.POINT_EARNED, savedNotification.type)
         assertEquals("포인트가 적립되었습니다", savedNotification.title)
@@ -86,4 +95,22 @@ class NotificationEventConsumerTest {
         assertEquals(metadata, savedNotification.metadata)
         assertEquals(false, savedNotification.isRead)
     }
-} 
+
+    @Test
+    fun `중복 알림 이벤트는 저장하지 않는다`() {
+        val event = NotificationEvent(
+            eventId = "EVENT-3",
+            userId = 3L,
+            type = NotificationType.PAYMENT_COMPLETED,
+            title = "중복 테스트",
+            content = "중복 처리 방지",
+            metadata = null
+        )
+
+        whenever(notificationRepository.existsByEventId(event.eventId)).thenReturn(true)
+
+        notificationEventConsumer.handleNotificationEvent(event)
+
+        verify(notificationRepository, never()).save(any())
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentEventConsumerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentEventConsumerTest.kt
@@ -3,12 +3,21 @@ package com.hoppingmall.mall.payment.service
 import com.hoppingmall.mall.payment.dto.event.PaymentCompletedEvent
 import com.hoppingmall.mall.payment.enum.PaymentMethod
 import com.hoppingmall.mall.payment.enum.PaymentStatus
+import com.hoppingmall.mall.payment.domain.repository.PaymentEventLogRepository
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import com.hoppingmall.mall.payment.domain.PaymentEventLog
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
@@ -16,7 +25,8 @@ import java.time.LocalDateTime
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class PaymentEventConsumerTest {
 
-    private val paymentEventConsumer = PaymentEventConsumer()
+    private val paymentEventLogRepository: PaymentEventLogRepository = mock()
+    private val paymentEventConsumer = PaymentEventConsumer(paymentEventLogRepository)
 
     @Nested
     @DisplayName("handlePaymentEvent")
@@ -37,8 +47,15 @@ class PaymentEventConsumerTest {
                 completedAt = LocalDateTime.now()
             )
 
-            // when & then
+            // when
             paymentEventConsumer.handlePaymentEvent(paymentEvent)
+
+            // then
+            val captor = argumentCaptor<PaymentEventLog>()
+            verify(paymentEventLogRepository).save(captor.capture())
+            assertEquals("TXN_1", captor.firstValue.transactionId)
+            assertEquals(1L, captor.firstValue.paymentId)
+            assertEquals(1L, captor.firstValue.orderId)
         }
 
         @Test
@@ -56,8 +73,15 @@ class PaymentEventConsumerTest {
                 completedAt = LocalDateTime.now()
             )
 
-            // when & then
+            // when
             paymentEventConsumer.handlePaymentEvent(paymentEvent)
+
+            // then
+            val captor = argumentCaptor<PaymentEventLog>()
+            verify(paymentEventLogRepository).save(captor.capture())
+            assertEquals("TXN_2", captor.firstValue.transactionId)
+            assertEquals(2L, captor.firstValue.paymentId)
+            assertEquals(2L, captor.firstValue.orderId)
         }
 
         @Test
@@ -79,6 +103,27 @@ class PaymentEventConsumerTest {
             assertThrows<RuntimeException> {
                 paymentEventConsumer.handlePaymentEvent(paymentEvent)
             }
+        }
+
+        @Test
+        fun 중복_결제_이벤트는_처리하지_않는다() {
+            val paymentEvent = PaymentCompletedEvent(
+                paymentId = 5L,
+                orderId = 5L,
+                userId = 5L,
+                amount = BigDecimal("30000"),
+                pointAmount = BigDecimal.ZERO,
+                method = PaymentMethod.BANK_TRANSFER,
+                status = PaymentStatus.SUCCESS,
+                transactionId = "TXN_DUP",
+                completedAt = LocalDateTime.now()
+            )
+
+            whenever(paymentEventLogRepository.existsByTransactionId(paymentEvent.transactionId)).thenReturn(true)
+
+            paymentEventConsumer.handlePaymentEvent(paymentEvent)
+
+            verify(paymentEventLogRepository, never()).save(any())
         }
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentEventServiceTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentEventServiceTest.kt
@@ -94,6 +94,7 @@ class PaymentEventServiceTest {
         // then
         verify(paymentEventPublisher).publishPointEarnRequestEvent(captor.capture())
         assertEquals(BigDecimal("100.00"), captor.firstValue.earnAmount)
+        assertEquals("payment-1", captor.firstValue.eventId)
     }
     
     @Test
@@ -113,7 +114,8 @@ class PaymentEventServiceTest {
                 val data = eventData as Map<String, Any>
                 val metadata = data["metadata"] as String
                 val metadataMap = objectMapper.readValue(metadata, Map::class.java)
-                data["content"] == "주문번호 1의 결제가 성공적으로 완료되었습니다. 결제 금액: 50000원" &&
+                data["eventId"] == "payment-1" &&
+                    data["content"] == "주문번호 1의 결제가 성공적으로 완료되었습니다. 결제 금액: 50000원" &&
                     metadataMap["orderId"].toString() == "1" &&
                     metadataMap["paymentId"].toString() == "1"
             },

--- a/src/test/kotlin/com/hoppingmall/mall/point/service/PointEventConsumerIntegrationTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/point/service/PointEventConsumerIntegrationTest.kt
@@ -9,12 +9,17 @@ import com.hoppingmall.mall.point.domain.PointHistoryRepository
 import com.hoppingmall.mall.point.domain.PointRepository
 import com.hoppingmall.mall.point.enum.PointType
 import com.hoppingmall.mall.support.withId
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
@@ -35,22 +40,19 @@ class PointEventConsumerIntegrationTest {
     
     @Mock
     private lateinit var transactionalEventPublisher: TransactionalEventPublisher
-    
+
     @Spy
     private val objectMapper = ObjectMapper()
     
     @InjectMocks
     private lateinit var pointEventConsumer: PointEventConsumer
 
-    @BeforeEach
-    fun setUp() {
-    }
-
     @Test
     fun 신규_사용자_포인트_적립() {
         val userId = 1L
         val earnAmount = BigDecimal("1000")
         val event = PointEarnRequestEvent(
+            eventId = "EVENT-1",
             userId = userId,
             orderId = 123L,
             paymentId = 456L,
@@ -68,7 +70,8 @@ class PointEventConsumerIntegrationTest {
             type = PointType.EARN,
             reason = event.reason,
             orderId = event.orderId,
-            paymentId = event.paymentId
+            paymentId = event.paymentId,
+            eventId = event.eventId
         ).withId(1L)
         whenever(pointHistoryRepository.save(any<PointHistory>())).thenReturn(savedHistory)
         
@@ -104,6 +107,7 @@ class PointEventConsumerIntegrationTest {
         whenever(pointRepository.save(any<Point>())).thenReturn(existingPoint)
         
         val event = PointEarnRequestEvent(
+            eventId = "EVENT-2",
             userId = userId,
             orderId = 789L,
             paymentId = 321L,
@@ -117,7 +121,8 @@ class PointEventConsumerIntegrationTest {
             type = PointType.EARN,
             reason = event.reason,
             orderId = event.orderId,
-            paymentId = event.paymentId
+            paymentId = event.paymentId,
+            eventId = event.eventId
         ).withId(2L)
         whenever(pointHistoryRepository.save(any<PointHistory>())).thenReturn(savedHistory2)
         
@@ -130,9 +135,32 @@ class PointEventConsumerIntegrationTest {
             eq("Point"),
             eq("2"),
             eq("PointEarnedNotificationRequested"),
-            any(),
+            argThat { eventData ->
+                val data = eventData as Map<String, Any>
+                data["eventId"] == "EVENT-2"
+            },
             eq("notification"),
             eq(userId.toString())
         )
+    }
+
+    @Test
+    fun 중복_이벤트는_포인트_적립을_건너뛴다() {
+        val event = PointEarnRequestEvent(
+            eventId = "EVENT-3",
+            userId = 3L,
+            orderId = 111L,
+            paymentId = 222L,
+            earnAmount = BigDecimal("500"),
+            reason = "중복 테스트"
+        )
+
+        whenever(pointHistoryRepository.existsByEventId(event.eventId)).thenReturn(true)
+
+        pointEventConsumer.handlePointEarnRequest(event)
+
+        verify(pointRepository, never()).save(any<Point>())
+        verify(pointHistoryRepository, never()).save(any<PointHistory>())
+        verify(transactionalEventPublisher, never()).publishEvent(any(), any(), any(), any(), any(), any())
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/PointHistoryFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/PointHistoryFixture.kt
@@ -11,7 +11,8 @@ fun PointHistory.Companion.fixture(
     type: PointType = PointType.EARN,
     reason: String? = "결제 완료",
     orderId: Long? = 1L,
-    paymentId: Long? = 1L
+    paymentId: Long? = 1L,
+    eventId: String? = null
 ): PointHistory {
     return PointHistory(
         userId = userId,
@@ -19,7 +20,8 @@ fun PointHistory.Companion.fixture(
         type = type,
         reason = reason,
         orderId = orderId,
-        paymentId = paymentId
+        paymentId = paymentId,
+        eventId = eventId
     ).withId(1L)
 }
 


### PR DESCRIPTION
Closes #28

## 📌 요약
- 전체 컨슈머(Payment, Point, Notification)에 멱등성 처리 적용
- 이벤트 간 eventId 전파 체계 구축
- Kafka 컨슈머 타임아웃 설정 명시

## ✅ 변경 내용
- **Payment**: `PaymentEventLog` 엔티티 + `transactionId` unique constraint 기반 중복 방지
- **Point**: `PointHistory.eventId` unique constraint 기반 중복 적립 방지
- **Notification**: `Notification.eventId` unique constraint 기반 중복 알림 방지
- **이벤트 전파**: `PaymentEventService`에서 `transactionId` 기반 `eventId` 생성, `PointEarnRequestEvent`/알림 이벤트에 포함
- **타임아웃**: `max.poll.interval.ms`, `max.poll.records`, `session.timeout.ms`, `heartbeat.interval.ms` 명시 설정
- 모든 컨슈머에 `existsBy{Key}` 선체크 + `DataIntegrityViolationException` 후처리 패턴 적용

## 🧪 테스트
- PaymentEventConsumerTest: 멱등성 검증 (ArgumentCaptor 기반 저장 값 검증 포함)
- PointEventConsumerIntegrationTest: 중복 이벤트 스킵 검증
- NotificationEventConsumerTest: 중복 알림 저장 방지 검증
- KafkaConfigTest: 타임아웃 설정 값 검증
- JaCoCo 80% 커버리지 통과

## 📎 참고
- 멱등성 패턴: `existsBy{Key}` 선체크 → `save` → `DataIntegrityViolationException` catch (race condition 대응)