### PR TITLE
feat: Inventory 도메인 구현

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
@@ -39,6 +39,7 @@ class SecurityConfig(
                     "/api/v1/point-policies/current",
                     "/api/v1/point-policies/{policyId}"
                 ).permitAll()
+                it.requestMatchers(HttpMethod.GET, "/api/v1/inventories/{productId}").permitAll()
 
                 it.requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                 it.requestMatchers("/api/v1/point-policies/**").hasRole("ADMIN")
@@ -50,6 +51,8 @@ class SecurityConfig(
                 ).hasRole("SELLER")
                 it.requestMatchers(HttpMethod.PUT, "/api/v1/products/{productId}").hasRole("SELLER")
                 it.requestMatchers(HttpMethod.DELETE, "/api/v1/products/{productId}").hasRole("SELLER")
+                it.requestMatchers(HttpMethod.POST, "/api/v1/inventories").hasRole("SELLER")
+                it.requestMatchers(HttpMethod.PATCH, "/api/v1/inventories/{productId}").hasRole("SELLER")
 
                 it.requestMatchers("/api/v1/**").authenticated()
                 it.anyRequest().denyAll()

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/controller/InventoryController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/controller/InventoryController.kt
@@ -1,0 +1,46 @@
+package com.hoppingmall.mall.inventory.controller
+
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.inventory.dto.request.InventoryInitRequest
+import com.hoppingmall.mall.inventory.dto.request.InventoryUpdateRequest
+import com.hoppingmall.mall.inventory.dto.response.InventoryResponse
+import com.hoppingmall.mall.inventory.service.InventoryCommandService
+import com.hoppingmall.mall.inventory.service.InventoryQueryService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/inventories")
+class InventoryController(
+    private val inventoryCommandService: InventoryCommandService,
+    private val inventoryQueryService: InventoryQueryService
+) {
+
+    @PostMapping
+    fun initStock(
+        @Valid @RequestBody request: InventoryInitRequest
+    ): ResponseEntity<ApiResponse<InventoryResponse>> {
+        val response = inventoryCommandService.initStock(request)
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.success(response))
+    }
+
+    @GetMapping("/{productId}")
+    fun getStock(
+        @PathVariable productId: Long
+    ): ResponseEntity<ApiResponse<InventoryResponse>> {
+        val response = inventoryQueryService.getStock(productId)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @PatchMapping("/{productId}")
+    fun updateStock(
+        @PathVariable productId: Long,
+        @Valid @RequestBody request: InventoryUpdateRequest
+    ): ResponseEntity<ApiResponse<InventoryResponse>> {
+        val response = inventoryCommandService.updateStock(productId, request)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/domain/Inventory.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/domain/Inventory.kt
@@ -1,0 +1,41 @@
+package com.hoppingmall.mall.inventory.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import com.hoppingmall.mall.inventory.exception.InventoryInsufficientStockException
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import org.hibernate.annotations.Filter
+
+@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
+@Entity
+@Table(name = "inventories")
+class Inventory private constructor(
+    @Column(unique = true, nullable = false)
+    val productId: Long,
+
+    @Column(nullable = false)
+    var stockQuantity: Int
+) : BaseEntity() {
+
+    fun decreaseStock(quantity: Int) {
+        if (!hasStock(quantity)) {
+            throw InventoryInsufficientStockException()
+        }
+        stockQuantity -= quantity
+    }
+
+    fun increaseStock(quantity: Int) {
+        stockQuantity += quantity
+    }
+
+    fun hasStock(quantity: Int): Boolean {
+        return stockQuantity >= quantity
+    }
+
+    companion object {
+        fun create(productId: Long, stockQuantity: Int): Inventory {
+            return Inventory(productId = productId, stockQuantity = stockQuantity)
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/domain/repository/InventoryRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/domain/repository/InventoryRepository.kt
@@ -1,0 +1,20 @@
+package com.hoppingmall.mall.inventory.domain.repository
+
+import com.hoppingmall.mall.inventory.domain.Inventory
+import jakarta.persistence.LockModeType
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface InventoryRepository : JpaRepository<Inventory, Long> {
+    fun findByProductId(productId: Long): Inventory?
+
+    @Query("SELECT i FROM Inventory i WHERE i.productId = :productId")
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    fun findByProductIdForUpdate(@Param("productId") productId: Long): Inventory?
+
+    fun existsByProductId(productId: Long): Boolean
+}

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/dto/request/InventoryInitRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/dto/request/InventoryInitRequest.kt
@@ -1,0 +1,13 @@
+package com.hoppingmall.mall.inventory.dto.request
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotNull
+
+data class InventoryInitRequest(
+    @field:NotNull(message = "상품 ID는 필수입니다")
+    val productId: Long,
+
+    @field:NotNull(message = "재고 수량은 필수입니다")
+    @field:Min(value = 0, message = "재고 수량은 0 이상이어야 합니다")
+    val stockQuantity: Int
+)

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/dto/request/InventoryUpdateRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/dto/request/InventoryUpdateRequest.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.mall.inventory.dto.request
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotNull
+
+data class InventoryUpdateRequest(
+    @field:NotNull(message = "재고 수량은 필수입니다")
+    @field:Min(value = 0, message = "재고 수량은 0 이상이어야 합니다")
+    val stockQuantity: Int
+)

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/dto/response/InventoryResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/dto/response/InventoryResponse.kt
@@ -1,0 +1,19 @@
+package com.hoppingmall.mall.inventory.dto.response
+
+import com.hoppingmall.mall.inventory.domain.Inventory
+
+data class InventoryResponse(
+    val id: Long,
+    val productId: Long,
+    val stockQuantity: Int
+) {
+    companion object {
+        fun from(inventory: Inventory): InventoryResponse {
+            return InventoryResponse(
+                id = inventory.id!!,
+                productId = inventory.productId,
+                stockQuantity = inventory.stockQuantity
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/exception/InventoryAlreadyExistsException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/exception/InventoryAlreadyExistsException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.inventory.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.inventory.exception.code.InventoryErrorCode
+
+class InventoryAlreadyExistsException : BusinessException(InventoryErrorCode.INVENTORY_ALREADY_EXISTS)

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/exception/InventoryInsufficientStockException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/exception/InventoryInsufficientStockException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.inventory.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.inventory.exception.code.InventoryErrorCode
+
+class InventoryInsufficientStockException : BusinessException(InventoryErrorCode.INVENTORY_INSUFFICIENT_STOCK)

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/exception/InventoryNotFoundException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/exception/InventoryNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.inventory.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.inventory.exception.code.InventoryErrorCode
+
+class InventoryNotFoundException : BusinessException(InventoryErrorCode.INVENTORY_NOT_FOUND)

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/exception/code/InventoryErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/exception/code/InventoryErrorCode.kt
@@ -1,0 +1,14 @@
+package com.hoppingmall.mall.inventory.exception.code
+
+import com.hoppingmall.mall.global.common.error.code.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class InventoryErrorCode(
+    override val code: String,
+    override val message: String,
+    override val status: HttpStatus
+) : ErrorCode {
+    INVENTORY_NOT_FOUND("INV001", "재고 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVENTORY_INSUFFICIENT_STOCK("INV002", "재고가 부족합니다.", HttpStatus.BAD_REQUEST),
+    INVENTORY_ALREADY_EXISTS("INV003", "해당 상품의 재고가 이미 존재합니다.", HttpStatus.CONFLICT),
+}

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/service/InventoryCommandService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/service/InventoryCommandService.kt
@@ -1,0 +1,12 @@
+package com.hoppingmall.mall.inventory.service
+
+import com.hoppingmall.mall.inventory.dto.request.InventoryInitRequest
+import com.hoppingmall.mall.inventory.dto.request.InventoryUpdateRequest
+import com.hoppingmall.mall.inventory.dto.response.InventoryResponse
+
+interface InventoryCommandService {
+    fun initStock(request: InventoryInitRequest): InventoryResponse
+    fun updateStock(productId: Long, request: InventoryUpdateRequest): InventoryResponse
+    fun decreaseStock(productId: Long, quantity: Int)
+    fun increaseStock(productId: Long, quantity: Int)
+}

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/service/InventoryCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/service/InventoryCommandServiceImpl.kt
@@ -1,0 +1,60 @@
+package com.hoppingmall.mall.inventory.service
+
+import com.hoppingmall.mall.inventory.domain.Inventory
+import com.hoppingmall.mall.inventory.domain.repository.InventoryRepository
+import com.hoppingmall.mall.inventory.dto.request.InventoryInitRequest
+import com.hoppingmall.mall.inventory.dto.request.InventoryUpdateRequest
+import com.hoppingmall.mall.inventory.dto.response.InventoryResponse
+import com.hoppingmall.mall.inventory.exception.InventoryAlreadyExistsException
+import com.hoppingmall.mall.inventory.exception.InventoryNotFoundException
+import com.hoppingmall.mall.product.domain.repository.ProductRepository
+import com.hoppingmall.mall.product.exception.ProductNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class InventoryCommandServiceImpl(
+    private val inventoryRepository: InventoryRepository,
+    private val productRepository: ProductRepository
+) : InventoryCommandService {
+
+    override fun initStock(request: InventoryInitRequest): InventoryResponse {
+        if (!productRepository.existsById(request.productId)) {
+            throw ProductNotFoundException()
+        }
+
+        if (inventoryRepository.existsByProductId(request.productId)) {
+            throw InventoryAlreadyExistsException()
+        }
+
+        val inventory = Inventory.create(
+            productId = request.productId,
+            stockQuantity = request.stockQuantity
+        )
+        val savedInventory = inventoryRepository.save(inventory)
+        return InventoryResponse.from(savedInventory)
+    }
+
+    override fun updateStock(productId: Long, request: InventoryUpdateRequest): InventoryResponse {
+        val inventory = inventoryRepository.findByProductIdForUpdate(productId)
+            ?: throw InventoryNotFoundException()
+
+        inventory.stockQuantity = request.stockQuantity
+        return InventoryResponse.from(inventory)
+    }
+
+    override fun decreaseStock(productId: Long, quantity: Int) {
+        val inventory = inventoryRepository.findByProductIdForUpdate(productId)
+            ?: throw InventoryNotFoundException()
+
+        inventory.decreaseStock(quantity)
+    }
+
+    override fun increaseStock(productId: Long, quantity: Int) {
+        val inventory = inventoryRepository.findByProductIdForUpdate(productId)
+            ?: throw InventoryNotFoundException()
+
+        inventory.increaseStock(quantity)
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/service/InventoryQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/service/InventoryQueryService.kt
@@ -1,0 +1,7 @@
+package com.hoppingmall.mall.inventory.service
+
+import com.hoppingmall.mall.inventory.dto.response.InventoryResponse
+
+interface InventoryQueryService {
+    fun getStock(productId: Long): InventoryResponse
+}

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/service/InventoryQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/service/InventoryQueryServiceImpl.kt
@@ -1,0 +1,21 @@
+package com.hoppingmall.mall.inventory.service
+
+import com.hoppingmall.mall.inventory.domain.repository.InventoryRepository
+import com.hoppingmall.mall.inventory.dto.response.InventoryResponse
+import com.hoppingmall.mall.inventory.exception.InventoryNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class InventoryQueryServiceImpl(
+    private val inventoryRepository: InventoryRepository
+) : InventoryQueryService {
+
+    override fun getStock(productId: Long): InventoryResponse {
+        val inventory = inventoryRepository.findByProductId(productId)
+            ?: throw InventoryNotFoundException()
+
+        return InventoryResponse.from(inventory)
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.mall.order.service
 
 import com.hoppingmall.mall.cartItem.domain.repository.CartItemRepository
+import com.hoppingmall.mall.inventory.service.InventoryCommandService
 import com.hoppingmall.mall.order.domain.Order
 import com.hoppingmall.mall.order.domain.OrderItem
 import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
@@ -21,7 +22,8 @@ import java.math.BigDecimal
 class OrderCommandServiceImpl(
     private val orderRepository: OrderRepository,
     private val orderItemRepository: OrderItemRepository,
-    private val cartItemRepository: CartItemRepository
+    private val cartItemRepository: CartItemRepository,
+    private val inventoryCommandService: InventoryCommandService
 ) : OrderCommandService {
 
     override fun createOrder(buyerId: Long, request: OrderCreateRequest): OrderResponse {
@@ -34,6 +36,10 @@ class OrderCommandServiceImpl(
         val hasOtherBuyerItem = cartItems.any { it.buyerId != buyerId }
         if (hasOtherBuyerItem) {
             throw OrderAccessDeniedException()
+        }
+
+        cartItems.sortedBy { it.productId }.forEach { cartItem ->
+            inventoryCommandService.decreaseStock(cartItem.productId, cartItem.quantity)
         }
 
         val totalAmount = cartItems.sumOf { BigDecimal(it.productPrice) * BigDecimal(it.quantity) }
@@ -67,6 +73,10 @@ class OrderCommandServiceImpl(
         order.updateStatus(OrderStatus.CANCELLED)
 
         val orderItems = orderItemRepository.findByOrderId(orderId)
+        orderItems.forEach { orderItem ->
+            inventoryCommandService.increaseStock(orderItem.productId, orderItem.quantity)
+        }
+
         return OrderResponse.from(order, orderItems)
     }
 

--- a/src/test/kotlin/com/hoppingmall/mall/inventory/controller/InventoryControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/inventory/controller/InventoryControllerTest.kt
@@ -1,0 +1,92 @@
+package com.hoppingmall.mall.inventory.controller
+
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.inventory.dto.request.InventoryInitRequest
+import com.hoppingmall.mall.inventory.dto.request.InventoryUpdateRequest
+import com.hoppingmall.mall.inventory.dto.response.InventoryResponse
+import com.hoppingmall.mall.inventory.service.InventoryCommandService
+import com.hoppingmall.mall.inventory.service.InventoryQueryService
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.mockito.kotlin.*
+import org.springframework.http.ResponseEntity
+
+@DisplayName("InventoryController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class InventoryControllerTest {
+
+    private val inventoryCommandService: InventoryCommandService = mock()
+    private val inventoryQueryService: InventoryQueryService = mock()
+    private val controller = InventoryController(inventoryCommandService, inventoryQueryService)
+
+    @Nested
+    @DisplayName("initStock")
+    inner class InitStock {
+        @Test
+        fun 재고_초기화_성공() {
+            // Data
+            val request = InventoryInitRequest(productId = 1L, stockQuantity = 100)
+            val expectedResponse = InventoryResponse(id = 1L, productId = 1L, stockQuantity = 100)
+
+            // Context
+            whenever(inventoryCommandService.initStock(request)).thenReturn(expectedResponse)
+
+            // Interaction
+            val response: ResponseEntity<ApiResponse<InventoryResponse>> = controller.initStock(request)
+
+            // Assertions
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals("성공", response.body?.message)
+            assertEquals(expectedResponse, response.body?.data)
+            verify(inventoryCommandService).initStock(request)
+        }
+    }
+
+    @Nested
+    @DisplayName("getStock")
+    inner class GetStock {
+        @Test
+        fun 재고_조회_성공() {
+            // Data
+            val productId = 1L
+            val expectedResponse = InventoryResponse(id = 1L, productId = productId, stockQuantity = 100)
+
+            // Context
+            whenever(inventoryQueryService.getStock(productId)).thenReturn(expectedResponse)
+
+            // Interaction
+            val response: ResponseEntity<ApiResponse<InventoryResponse>> = controller.getStock(productId)
+
+            // Assertions
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals("성공", response.body?.message)
+            assertEquals(expectedResponse, response.body?.data)
+            verify(inventoryQueryService).getStock(productId)
+        }
+    }
+
+    @Nested
+    @DisplayName("updateStock")
+    inner class UpdateStock {
+        @Test
+        fun 재고_수량_변경_성공() {
+            // Data
+            val productId = 1L
+            val request = InventoryUpdateRequest(stockQuantity = 200)
+            val expectedResponse = InventoryResponse(id = 1L, productId = productId, stockQuantity = 200)
+
+            // Context
+            whenever(inventoryCommandService.updateStock(productId, request)).thenReturn(expectedResponse)
+
+            // Interaction
+            val response: ResponseEntity<ApiResponse<InventoryResponse>> = controller.updateStock(productId, request)
+
+            // Assertions
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals("성공", response.body?.message)
+            assertEquals(expectedResponse, response.body?.data)
+            verify(inventoryCommandService).updateStock(productId, request)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/inventory/domain/InventoryTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/inventory/domain/InventoryTest.kt
@@ -1,0 +1,117 @@
+package com.hoppingmall.mall.inventory.domain
+
+import com.hoppingmall.mall.inventory.exception.InventoryInsufficientStockException
+import com.hoppingmall.mall.support.fixture.emptyStockFixture
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.fixture.lowStockFixture
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("Inventory")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class InventoryTest {
+
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+        @Test
+        fun 재고를_생성한다() {
+            // when
+            val inventory = Inventory.create(productId = 1L, stockQuantity = 100)
+
+            // then
+            assertEquals(1L, inventory.productId)
+            assertEquals(100, inventory.stockQuantity)
+        }
+    }
+
+    @Nested
+    @DisplayName("decreaseStock")
+    inner class DecreaseStock {
+        @Test
+        fun 재고를_차감한다() {
+            // given
+            val inventory = Inventory.fixture(stockQuantity = 100)
+
+            // when
+            inventory.decreaseStock(30)
+
+            // then
+            assertEquals(70, inventory.stockQuantity)
+        }
+
+        @Test
+        fun 재고가_부족하면_예외가_발생한다() {
+            // given
+            val inventory = Inventory.lowStockFixture(stockQuantity = 3)
+
+            // when & then
+            assertThrows<InventoryInsufficientStockException> {
+                inventory.decreaseStock(5)
+            }
+        }
+
+        @Test
+        fun 재고가_0이면_차감시_예외가_발생한다() {
+            // given
+            val inventory = Inventory.emptyStockFixture()
+
+            // when & then
+            assertThrows<InventoryInsufficientStockException> {
+                inventory.decreaseStock(1)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("increaseStock")
+    inner class IncreaseStock {
+        @Test
+        fun 재고를_증가시킨다() {
+            // given
+            val inventory = Inventory.fixture(stockQuantity = 50)
+
+            // when
+            inventory.increaseStock(30)
+
+            // then
+            assertEquals(80, inventory.stockQuantity)
+        }
+    }
+
+    @Nested
+    @DisplayName("hasStock")
+    inner class HasStock {
+        @Test
+        fun 재고가_충분하면_true를_반환한다() {
+            // given
+            val inventory = Inventory.fixture(stockQuantity = 100)
+
+            // when & then
+            assertTrue(inventory.hasStock(50))
+        }
+
+        @Test
+        fun 재고가_부족하면_false를_반환한다() {
+            // given
+            val inventory = Inventory.lowStockFixture(stockQuantity = 3)
+
+            // when & then
+            assertFalse(inventory.hasStock(5))
+        }
+
+        @Test
+        fun 재고와_요청_수량이_동일하면_true를_반환한다() {
+            // given
+            val inventory = Inventory.fixture(stockQuantity = 10)
+
+            // when & then
+            assertTrue(inventory.hasStock(10))
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/inventory/service/InventoryCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/inventory/service/InventoryCommandServiceImplTest.kt
@@ -1,0 +1,178 @@
+package com.hoppingmall.mall.inventory.service
+
+import com.hoppingmall.mall.inventory.domain.Inventory
+import com.hoppingmall.mall.inventory.domain.repository.InventoryRepository
+import com.hoppingmall.mall.inventory.dto.request.InventoryInitRequest
+import com.hoppingmall.mall.inventory.dto.request.InventoryUpdateRequest
+import com.hoppingmall.mall.inventory.exception.InventoryAlreadyExistsException
+import com.hoppingmall.mall.inventory.exception.InventoryNotFoundException
+import com.hoppingmall.mall.product.domain.repository.ProductRepository
+import com.hoppingmall.mall.product.exception.ProductNotFoundException
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.*
+
+@DisplayName("InventoryCommandServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class InventoryCommandServiceImplTest {
+
+    private val inventoryRepository: InventoryRepository = mock()
+    private val productRepository: ProductRepository = mock()
+    private val inventoryCommandService = InventoryCommandServiceImpl(inventoryRepository, productRepository)
+
+    @Nested
+    @DisplayName("initStock")
+    inner class InitStock {
+        @Test
+        fun 재고를_초기화한다() {
+            // given
+            val request = InventoryInitRequest(productId = 1L, stockQuantity = 100)
+
+            whenever(productRepository.existsById(1L)).thenReturn(true)
+            whenever(inventoryRepository.existsByProductId(1L)).thenReturn(false)
+            whenever(inventoryRepository.save(any<Inventory>())).thenAnswer { invocation ->
+                invocation.getArgument<Inventory>(0).withId(1L)
+            }
+
+            // when
+            val response = inventoryCommandService.initStock(request)
+
+            // then
+            assertEquals(1L, response.id)
+            assertEquals(1L, response.productId)
+            assertEquals(100, response.stockQuantity)
+        }
+
+        @Test
+        fun 상품이_존재하지_않으면_예외가_발생한다() {
+            // given
+            val request = InventoryInitRequest(productId = 999L, stockQuantity = 100)
+
+            whenever(productRepository.existsById(999L)).thenReturn(false)
+
+            // when & then
+            assertThrows<ProductNotFoundException> {
+                inventoryCommandService.initStock(request)
+            }
+        }
+
+        @Test
+        fun 이미_재고가_존재하면_예외가_발생한다() {
+            // given
+            val request = InventoryInitRequest(productId = 1L, stockQuantity = 100)
+
+            whenever(productRepository.existsById(1L)).thenReturn(true)
+            whenever(inventoryRepository.existsByProductId(1L)).thenReturn(true)
+
+            // when & then
+            assertThrows<InventoryAlreadyExistsException> {
+                inventoryCommandService.initStock(request)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("updateStock")
+    inner class UpdateStock {
+        @Test
+        fun 재고_수량을_변경한다() {
+            // given
+            val productId = 1L
+            val request = InventoryUpdateRequest(stockQuantity = 200)
+            val inventory = Inventory.fixture(productId = productId, stockQuantity = 100).withId(1L)
+
+            whenever(inventoryRepository.findByProductIdForUpdate(productId)).thenReturn(inventory)
+
+            // when
+            val response = inventoryCommandService.updateStock(productId, request)
+
+            // then
+            assertEquals(200, response.stockQuantity)
+        }
+
+        @Test
+        fun 재고가_존재하지_않으면_예외가_발생한다() {
+            // given
+            val productId = 999L
+            val request = InventoryUpdateRequest(stockQuantity = 200)
+
+            whenever(inventoryRepository.findByProductIdForUpdate(productId)).thenReturn(null)
+
+            // when & then
+            assertThrows<InventoryNotFoundException> {
+                inventoryCommandService.updateStock(productId, request)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("decreaseStock")
+    inner class DecreaseStock {
+        @Test
+        fun 재고를_차감한다() {
+            // given
+            val productId = 1L
+            val inventory = Inventory.fixture(productId = productId, stockQuantity = 100).withId(1L)
+
+            whenever(inventoryRepository.findByProductIdForUpdate(productId)).thenReturn(inventory)
+
+            // when
+            inventoryCommandService.decreaseStock(productId, 30)
+
+            // then
+            assertEquals(70, inventory.stockQuantity)
+        }
+
+        @Test
+        fun 재고가_존재하지_않으면_예외가_발생한다() {
+            // given
+            val productId = 999L
+
+            whenever(inventoryRepository.findByProductIdForUpdate(productId)).thenReturn(null)
+
+            // when & then
+            assertThrows<InventoryNotFoundException> {
+                inventoryCommandService.decreaseStock(productId, 10)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("increaseStock")
+    inner class IncreaseStock {
+        @Test
+        fun 재고를_증가시킨다() {
+            // given
+            val productId = 1L
+            val inventory = Inventory.fixture(productId = productId, stockQuantity = 50).withId(1L)
+
+            whenever(inventoryRepository.findByProductIdForUpdate(productId)).thenReturn(inventory)
+
+            // when
+            inventoryCommandService.increaseStock(productId, 30)
+
+            // then
+            assertEquals(80, inventory.stockQuantity)
+        }
+
+        @Test
+        fun 재고가_존재하지_않으면_예외가_발생한다() {
+            // given
+            val productId = 999L
+
+            whenever(inventoryRepository.findByProductIdForUpdate(productId)).thenReturn(null)
+
+            // when & then
+            assertThrows<InventoryNotFoundException> {
+                inventoryCommandService.increaseStock(productId, 10)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/inventory/service/InventoryQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/inventory/service/InventoryQueryServiceImplTest.kt
@@ -1,0 +1,58 @@
+package com.hoppingmall.mall.inventory.service
+
+import com.hoppingmall.mall.inventory.domain.Inventory
+import com.hoppingmall.mall.inventory.domain.repository.InventoryRepository
+import com.hoppingmall.mall.inventory.exception.InventoryNotFoundException
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@DisplayName("InventoryQueryServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class InventoryQueryServiceImplTest {
+
+    private val inventoryRepository: InventoryRepository = mock()
+    private val inventoryQueryService = InventoryQueryServiceImpl(inventoryRepository)
+
+    @Nested
+    @DisplayName("getStock")
+    inner class GetStock {
+        @Test
+        fun 재고를_조회한다() {
+            // given
+            val productId = 1L
+            val inventory = Inventory.fixture(productId = productId, stockQuantity = 100).withId(1L)
+
+            whenever(inventoryRepository.findByProductId(productId)).thenReturn(inventory)
+
+            // when
+            val response = inventoryQueryService.getStock(productId)
+
+            // then
+            assertEquals(1L, response.id)
+            assertEquals(productId, response.productId)
+            assertEquals(100, response.stockQuantity)
+        }
+
+        @Test
+        fun 재고가_존재하지_않으면_예외가_발생한다() {
+            // given
+            val productId = 999L
+
+            whenever(inventoryRepository.findByProductId(productId)).thenReturn(null)
+
+            // when & then
+            assertThrows<InventoryNotFoundException> {
+                inventoryQueryService.getStock(productId)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.order.service
 
 import com.hoppingmall.mall.cartItem.domain.CartItem
 import com.hoppingmall.mall.cartItem.domain.repository.CartItemRepository
+import com.hoppingmall.mall.inventory.service.InventoryCommandService
 import com.hoppingmall.mall.order.domain.Order
 import com.hoppingmall.mall.order.domain.OrderItem
 import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
@@ -34,8 +35,9 @@ class OrderCommandServiceImplTest {
     private val orderRepository: OrderRepository = mock()
     private val orderItemRepository: OrderItemRepository = mock()
     private val cartItemRepository: CartItemRepository = mock()
+    private val inventoryCommandService: InventoryCommandService = mock()
     private val orderCommandService = OrderCommandServiceImpl(
-        orderRepository, orderItemRepository, cartItemRepository
+        orderRepository, orderItemRepository, cartItemRepository, inventoryCommandService
     )
 
     @Nested
@@ -70,6 +72,8 @@ class OrderCommandServiceImplTest {
             assertEquals(OrderStatus.CREATED, response.status)
             assertEquals(BigDecimal("50000"), response.totalAmount)
             assertEquals(2, response.items.size)
+            verify(inventoryCommandService).decreaseStock(100L, 2)
+            verify(inventoryCommandService).decreaseStock(200L, 1)
             verify(cartItemRepository).deleteAllById(request.cartItemIds)
         }
 
@@ -122,6 +126,7 @@ class OrderCommandServiceImplTest {
 
             // then
             assertEquals(OrderStatus.CANCELLED, response.status)
+            verify(inventoryCommandService).increaseStock(100L, 2)
         }
 
         @Test

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/InventoryFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/InventoryFixture.kt
@@ -1,0 +1,23 @@
+package com.hoppingmall.mall.support.fixture
+
+import com.hoppingmall.mall.inventory.domain.Inventory
+
+fun Inventory.Companion.fixture(
+    productId: Long = 100L,
+    stockQuantity: Int = 100
+): Inventory {
+    return Inventory.create(productId = productId, stockQuantity = stockQuantity)
+}
+
+fun Inventory.Companion.emptyStockFixture(
+    productId: Long = 100L
+): Inventory {
+    return Inventory.create(productId = productId, stockQuantity = 0)
+}
+
+fun Inventory.Companion.lowStockFixture(
+    productId: Long = 100L,
+    stockQuantity: Int = 3
+): Inventory {
+    return Inventory.create(productId = productId, stockQuantity = stockQuantity)
+}


### PR DESCRIPTION
Closes #30

## 📌 변경 사항
- Inventory 엔티티 + 비관적 락 Repository 구현
- CQRS 서비스 (InventoryCommandService / InventoryQueryService) 분리
- REST API 3개 (POST 초기화, GET 조회, PATCH 수량 변경)
- SecurityConfig에 SELLER 권한 제한 추가
- OrderCommandServiceImpl 연동: 주문 생성 시 재고 차감, 취소 시 복구
- productId 정렬 후 차감으로 데드락 방지

## ✅ 주요 구현
- `Inventory` 엔티티: BaseEntity 상속, softDeleteFilter, decreaseStock/increaseStock/hasStock 메서드
- `InventoryRepository`: findByProductIdForUpdate (PESSIMISTIC_WRITE)
- `InventoryCommandServiceImpl`: initStock 시 상품 존재/중복 검증, updateStock/decreaseStock/increaseStock 비관적 락
- `InventoryQueryServiceImpl`: readOnly 트랜잭션 조회
- `InventoryErrorCode`: INV001(미존재), INV002(재고부족), INV003(이미존재)

## 🧪 테스트
- InventoryTest: 엔티티 단위 테스트 (create, decreaseStock, increaseStock, hasStock)
- InventoryCommandServiceImplTest: 서비스 단위 테스트 (initStock, updateStock, decreaseStock, increaseStock)
- InventoryQueryServiceImplTest: 조회 서비스 단위 테스트
- InventoryControllerTest: 컨트롤러 단위 테스트
- OrderCommandServiceImplTest: 재고 연동 검증 추가
- Jacoco 80% 커버리지 검증 통과

## 📎 참고
- Kafka 이벤트 기반 보상 트랜잭션은 #31 범위