### PR TITLE
fix: JWT Secret 환경변수 주입으로 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,7 +65,7 @@ logging:
     org.hibernate.type.descriptor.sql.BasicBinder: trace
 
 jwt:
-  secret: my-secret-secret-secret-secret-secret-key-123456789
+  secret: ${JWT_SECRET}
   access-expiration-ms: 3600000 # 1 hour
   refresh-expiration-ms: 86400000 # 24 hour
 

--- a/src/test/kotlin/com/hoppingmall/mall/MallApplicationTests.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/MallApplicationTests.kt
@@ -2,8 +2,10 @@ package com.hoppingmall.mall
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 
 @SpringBootTest
+@ActiveProfiles("test")
 class MallApplicationTests {
 
 	@Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,50 @@
+spring:
+  main:
+    allow-bean-definition-overriding: true
+  jackson:
+    property-naming-strategy: SNAKE_CASE
+
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MYSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+        legacy_id_generator_strategy: true
+
+  kafka:
+    topics:
+      payment: payment-test
+      point: point-test
+    consumer:
+      bootstrap-servers: localhost:9092
+      group-id: test-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "*"
+    producer:
+      bootstrap-servers: localhost:9092
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
+jwt:
+  secret: test-secret-secret-secret-secret-secret-key-123456789
+  access-expiration-ms: 3600000
+  refresh-expiration-ms: 86400000
+
+logging:
+  level:
+    com.hoppingmall.mall: INFO
+    org.hibernate.SQL: WARN
+    org.hibernate.type.descriptor.sql.BasicBinder: WARN


### PR DESCRIPTION
Closes #42

### 📌 작업 개요
application.yml에 하드코딩된 JWT Secret을 환경변수 참조로 전환하여 보안을 강화했습니다.
테스트 환경에서는 별도의 테스트 전용 Secret을 사용하도록 설정했습니다.

---

### ✅ 주요 변경 사항

- `src/main/resources/application.yml`
  - `jwt.secret`: 하드코딩 값을 `${JWT_SECRET}` 환경변수 참조로 변경

- `src/test/resources/application-test.yml`
  - 테스트 전용 `jwt.secret`, `access-expiration-ms`, `refresh-expiration-ms` 설정 추가

- `MallApplicationTests`
  - `@ActiveProfiles("test")` 추가하여 테스트 프로필 명시 적용

---

### 🧪 테스트

- 전체 테스트 357개 통과 확인

---

### 📎 관련 이슈
- #42