### PR TITLE
test: Kafka Consumer 통합 테스트 추가

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/KafkaConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/KafkaConfig.kt
@@ -21,6 +21,7 @@ import org.apache.kafka.common.errors.SerializationException
 import org.springframework.kafka.support.serializer.DeserializationException
 import java.util.UUID
 @Configuration
+@org.springframework.context.annotation.Profile("!test")
 class KafkaConfig {
 
     @Value("\${spring.kafka.bootstrap-servers}")

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/config/TestKafkaConfig.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/config/TestKafkaConfig.kt
@@ -1,6 +1,77 @@
 package com.hoppingmall.mall.global.common.config
 
+import jakarta.persistence.EntityManagerFactory
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.StringSerializer
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.core.*
+import org.springframework.kafka.support.serializer.JsonDeserializer
+import org.springframework.kafka.support.serializer.JsonSerializer
+import org.springframework.kafka.transaction.KafkaTransactionManager
+import org.springframework.orm.jpa.JpaTransactionManager
+import org.springframework.transaction.PlatformTransactionManager
+import org.mockito.Mockito
 
 @TestConfiguration
-class TestKafkaConfig
+class TestKafkaConfig {
+
+    @Value("\${spring.kafka.bootstrap-servers}")
+    private lateinit var bootstrapServers: String
+
+    @Bean
+    @Primary
+    fun producerFactory(): ProducerFactory<String, Any> {
+        val configProps = HashMap<String, Any>()
+        configProps[ProducerConfig.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers
+        configProps[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java
+        configProps[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JsonSerializer::class.java
+        return DefaultKafkaProducerFactory(configProps)
+    }
+
+    @Bean
+    @Primary
+    fun kafkaTemplate(): KafkaTemplate<String, Any> {
+        return KafkaTemplate(producerFactory())
+    }
+
+    @Bean
+    @Primary
+    fun consumerFactory(): ConsumerFactory<String, Any> {
+        val configProps = HashMap<String, Any>()
+        configProps[ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers
+        configProps[ConsumerConfig.GROUP_ID_CONFIG] = "test-group"
+        configProps[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+        configProps[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+        configProps[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = JsonDeserializer::class.java
+        configProps[JsonDeserializer.TRUSTED_PACKAGES] = "*"
+        configProps[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = false
+        return DefaultKafkaConsumerFactory(configProps)
+    }
+
+    @Bean
+    @Primary
+    fun kafkaListenerContainerFactory(): ConcurrentKafkaListenerContainerFactory<String, Any> {
+        val factory = ConcurrentKafkaListenerContainerFactory<String, Any>()
+        factory.consumerFactory = consumerFactory()
+        factory.setConcurrency(1)
+        return factory
+    }
+
+    @Bean("kafkaTransactionManager")
+    @Suppress("UNCHECKED_CAST")
+    fun kafkaTransactionManager(): KafkaTransactionManager<String, Any> {
+        return Mockito.mock(KafkaTransactionManager::class.java) as KafkaTransactionManager<String, Any>
+    }
+
+    @Bean("transactionManager")
+    @Primary
+    fun transactionManager(entityManagerFactory: EntityManagerFactory): PlatformTransactionManager {
+        return JpaTransactionManager(entityManagerFactory)
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/service/DLQServiceIntegrationTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/service/DLQServiceIntegrationTest.kt
@@ -1,0 +1,139 @@
+package com.hoppingmall.mall.global.common.service
+
+import com.hoppingmall.mall.global.common.config.DeadLetterMessage
+import com.hoppingmall.mall.global.common.config.TestKafkaConfig
+import com.hoppingmall.mall.global.common.domain.DLQStatus
+import com.hoppingmall.mall.global.common.domain.repository.DLQMessageRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import org.springframework.kafka.test.context.EmbeddedKafka
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest(properties = ["spring.main.allow-bean-definition-overriding=true"])
+@ActiveProfiles("test")
+@Import(TestKafkaConfig::class)
+@EmbeddedKafka(
+    partitions = 1,
+    topics = ["notification", "point-earn-request", "payment", "payment-compensation"],
+    brokerProperties = ["listeners=PLAINTEXT://localhost:0", "port=0"]
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayName("DLQService 통합 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class DLQServiceIntegrationTest {
+
+    @MockBean
+    private lateinit var outboxEventService: OutboxEventService
+
+    @Autowired
+    private lateinit var dlqService: DLQService
+
+    @Autowired
+    private lateinit var dlqMessageRepository: DLQMessageRepository
+
+    @Test
+    fun DLQ_메시지를_저장한다() {
+        val deadLetterMessage = DeadLetterMessage(
+            originalTopic = "payment",
+            originalPartition = 0,
+            originalOffset = 1L,
+            originalKey = "key-1",
+            originalValue = """{"orderId": 1}""",
+            exception = "테스트 오류",
+            timestamp = System.currentTimeMillis()
+        )
+
+        dlqService.saveDLQMessage(deadLetterMessage)
+
+        val saved = dlqMessageRepository.findAll()
+            .find { it.originalTopic == "payment" && it.originalOffset == 1L }
+        assertThat(saved).isNotNull
+        assertThat(saved!!.originalKey).isEqualTo("key-1")
+        assertThat(saved.status).isEqualTo(DLQStatus.PENDING)
+    }
+
+    @Test
+    fun 중복_DLQ_메시지는_무시된다() {
+        val deadLetterMessage = DeadLetterMessage(
+            originalTopic = "notification",
+            originalPartition = 0,
+            originalOffset = 100L,
+            originalKey = "key-dup",
+            originalValue = """{"test": true}""",
+            exception = "중복 테스트",
+            timestamp = System.currentTimeMillis()
+        )
+
+        dlqService.saveDLQMessage(deadLetterMessage)
+        dlqService.saveDLQMessage(deadLetterMessage)
+
+        val count = dlqMessageRepository.findAll()
+            .count { it.originalTopic == "notification" && it.originalOffset == 100L }
+        assertThat(count).isEqualTo(1)
+    }
+
+    @Test
+    fun DLQ_통계를_조회한다() {
+        dlqService.saveDLQMessage(
+            DeadLetterMessage(
+                originalTopic = "payment",
+                originalPartition = 0,
+                originalOffset = 200L,
+                originalKey = null,
+                originalValue = "msg1",
+                exception = "error1",
+                timestamp = System.currentTimeMillis()
+            )
+        )
+        dlqService.saveDLQMessage(
+            DeadLetterMessage(
+                originalTopic = "payment",
+                originalPartition = 0,
+                originalOffset = 201L,
+                originalKey = null,
+                originalValue = "msg2",
+                exception = "error2",
+                timestamp = System.currentTimeMillis()
+            )
+        )
+
+        val stats = dlqService.getDLQStats()
+
+        assertThat(stats["totalMessages"] as Long).isGreaterThanOrEqualTo(2L)
+        assertThat(stats["pendingCount"] as Long).isGreaterThanOrEqualTo(2L)
+    }
+
+    @Test
+    fun DLQ_메시지를_재처리한다() {
+        dlqService.saveDLQMessage(
+            DeadLetterMessage(
+                originalTopic = "notification",
+                originalPartition = 0,
+                originalOffset = 300L,
+                originalKey = "retry-key",
+                originalValue = """{"eventId":"retry-test"}""",
+                exception = "재시도 테스트",
+                timestamp = System.currentTimeMillis()
+            )
+        )
+
+        val saved = dlqMessageRepository.findAll()
+            .find { it.originalOffset == 300L && it.originalTopic == "notification" }
+        assertThat(saved).isNotNull
+
+        val result = dlqService.retryDLQMessage(saved!!.id!!)
+        assertThat(result).isTrue()
+
+        val updated = dlqMessageRepository.findById(saved.id!!).get()
+        assertThat(updated.status).isEqualTo(DLQStatus.PROCESSED)
+        assertThat(updated.retryCount).isEqualTo(1)
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/notification/service/NotificationEventConsumerIntegrationTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/notification/service/NotificationEventConsumerIntegrationTest.kt
@@ -1,0 +1,71 @@
+package com.hoppingmall.mall.notification.service
+
+import com.hoppingmall.mall.notification.domain.NotificationRepository
+import com.hoppingmall.mall.notification.dto.event.NotificationEvent
+import com.hoppingmall.mall.notification.enum.NotificationType
+import com.hoppingmall.mall.support.IntegrationTestBase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.kafka.core.KafkaTemplate
+
+@DisplayName("NotificationEventConsumer 통합 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class NotificationEventConsumerIntegrationTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var kafkaTemplate: KafkaTemplate<String, Any>
+
+    @Autowired
+    private lateinit var notificationRepository: NotificationRepository
+
+    @Test
+    fun 알림_이벤트를_수신하여_DB에_저장한다() {
+        val event = NotificationEvent(
+            eventId = "notif-integration-001",
+            userId = 1L,
+            type = NotificationType.PAYMENT_COMPLETED,
+            title = "결제 완료",
+            content = "주문번호 100의 결제가 완료되었습니다",
+            metadata = """{"orderId": 100}"""
+        )
+
+        kafkaTemplate.send("notification", event.userId.toString(), event)
+
+        awaitUntil {
+            notificationRepository.existsByEventId("notif-integration-001")
+        }
+
+        val saved = notificationRepository.findByUserId(1L)
+        assertThat(saved).hasSize(1)
+        assertThat(saved[0].eventId).isEqualTo("notif-integration-001")
+        assertThat(saved[0].type).isEqualTo(NotificationType.PAYMENT_COMPLETED)
+        assertThat(saved[0].title).isEqualTo("결제 완료")
+        assertThat(saved[0].content).isEqualTo("주문번호 100의 결제가 완료되었습니다")
+    }
+
+    @Test
+    fun 중복_이벤트는_한_번만_저장된다() {
+        val event = NotificationEvent(
+            eventId = "notif-dedup-001",
+            userId = 2L,
+            type = NotificationType.POINT_EARNED,
+            title = "포인트 적립",
+            content = "100포인트가 적립되었습니다"
+        )
+
+        kafkaTemplate.send("notification", event.userId.toString(), event)
+        kafkaTemplate.send("notification", event.userId.toString(), event)
+
+        awaitUntil {
+            notificationRepository.existsByEventId("notif-dedup-001")
+        }
+        Thread.sleep(1000)
+
+        val saved = notificationRepository.findByUserId(2L)
+        assertThat(saved).hasSize(1)
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentCompensationConsumerIntegrationTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentCompensationConsumerIntegrationTest.kt
@@ -1,0 +1,204 @@
+package com.hoppingmall.mall.payment.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.mall.inventory.domain.Inventory
+import com.hoppingmall.mall.inventory.domain.repository.InventoryRepository
+import com.hoppingmall.mall.order.domain.Order
+import com.hoppingmall.mall.order.domain.OrderItem
+import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
+import com.hoppingmall.mall.order.domain.repository.OrderRepository
+import com.hoppingmall.mall.order.enum.OrderStatus
+import com.hoppingmall.mall.payment.domain.repository.CompensationEventLogRepository
+import com.hoppingmall.mall.point.domain.Point
+import com.hoppingmall.mall.point.domain.PointHistory
+import com.hoppingmall.mall.point.domain.PointHistoryRepository
+import com.hoppingmall.mall.point.domain.PointRepository
+import com.hoppingmall.mall.point.enum.PointType
+import com.hoppingmall.mall.support.IntegrationTestBase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.kafka.core.KafkaTemplate
+import java.math.BigDecimal
+
+@DisplayName("PaymentCompensationConsumer 통합 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class PaymentCompensationConsumerIntegrationTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var kafkaTemplate: KafkaTemplate<String, Any>
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var orderRepository: OrderRepository
+
+    @Autowired
+    private lateinit var orderItemRepository: OrderItemRepository
+
+    @Autowired
+    private lateinit var inventoryRepository: InventoryRepository
+
+    @Autowired
+    private lateinit var compensationEventLogRepository: CompensationEventLogRepository
+
+    @Autowired
+    private lateinit var pointRepository: PointRepository
+
+    @Autowired
+    private lateinit var pointHistoryRepository: PointHistoryRepository
+
+    @Test
+    fun 결제_실패_시_주문을_취소하고_재고를_복구한다() {
+        val order = orderRepository.save(
+            Order.create(buyerId = 1L, totalAmount = BigDecimal("30000"))
+        )
+        order.updateStatus(OrderStatus.PAID)
+        orderRepository.save(order)
+
+        inventoryRepository.save(
+            Inventory.create(productId = 500L, stockQuantity = 8)
+        )
+
+        orderItemRepository.save(
+            OrderItem.create(
+                orderId = order.id!!,
+                productId = 500L,
+                productName = "테스트 상품",
+                productPrice = BigDecimal("15000"),
+                quantity = 2
+            )
+        )
+
+        val message = objectMapper.writeValueAsString(
+            mapOf(
+                "eventType" to "PaymentFailed",
+                "eventId" to "comp-fail-001",
+                "paymentId" to 1L,
+                "orderId" to order.id!!,
+                "userId" to 1L,
+                "amount" to "30000",
+                "reason" to "잔액 부족"
+            )
+        )
+
+        kafkaTemplate.send("payment-compensation", message)
+
+        awaitUntil {
+            compensationEventLogRepository.existsByEventId("comp-fail-001")
+        }
+
+        val updatedOrder = orderRepository.findById(order.id!!).get()
+        assertThat(updatedOrder.status).isEqualTo(OrderStatus.CANCELLED)
+
+        val updatedInventory = inventoryRepository.findByProductId(500L)
+        assertThat(updatedInventory).isNotNull
+        assertThat(updatedInventory!!.stockQuantity).isEqualTo(10)
+    }
+
+    @Test
+    fun 결제_취소_시_포인트까지_반환한다() {
+        val order = orderRepository.save(
+            Order.create(buyerId = 2L, totalAmount = BigDecimal("20000"))
+        )
+        order.updateStatus(OrderStatus.PAID)
+        orderRepository.save(order)
+
+        inventoryRepository.save(
+            Inventory.create(productId = 600L, stockQuantity = 5)
+        )
+
+        orderItemRepository.save(
+            OrderItem.create(
+                orderId = order.id!!,
+                productId = 600L,
+                productName = "테스트 상품2",
+                productPrice = BigDecimal("20000"),
+                quantity = 1
+            )
+        )
+
+        pointRepository.save(Point(userId = 2L, balance = BigDecimal("200")))
+
+        pointHistoryRepository.save(
+            PointHistory(
+                userId = 2L,
+                amount = BigDecimal("200"),
+                type = PointType.EARN,
+                reason = "결제 완료",
+                orderId = order.id!!,
+                paymentId = 10L,
+                eventId = "earn-for-cancel-test"
+            )
+        )
+
+        val message = objectMapper.writeValueAsString(
+            mapOf(
+                "eventType" to "PaymentCancelled",
+                "eventId" to "comp-cancel-001",
+                "paymentId" to 10L,
+                "orderId" to order.id!!,
+                "userId" to 2L,
+                "amount" to "20000",
+                "transactionId" to "tx-cancel-001"
+            )
+        )
+
+        kafkaTemplate.send("payment-compensation", message)
+
+        awaitUntil {
+            compensationEventLogRepository.existsByEventId("comp-cancel-001")
+        }
+
+        val updatedOrder = orderRepository.findById(order.id!!).get()
+        assertThat(updatedOrder.status).isEqualTo(OrderStatus.CANCELLED)
+
+        val updatedInventory = inventoryRepository.findByProductId(600L)
+        assertThat(updatedInventory!!.stockQuantity).isEqualTo(6)
+
+        val updatedPoint = pointRepository.findByUserId(2L)
+        assertThat(updatedPoint).isNotNull
+        assertThat(updatedPoint!!.balance).isEqualByComparingTo(BigDecimal.ZERO)
+
+        val refundHistory = pointHistoryRepository.findByPaymentIdAndType(10L, PointType.REFUND)
+        assertThat(refundHistory).isNotNull
+    }
+
+    @Test
+    fun 중복_보상_이벤트는_무시된다() {
+        val order = orderRepository.save(
+            Order.create(buyerId = 3L, totalAmount = BigDecimal("10000"))
+        )
+        order.updateStatus(OrderStatus.PAID)
+        orderRepository.save(order)
+
+        val message = objectMapper.writeValueAsString(
+            mapOf(
+                "eventType" to "PaymentFailed",
+                "eventId" to "comp-dedup-001",
+                "paymentId" to 3L,
+                "orderId" to order.id!!,
+                "userId" to 3L,
+                "amount" to "10000",
+                "reason" to "잔액 부족"
+            )
+        )
+
+        kafkaTemplate.send("payment-compensation", message)
+
+        awaitUntil {
+            compensationEventLogRepository.existsByEventId("comp-dedup-001")
+        }
+
+        kafkaTemplate.send("payment-compensation", message)
+        Thread.sleep(1000)
+
+        val count = compensationEventLogRepository.findAll()
+            .count { it.eventId == "comp-dedup-001" }
+        assertThat(count).isEqualTo(1)
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentEventConsumerIntegrationTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentEventConsumerIntegrationTest.kt
@@ -1,0 +1,82 @@
+package com.hoppingmall.mall.payment.service
+
+import com.hoppingmall.mall.payment.domain.repository.PaymentEventLogRepository
+import com.hoppingmall.mall.payment.dto.event.PaymentCompletedEvent
+import com.hoppingmall.mall.payment.enum.PaymentMethod
+import com.hoppingmall.mall.payment.enum.PaymentStatus
+import com.hoppingmall.mall.support.IntegrationTestBase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.kafka.core.KafkaTemplate
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@DisplayName("PaymentEventConsumer 통합 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class PaymentEventConsumerIntegrationTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var kafkaTemplate: KafkaTemplate<String, Any>
+
+    @Autowired
+    private lateinit var paymentEventLogRepository: PaymentEventLogRepository
+
+    @Test
+    fun 결제_완료_이벤트를_수신하여_처리한다() {
+        val event = PaymentCompletedEvent(
+            paymentId = 1L,
+            orderId = 100L,
+            userId = 1L,
+            amount = BigDecimal("50000"),
+            pointAmount = BigDecimal("500"),
+            method = PaymentMethod.CREDIT_CARD,
+            status = PaymentStatus.SUCCESS,
+            transactionId = "tx-integration-001",
+            completedAt = LocalDateTime.now()
+        )
+
+        kafkaTemplate.send("payment", event.orderId.toString(), event)
+
+        awaitUntil {
+            paymentEventLogRepository.existsByTransactionId("tx-integration-001")
+        }
+
+        val logs = paymentEventLogRepository.findAll()
+        val saved = logs.find { it.transactionId == "tx-integration-001" }
+        assertThat(saved).isNotNull
+        assertThat(saved!!.paymentId).isEqualTo(1L)
+        assertThat(saved.orderId).isEqualTo(100L)
+    }
+
+    @Test
+    fun 중복_결제_이벤트는_무시된다() {
+        val event = PaymentCompletedEvent(
+            paymentId = 2L,
+            orderId = 200L,
+            userId = 2L,
+            amount = BigDecimal("30000"),
+            pointAmount = BigDecimal("300"),
+            method = PaymentMethod.BANK_TRANSFER,
+            status = PaymentStatus.SUCCESS,
+            transactionId = "tx-dedup-001",
+            completedAt = LocalDateTime.now()
+        )
+
+        kafkaTemplate.send("payment", event.orderId.toString(), event)
+
+        awaitUntil {
+            paymentEventLogRepository.existsByTransactionId("tx-dedup-001")
+        }
+
+        kafkaTemplate.send("payment", event.orderId.toString(), event)
+        Thread.sleep(1000)
+
+        val count = paymentEventLogRepository.findAll()
+            .count { it.transactionId == "tx-dedup-001" }
+        assertThat(count).isEqualTo(1)
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/point/service/PointEventConsumerIntegrationTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/point/service/PointEventConsumerIntegrationTest.kt
@@ -1,0 +1,120 @@
+package com.hoppingmall.mall.point.service
+
+import com.hoppingmall.mall.global.common.service.TransactionalEventPublisher
+import com.hoppingmall.mall.payment.dto.event.PointEarnRequestEvent
+import com.hoppingmall.mall.point.domain.PointHistoryRepository
+import com.hoppingmall.mall.point.domain.PointRepository
+import com.hoppingmall.mall.point.enum.PointType
+import com.hoppingmall.mall.support.IntegrationTestBase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.kafka.core.KafkaTemplate
+import java.math.BigDecimal
+
+@DisplayName("PointEventConsumer 통합 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class PointEventConsumerIntegrationTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var kafkaTemplate: KafkaTemplate<String, Any>
+
+    @Autowired
+    private lateinit var pointRepository: PointRepository
+
+    @Autowired
+    private lateinit var pointHistoryRepository: PointHistoryRepository
+
+    @MockBean
+    private lateinit var transactionalEventPublisher: TransactionalEventPublisher
+
+    @Test
+    fun 포인트_적립_이벤트를_수신하여_포인트를_적립한다() {
+        val event = PointEarnRequestEvent(
+            eventId = "point-integration-001",
+            userId = 10L,
+            orderId = 100L,
+            paymentId = 200L,
+            earnAmount = BigDecimal("500"),
+            reason = "결제 완료"
+        )
+
+        kafkaTemplate.send("point-earn-request", event.userId.toString(), event)
+
+        awaitUntil {
+            pointHistoryRepository.existsByEventId("point-integration-001")
+        }
+
+        val point = pointRepository.findByUserId(10L)
+        assertThat(point).isNotNull
+        assertThat(point!!.balance).isEqualByComparingTo(BigDecimal("500"))
+
+        val history = pointHistoryRepository.findByUserIdOrderByCreatedAtDesc(10L)
+        assertThat(history).hasSize(1)
+        assertThat(history[0].type).isEqualTo(PointType.EARN)
+        assertThat(history[0].amount).isEqualByComparingTo(BigDecimal("500"))
+        assertThat(history[0].eventId).isEqualTo("point-integration-001")
+    }
+
+    @Test
+    fun 중복_포인트_적립_이벤트는_무시된다() {
+        val event = PointEarnRequestEvent(
+            eventId = "point-dedup-001",
+            userId = 11L,
+            orderId = 101L,
+            paymentId = 201L,
+            earnAmount = BigDecimal("300"),
+            reason = "결제 완료"
+        )
+
+        kafkaTemplate.send("point-earn-request", event.userId.toString(), event)
+
+        awaitUntil {
+            pointHistoryRepository.existsByEventId("point-dedup-001")
+        }
+
+        kafkaTemplate.send("point-earn-request", event.userId.toString(), event)
+        Thread.sleep(1000)
+
+        val point = pointRepository.findByUserId(11L)
+        assertThat(point).isNotNull
+        assertThat(point!!.balance).isEqualByComparingTo(BigDecimal("300"))
+
+        val histories = pointHistoryRepository.findByUserIdOrderByCreatedAtDesc(11L)
+        assertThat(histories).hasSize(1)
+    }
+
+    @Test
+    fun 알림_발행이_호출된다() {
+        val event = PointEarnRequestEvent(
+            eventId = "point-notif-001",
+            userId = 12L,
+            orderId = 102L,
+            paymentId = 202L,
+            earnAmount = BigDecimal("100"),
+            reason = "결제 완료"
+        )
+
+        kafkaTemplate.send("point-earn-request", event.userId.toString(), event)
+
+        awaitUntil {
+            pointHistoryRepository.existsByEventId("point-notif-001")
+        }
+
+        verify(transactionalEventPublisher, atLeastOnce()).publishEvent(
+            aggregateType = any(),
+            aggregateId = any(),
+            eventType = any(),
+            eventData = any(),
+            topic = any(),
+            partitionKey = any()
+        )
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/point/service/PointEventConsumerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/point/service/PointEventConsumerTest.kt
@@ -30,7 +30,7 @@ import java.math.BigDecimal
 @ExtendWith(MockitoExtension::class)
 @DisplayName("PointEventConsumer 단위 테스트")
 @DisplayNameGeneration(ReplaceUnderscores::class)
-class PointEventConsumerIntegrationTest {
+class PointEventConsumerTest {
 
     @Mock
     private lateinit var pointRepository: PointRepository

--- a/src/test/kotlin/com/hoppingmall/mall/support/IntegrationTestBase.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/IntegrationTestBase.kt
@@ -1,0 +1,50 @@
+package com.hoppingmall.mall.support
+
+import com.hoppingmall.mall.global.common.config.TestKafkaConfig
+import com.hoppingmall.mall.global.common.service.OutboxEventService
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import org.springframework.kafka.test.context.EmbeddedKafka
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import jakarta.persistence.EntityManager
+import java.time.Duration
+
+@SpringBootTest(properties = ["spring.main.allow-bean-definition-overriding=true"])
+@ActiveProfiles("test")
+@Import(TestKafkaConfig::class)
+@EmbeddedKafka(
+    partitions = 1,
+    topics = ["notification", "point-earn-request", "payment", "payment-compensation"],
+    brokerProperties = ["listeners=PLAINTEXT://localhost:0", "port=0"]
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+abstract class IntegrationTestBase {
+
+    @MockBean
+    protected lateinit var outboxEventService: OutboxEventService
+
+    @Autowired
+    protected lateinit var entityManager: EntityManager
+
+    @BeforeEach
+    fun cleanUp() {
+        entityManager.clear()
+    }
+
+    protected fun awaitUntil(
+        timeout: Duration = Duration.ofSeconds(10),
+        interval: Duration = Duration.ofMillis(200),
+        condition: () -> Boolean
+    ) {
+        val deadline = System.currentTimeMillis() + timeout.toMillis()
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return
+            Thread.sleep(interval.toMillis())
+        }
+        throw AssertionError("조건이 ${timeout.seconds}초 내에 충족되지 않았습니다")
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -22,11 +22,12 @@ spring:
         legacy_id_generator_strategy: true
 
   kafka:
+    bootstrap-servers: ${spring.embedded.kafka.brokers:localhost:9092}
     topics:
       payment: payment-test
       point: point-test
     consumer:
-      bootstrap-servers: localhost:9092
+      bootstrap-servers: ${spring.embedded.kafka.brokers:localhost:9092}
       group-id: test-group
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
@@ -34,9 +35,11 @@ spring:
       properties:
         spring.json.trusted.packages: "*"
     producer:
-      bootstrap-servers: localhost:9092
+      bootstrap-servers: ${spring.embedded.kafka.brokers:localhost:9092}
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    listener:
+      concurrency: 1
 
 jwt:
   secret: test-secret-secret-secret-secret-secret-key-123456789


### PR DESCRIPTION
## 📌 변경사항

Closes #33

EmbeddedKafka를 활용한 Kafka Consumer 통합 테스트를 추가합니다.
기존 Mock 기반 단위 테스트만 존재했던 Consumer들에 대해, 실제 메시지 수신 → DB 저장 흐름을 검증하는 통합 테스트를 작성했습니다.

## ✅ 구현 내용

### 테스트 인프라
- `application-test.yml`에 EmbeddedKafka 브로커 설정 추가
- `TestKafkaConfig`: 프로덕션 EOS 설정을 비트랜잭션 빈으로 오버라이드
- `IntegrationTestBase`: 공통 추상 클래스 (EmbeddedKafka, MockBean, awaitUntil 유틸)
- `KafkaConfig`에 `@Profile("!test")` 추가

### 통합 테스트 (14개 테스트 케이스)
- **NotificationEventConsumer**: 이벤트 수신 → DB 저장, 중복 이벤트 멱등성
- **PointEventConsumer**: 포인트 적립, 중복 멱등성, 알림 발행 호출 검증
- **PaymentEventConsumer**: 결제 완료 이벤트 처리, 중복 멱등성
- **PaymentCompensationConsumer**: 결제 실패 → 주문 취소/재고 복구, 결제 취소 → 포인트 반환, 중복 멱등성
- **DLQService**: 메시지 저장/중복/통계/재처리 검증

### 기존 테스트 정리
- `PointEventConsumerIntegrationTest` → `PointEventConsumerTest` 이름 변경 (단위 테스트)

## 🧪 테스트

```bash
./gradlew test                    # 전체 테스트 통과
./gradlew jacocoTestVerification  # 커버리지 80% 검증 통과
```

## 📎 참고
- spring-kafka-test의 EmbeddedKafka 사용 (Docker 불필요)
- Outbox 스케줄러는 `@MockBean`으로 비활성화하여 직접 토픽 전송 방식 사용