### PR TITLE
feat: SecurityConfig 역할 기반 접근 제어 강화

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.global.common.config
 import jakarta.servlet.Filter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -27,7 +28,29 @@ class SecurityConfig(
             .exceptionHandling { it.authenticationEntryPoint(jwtAuthenticationEntryPoint) }
             .authorizeHttpRequests {
                 it.requestMatchers("/api/v1/users/signup", "/api/v1/users/login").permitAll()
-                it.requestMatchers("/api/v1/admin/**", "/api/v1/point-policies/**").hasRole("ADMIN")
+                it.requestMatchers(
+                    HttpMethod.GET,
+                    "/api/v1/products",
+                    "/api/v1/products/{productId}",
+                    "/api/v1/products/seller/{sellerId}"
+                ).permitAll()
+                it.requestMatchers(
+                    HttpMethod.GET,
+                    "/api/v1/point-policies/current",
+                    "/api/v1/point-policies/{policyId}"
+                ).permitAll()
+
+                it.requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                it.requestMatchers("/api/v1/point-policies/**").hasRole("ADMIN")
+
+                it.requestMatchers(
+                    HttpMethod.POST,
+                    "/api/v1/products",
+                    "/api/v1/products/images/upload"
+                ).hasRole("SELLER")
+                it.requestMatchers(HttpMethod.PUT, "/api/v1/products/{productId}").hasRole("SELLER")
+                it.requestMatchers(HttpMethod.DELETE, "/api/v1/products/{productId}").hasRole("SELLER")
+
                 it.requestMatchers("/api/v1/**").authenticated()
                 it.anyRequest().denyAll()
             }


### PR DESCRIPTION
Closes #39

### 📌 작업 개요
SecurityConfig에서 인증 여부만 체크하던 엔드포인트에 HTTP 메서드 기반 역할(SELLER/ADMIN) 접근 제어를 추가했습니다.
상품 조회는 비로그인 허용, 상품 CUD는 SELLER 전용, 포인트 정책 조회는 비로그인 허용으로 세분화했습니다.

---

### ✅ 주요 변경 사항

- `global.common.config`
  - `SecurityConfig`: HttpMethod 기반 역할별 접근 제어 규칙 추가
    - `GET /api/v1/products/**` → permitAll (비로그인 상품 조회)
    - `POST/PUT/DELETE /api/v1/products/**` → hasRole("SELLER")
    - `GET /api/v1/point-policies/current, {policyId}` → permitAll
    - 기존 ADMIN, authenticated 규칙 유지

---

### 🧪 테스트

- `./gradlew test` 전체 통과 확인

---

### 📎 관련 이슈
- #39