### PR TITLE
feat: 결제 실패/취소 보상 흐름 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,7 +108,9 @@ val jacocoExcludedDirs = listOf(
 	"**/com/hoppingmall/mall/payment/service/KafkaPaymentEventPublisher*",
 	"**/com/hoppingmall/mall/global/common/service/OutboxEventService*",
 	"**/com/hoppingmall/mall/global/common/repository/OutboxEventRepository*",
-	"**/com/hoppingmall/mall/point/service/PointEventConsumer*"
+	"**/com/hoppingmall/mall/point/service/PointEventConsumer*",
+	"**/com/hoppingmall/mall/payment/service/PaymentCompensationConsumer*",
+	"**/com/hoppingmall/mall/payment/service/PaymentEventConsumer*"
 )
 
 tasks.jacocoTestReport {

--- a/src/main/kotlin/com/hoppingmall/mall/notification/enum/NotificationType.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/enum/NotificationType.kt
@@ -1,9 +1,8 @@
 package com.hoppingmall.mall.notification.enum
 
 enum class NotificationType {
-    // 결제 관련
-    PAYMENT_COMPLETED,    // 결제 완료
-    
-    // 포인트 관련
-    POINT_EARNED          // 포인트 적립
+    PAYMENT_COMPLETED,
+    PAYMENT_FAILED,
+    PAYMENT_CANCELLED,
+    POINT_EARNED
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/payment/controller/PaymentController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/controller/PaymentController.kt
@@ -52,4 +52,14 @@ class PaymentController(
         val payments = paymentQueryService.getPaymentsByOrderId(orderId)
         return ResponseEntity.ok(payments)
     }
+
+    @PostMapping("/{paymentId}/cancel")
+    fun cancelPayment(
+        @PathVariable paymentId: Long,
+        @AuthenticationPrincipal userDetails: UserDetails
+    ): ResponseEntity<PaymentResponse> {
+        val userId = userDetails.username.toLong()
+        val paymentResponse = paymentCommandService.cancelPayment(paymentId, userId)
+        return ResponseEntity.ok(paymentResponse)
+    }
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/payment/domain/CompensationEventLog.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/domain/CompensationEventLog.kt
@@ -1,0 +1,26 @@
+package com.hoppingmall.mall.payment.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "compensation_event_logs",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["event_id"])]
+)
+class CompensationEventLog(
+    @Column(name = "event_id", nullable = false, unique = true)
+    val eventId: String,
+
+    @Column(nullable = false)
+    val compensationType: String,
+
+    @Column(nullable = false)
+    val paymentId: Long,
+
+    @Column(nullable = false)
+    val orderId: Long
+) : BaseEntity()

--- a/src/main/kotlin/com/hoppingmall/mall/payment/domain/repository/CompensationEventLogRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/domain/repository/CompensationEventLogRepository.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.mall.payment.domain.repository
+
+import com.hoppingmall.mall.payment.domain.CompensationEventLog
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CompensationEventLogRepository : JpaRepository<CompensationEventLog, Long> {
+    fun existsByEventId(eventId: String): Boolean
+}

--- a/src/main/kotlin/com/hoppingmall/mall/payment/dto/event/PaymentCancelledEvent.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/dto/event/PaymentCancelledEvent.kt
@@ -1,0 +1,12 @@
+package com.hoppingmall.mall.payment.dto.event
+
+import java.math.BigDecimal
+
+data class PaymentCancelledEvent(
+    val eventId: String,
+    val paymentId: Long,
+    val orderId: Long,
+    val userId: Long,
+    val amount: BigDecimal,
+    val transactionId: String
+)

--- a/src/main/kotlin/com/hoppingmall/mall/payment/dto/event/PaymentFailedEvent.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/dto/event/PaymentFailedEvent.kt
@@ -1,0 +1,12 @@
+package com.hoppingmall.mall.payment.dto.event
+
+import java.math.BigDecimal
+
+data class PaymentFailedEvent(
+    val eventId: String,
+    val paymentId: Long,
+    val orderId: Long,
+    val userId: Long,
+    val amount: BigDecimal,
+    val reason: String
+)

--- a/src/main/kotlin/com/hoppingmall/mall/payment/exception/PaymentAccessDeniedException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/exception/PaymentAccessDeniedException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.payment.exception
+
+import com.hoppingmall.mall.payment.exception.code.PaymentErrorCode
+
+class PaymentAccessDeniedException : PaymentException(PaymentErrorCode.PAYMENT_ACCESS_DENIED)

--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/KafkaPaymentEventPublisher.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/KafkaPaymentEventPublisher.kt
@@ -1,6 +1,8 @@
 package com.hoppingmall.mall.payment.service
 
+import com.hoppingmall.mall.payment.dto.event.PaymentCancelledEvent
 import com.hoppingmall.mall.payment.dto.event.PaymentCompletedEvent
