### PR TITLE
feat: Order 도메인 구현

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/order/controller/OrderController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/controller/OrderController.kt
@@ -1,0 +1,71 @@
+package com.hoppingmall.mall.order.controller
+
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.order.dto.request.OrderCreateRequest
+import com.hoppingmall.mall.order.dto.request.OrderStatusUpdateRequest
+import com.hoppingmall.mall.order.dto.response.OrderResponse
+import com.hoppingmall.mall.order.service.OrderCommandService
+import com.hoppingmall.mall.order.service.OrderQueryService
+import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/orders")
+class OrderController(
+    private val orderCommandService: OrderCommandService,
+    private val orderQueryService: OrderQueryService
+) {
+
+    @PostMapping
+    fun createOrder(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @Valid @RequestBody request: OrderCreateRequest
+    ): ResponseEntity<ApiResponse<OrderResponse>> {
+        val order = orderCommandService.createOrder(userPrincipal.getUserId(), request)
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.success(order))
+    }
+
+    @GetMapping("/{orderId}")
+    fun getOrder(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PathVariable orderId: Long
+    ): ResponseEntity<ApiResponse<OrderResponse>> {
+        val order = orderQueryService.getOrder(orderId, userPrincipal.getUserId())
+        return ResponseEntity.ok(ApiResponse.success(order))
+    }
+
+    @GetMapping
+    fun getMyOrders(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PageableDefault(size = 20) pageable: Pageable
+    ): ResponseEntity<ApiResponse<Page<OrderResponse>>> {
+        val orders = orderQueryService.getMyOrders(userPrincipal.getUserId(), pageable)
+        return ResponseEntity.ok(ApiResponse.success(orders))
+    }
+
+    @PatchMapping("/{orderId}/cancel")
+    fun cancelOrder(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PathVariable orderId: Long
+    ): ResponseEntity<ApiResponse<OrderResponse>> {
+        val order = orderCommandService.cancelOrder(userPrincipal.getUserId(), orderId)
+        return ResponseEntity.ok(ApiResponse.success(order))
+    }
+
+    @PatchMapping("/{orderId}/status")
+    fun updateOrderStatus(
+        @PathVariable orderId: Long,
+        @Valid @RequestBody request: OrderStatusUpdateRequest
+    ): ResponseEntity<ApiResponse<OrderResponse>> {
+        val order = orderCommandService.updateOrderStatus(orderId, request)
+        return ResponseEntity.ok(ApiResponse.success(order))
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/order/domain/Order.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/domain/Order.kt
@@ -1,0 +1,61 @@
+package com.hoppingmall.mall.order.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import com.hoppingmall.mall.order.enum.OrderStatus
+import com.hoppingmall.mall.order.exception.OrderInvalidStatusException
+import jakarta.persistence.*
+import org.hibernate.annotations.Filter
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "orders")
+@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
+class Order private constructor(
+    @Column(nullable = false)
+    val buyerId: Long,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var status: OrderStatus = OrderStatus.CREATED,
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    val totalAmount: BigDecimal
+) : BaseEntity() {
+
+    companion object {
+        private val allowedTransitions: Map<OrderStatus, Set<OrderStatus>> = mapOf(
+            OrderStatus.CREATED to setOf(OrderStatus.PAID, OrderStatus.CANCELLED),
+            OrderStatus.PAID to setOf(OrderStatus.SHIPPED, OrderStatus.CANCELLED),
+            OrderStatus.SHIPPED to setOf(OrderStatus.DELIVERED),
+            OrderStatus.DELIVERED to emptySet(),
+            OrderStatus.CANCELLED to emptySet()
+        )
+
+        fun create(
+            buyerId: Long,
+            totalAmount: BigDecimal
+        ): Order {
+            return Order(
+                buyerId = buyerId,
+                totalAmount = totalAmount
+            )
+        }
+    }
+
+    fun updateStatus(newStatus: OrderStatus) {
+        val allowed = allowedTransitions[this.status] ?: emptySet()
+        if (newStatus !in allowed) {
+            throw OrderInvalidStatusException()
+        }
+        this.status = newStatus
+    }
+
+    fun isCancellable(): Boolean {
+        val allowed = allowedTransitions[this.status] ?: emptySet()
+        return OrderStatus.CANCELLED in allowed
+    }
+
+    fun isCancelled(): Boolean {
+        return this.status == OrderStatus.CANCELLED
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/order/domain/OrderItem.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/domain/OrderItem.kt
@@ -1,0 +1,51 @@
+package com.hoppingmall.mall.order.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import org.hibernate.annotations.Filter
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "order_items")
+@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
+class OrderItem private constructor(
+    @Column(nullable = false)
+    val orderId: Long,
+
+    @Column(nullable = false)
+    val productId: Long,
+
+    @Column(nullable = false)
+    val productName: String,
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    val productPrice: BigDecimal,
+
+    @Column(nullable = false)
+    val quantity: Int,
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    val totalPrice: BigDecimal
+) : BaseEntity() {
+
+    companion object {
+        fun create(
+            orderId: Long,
+            productId: Long,
+            productName: String,
+            productPrice: BigDecimal,
+            quantity: Int
+        ): OrderItem {
+            return OrderItem(
+                orderId = orderId,
+                productId = productId,
+                productName = productName,
+                productPrice = productPrice,
+                quantity = quantity,
+                totalPrice = productPrice.multiply(BigDecimal(quantity))
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/order/domain/repository/OrderItemRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/domain/repository/OrderItemRepository.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.mall.order.domain.repository
+
+import com.hoppingmall.mall.order.domain.OrderItem
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface OrderItemRepository : JpaRepository<OrderItem, Long> {
+    fun findByOrderId(orderId: Long): List<OrderItem>
+}

--- a/src/main/kotlin/com/hoppingmall/mall/order/domain/repository/OrderRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/domain/repository/OrderRepository.kt
@@ -1,0 +1,12 @@
+package com.hoppingmall.mall.order.domain.repository
+
+import com.hoppingmall.mall.order.domain.Order
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface OrderRepository : JpaRepository<Order, Long> {
+    fun findByBuyerId(buyerId: Long, pageable: Pageable): Page<Order>
+}

--- a/src/main/kotlin/com/hoppingmall/mall/order/dto/request/OrderCreateRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/dto/request/OrderCreateRequest.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.mall.order.dto.request
+
+import jakarta.validation.constraints.NotEmpty
+
+data class OrderCreateRequest(
+    @field:NotEmpty(message = "장바구니 아이템 ID 목록은 비어있을 수 없습니다")
+    val cartItemIds: List<Long>
+)

--- a/src/main/kotlin/com/hoppingmall/mall/order/dto/request/OrderStatusUpdateRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/dto/request/OrderStatusUpdateRequest.kt
@@ -1,0 +1,9 @@
+package com.hoppingmall.mall.order.dto.request
+
+import com.hoppingmall.mall.order.enum.OrderStatus
+import jakarta.validation.constraints.NotNull
+
+data class OrderStatusUpdateRequest(
+    @field:NotNull(message = "주문 상태는 필수입니다")
+    val status: OrderStatus
+)

--- a/src/main/kotlin/com/hoppingmall/mall/order/dto/response/OrderItemResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/dto/response/OrderItemResponse.kt
@@ -1,0 +1,26 @@
+package com.hoppingmall.mall.order.dto.response
+
+import com.hoppingmall.mall.order.domain.OrderItem
+import java.math.BigDecimal
+
+data class OrderItemResponse(
+    val id: Long,
+    val productId: Long,
+    val productName: String,
+    val productPrice: BigDecimal,
+    val quantity: Int,
+    val totalPrice: BigDecimal
+) {
+    companion object {
+        fun from(orderItem: OrderItem): OrderItemResponse {
+            return OrderItemResponse(
+                id = orderItem.id!!,
+                productId = orderItem.productId,
+                productName = orderItem.productName,
+                productPrice = orderItem.productPrice,
+                quantity = orderItem.quantity,
+                totalPrice = orderItem.totalPrice
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/order/dto/response/OrderResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/dto/response/OrderResponse.kt
@@ -1,0 +1,29 @@
+package com.hoppingmall.mall.order.dto.response
+
+import com.hoppingmall.mall.order.domain.Order
+import com.hoppingmall.mall.order.domain.OrderItem
+import com.hoppingmall.mall.order.enum.OrderStatus
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+data class OrderResponse(
+    val id: Long,
+    val buyerId: Long,
+    val status: OrderStatus,
+    val totalAmount: BigDecimal,
+    val items: List<OrderItemResponse>,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(order: Order, orderItems: List<OrderItem>): OrderResponse {
+            return OrderResponse(
+                id = order.id!!,
+                buyerId = order.buyerId,
+                status = order.status,
+                totalAmount = order.totalAmount,
+                items = orderItems.map { OrderItemResponse.from(it) },
+                createdAt = order.createdAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/order/enum/OrderStatus.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/enum/OrderStatus.kt
@@ -1,0 +1,9 @@
+package com.hoppingmall.mall.order.enum
+
+enum class OrderStatus {
+    CREATED,
+    PAID,
+    SHIPPED,
+    DELIVERED,
+    CANCELLED
+}

--- a/src/main/kotlin/com/hoppingmall/mall/order/exception/OrderAccessDeniedException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/exception/OrderAccessDeniedException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.order.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.order.exception.code.OrderErrorCode
+
+class OrderAccessDeniedException : BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED)

--- a/src/main/kotlin/com/hoppingmall/mall/order/exception/OrderEmptyItemsException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/exception/OrderEmptyItemsException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.order.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.order.exception.code.OrderErrorCode
+
+class OrderEmptyItemsException : BusinessException(OrderErrorCode.ORDER_EMPTY_ITEMS)

--- a/src/main/kotlin/com/hoppingmall/mall/order/exception/OrderInvalidStatusException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/exception/OrderInvalidStatusException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.order.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.order.exception.code.OrderErrorCode
+
+class OrderInvalidStatusException : BusinessException(OrderErrorCode.ORDER_INVALID_STATUS)

--- a/src/main/kotlin/com/hoppingmall/mall/order/exception/OrderNotFoundException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/exception/OrderNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.order.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.order.exception.code.OrderErrorCode
+
+class OrderNotFoundException : BusinessException(OrderErrorCode.ORDER_NOT_FOUND)

--- a/src/main/kotlin/com/hoppingmall/mall/order/exception/code/OrderErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/exception/code/OrderErrorCode.kt
@@ -1,0 +1,15 @@
+package com.hoppingmall.mall.order.exception.code
+
+import com.hoppingmall.mall.global.common.error.code.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class OrderErrorCode(
+    override val code: String,
+    override val message: String,
+    override val status: HttpStatus
+) : ErrorCode {
+    ORDER_NOT_FOUND("ORD001", "주문을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    ORDER_ACCESS_DENIED("ORD002", "본인의 주문만 조회할 수 있습니다.", HttpStatus.FORBIDDEN),
+    ORDER_INVALID_STATUS("ORD003", "유효하지 않은 주문 상태 변경입니다.", HttpStatus.BAD_REQUEST),
+    ORDER_EMPTY_ITEMS("ORD004", "주문 항목이 비어있습니다.", HttpStatus.BAD_REQUEST),
+}

--- a/src/main/kotlin/com/hoppingmall/mall/order/service/OrderCommandService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/service/OrderCommandService.kt
@@ -1,0 +1,11 @@
+package com.hoppingmall.mall.order.service
+
+import com.hoppingmall.mall.order.dto.request.OrderCreateRequest
+import com.hoppingmall.mall.order.dto.request.OrderStatusUpdateRequest
+import com.hoppingmall.mall.order.dto.response.OrderResponse
+
+interface OrderCommandService {
+    fun createOrder(buyerId: Long, request: OrderCreateRequest): OrderResponse
+    fun cancelOrder(buyerId: Long, orderId: Long): OrderResponse
+    fun updateOrderStatus(orderId: Long, request: OrderStatusUpdateRequest): OrderResponse
+}

--- a/src/main/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImpl.kt
@@ -1,0 +1,82 @@
+package com.hoppingmall.mall.order.service
+
+import com.hoppingmall.mall.cartItem.domain.repository.CartItemRepository
+import com.hoppingmall.mall.order.domain.Order
+import com.hoppingmall.mall.order.domain.OrderItem
+import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
+import com.hoppingmall.mall.order.domain.repository.OrderRepository
+import com.hoppingmall.mall.order.dto.request.OrderCreateRequest
+import com.hoppingmall.mall.order.dto.request.OrderStatusUpdateRequest
+import com.hoppingmall.mall.order.dto.response.OrderResponse
+import com.hoppingmall.mall.order.enum.OrderStatus
+import com.hoppingmall.mall.order.exception.OrderAccessDeniedException
+import com.hoppingmall.mall.order.exception.OrderEmptyItemsException
+import com.hoppingmall.mall.order.exception.OrderNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@Service
+@Transactional
+class OrderCommandServiceImpl(
+    private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository,
+    private val cartItemRepository: CartItemRepository
+) : OrderCommandService {
+
+    override fun createOrder(buyerId: Long, request: OrderCreateRequest): OrderResponse {
+        val cartItems = cartItemRepository.findAllById(request.cartItemIds)
+
+        if (cartItems.isEmpty()) {
+            throw OrderEmptyItemsException()
+        }
+
+        val hasOtherBuyerItem = cartItems.any { it.buyerId != buyerId }
+        if (hasOtherBuyerItem) {
+            throw OrderAccessDeniedException()
+        }
+
+        val totalAmount = cartItems.sumOf { BigDecimal(it.productPrice) * BigDecimal(it.quantity) }
+
+        val order = orderRepository.save(Order.create(buyerId = buyerId, totalAmount = totalAmount))
+
+        val orderItems = cartItems.map { cartItem ->
+            OrderItem.create(
+                orderId = order.id!!,
+                productId = cartItem.productId,
+                productName = cartItem.productName,
+                productPrice = BigDecimal(cartItem.productPrice),
+                quantity = cartItem.quantity
+            )
+        }
+        val savedOrderItems = orderItemRepository.saveAll(orderItems)
+
+        cartItemRepository.deleteAllById(request.cartItemIds)
+
+        return OrderResponse.from(order, savedOrderItems)
+    }
+
+    override fun cancelOrder(buyerId: Long, orderId: Long): OrderResponse {
+        val order = orderRepository.findById(orderId)
+            .orElseThrow { OrderNotFoundException() }
+
+        if (order.buyerId != buyerId) {
+            throw OrderAccessDeniedException()
+        }
+
+        order.updateStatus(OrderStatus.CANCELLED)
+
+        val orderItems = orderItemRepository.findByOrderId(orderId)
+        return OrderResponse.from(order, orderItems)
+    }
+
+    override fun updateOrderStatus(orderId: Long, request: OrderStatusUpdateRequest): OrderResponse {
+        val order = orderRepository.findById(orderId)
+            .orElseThrow { OrderNotFoundException() }
+
+        order.updateStatus(request.status)
+
+        val orderItems = orderItemRepository.findByOrderId(orderId)
+        return OrderResponse.from(order, orderItems)
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/order/service/OrderQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/service/OrderQueryService.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.mall.order.service
+
+import com.hoppingmall.mall.order.dto.response.OrderResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface OrderQueryService {
+    fun getOrder(orderId: Long, buyerId: Long): OrderResponse
+    fun getMyOrders(buyerId: Long, pageable: Pageable): Page<OrderResponse>
+}

--- a/src/main/kotlin/com/hoppingmall/mall/order/service/OrderQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/service/OrderQueryServiceImpl.kt
@@ -1,0 +1,38 @@
+package com.hoppingmall.mall.order.service
+
+import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
+import com.hoppingmall.mall.order.domain.repository.OrderRepository
+import com.hoppingmall.mall.order.dto.response.OrderResponse
+import com.hoppingmall.mall.order.exception.OrderAccessDeniedException
+import com.hoppingmall.mall.order.exception.OrderNotFoundException
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class OrderQueryServiceImpl(
+    private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository
+) : OrderQueryService {
+
+    override fun getOrder(orderId: Long, buyerId: Long): OrderResponse {
+        val order = orderRepository.findById(orderId)
+            .orElseThrow { OrderNotFoundException() }
+
+        if (order.buyerId != buyerId) {
+            throw OrderAccessDeniedException()
+        }
+
+        val orderItems = orderItemRepository.findByOrderId(orderId)
+        return OrderResponse.from(order, orderItems)
+    }
+
+    override fun getMyOrders(buyerId: Long, pageable: Pageable): Page<OrderResponse> {
+        return orderRepository.findByBuyerId(buyerId, pageable).map { order ->
+            val orderItems = orderItemRepository.findByOrderId(order.id!!)
+            OrderResponse.from(order, orderItems)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/order/controller/OrderControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/order/controller/OrderControllerTest.kt
@@ -1,0 +1,163 @@
+package com.hoppingmall.mall.order.controller
+
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.order.dto.request.OrderCreateRequest
+import com.hoppingmall.mall.order.dto.request.OrderStatusUpdateRequest
+import com.hoppingmall.mall.order.dto.response.OrderItemResponse
+import com.hoppingmall.mall.order.dto.response.OrderResponse
+import com.hoppingmall.mall.order.enum.OrderStatus
+import com.hoppingmall.mall.order.service.OrderCommandService
+import com.hoppingmall.mall.order.service.OrderQueryService
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.mockito.kotlin.*
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@DisplayName("OrderController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class OrderControllerTest {
+
+    private val orderCommandService: OrderCommandService = mock()
+    private val orderQueryService: OrderQueryService = mock()
+    private val controller = OrderController(orderCommandService, orderQueryService)
+
+    private val userPrincipal = UserPrincipal(1L, "test@example.com", "BUYER")
+    private val now = LocalDateTime.now()
+
+    private fun createOrderResponse(
+        id: Long = 1L,
+        status: OrderStatus = OrderStatus.CREATED
+    ): OrderResponse {
+        return OrderResponse(
+            id = id,
+            buyerId = 1L,
+            status = status,
+            totalAmount = BigDecimal("50000"),
+            items = listOf(
+                OrderItemResponse(
+                    id = 1L,
+                    productId = 100L,
+                    productName = "테스트 상품",
+                    productPrice = BigDecimal("25000"),
+                    quantity = 2,
+                    totalPrice = BigDecimal("50000")
+                )
+            ),
+            createdAt = now
+        )
+    }
+
+    @Nested
+    @DisplayName("createOrder")
+    inner class CreateOrder {
+        @Test
+        fun 주문_생성_성공() {
+            // given
+            val request = OrderCreateRequest(cartItemIds = listOf(1L, 2L))
+            val expectedResponse = createOrderResponse()
+
+            whenever(orderCommandService.createOrder(userPrincipal.getUserId(), request)).thenReturn(expectedResponse)
+
+            // when
+            val response: ResponseEntity<ApiResponse<OrderResponse>> = controller.createOrder(userPrincipal, request)
+
+            // then
+            assertEquals(HttpStatus.CREATED, response.statusCode)
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(expectedResponse, response.body?.data)
+            verify(orderCommandService).createOrder(userPrincipal.getUserId(), request)
+        }
+    }
+
+    @Nested
+    @DisplayName("getOrder")
+    inner class GetOrder {
+        @Test
+        fun 주문_상세_조회_성공() {
+            // given
+            val orderId = 1L
+            val expectedResponse = createOrderResponse()
+
+            whenever(orderQueryService.getOrder(orderId, userPrincipal.getUserId())).thenReturn(expectedResponse)
+
+            // when
+            val response: ResponseEntity<ApiResponse<OrderResponse>> = controller.getOrder(userPrincipal, orderId)
+
+            // then
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(expectedResponse, response.body?.data)
+            verify(orderQueryService).getOrder(orderId, userPrincipal.getUserId())
+        }
+    }
+
+    @Nested
+    @DisplayName("getMyOrders")
+    inner class GetMyOrders {
+        @Test
+        fun 내_주문_목록_조회_성공() {
+            // given
+            val pageable = PageRequest.of(0, 20)
+            val expectedPage = PageImpl(listOf(createOrderResponse()), pageable, 1)
+
+            whenever(orderQueryService.getMyOrders(userPrincipal.getUserId(), pageable)).thenReturn(expectedPage)
+
+            // when
+            val response = controller.getMyOrders(userPrincipal, pageable)
+
+            // then
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(1, response.body?.data?.totalElements)
+            verify(orderQueryService).getMyOrders(userPrincipal.getUserId(), pageable)
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelOrder")
+    inner class CancelOrder {
+        @Test
+        fun 주문_취소_성공() {
+            // given
+            val orderId = 1L
+            val expectedResponse = createOrderResponse(status = OrderStatus.CANCELLED)
+
+            whenever(orderCommandService.cancelOrder(userPrincipal.getUserId(), orderId)).thenReturn(expectedResponse)
+
+            // when
+            val response: ResponseEntity<ApiResponse<OrderResponse>> = controller.cancelOrder(userPrincipal, orderId)
+
+            // then
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(OrderStatus.CANCELLED, response.body?.data?.status)
+            verify(orderCommandService).cancelOrder(userPrincipal.getUserId(), orderId)
+        }
+    }
+
+    @Nested
+    @DisplayName("updateOrderStatus")
+    inner class UpdateOrderStatus {
+        @Test
+        fun 주문_상태_변경_성공() {
+            // given
+            val orderId = 1L
+            val request = OrderStatusUpdateRequest(status = OrderStatus.PAID)
+            val expectedResponse = createOrderResponse(status = OrderStatus.PAID)
+
+            whenever(orderCommandService.updateOrderStatus(orderId, request)).thenReturn(expectedResponse)
+
+            // when
+            val response: ResponseEntity<ApiResponse<OrderResponse>> = controller.updateOrderStatus(orderId, request)
+
+            // then
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(OrderStatus.PAID, response.body?.data?.status)
+            verify(orderCommandService).updateOrderStatus(orderId, request)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/order/domain/OrderItemTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/order/domain/OrderItemTest.kt
@@ -1,0 +1,49 @@
+package com.hoppingmall.mall.order.domain
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("OrderItem")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class OrderItemTest {
+
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+        @Test
+        fun 주문_항목을_생성한다() {
+            val orderItem = OrderItem.create(
+                orderId = 1L,
+                productId = 100L,
+                productName = "테스트 상품",
+                productPrice = BigDecimal("15000"),
+                quantity = 3
+            )
+
+            assertEquals(1L, orderItem.orderId)
+            assertEquals(100L, orderItem.productId)
+            assertEquals("테스트 상품", orderItem.productName)
+            assertEquals(BigDecimal("15000"), orderItem.productPrice)
+            assertEquals(3, orderItem.quantity)
+            assertEquals(BigDecimal("45000"), orderItem.totalPrice)
+        }
+
+        @Test
+        fun 총_가격이_자동_계산된다() {
+            val orderItem = OrderItem.create(
+                orderId = 1L,
+                productId = 100L,
+                productName = "상품",
+                productPrice = BigDecimal("25000"),
+                quantity = 4
+            )
+
+            assertEquals(BigDecimal("100000"), orderItem.totalPrice)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/order/domain/OrderTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/order/domain/OrderTest.kt
@@ -1,0 +1,145 @@
+package com.hoppingmall.mall.order.domain
+
+import com.hoppingmall.mall.order.enum.OrderStatus
+import com.hoppingmall.mall.order.exception.OrderInvalidStatusException
+import com.hoppingmall.mall.support.fixture.cancelledFixture
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.fixture.paidFixture
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("Order")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class OrderTest {
+
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+        @Test
+        fun 주문을_생성한다() {
+            val order = Order.create(buyerId = 1L, totalAmount = BigDecimal("50000"))
+
+            assertEquals(1L, order.buyerId)
+            assertEquals(BigDecimal("50000"), order.totalAmount)
+            assertEquals(OrderStatus.CREATED, order.status)
+        }
+    }
+
+    @Nested
+    @DisplayName("updateStatus")
+    inner class UpdateStatus {
+        @Test
+        fun CREATED에서_PAID로_변경한다() {
+            val order = Order.fixture()
+            order.updateStatus(OrderStatus.PAID)
+            assertEquals(OrderStatus.PAID, order.status)
+        }
+
+        @Test
+        fun CREATED에서_CANCELLED로_변경한다() {
+            val order = Order.fixture()
+            order.updateStatus(OrderStatus.CANCELLED)
+            assertEquals(OrderStatus.CANCELLED, order.status)
+        }
+
+        @Test
+        fun PAID에서_SHIPPED로_변경한다() {
+            val order = Order.paidFixture()
+            order.updateStatus(OrderStatus.SHIPPED)
+            assertEquals(OrderStatus.SHIPPED, order.status)
+        }
+
+        @Test
+        fun PAID에서_CANCELLED로_변경한다() {
+            val order = Order.paidFixture()
+            order.updateStatus(OrderStatus.CANCELLED)
+            assertEquals(OrderStatus.CANCELLED, order.status)
+        }
+
+        @Test
+        fun SHIPPED에서_DELIVERED로_변경한다() {
+            val order = Order.fixture(status = OrderStatus.SHIPPED)
+            order.updateStatus(OrderStatus.DELIVERED)
+            assertEquals(OrderStatus.DELIVERED, order.status)
+        }
+
+        @Test
+        fun CREATED에서_SHIPPED로_변경하면_예외가_발생한다() {
+            val order = Order.fixture()
+            assertThrows(OrderInvalidStatusException::class.java) {
+                order.updateStatus(OrderStatus.SHIPPED)
+            }
+        }
+
+        @Test
+        fun DELIVERED에서_다른_상태로_변경하면_예외가_발생한다() {
+            val order = Order.fixture(status = OrderStatus.DELIVERED)
+            assertThrows(OrderInvalidStatusException::class.java) {
+                order.updateStatus(OrderStatus.CANCELLED)
+            }
+        }
+
+        @Test
+        fun CANCELLED에서_다른_상태로_변경하면_예외가_발생한다() {
+            val order = Order.cancelledFixture()
+            assertThrows(OrderInvalidStatusException::class.java) {
+                order.updateStatus(OrderStatus.PAID)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("isCancellable")
+    inner class IsCancellable {
+        @Test
+        fun CREATED_상태는_취소_가능하다() {
+            val order = Order.fixture()
+            assertTrue(order.isCancellable())
+        }
+
+        @Test
+        fun PAID_상태는_취소_가능하다() {
+            val order = Order.paidFixture()
+            assertTrue(order.isCancellable())
+        }
+
+        @Test
+        fun SHIPPED_상태는_취소_불가능하다() {
+            val order = Order.fixture(status = OrderStatus.SHIPPED)
+            assertFalse(order.isCancellable())
+        }
+
+        @Test
+        fun DELIVERED_상태는_취소_불가능하다() {
+            val order = Order.fixture(status = OrderStatus.DELIVERED)
+            assertFalse(order.isCancellable())
+        }
+
+        @Test
+        fun CANCELLED_상태는_취소_불가능하다() {
+            val order = Order.cancelledFixture()
+            assertFalse(order.isCancellable())
+        }
+    }
+
+    @Nested
+    @DisplayName("isCancelled")
+    inner class IsCancelled {
+        @Test
+        fun CANCELLED_상태이면_true를_반환한다() {
+            val order = Order.cancelledFixture()
+            assertTrue(order.isCancelled())
+        }
+
+        @Test
+        fun CANCELLED_상태가_아니면_false를_반환한다() {
+            val order = Order.fixture()
+            assertFalse(order.isCancelled())
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImplTest.kt
@@ -1,0 +1,207 @@
+package com.hoppingmall.mall.order.service
+
+import com.hoppingmall.mall.cartItem.domain.CartItem
+import com.hoppingmall.mall.cartItem.domain.repository.CartItemRepository
+import com.hoppingmall.mall.order.domain.Order
+import com.hoppingmall.mall.order.domain.OrderItem
+import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
+import com.hoppingmall.mall.order.domain.repository.OrderRepository
+import com.hoppingmall.mall.order.dto.request.OrderCreateRequest
+import com.hoppingmall.mall.order.dto.request.OrderStatusUpdateRequest
+import com.hoppingmall.mall.order.enum.OrderStatus
+import com.hoppingmall.mall.order.exception.OrderAccessDeniedException
+import com.hoppingmall.mall.order.exception.OrderEmptyItemsException
+import com.hoppingmall.mall.order.exception.OrderInvalidStatusException
+import com.hoppingmall.mall.order.exception.OrderNotFoundException
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.fixture.paidFixture
+import com.hoppingmall.mall.support.withId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.*
+import java.math.BigDecimal
+import java.util.*
+
+@DisplayName("OrderCommandServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class OrderCommandServiceImplTest {
+
+    private val orderRepository: OrderRepository = mock()
+    private val orderItemRepository: OrderItemRepository = mock()
+    private val cartItemRepository: CartItemRepository = mock()
+    private val orderCommandService = OrderCommandServiceImpl(
+        orderRepository, orderItemRepository, cartItemRepository
+    )
+
+    @Nested
+    @DisplayName("createOrder")
+    inner class CreateOrder {
+        @Test
+        fun 주문을_생성한다() {
+            // given
+            val buyerId = 1L
+            val request = OrderCreateRequest(cartItemIds = listOf(1L, 2L))
+            val cartItem1 = CartItem.fixture(buyerId = 1L, productId = 100L, productName = "상품1", productPrice = 15000L, quantity = 2).withId(1L)
+            val cartItem2 = CartItem.fixture(buyerId = 1L, productId = 200L, productName = "상품2", productPrice = 20000L, quantity = 1).withId(2L)
+
+            val orderCaptor = argumentCaptor<Order>()
+
+            whenever(cartItemRepository.findAllById(request.cartItemIds)).thenReturn(listOf(cartItem1, cartItem2))
+            whenever(orderRepository.save(orderCaptor.capture())).thenAnswer {
+                orderCaptor.lastValue.withId(1L)
+            }
+            whenever(orderItemRepository.saveAll(any<List<OrderItem>>())).thenAnswer { invocation ->
+                @Suppress("UNCHECKED_CAST")
+                val items = invocation.getArgument<List<OrderItem>>(0)
+                items.mapIndexed { index, item -> item.withId(index.toLong() + 1) }
+            }
+
+            // when
+            val response = orderCommandService.createOrder(buyerId, request)
+
+            // then
+            assertEquals(1L, response.id)
+            assertEquals(buyerId, response.buyerId)
+            assertEquals(OrderStatus.CREATED, response.status)
+            assertEquals(BigDecimal("50000"), response.totalAmount)
+            assertEquals(2, response.items.size)
+            verify(cartItemRepository).deleteAllById(request.cartItemIds)
+        }
+
+        @Test
+        fun 장바구니가_비어있으면_예외가_발생한다() {
+            // given
+            val buyerId = 1L
+            val request = OrderCreateRequest(cartItemIds = listOf(999L))
+
+            whenever(cartItemRepository.findAllById(request.cartItemIds)).thenReturn(emptyList())
+
+            // when & then
+            assertThrows<OrderEmptyItemsException> {
+                orderCommandService.createOrder(buyerId, request)
+            }
+        }
+
+        @Test
+        fun 다른_사용자의_장바구니_아이템이면_예외가_발생한다() {
+            // given
+            val buyerId = 1L
+            val request = OrderCreateRequest(cartItemIds = listOf(1L))
+            val otherBuyerCartItem = CartItem.fixture(buyerId = 999L).withId(1L)
+
+            whenever(cartItemRepository.findAllById(request.cartItemIds)).thenReturn(listOf(otherBuyerCartItem))
+
+            // when & then
+            assertThrows<OrderAccessDeniedException> {
+                orderCommandService.createOrder(buyerId, request)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelOrder")
+    inner class CancelOrder {
+        @Test
+        fun 주문을_취소한다() {
+            // given
+            val buyerId = 1L
+            val orderId = 1L
+            val order = Order.fixture(buyerId = buyerId)
+            val orderItems = listOf(OrderItem.fixture(orderId = orderId))
+
+            whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
+            whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(orderItems)
+
+            // when
+            val response = orderCommandService.cancelOrder(buyerId, orderId)
+
+            // then
+            assertEquals(OrderStatus.CANCELLED, response.status)
+        }
+
+        @Test
+        fun 존재하지_않는_주문이면_예외가_발생한다() {
+            // given
+            val buyerId = 1L
+            val orderId = 999L
+
+            whenever(orderRepository.findById(orderId)).thenReturn(Optional.empty())
+
+            // when & then
+            assertThrows<OrderNotFoundException> {
+                orderCommandService.cancelOrder(buyerId, orderId)
+            }
+        }
+
+        @Test
+        fun 다른_사용자의_주문이면_예외가_발생한다() {
+            // given
+            val buyerId = 1L
+            val orderId = 1L
+            val order = Order.fixture(buyerId = 999L)
+
+            whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
+
+            // when & then
+            assertThrows<OrderAccessDeniedException> {
+                orderCommandService.cancelOrder(buyerId, orderId)
+            }
+        }
+
+        @Test
+        fun 취소_불가능한_상태이면_예외가_발생한다() {
+            // given
+            val buyerId = 1L
+            val orderId = 1L
+            val order = Order.fixture(buyerId = buyerId, status = OrderStatus.DELIVERED)
+
+            whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
+
+            // when & then
+            assertThrows<OrderInvalidStatusException> {
+                orderCommandService.cancelOrder(buyerId, orderId)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("updateOrderStatus")
+    inner class UpdateOrderStatus {
+        @Test
+        fun 주문_상태를_변경한다() {
+            // given
+            val orderId = 1L
+            val request = OrderStatusUpdateRequest(status = OrderStatus.PAID)
+            val order = Order.fixture()
+            val orderItems = listOf(OrderItem.fixture(orderId = orderId))
+
+            whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
+            whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(orderItems)
+
+            // when
+            val response = orderCommandService.updateOrderStatus(orderId, request)
+
+            // then
+            assertEquals(OrderStatus.PAID, response.status)
+        }
+
+        @Test
+        fun 존재하지_않는_주문이면_예외가_발생한다() {
+            // given
+            val orderId = 999L
+            val request = OrderStatusUpdateRequest(status = OrderStatus.PAID)
+
+            whenever(orderRepository.findById(orderId)).thenReturn(Optional.empty())
+
+            // when & then
+            assertThrows<OrderNotFoundException> {
+                orderCommandService.updateOrderStatus(orderId, request)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/order/service/OrderQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/order/service/OrderQueryServiceImplTest.kt
@@ -1,0 +1,111 @@
+package com.hoppingmall.mall.order.service
+
+import com.hoppingmall.mall.order.domain.Order
+import com.hoppingmall.mall.order.domain.OrderItem
+import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
+import com.hoppingmall.mall.order.domain.repository.OrderRepository
+import com.hoppingmall.mall.order.enum.OrderStatus
+import com.hoppingmall.mall.order.exception.OrderAccessDeniedException
+import com.hoppingmall.mall.order.exception.OrderNotFoundException
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.util.*
+
+@DisplayName("OrderQueryServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class OrderQueryServiceImplTest {
+
+    private val orderRepository: OrderRepository = mock()
+    private val orderItemRepository: OrderItemRepository = mock()
+    private val orderQueryService = OrderQueryServiceImpl(orderRepository, orderItemRepository)
+
+    @Nested
+    @DisplayName("getOrder")
+    inner class GetOrder {
+        @Test
+        fun 주문을_조회한다() {
+            // given
+            val buyerId = 1L
+            val orderId = 1L
+            val order = Order.fixture(buyerId = buyerId)
+            val orderItems = listOf(OrderItem.fixture(orderId = orderId))
+
+            whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
+            whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(orderItems)
+
+            // when
+            val response = orderQueryService.getOrder(orderId, buyerId)
+
+            // then
+            assertEquals(orderId, response.id)
+            assertEquals(buyerId, response.buyerId)
+            assertEquals(OrderStatus.CREATED, response.status)
+            assertEquals(1, response.items.size)
+        }
+
+        @Test
+        fun 존재하지_않는_주문이면_예외가_발생한다() {
+            // given
+            val orderId = 999L
+            val buyerId = 1L
+
+            whenever(orderRepository.findById(orderId)).thenReturn(Optional.empty())
+
+            // when & then
+            assertThrows<OrderNotFoundException> {
+                orderQueryService.getOrder(orderId, buyerId)
+            }
+        }
+
+        @Test
+        fun 다른_사용자의_주문이면_예외가_발생한다() {
+            // given
+            val orderId = 1L
+            val buyerId = 1L
+            val order = Order.fixture(buyerId = 999L)
+
+            whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
+
+            // when & then
+            assertThrows<OrderAccessDeniedException> {
+                orderQueryService.getOrder(orderId, buyerId)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getMyOrders")
+    inner class GetMyOrders {
+        @Test
+        fun 내_주문_목록을_조회한다() {
+            // given
+            val buyerId = 1L
+            val pageable = PageRequest.of(0, 20)
+            val order1 = Order.fixture(buyerId = buyerId).withId(1L)
+            val order2 = Order.fixture(buyerId = buyerId).withId(2L)
+            val page = PageImpl(listOf(order1, order2), pageable, 2)
+
+            whenever(orderRepository.findByBuyerId(buyerId, pageable)).thenReturn(page)
+            whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(OrderItem.fixture(orderId = 1L)))
+            whenever(orderItemRepository.findByOrderId(2L)).thenReturn(listOf(OrderItem.fixture(orderId = 2L)))
+
+            // when
+            val response = orderQueryService.getMyOrders(buyerId, pageable)
+
+            // then
+            assertEquals(2, response.totalElements)
+            assertEquals(2, response.content.size)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/OrderFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/OrderFixture.kt
@@ -1,0 +1,41 @@
+package com.hoppingmall.mall.support.fixture
+
+import com.hoppingmall.mall.order.domain.Order
+import com.hoppingmall.mall.order.enum.OrderStatus
+import com.hoppingmall.mall.support.withId
+import java.math.BigDecimal
+
+fun Order.Companion.fixture(
+    buyerId: Long = 1L,
+    totalAmount: BigDecimal = BigDecimal("50000"),
+    status: OrderStatus = OrderStatus.CREATED
+): Order {
+    return Order.create(
+        buyerId = buyerId,
+        totalAmount = totalAmount
+    ).apply {
+        this.status = status
+    }.withId(1L)
+}
+
+fun Order.Companion.paidFixture(
+    buyerId: Long = 1L,
+    totalAmount: BigDecimal = BigDecimal("50000")
+): Order {
+    return Order.fixture(
+        buyerId = buyerId,
+        totalAmount = totalAmount,
+        status = OrderStatus.PAID
+    )
+}
+
+fun Order.Companion.cancelledFixture(
+    buyerId: Long = 1L,
+    totalAmount: BigDecimal = BigDecimal("50000")
+): Order {
+    return Order.fixture(
+        buyerId = buyerId,
+        totalAmount = totalAmount,
+        status = OrderStatus.CANCELLED
+    )
+}

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/OrderItemFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/OrderItemFixture.kt
@@ -1,0 +1,21 @@
+package com.hoppingmall.mall.support.fixture
+
+import com.hoppingmall.mall.order.domain.OrderItem
+import com.hoppingmall.mall.support.withId
+import java.math.BigDecimal
+
+fun OrderItem.Companion.fixture(
+    orderId: Long = 1L,
+    productId: Long = 100L,
+    productName: String = "테스트 상품",
+    productPrice: BigDecimal = BigDecimal("15000"),
+    quantity: Int = 2
+): OrderItem {
+    return OrderItem.create(
+        orderId = orderId,
+        productId = productId,
+        productName = productName,
+        productPrice = productPrice,
+        quantity = quantity
+    ).withId(1L)
+}


### PR DESCRIPTION
Closes #29

### 📌 작업 개요
Order/OrderItem 엔티티를 DDD 방식으로 구현하고,
CQRS 패턴(Command/Query 분리)으로 주문 생성/취소/상태변경/조회 서비스를 구성했습니다.
CartItem 기반 주문 생성 및 상태 전이 검증을 포함하며, 단위 테스트를 통해 검증하였습니다.

---

### ✅ 주요 변경 사항

- `order.domain`
  - `Order`: 주문 엔티티, allowedTransitions Map 기반 상태 전이 검증 (CREATED→PAID→SHIPPED→DELIVERED, CANCELLED)
  - `OrderItem`: 주문 항목 엔티티, totalPrice 자동 계산

- `order.domain.repository`
  - `OrderRepository`: 구매자별 주문 페이징 조회
  - `OrderItemRepository`: 주문별 항목 조회

- `order.service`
  - `OrderCommandService`, `OrderCommandServiceImpl`: 주문 생성/취소/상태변경 처리, CartItem 기반 주문 생성 및 장바구니 자동 삭제
  - `OrderQueryService`, `OrderQueryServiceImpl`: 주문 상세 조회, 내 주문 목록 페이징 조회

- `order.controller`
  - `OrderController`: REST API 5개 엔드포인트 (POST 생성, GET 상세/목록, PATCH 취소/상태변경)

- `order.dto`
  - `OrderCreateRequest`, `OrderStatusUpdateRequest`: 요청 DTO
  - `OrderResponse`, `OrderItemResponse`: 응답 DTO

- `order.enum`
  - `OrderStatus`: CREATED, PAID, SHIPPED, DELIVERED, CANCELLED

- `order.exception`
  - `OrderErrorCode`: ORD001~ORD004
  - `OrderNotFoundException`, `OrderAccessDeniedException`, `OrderInvalidStatusException`, `OrderEmptyItemsException`

---

### 🧪 테스트

- `OrderTest`: 주문 생성, 상태 전이(유효/무효), isCancellable, isCancelled
- `OrderItemTest`: 주문 항목 생성, totalPrice 자동 계산 검증
- `OrderCommandServiceImplTest`: createOrder(성공/빈 목록/권한 없음), cancelOrder(성공/미존재/권한 없음/잘못된 상태), updateOrderStatus(성공/미존재)
- `OrderQueryServiceImplTest`: getOrder(성공/미존재/권한 없음), getMyOrders(성공)
- `OrderControllerTest`: 5개 엔드포인트 성공 케이스
- Jacoco 80% 커버리지 검증 통과

---

### 📎 관련 이슈
- #29