+import com.hoppingmall.mall.payment.dto.event.PaymentFailedEvent
 import com.hoppingmall.mall.payment.dto.event.PointEarnRequestEvent
 import com.hoppingmall.mall.global.common.service.TransactionalEventPublisher
 import org.springframework.stereotype.Service
@@ -46,6 +48,42 @@ class KafkaPaymentEventPublisher(
             ),
             topic = "point-earn-request",
             partitionKey = event.userId.toString()
+        )
+    }
+
+    override fun publishPaymentFailedEvent(event: PaymentFailedEvent) {
+        transactionalEventPublisher.publishEvent(
+            aggregateType = "Payment",
+            aggregateId = event.paymentId.toString(),
+            eventType = "PaymentFailed",
+            eventData = mapOf(
+                "eventId" to event.eventId,
+                "paymentId" to event.paymentId,
+                "orderId" to event.orderId,
+                "userId" to event.userId,
+                "amount" to event.amount,
+                "reason" to event.reason
+            ),
+            topic = "payment-compensation",
+            partitionKey = event.orderId.toString()
+        )
+    }
+
+    override fun publishPaymentCancelledEvent(event: PaymentCancelledEvent) {
+        transactionalEventPublisher.publishEvent(
+            aggregateType = "Payment",
+            aggregateId = event.paymentId.toString(),
+            eventType = "PaymentCancelled",
+            eventData = mapOf(
+                "eventId" to event.eventId,
+                "paymentId" to event.paymentId,
+                "orderId" to event.orderId,
+                "userId" to event.userId,
+                "amount" to event.amount,
+                "transactionId" to event.transactionId
+            ),
+            topic = "payment-compensation",
+            partitionKey = event.orderId.toString()
         )
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentCommandService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentCommandService.kt
@@ -5,4 +5,5 @@ import com.hoppingmall.mall.payment.dto.response.PaymentResponse
 
 interface PaymentCommandService {
     fun processPayment(paymentRequest: PaymentRequest, userId: Long): PaymentResponse
+    fun cancelPayment(paymentId: Long, userId: Long): PaymentResponse
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentCommandServiceImpl.kt
@@ -6,6 +6,9 @@ import com.hoppingmall.mall.payment.dto.PaymentResult
 import com.hoppingmall.mall.payment.enum.PaymentStatus
 import com.hoppingmall.mall.payment.dto.request.PaymentRequest
 import com.hoppingmall.mall.payment.dto.response.PaymentResponse
+import com.hoppingmall.mall.payment.exception.PaymentAccessDeniedException
+import com.hoppingmall.mall.payment.exception.PaymentInvalidStateException
+import com.hoppingmall.mall.payment.exception.PaymentNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -38,8 +41,34 @@ class PaymentCommandServiceImpl(
         if (finalPayment.status == PaymentStatus.SUCCESS) {
             publishPaymentEvents(finalPayment)
         }
-        
+
+        if (finalPayment.status == PaymentStatus.FAILED) {
+            paymentEventService.publishPaymentFailedEvent(finalPayment)
+            paymentEventService.publishPaymentFailedNotification(finalPayment)
+        }
+
         return PaymentResponse.from(finalPayment)
+    }
+
+    override fun cancelPayment(paymentId: Long, userId: Long): PaymentResponse {
+        val payment = paymentRepository.findById(paymentId)
+            .orElseThrow { PaymentNotFoundException() }
+
+        if (payment.userId != userId) {
+            throw PaymentAccessDeniedException()
+        }
+
+        if (payment.status != PaymentStatus.SUCCESS) {
+            throw PaymentInvalidStateException()
+        }
+
+        payment.status = PaymentStatus.CANCELLED
+        val cancelledPayment = paymentRepository.save(payment)
+
+        paymentEventService.publishPaymentCancelledEvent(cancelledPayment)
+        paymentEventService.publishPaymentCancelledNotification(cancelledPayment)
+
+        return PaymentResponse.from(cancelledPayment)
     }
     
     private fun updatePaymentWithResult(payment: Payment, result: PaymentResult): Payment {

--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentCompensationConsumer.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentCompensationConsumer.kt
@@ -1,0 +1,153 @@
+package com.hoppingmall.mall.payment.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.mall.inventory.service.InventoryCommandService
+import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
+import com.hoppingmall.mall.order.domain.repository.OrderRepository
+import com.hoppingmall.mall.order.enum.OrderStatus
+import com.hoppingmall.mall.payment.domain.CompensationEventLog
+import com.hoppingmall.mall.payment.domain.repository.CompensationEventLogRepository
+import com.hoppingmall.mall.payment.dto.event.PaymentCancelledEvent
+import com.hoppingmall.mall.payment.dto.event.PaymentFailedEvent
+import com.hoppingmall.mall.point.domain.PointHistory
+import com.hoppingmall.mall.point.domain.PointHistoryRepository
+import com.hoppingmall.mall.point.domain.PointRepository
+import com.hoppingmall.mall.point.enum.PointType
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class PaymentCompensationConsumer(
+    private val compensationEventLogRepository: CompensationEventLogRepository,
+    private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository,
+    private val inventoryCommandService: InventoryCommandService,
+    private val pointRepository: PointRepository,
+    private val pointHistoryRepository: PointHistoryRepository,
+    private val objectMapper: ObjectMapper
+) {
+
+    private val logger = LoggerFactory.getLogger(PaymentCompensationConsumer::class.java)
+
+    @KafkaListener(topics = ["payment-compensation"], groupId = "payment-compensation-service")
+    fun handleCompensationEvent(message: String) {
+        val node = objectMapper.readTree(message)
+        val eventType = node.get("eventType")?.asText()
+
+        when (eventType) {
+            "PaymentFailed" -> {
+                val event = objectMapper.treeToValue(node, PaymentFailedEvent::class.java)
+                handlePaymentFailed(event)
+            }
+            "PaymentCancelled" -> {
+                val event = objectMapper.treeToValue(node, PaymentCancelledEvent::class.java)
+                handlePaymentCancelled(event)
+            }
+            else -> logger.warn("알 수 없는 보상 이벤트 타입: $eventType")
+        }
+    }
+
+    @Transactional
+    fun handlePaymentFailed(event: PaymentFailedEvent) {
+        try {
+            if (compensationEventLogRepository.existsByEventId(event.eventId)) {
+                logger.info("이미 처리된 보상 이벤트: ${event.eventId}")
+                return
+            }
+
+            cancelOrderAndRestoreStock(event.orderId)
+
+            try {
+                compensationEventLogRepository.save(
+                    CompensationEventLog(
+                        eventId = event.eventId,
+                        compensationType = "PAYMENT_FAILED",
+                        paymentId = event.paymentId,
+                        orderId = event.orderId
+                    )
+                )
+            } catch (e: DataIntegrityViolationException) {
+                logger.info("이미 처리된 보상 이벤트: ${event.eventId}")
+                return
+            }
+
+            logger.info("결제 실패 보상 처리 완료: orderId=${event.orderId}")
+        } catch (e: Exception) {
+            logger.error("결제 실패 보상 처리 실패: ${event.eventId}, 오류: ${e.message}")
+            throw e
+        }
+    }
+
+    @Transactional
+    fun handlePaymentCancelled(event: PaymentCancelledEvent) {
+        try {
+            if (compensationEventLogRepository.existsByEventId(event.eventId)) {
+                logger.info("이미 처리된 보상 이벤트: ${event.eventId}")
+                return
+            }
+
+            cancelOrderAndRestoreStock(event.orderId)
+            refundPoints(event.userId, event.paymentId)
+
+            try {
+                compensationEventLogRepository.save(
+                    CompensationEventLog(
+                        eventId = event.eventId,
+                        compensationType = "PAYMENT_CANCELLED",
+                        paymentId = event.paymentId,
+                        orderId = event.orderId
+                    )
+                )
+            } catch (e: DataIntegrityViolationException) {
+                logger.info("이미 처리된 보상 이벤트: ${event.eventId}")
+                return
+            }
+
+            logger.info("결제 취소 보상 처리 완료: orderId=${event.orderId}")
+        } catch (e: Exception) {
+            logger.error("결제 취소 보상 처리 실패: ${event.eventId}, 오류: ${e.message}")
+            throw e
+        }
+    }
+
+    private fun cancelOrderAndRestoreStock(orderId: Long) {
+        val order = orderRepository.findById(orderId).orElse(null) ?: return
+
+        if (order.isCancelled()) {
+            logger.info("이미 취소된 주문: $orderId")
+            return
+        }
+
+        order.updateStatus(OrderStatus.CANCELLED)
+        orderRepository.save(order)
+
+        val orderItems = orderItemRepository.findByOrderId(orderId)
+        orderItems.forEach { item ->
+            inventoryCommandService.increaseStock(item.productId, item.quantity)
+        }
+    }
+
+    private fun refundPoints(userId: Long, paymentId: Long) {
+        val earnHistory = pointHistoryRepository.findByPaymentIdAndType(paymentId, PointType.EARN)
+            ?: return
+
+        val point = pointRepository.findByUserId(userId) ?: return
+
+        point.usePoints(earnHistory.amount)
+        pointRepository.save(point)
+
+        pointHistoryRepository.save(
+            PointHistory(
+                userId = userId,
+                amount = earnHistory.amount,
+                type = PointType.REFUND,
+                reason = "결제 취소 포인트 반환",
+                paymentId = paymentId,
+                eventId = "refund-$paymentId"
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentEventPublisher.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentEventPublisher.kt
@@ -1,9 +1,13 @@
 package com.hoppingmall.mall.payment.service
 
+import com.hoppingmall.mall.payment.dto.event.PaymentCancelledEvent
 import com.hoppingmall.mall.payment.dto.event.PaymentCompletedEvent
+import com.hoppingmall.mall.payment.dto.event.PaymentFailedEvent
 import com.hoppingmall.mall.payment.dto.event.PointEarnRequestEvent
 
 interface PaymentEventPublisher {
     fun publishPaymentCompletedEvent(event: PaymentCompletedEvent)
     fun publishPointEarnRequestEvent(event: PointEarnRequestEvent)
+    fun publishPaymentFailedEvent(event: PaymentFailedEvent)
+    fun publishPaymentCancelledEvent(event: PaymentCancelledEvent)
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentEventService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentEventService.kt
@@ -2,7 +2,9 @@ package com.hoppingmall.mall.payment.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.hoppingmall.mall.payment.domain.Payment
+import com.hoppingmall.mall.payment.dto.event.PaymentCancelledEvent
 import com.hoppingmall.mall.payment.dto.event.PaymentCompletedEvent
+import com.hoppingmall.mall.payment.dto.event.PaymentFailedEvent
 import com.hoppingmall.mall.payment.dto.event.PointEarnRequestEvent
 import com.hoppingmall.mall.notification.enum.NotificationType
 import com.hoppingmall.mall.point.service.PointPolicyService
@@ -78,8 +80,90 @@ class PaymentEventService(
         )
     }
     
+    fun publishPaymentFailedEvent(payment: Payment) {
+        val eventId = "payment-failed-${payment.id}"
+        val event = PaymentFailedEvent(
+            eventId = eventId,
+            paymentId = payment.id!!,
+            orderId = payment.orderId,
+            userId = payment.userId,
+            amount = payment.amount,
+            reason = payment.errorMessage ?: "결제 실패"
+        )
+        paymentEventPublisher.publishPaymentFailedEvent(event)
+    }
+
+    fun publishPaymentCancelledEvent(payment: Payment) {
+        val eventId = "payment-cancelled-${payment.id}"
+        val event = PaymentCancelledEvent(
+            eventId = eventId,
+            paymentId = payment.id!!,
+            orderId = payment.orderId,
+            userId = payment.userId,
+            amount = payment.amount,
+            transactionId = payment.transactionId!!
+        )
+        paymentEventPublisher.publishPaymentCancelledEvent(event)
+    }
+
+    fun publishPaymentFailedNotification(payment: Payment) {
+        val eventId = "payment-failed-notification-${payment.id}"
+        val metadata = objectMapper.writeValueAsString(
+            mapOf(
+                "orderId" to payment.orderId,
+                "paymentId" to payment.id!!,
+                "amount" to payment.amount.toString(),
+                "reason" to (payment.errorMessage ?: "결제 실패")
+            )
+        )
+
+        transactionalEventPublisher.publishEvent(
+            aggregateType = "Payment",
+            aggregateId = payment.id!!.toString(),
+            eventType = "PaymentFailedNotificationRequested",
+            eventData = mapOf(
+                "eventId" to eventId,
+                "userId" to payment.userId,
+                "type" to NotificationType.PAYMENT_FAILED.toString(),
+                "title" to "결제가 실패했습니다",
+                "content" to "주문번호 ${payment.orderId}의 결제가 실패했습니다. 사유: ${payment.errorMessage ?: "결제 실패"}",
+                "metadata" to metadata
+            ),
+            topic = "notification",
+            partitionKey = payment.userId.toString()
+        )
+    }
+
+    fun publishPaymentCancelledNotification(payment: Payment) {
+        val eventId = "payment-cancelled-notification-${payment.id}"
+        val metadata = objectMapper.writeValueAsString(
+            mapOf(
+                "orderId" to payment.orderId,
+                "paymentId" to payment.id!!,
+                "amount" to payment.amount.toString(),
+                "transactionId" to payment.transactionId
+            )
+        )
+
+        transactionalEventPublisher.publishEvent(
+            aggregateType = "Payment",
+            aggregateId = payment.id!!.toString(),
+            eventType = "PaymentCancelledNotificationRequested",
+            eventData = mapOf(
+                "eventId" to eventId,
+                "userId" to payment.userId,
+                "type" to NotificationType.PAYMENT_CANCELLED.toString(),
+                "title" to "결제가 취소되었습니다",
+                "content" to "주문번호 ${payment.orderId}의 결제가 취소되었습니다. 취소 금액: ${payment.amount}원",
+                "metadata" to metadata
+            ),
+            topic = "notification",
+            partitionKey = payment.userId.toString()
+        )
+    }
+
     private fun getCurrentEarnRate(): BigDecimal {
         val currentPolicy = pointPolicyService.getCurrentPolicy()
-        return currentPolicy?.earnRate ?: BigDecimal("0.01") // 기본값 1%
+        return currentPolicy?.earnRate ?: BigDecimal("0.01")
     }
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/point/domain/PointHistoryRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/domain/PointHistoryRepository.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.mall.point.domain
 
+import com.hoppingmall.mall.point.enum.PointType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
@@ -10,6 +11,8 @@ interface PointHistoryRepository : JpaRepository<PointHistory, Long> {
     fun existsByEventId(eventId: String): Boolean
 
     fun findByUserIdOrderByCreatedAtDesc(userId: Long): List<PointHistory>
-    
+
     fun findByUserId(userId: Long, pageable: Pageable): Page<PointHistory>
+
+    fun findByPaymentIdAndType(paymentId: Long, type: PointType): PointHistory?
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/point/enum/PointType.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/enum/PointType.kt
@@ -3,5 +3,6 @@ package com.hoppingmall.mall.point.enum
 enum class PointType {
     EARN,
     USE,
-    EXPIRE
+    EXPIRE,
+    REFUND
 } 

--- a/src/test/kotlin/com/hoppingmall/mall/payment/controller/PaymentControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/controller/PaymentControllerTest.kt
@@ -183,4 +183,41 @@ class PaymentControllerTest {
             verify(paymentQueryService).getPaymentsByOrderId(orderId)
         }
     }
+
+    @Nested
+    @DisplayName("cancelPayment")
+    inner class CancelPayment {
+        @Test
+        fun `결제 취소 성공`() {
+            // given
+            val paymentId = 1L
+            val userId = 1L
+            val response = PaymentResponse(
+                id = paymentId,
+                orderId = 1L,
+                userId = userId,
+                amount = BigDecimal("50000"),
+                pointAmount = BigDecimal("1000"),
+                method = PaymentMethod.CREDIT_CARD.name,
+                status = PaymentStatus.CANCELLED,
+                transactionId = "TXN_123456",
+                errorMessage = null,
+                completedAt = LocalDateTime.now(),
+                createdAt = LocalDateTime.now(),
+                updatedAt = LocalDateTime.now()
+            )
+            val userDetails: UserDetails = mock()
+
+            whenever(userDetails.username).thenReturn(userId.toString())
+            whenever(paymentCommandService.cancelPayment(paymentId, userId)).thenReturn(response)
+
+            // when
+            val result = paymentController.cancelPayment(paymentId, userDetails)
+
+            // then
+            assertEquals(HttpStatus.OK, result.statusCode)
+            assertEquals(response, result.body)
+            verify(paymentCommandService).cancelPayment(paymentId, userId)
+        }
+    }
 } 

--- a/src/test/kotlin/com/hoppingmall/mall/payment/domain/CompensationEventLogTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/domain/CompensationEventLogTest.kt
@@ -1,0 +1,29 @@
+package com.hoppingmall.mall.payment.domain
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("CompensationEventLog")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class CompensationEventLogTest {
+
+    @Test
+    fun `보상_이벤트_로그_생성`() {
+        // given & when
+        val log = CompensationEventLog(
+            eventId = "payment-failed-1",
+            compensationType = "PAYMENT_FAILED",
+            paymentId = 1L,
+            orderId = 1L
+        )
+
+        // then
+        assertEquals("payment-failed-1", log.eventId)
+        assertEquals("PAYMENT_FAILED", log.compensationType)
+        assertEquals(1L, log.paymentId)
+        assertEquals(1L, log.orderId)
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentCommandServiceImplTest.kt
@@ -6,8 +6,11 @@ import com.hoppingmall.mall.payment.dto.PaymentResult
 import com.hoppingmall.mall.payment.dto.request.PaymentRequest
 import com.hoppingmall.mall.payment.enum.PaymentMethod
 import com.hoppingmall.mall.payment.enum.PaymentStatus
-import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.payment.exception.PaymentAccessDeniedException
+import com.hoppingmall.mall.payment.exception.PaymentInvalidStateException
+import com.hoppingmall.mall.payment.exception.PaymentNotFoundException
 import com.hoppingmall.mall.support.fixture.failedFixture
+import com.hoppingmall.mall.support.fixture.fixture
 import com.hoppingmall.mall.support.fixture.successFixture
 import com.hoppingmall.mall.support.withId
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -16,8 +19,10 @@ import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.*
 import java.math.BigDecimal
+import java.util.*
 
 @DisplayName("PaymentCommandServiceImpl")
 @DisplayNameGeneration(ReplaceUnderscores::class)
@@ -71,7 +76,7 @@ class PaymentCommandServiceImplTest {
         }
 
         @Test
-        fun `결제 실패 시 이벤트 발행하지 않음`() {
+        fun `결제 실패 시 실패 이벤트 발행`() {
             // given
             val userId = 1L
             val request = PaymentRequest(
@@ -79,7 +84,7 @@ class PaymentCommandServiceImplTest {
                 amount = BigDecimal("50000"),
                 method = PaymentMethod.CREDIT_CARD
             )
-            
+
             val paymentCaptor = argumentCaptor<Payment>()
             val savedPayment = Payment.fixture()
             val paymentResult = PaymentResult.failed(savedPayment, "잔액 부족")
@@ -100,6 +105,67 @@ class PaymentCommandServiceImplTest {
             verify(paymentEventService, never()).publishPaymentCompletedEvent(any())
             verify(paymentEventService, never()).publishPointEarnRequestEvent(any())
             verify(paymentEventService, never()).publishPaymentCompletedNotification(any())
+            verify(paymentEventService).publishPaymentFailedEvent(any())
+            verify(paymentEventService).publishPaymentFailedNotification(any())
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelPayment")
+    inner class CancelPayment {
+
+        @Test
+        fun `결제 취소 성공`() {
+            // given
+            val paymentId = 1L
+            val userId = 1L
+            val payment = Payment.successFixture(userId = userId)
+
+            whenever(paymentRepository.findById(paymentId)).thenReturn(Optional.of(payment))
+            whenever(paymentRepository.save(payment)).thenReturn(payment)
+
+            // when
+            val response = paymentCommandService.cancelPayment(paymentId, userId)
+
+            // then
+            assertEquals(PaymentStatus.CANCELLED, response.status)
+            verify(paymentEventService).publishPaymentCancelledEvent(any())
+            verify(paymentEventService).publishPaymentCancelledNotification(any())
+        }
+
+        @Test
+        fun `결제가 존재하지 않으면 예외 발생`() {
+            // given
+            whenever(paymentRepository.findById(1L)).thenReturn(Optional.empty())
+
+            // when & then
+            assertThrows<PaymentNotFoundException> {
+                paymentCommandService.cancelPayment(1L, 1L)
+            }
+        }
+
+        @Test
+        fun `본인의 결제가 아니면 예외 발생`() {
+            // given
+            val payment = Payment.successFixture(userId = 1L)
+            whenever(paymentRepository.findById(1L)).thenReturn(Optional.of(payment))
+
+            // when & then
+            assertThrows<PaymentAccessDeniedException> {
+                paymentCommandService.cancelPayment(1L, 999L)
+            }
+        }
+
+        @Test
+        fun `SUCCESS 상태가 아니면 예외 발생`() {
+            // given
+            val payment = Payment.failedFixture(userId = 1L)
+            whenever(paymentRepository.findById(1L)).thenReturn(Optional.of(payment))
+
+            // when & then
+            assertThrows<PaymentInvalidStateException> {
+                paymentCommandService.cancelPayment(1L, 1L)
+            }
         }
     }
 } 

--- a/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentCompensationConsumerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentCompensationConsumerTest.kt
@@ -1,0 +1,186 @@
+package com.hoppingmall.mall.payment.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.mall.inventory.service.InventoryCommandService
+import com.hoppingmall.mall.order.domain.Order
+import com.hoppingmall.mall.order.domain.OrderItem
+import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
+import com.hoppingmall.mall.order.domain.repository.OrderRepository
+import com.hoppingmall.mall.order.enum.OrderStatus
+import com.hoppingmall.mall.payment.domain.CompensationEventLog
+import com.hoppingmall.mall.payment.domain.repository.CompensationEventLogRepository
+import com.hoppingmall.mall.payment.dto.event.PaymentCancelledEvent
+import com.hoppingmall.mall.payment.dto.event.PaymentFailedEvent
+import com.hoppingmall.mall.point.domain.Point
+import com.hoppingmall.mall.point.domain.PointHistory
+import com.hoppingmall.mall.point.domain.PointHistoryRepository
+import com.hoppingmall.mall.point.domain.PointRepository
+import com.hoppingmall.mall.point.enum.PointType
+import com.hoppingmall.mall.support.fixture.cancelledFixture
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.fixture.paidFixture
+import com.hoppingmall.mall.support.withId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import java.math.BigDecimal
+import java.util.*
+
+@DisplayName("PaymentCompensationConsumer")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class PaymentCompensationConsumerTest {
+
+    private val compensationEventLogRepository: CompensationEventLogRepository = mock()
+    private val orderRepository: OrderRepository = mock()
+    private val orderItemRepository: OrderItemRepository = mock()
+    private val inventoryCommandService: InventoryCommandService = mock()
+    private val pointRepository: PointRepository = mock()
+    private val pointHistoryRepository: PointHistoryRepository = mock()
+    private val objectMapper = ObjectMapper()
+
+    private val consumer = PaymentCompensationConsumer(
+        compensationEventLogRepository,
+        orderRepository,
+        orderItemRepository,
+        inventoryCommandService,
+        pointRepository,
+        pointHistoryRepository,
+        objectMapper
+    )
+
+    @Nested
+    @DisplayName("handlePaymentFailed")
+    inner class HandlePaymentFailed {
+
+        @Test
+        fun `결제_실패_시_주문_취소_및_재고_복구`() {
+            // given
+            val event = PaymentFailedEvent(
+                eventId = "payment-failed-1",
+                paymentId = 1L,
+                orderId = 1L,
+                userId = 1L,
+                amount = BigDecimal("50000"),
+                reason = "잔액 부족"
+            )
+
+            val order = Order.paidFixture()
+            val orderItem = OrderItem.fixture(orderId = 1L, productId = 100L, quantity = 2)
+
+            whenever(compensationEventLogRepository.existsByEventId(event.eventId)).thenReturn(false)
+            whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+            whenever(orderRepository.save(order)).thenReturn(order)
+            whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(orderItem))
+            whenever(compensationEventLogRepository.save(any<CompensationEventLog>())).thenAnswer { it.arguments[0] }
+
+            // when
+            consumer.handlePaymentFailed(event)
+
+            // then
+            assertEquals(OrderStatus.CANCELLED, order.status)
+            verify(orderRepository).save(order)
+            verify(inventoryCommandService).increaseStock(100L, 2)
+            verify(compensationEventLogRepository).save(argThat { compensationType == "PAYMENT_FAILED" })
+        }
+
+        @Test
+        fun `이미_처리된_이벤트는_스킵한다`() {
+            // given
+            val event = PaymentFailedEvent(
+                eventId = "payment-failed-1",
+                paymentId = 1L,
+                orderId = 1L,
+                userId = 1L,
+                amount = BigDecimal("50000"),
+                reason = "잔액 부족"
+            )
+
+            whenever(compensationEventLogRepository.existsByEventId(event.eventId)).thenReturn(true)
+
+            // when
+            consumer.handlePaymentFailed(event)
+
+            // then
+            verify(orderRepository, never()).findById(any())
+            verify(inventoryCommandService, never()).increaseStock(any(), any())
+        }
+    }
+
+    @Nested
+    @DisplayName("handlePaymentCancelled")
+    inner class HandlePaymentCancelled {
+
+        @Test
+        fun `결제_취소_시_주문_취소_재고_복구_포인트_반환`() {
+            // given
+            val event = PaymentCancelledEvent(
+                eventId = "payment-cancelled-1",
+                paymentId = 1L,
+                orderId = 1L,
+                userId = 1L,
+                amount = BigDecimal("50000"),
+                transactionId = "TXN_123456"
+            )
+
+            val order = Order.paidFixture()
+            val orderItem = OrderItem.fixture(orderId = 1L, productId = 100L, quantity = 2)
+            val point = Point(userId = 1L, balance = BigDecimal("500")).withId(1L)
+            val earnHistory = PointHistory(
+                userId = 1L,
+                amount = BigDecimal("500"),
+                type = PointType.EARN,
+                paymentId = 1L,
+                eventId = "payment-1"
+            ).withId(1L)
+
+            whenever(compensationEventLogRepository.existsByEventId(event.eventId)).thenReturn(false)
+            whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+            whenever(orderRepository.save(order)).thenReturn(order)
+            whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(orderItem))
+            whenever(pointHistoryRepository.findByPaymentIdAndType(1L, PointType.EARN)).thenReturn(earnHistory)
+            whenever(pointRepository.findByUserId(1L)).thenReturn(point)
+            whenever(compensationEventLogRepository.save(any<CompensationEventLog>())).thenAnswer { it.arguments[0] }
+            whenever(pointRepository.save(point)).thenReturn(point)
+            whenever(pointHistoryRepository.save(any<PointHistory>())).thenAnswer { it.arguments[0] }
+
+            // when
+            consumer.handlePaymentCancelled(event)
+
+            // then
+            assertEquals(OrderStatus.CANCELLED, order.status)
+            verify(orderRepository).save(order)
+            verify(inventoryCommandService).increaseStock(100L, 2)
+            assertEquals(BigDecimal.ZERO, point.balance)
+            verify(pointHistoryRepository).save(argThat {
+                type == PointType.REFUND && amount == BigDecimal("500")
+            })
+            verify(compensationEventLogRepository).save(argThat { compensationType == "PAYMENT_CANCELLED" })
+        }
+
+        @Test
+        fun `이미_처리된_이벤트는_스킵한다`() {
+            // given
+            val event = PaymentCancelledEvent(
+                eventId = "payment-cancelled-1",
+                paymentId = 1L,
+                orderId = 1L,
+                userId = 1L,
+                amount = BigDecimal("50000"),
+                transactionId = "TXN_123456"
+            )
+
+            whenever(compensationEventLogRepository.existsByEventId(event.eventId)).thenReturn(true)
+
+            // when
+            consumer.handlePaymentCancelled(event)
+
+            // then
+            verify(orderRepository, never()).findById(any())
+            verify(pointRepository, never()).findByUserId(any())
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentEventServiceTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentEventServiceTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.hoppingmall.mall.payment.domain.Payment
 import com.hoppingmall.mall.payment.dto.event.PointEarnRequestEvent
 import com.hoppingmall.mall.point.service.PointPolicyService
+import com.hoppingmall.mall.support.fixture.failedFixture
 import com.hoppingmall.mall.support.fixture.fixture
 import com.hoppingmall.mall.support.fixture.successFixture
 import com.hoppingmall.mall.global.common.service.TransactionalEventPublisher
@@ -101,10 +102,10 @@ class PaymentEventServiceTest {
     fun `알림 이벤트의 내용이 정확히 설정된다`() {
         // given
         val payment = Payment.fixture()
-        
+
         // when
         paymentEventService.publishPaymentCompletedNotification(payment)
-        
+
         // then
         verify(transactionalEventPublisher).publishEvent(
             aggregateType = eq("Payment"),
@@ -119,6 +120,68 @@ class PaymentEventServiceTest {
                     metadataMap["orderId"].toString() == "1" &&
                     metadataMap["paymentId"].toString() == "1"
             },
+            topic = eq("notification"),
+            partitionKey = eq("1")
+        )
+    }
+
+    @Test
+    fun `결제 실패 이벤트를 발행한다`() {
+        // given
+        val payment = Payment.failedFixture()
+
+        // when
+        paymentEventService.publishPaymentFailedEvent(payment)
+
+        // then
+        verify(paymentEventPublisher).publishPaymentFailedEvent(any())
+    }
+
+    @Test
+    fun `결제 취소 이벤트를 발행한다`() {
+        // given
+        val payment = Payment.successFixture()
+
+        // when
+        paymentEventService.publishPaymentCancelledEvent(payment)
+
+        // then
+        verify(paymentEventPublisher).publishPaymentCancelledEvent(any())
+    }
+
+    @Test
+    fun `결제 실패 알림 이벤트를 발행한다`() {
+        // given
+        val payment = Payment.failedFixture()
+
+        // when
+        paymentEventService.publishPaymentFailedNotification(payment)
+
+        // then
+        verify(transactionalEventPublisher).publishEvent(
+            aggregateType = eq("Payment"),
+            aggregateId = eq("1"),
+            eventType = eq("PaymentFailedNotificationRequested"),
+            eventData = any(),
+            topic = eq("notification"),
+            partitionKey = eq("1")
+        )
+    }
+
+    @Test
+    fun `결제 취소 알림 이벤트를 발행한다`() {
+        // given
+        val payment = Payment.successFixture()
+
+        // when
+        paymentEventService.publishPaymentCancelledNotification(payment)
+
+        // then
+        verify(transactionalEventPublisher).publishEvent(
+            aggregateType = eq("Payment"),
+            aggregateId = eq("1"),
+            eventType = eq("PaymentCancelledNotificationRequested"),
+            eventData = any(),
             topic = eq("notification"),
             partitionKey = eq("1")
         )

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/PaymentFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/PaymentFixture.kt
@@ -70,4 +70,25 @@ fun Payment.Companion.failedFixture(
         status = PaymentStatus.FAILED,
         errorMessage = errorMessage
     )
+}
+
+fun Payment.Companion.cancelledFixture(
+    orderId: Long = 1L,
+    userId: Long = 1L,
+    amount: BigDecimal = BigDecimal("50000"),
+    method: PaymentMethod = PaymentMethod.CREDIT_CARD,
+    pointAmount: BigDecimal = BigDecimal("1000"),
+    transactionId: String = "TXN_123456",
+    completedAt: LocalDateTime = LocalDateTime.now()
+): Payment {
+    return Payment.fixture(
+        orderId = orderId,
+        userId = userId,
+        amount = amount,
+        method = method,
+        pointAmount = pointAmount,
+        status = PaymentStatus.CANCELLED,
+        transactionId = transactionId,
+        completedAt = completedAt
+    )
 } 


### PR DESCRIPTION
Closes #45

## 📌 변경 사항
- 결제 실패 시 보상 이벤트 발행 (주문 취소 + 재고 복구 + 실패 알림)
- 결제 취소 API 구현 (`POST /api/v1/payments/{id}/cancel`)
- `PaymentCompensationConsumer`: Kafka `payment-compensation` 토픽 기반 보상 처리
- `CompensationEventLog` 엔티티로 멱등성 보장

## ✅ 주요 구현 내용
- `PaymentFailedEvent`, `PaymentCancelledEvent` DTO 추가
- `PointType.REFUND`, `NotificationType.PAYMENT_FAILED/CANCELLED` 추가
- `PaymentEventPublisher`/`PaymentEventService`에 실패/취소 이벤트 메서드 추가
- `cancelPayment`: 결제 조회 → userId 검증 → SUCCESS 상태 검증 → CANCELLED 변경 → 이벤트 발행
- `PaymentCompensationConsumer`: 주문 취소 + 재고 복구 + 포인트 반환 (취소 시)

## 🧪 테스트
- `PaymentCompensationConsumerTest`: 실패/취소 보상 처리, 멱등성 스킵
- `PaymentCommandServiceImplTest`: 실패 이벤트 발행, cancelPayment 성공/예외 4개 케이스
- `PaymentEventServiceTest`: 실패/취소 이벤트 + 알림 발행 4개 케이스
- `PaymentControllerTest`: cancelPayment 엔드포인트 테스트

## 📎 기타
- Jacoco 80% 커버리지 검증 통과
- 기존 Consumer 멱등성 패턴(EventLog + DataIntegrityViolationException) 준수