### PR TITLE
refactor: Product/CartItem 가격 타입 BigDecimal 통일

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/cartItem/domain/CartItem.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/cartItem/domain/CartItem.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
 import org.hibernate.annotations.Filter
+import java.math.BigDecimal
 
 @Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 @Entity
@@ -19,28 +20,28 @@ class CartItem private constructor(
     @Column
     val productName: String,
 
-    @Column
-    val productPrice: Long,
+    @Column(precision = 10, scale = 2)
+    val productPrice: BigDecimal,
 
     @Column
     val productImageUrl: String?,
 
     @Column
     val quantity: Int,
-    
-    @Column
-    val totalPrice: Long,
+
+    @Column(precision = 10, scale = 2)
+    val totalPrice: BigDecimal,
 ): BaseEntity() {
     companion object {
         fun create(
             buyerId: Long,
             productId: Long,
             productName: String,
-            productPrice: Long,
+            productPrice: BigDecimal,
             productImageUrl: String?,
             quantity: Int
         ): CartItem {
-            val totalPrice = productPrice * quantity
+            val totalPrice = productPrice.multiply(BigDecimal(quantity))
             return CartItem(buyerId, productId, productName, productPrice, productImageUrl, quantity, totalPrice)
         }
     }

--- a/src/main/kotlin/com/hoppingmall/mall/cartItem/dto/response/CartItemResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/cartItem/dto/response/CartItemResponse.kt
@@ -1,15 +1,16 @@
 package com.hoppingmall.mall.cartItem.dto.response
 
 import com.hoppingmall.mall.cartItem.domain.CartItem
+import java.math.BigDecimal
 
 data class CartItemResponse(
     val id: Long,
     val productId: Long,
     val productName: String,
-    val productPrice: Long,
+    val productPrice: BigDecimal,
     val productImageUrl: String?,
     val quantity: Int,
-    val totalPrice: Long
+    val totalPrice: BigDecimal
 ) {
     companion object {
         fun from(cartItem: CartItem): CartItemResponse {

--- a/src/main/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImpl.kt
@@ -42,7 +42,7 @@ class OrderCommandServiceImpl(
             inventoryCommandService.decreaseStock(cartItem.productId, cartItem.quantity)
         }
 
-        val totalAmount = cartItems.sumOf { BigDecimal(it.productPrice) * BigDecimal(it.quantity) }
+        val totalAmount = cartItems.fold(BigDecimal.ZERO) { acc, it -> acc.add(it.productPrice.multiply(BigDecimal(it.quantity))) }
 
         val order = orderRepository.save(Order.create(buyerId = buyerId, totalAmount = totalAmount))
 
@@ -51,7 +51,7 @@ class OrderCommandServiceImpl(
                 orderId = order.id!!,
                 productId = cartItem.productId,
                 productName = cartItem.productName,
-                productPrice = BigDecimal(cartItem.productPrice),
+                productPrice = cartItem.productPrice,
                 quantity = cartItem.quantity
             )
         }

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/Product.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/Product.kt
@@ -4,6 +4,7 @@ import com.hoppingmall.mall.global.common.entity.BaseEntity
 import com.hoppingmall.mall.global.enums.ProductStatus
 import jakarta.persistence.*
 import org.hibernate.annotations.Filter
+import java.math.BigDecimal
 
 @Entity
 @Table(name = "products")
@@ -19,8 +20,8 @@ class Product private constructor(
     @Column(columnDefinition = "TEXT")
     var description: String,
 
-    @Column(nullable = false)
-    var price: Long,
+    @Column(nullable = false, precision = 10, scale = 2)
+    var price: BigDecimal,
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -33,7 +34,7 @@ class Product private constructor(
             sellerId: Long,
             name: String,
             description: String,
-            price: Long,
+            price: BigDecimal,
             status: ProductStatus
         ): Product{
             return Product(sellerId, name, description, price, status)

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/request/ProductCreateRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/request/ProductCreateRequest.kt
@@ -4,6 +4,7 @@ import com.hoppingmall.mall.global.enums.ProductStatus
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Positive
+import java.math.BigDecimal
 
 data class ProductCreateRequest(
     @field:NotNull(message = "판매자 ID는 필수입니다.")
@@ -16,7 +17,7 @@ data class ProductCreateRequest(
     val description: String,
     
     @field:Positive(message = "가격은 0보다 커야 합니다.")
-    val price: Long,
+    val price: BigDecimal,
     
     val imageUrl: String? = null,
     

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/request/ProductUpdateRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/request/ProductUpdateRequest.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.product.dto.request
 import com.hoppingmall.mall.global.enums.ProductStatus
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Positive
+import java.math.BigDecimal
 
 data class ProductUpdateRequest(
     @field:NotBlank(message = "상품명은 필수입니다.")
@@ -12,7 +13,7 @@ data class ProductUpdateRequest(
     val description: String,
     
     @field:Positive(message = "가격은 0보다 커야 합니다.")
-    val price: Long,
+    val price: BigDecimal,
     
     val imageUrl: String? = null,
     

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/response/ProductWithImageResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/response/ProductWithImageResponse.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.product.dto.response
 import com.hoppingmall.mall.global.enums.ProductStatus
 import com.hoppingmall.mall.product.domain.Product
 import com.hoppingmall.mall.product.domain.ProductImage
+import java.math.BigDecimal
 import java.time.LocalDateTime
 
 data class ProductResponse(
@@ -10,7 +11,7 @@ data class ProductResponse(
     val sellerId: Long,
     val name: String,
     val description: String,
-    val price: Long,
+    val price: BigDecimal,
     val status: ProductStatus,
     val imageUrl: String?,
     val createdAt: LocalDateTime,

--- a/src/test/kotlin/com/hoppingmall/mall/cartItem/controller/CartItemControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/cartItem/controller/CartItemControllerTest.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.mall.cartItem.controller
 
 import com.hoppingmall.mall.cartItem.dto.request.CartItemCreateRequest
+import java.math.BigDecimal
 import com.hoppingmall.mall.cartItem.dto.request.CartItemUpdateRequest
 import com.hoppingmall.mall.cartItem.dto.response.CartItemResponse
 import com.hoppingmall.mall.cartItem.service.CartItemCommandService
@@ -33,10 +34,10 @@ class CartItemControllerTest {
                 id = 1L,
                 productId = 100L,
                 productName = "테스트 상품",
-                productPrice = 15000L,
+                productPrice = BigDecimal("15000"),
                 productImageUrl = "https://example.com/image.jpg",
                 quantity = 2,
-                totalPrice = 30000L
+                totalPrice = BigDecimal("30000")
             )
 
             // Context
@@ -65,19 +66,19 @@ class CartItemControllerTest {
                     id = 1L,
                     productId = 100L,
                     productName = "테스트 상품 1",
-                    productPrice = 15000L,
+                    productPrice = BigDecimal("15000"),
                     productImageUrl = "https://example.com/image1.jpg",
                     quantity = 2,
-                    totalPrice = 30000L
+                    totalPrice = BigDecimal("30000")
                 ),
                 CartItemResponse(
                     id = 2L,
                     productId = 200L,
                     productName = "테스트 상품 2",
-                    productPrice = 20000L,
+                    productPrice = BigDecimal("20000"),
                     productImageUrl = "https://example.com/image2.jpg",
                     quantity = 1,
-                    totalPrice = 20000L
+                    totalPrice = BigDecimal("20000")
                 )
             )
 
@@ -108,10 +109,10 @@ class CartItemControllerTest {
                 id = 1L,
                 productId = 100L,
                 productName = "테스트 상품",
-                productPrice = 15000L,
+                productPrice = BigDecimal("15000"),
                 productImageUrl = "https://example.com/image.jpg",
                 quantity = 5,
-                totalPrice = 75000L
+                totalPrice = BigDecimal("75000")
             )
 
             // Context

--- a/src/test/kotlin/com/hoppingmall/mall/cartItem/domain/CartItemTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/cartItem/domain/CartItemTest.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.mall.cartItem.domain
 
 import org.assertj.core.api.Assertions.assertThat
+import java.math.BigDecimal
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
@@ -16,17 +17,17 @@ class CartItemTest {
         val buyerId = 1L
         val productId = 100L
         val productName = "테스트 상품"
-        val productPrice = 15000L
+        val productPrice = BigDecimal("15000")
         val productImageUrl = "https://example.com/image.jpg"
         val quantity = 2
 
         // Interaction
         val cartItem = CartItem.create(
-            buyerId, 
-            productId, 
-            productName, 
-            productPrice, 
-            productImageUrl, 
+            buyerId,
+            productId,
+            productName,
+            productPrice,
+            productImageUrl,
             quantity
         )
 
@@ -34,21 +35,21 @@ class CartItemTest {
         assertThat(cartItem.buyerId).isEqualTo(buyerId)
         assertThat(cartItem.productId).isEqualTo(productId)
         assertThat(cartItem.productName).isEqualTo(productName)
-        assertThat(cartItem.productPrice).isEqualTo(productPrice)
+        assertThat(cartItem.productPrice).isEqualByComparingTo(productPrice)
         assertThat(cartItem.productImageUrl).isEqualTo(productImageUrl)
         assertThat(cartItem.quantity).isEqualTo(quantity)
-        assertThat(cartItem.totalPrice).isEqualTo(productPrice * quantity)
+        assertThat(cartItem.totalPrice).isEqualByComparingTo(productPrice.multiply(BigDecimal(quantity)))
     }
 
     @Test
     fun 장바구니_아이템_수량_변경_성공() {
         // Data
         val cartItem = CartItem.create(
-            1L, 
-            100L, 
-            "테스트 상품", 
-            15000L, 
-            "https://example.com/image.jpg", 
+            1L,
+            100L,
+            "테스트 상품",
+            BigDecimal("15000"),
+            "https://example.com/image.jpg",
             2
         )
         val newQuantity = 5
@@ -65,11 +66,11 @@ class CartItemTest {
 
         // Assertions
         assertThat(updatedCartItem.quantity).isEqualTo(newQuantity)
-        assertThat(updatedCartItem.totalPrice).isEqualTo(cartItem.productPrice * newQuantity)
+        assertThat(updatedCartItem.totalPrice).isEqualByComparingTo(cartItem.productPrice.multiply(BigDecimal(newQuantity)))
         assertThat(updatedCartItem.buyerId).isEqualTo(cartItem.buyerId)
         assertThat(updatedCartItem.productId).isEqualTo(cartItem.productId)
         assertThat(updatedCartItem.productName).isEqualTo(cartItem.productName)
-        assertThat(updatedCartItem.productPrice).isEqualTo(cartItem.productPrice)
+        assertThat(updatedCartItem.productPrice).isEqualByComparingTo(cartItem.productPrice)
     }
 
     @Test
@@ -78,22 +79,22 @@ class CartItemTest {
         val buyerId = 1L
         val productId = 100L
         val productName = "이미지 없는 상품"
-        val productPrice = 10000L
+        val productPrice = BigDecimal("10000")
         val productImageUrl = null
         val quantity = 1
 
         // Interaction
         val cartItem = CartItem.create(
-            buyerId, 
-            productId, 
-            productName, 
-            productPrice, 
-            productImageUrl, 
+            buyerId,
+            productId,
+            productName,
+            productPrice,
+            productImageUrl,
             quantity
         )
 
         // Assertions
         assertThat(cartItem.productImageUrl).isNull()
-        assertThat(cartItem.totalPrice).isEqualTo(productPrice * quantity)
+        assertThat(cartItem.totalPrice).isEqualByComparingTo(productPrice.multiply(BigDecimal(quantity)))
     }
 } 

--- a/src/test/kotlin/com/hoppingmall/mall/cartItem/service/CartItemCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/cartItem/service/CartItemCommandServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.cartItem.service
 
 import com.hoppingmall.mall.cartItem.domain.CartItem
 import com.hoppingmall.mall.cartItem.domain.repository.CartItemRepository
+import java.math.BigDecimal
 import com.hoppingmall.mall.cartItem.dto.request.CartItemCreateRequest
 import com.hoppingmall.mall.cartItem.dto.request.CartItemUpdateRequest
 import com.hoppingmall.mall.cartItem.dto.response.CartItemResponse
@@ -79,7 +80,7 @@ class CartItemCommandServiceImplTest {
             assertThat(result.productPrice).isEqualTo(product.price)
             assertThat(result.productImageUrl).isEqualTo(productImage.imageUrl)
             assertThat(result.quantity).isEqualTo(request.quantity)
-            assertThat(result.totalPrice).isEqualTo(product.price * request.quantity)
+            assertThat(result.totalPrice).isEqualByComparingTo(product.price.multiply(BigDecimal(request.quantity)))
 
             verify(cartItemRepository).save(any())
         }
@@ -107,7 +108,7 @@ class CartItemCommandServiceImplTest {
 
             // Assertions
             assertThat(result.quantity).isEqualTo(5) // 2 + 3
-            assertThat(result.totalPrice).isEqualTo(existingCartItem.productPrice * 5)
+            assertThat(result.totalPrice).isEqualByComparingTo(existingCartItem.productPrice.multiply(BigDecimal(5)))
 
             verify(cartItemRepository).save(any())
         }
@@ -133,7 +134,7 @@ class CartItemCommandServiceImplTest {
 
             // Assertions
             assertThat(result.productImageUrl).isNull()
-            assertThat(result.totalPrice).isEqualTo(product.price * request.quantity)
+            assertThat(result.totalPrice).isEqualByComparingTo(product.price.multiply(BigDecimal(request.quantity)))
 
             verify(cartItemRepository).save(any())
         }
@@ -177,7 +178,7 @@ class CartItemCommandServiceImplTest {
 
             // Assertions
             assertThat(result.quantity).isEqualTo(request.quantity)
-            assertThat(result.totalPrice).isEqualTo(existingCartItem.productPrice * request.quantity)
+            assertThat(result.totalPrice).isEqualByComparingTo(existingCartItem.productPrice.multiply(BigDecimal(request.quantity)))
 
             verify(cartItemRepository).save(any())
         }

--- a/src/test/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImplTest.kt
@@ -48,8 +48,8 @@ class OrderCommandServiceImplTest {
             // given
             val buyerId = 1L
             val request = OrderCreateRequest(cartItemIds = listOf(1L, 2L))
-            val cartItem1 = CartItem.fixture(buyerId = 1L, productId = 100L, productName = "상품1", productPrice = 15000L, quantity = 2).withId(1L)
-            val cartItem2 = CartItem.fixture(buyerId = 1L, productId = 200L, productName = "상품2", productPrice = 20000L, quantity = 1).withId(2L)
+            val cartItem1 = CartItem.fixture(buyerId = 1L, productId = 100L, productName = "상품1", productPrice = BigDecimal("15000"), quantity = 2).withId(1L)
+            val cartItem2 = CartItem.fixture(buyerId = 1L, productId = 200L, productName = "상품2", productPrice = BigDecimal("20000"), quantity = 1).withId(2L)
 
             val orderCaptor = argumentCaptor<Order>()
 

--- a/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductControllerTest.kt
@@ -11,6 +11,7 @@ import com.hoppingmall.mall.product.service.ProductImageService
 import com.hoppingmall.mall.product.service.ProductQueryService
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
+import java.math.BigDecimal
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.mockito.kotlin.*
 import org.springframework.data.domain.Page
@@ -40,7 +41,7 @@ class ProductControllerTest {
                     sellerId = 1L,
                     name = "상품1",
                     description = "설명1",
-                    price = 10000L,
+                    price = BigDecimal("10000"),
                     status = ProductStatus.AVAILABLE,
                     imageUrl = "https://example.com/image1.jpg",
                     createdAt = LocalDateTime.now(),
@@ -51,7 +52,7 @@ class ProductControllerTest {
                     sellerId = 2L,
                     name = "상품2",
                     description = "설명2",
-                    price = 20000L,
+                    price = BigDecimal("20000"),
                     status = ProductStatus.AVAILABLE,
                     imageUrl = "https://example.com/image2.jpg",
                     createdAt = LocalDateTime.now(),
@@ -82,7 +83,7 @@ class ProductControllerTest {
                 sellerId = 1L,
                 name = "상품1",
                 description = "설명1",
-                price = 10000L,
+                price = BigDecimal("10000"),
                 status = ProductStatus.AVAILABLE,
                 imageUrl = "https://example.com/image.jpg",
                 createdAt = LocalDateTime.now(),
@@ -128,7 +129,7 @@ class ProductControllerTest {
                     sellerId = sellerId,
                     name = "상품1",
                     description = "설명1",
-                    price = 10000L,
+                    price = BigDecimal("10000"),
                     status = ProductStatus.AVAILABLE,
                     imageUrl = "https://example.com/image1.jpg",
                     createdAt = LocalDateTime.now(),
@@ -139,7 +140,7 @@ class ProductControllerTest {
                     sellerId = sellerId,
                     name = "상품2",
                     description = "설명2",
-                    price = 20000L,
+                    price = BigDecimal("20000"),
                     status = ProductStatus.AVAILABLE,
                     imageUrl = "https://example.com/image2.jpg",
                     createdAt = LocalDateTime.now(),
@@ -168,7 +169,7 @@ class ProductControllerTest {
                 sellerId = 1L,
                 name = "새 상품",
                 description = "새 상품 설명",
-                price = 15000L,
+                price = BigDecimal("15000"),
                 imageUrl = "https://example.com/new-image.jpg",
                 status = ProductStatus.AVAILABLE
             )
@@ -178,7 +179,7 @@ class ProductControllerTest {
                 sellerId = 1L,
                 name = "새 상품",
                 description = "새 상품 설명",
-                price = 15000L,
+                price = BigDecimal("15000"),
                 status = ProductStatus.AVAILABLE,
                 imageUrl = "https://example.com/new-image.jpg",
                 createdAt = LocalDateTime.now(),
@@ -205,7 +206,7 @@ class ProductControllerTest {
             val request = ProductUpdateRequest(
                 name = "수정된 상품",
                 description = "수정된 상품 설명",
-                price = 20000L,
+                price = BigDecimal("20000"),
                 imageUrl = "https://example.com/updated-image.jpg",
                 status = ProductStatus.AVAILABLE
             )
@@ -215,7 +216,7 @@ class ProductControllerTest {
                 sellerId = 1L,
                 name = "수정된 상품",
                 description = "수정된 상품 설명",
-                price = 20000L,
+                price = BigDecimal("20000"),
                 status = ProductStatus.AVAILABLE,
                 imageUrl = "https://example.com/updated-image.jpg",
                 createdAt = LocalDateTime.now(),

--- a/src/test/kotlin/com/hoppingmall/mall/product/domain/ProductTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/domain/ProductTest.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.product.domain
 
 import com.hoppingmall.mall.global.enums.ProductStatus
 import org.junit.jupiter.api.Assertions.assertEquals
+import java.math.BigDecimal
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
@@ -20,7 +21,7 @@ class ProductTest {
             val sellerId = 1L
             val name = "테스트 상품"
             val description = "테스트 상품 설명"
-            val price = 10000L
+            val price = BigDecimal("10000")
             val status = ProductStatus.AVAILABLE
 
             val product = Product.create(sellerId, name, description, price, status)
@@ -37,7 +38,7 @@ class ProductTest {
             val sellerId = 1L
             val name = "테스트 상품"
             val description = "테스트 상품 설명"
-            val price = 10000L
+            val price = BigDecimal("10000")
 
             val product = Product.create(sellerId, name, description, price, ProductStatus.AVAILABLE)
 
@@ -49,7 +50,7 @@ class ProductTest {
             val sellerId = 1L
             val name = "테스트 상품"
             val description = "테스트 상품 설명"
-            val price = 10000L
+            val price = BigDecimal("10000")
 
             val product = Product.create(sellerId, name, description, price, ProductStatus.SOLD_OUT)
 

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.product.service
 
 import com.hoppingmall.mall.global.enums.ProductStatus
 import com.hoppingmall.mall.product.domain.Product
+import java.math.BigDecimal
 import com.hoppingmall.mall.product.domain.ProductImage
 import com.hoppingmall.mall.product.domain.repository.ProductImageRepository
 import com.hoppingmall.mall.product.domain.repository.ProductRepository
@@ -37,7 +38,7 @@ class ProductCommandServiceImplTest {
                 sellerId = 1L,
                 name = "테스트 상품",
                 description = "테스트 상품 설명",
-                price = 10000L,
+                price = BigDecimal("10000"),
                 imageUrl = "https://example.com/image.jpg",
                 status = ProductStatus.AVAILABLE
             )
@@ -84,7 +85,7 @@ class ProductCommandServiceImplTest {
                 sellerId = 1L,
                 name = "테스트 상품",
                 description = "테스트 상품 설명",
-                price = 10000L,
+                price = BigDecimal("10000"),
                 imageUrl = null,
                 status = ProductStatus.AVAILABLE
             )
@@ -132,7 +133,7 @@ class ProductCommandServiceImplTest {
             val request = ProductUpdateRequest(
                 name = "수정된 상품명",
                 description = "수정된 상품 설명",
-                price = 20000L,
+                price = BigDecimal("20000"),
                 imageUrl = "https://example.com/updated-image.jpg",
                 status = ProductStatus.SOLD_OUT
             )
@@ -177,7 +178,7 @@ class ProductCommandServiceImplTest {
             val request = ProductUpdateRequest(
                 name = "수정된 상품명",
                 description = "수정된 상품 설명",
-                price = 20000L,
+                price = BigDecimal("20000"),
                 imageUrl = "https://example.com/updated-image.jpg",
                 status = ProductStatus.AVAILABLE
             )
@@ -201,7 +202,7 @@ class ProductCommandServiceImplTest {
             val request = ProductUpdateRequest(
                 name = "수정된 상품명",
                 description = "수정된 상품 설명",
-                price = 20000L,
+                price = BigDecimal("20000"),
                 imageUrl = "https://example.com/new-image.jpg",
                 status = ProductStatus.AVAILABLE
             )
@@ -243,7 +244,7 @@ class ProductCommandServiceImplTest {
             val request = ProductUpdateRequest(
                 name = "수정된 상품명",
                 description = "수정된 상품 설명",
-                price = 20000L,
+                price = BigDecimal("20000"),
                 imageUrl = null,
                 status = ProductStatus.AVAILABLE
             )

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.product.service
 
 import com.hoppingmall.mall.global.enums.ProductStatus
 import com.hoppingmall.mall.product.domain.Product
+import java.math.BigDecimal
 import com.hoppingmall.mall.product.domain.ProductImage
 import com.hoppingmall.mall.product.domain.repository.ProductImageRepository
 import com.hoppingmall.mall.product.domain.repository.ProductRepository
@@ -35,8 +36,8 @@ class ProductQueryServiceImplTest {
         fun 상품_목록_조회_성공() {
             val pageable = PageRequest.of(0, 10)
             val products = listOf(
-                Product.create(1L, "상품1", "설명1", 10000L, ProductStatus.AVAILABLE).withId(1L),
-                Product.create(2L, "상품2", "설명2", 20000L, ProductStatus.AVAILABLE).withId(2L)
+                Product.create(1L, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(1L),
+                Product.create(2L, "상품2", "설명2", BigDecimal("20000"), ProductStatus.AVAILABLE).withId(2L)
             )
             val productPage = PageImpl(products, pageable, products.size.toLong())
 
@@ -61,7 +62,7 @@ class ProductQueryServiceImplTest {
         @Test
         fun 상품_상세_조회_성공() {
             val productId = 1L
-            val product = Product.create(1L, "상품1", "설명1", 10000L, ProductStatus.AVAILABLE).withId(productId)
+            val product = Product.create(1L, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(productId)
             val image = ProductImage.create(productId, "https://example.com/image.jpg")
 
             whenever(productRepository.findNullableById(productId)).thenReturn(product)
@@ -92,7 +93,7 @@ class ProductQueryServiceImplTest {
         @Test
         fun 이미지가_없는_상품_조회_성공() {
             val productId = 1L
-            val product = Product.create(1L, "상품1", "설명1", 10000L, ProductStatus.AVAILABLE).withId(productId)
+            val product = Product.create(1L, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(productId)
 
             whenever(productRepository.findNullableById(productId)).thenReturn(product)
             whenever(productImageRepository.findByProductId(productId)).thenReturn(null)
@@ -115,8 +116,8 @@ class ProductQueryServiceImplTest {
             val sellerId = 1L
             val pageable = PageRequest.of(0, 10)
             val products = listOf(
-                Product.create(sellerId, "상품1", "설명1", 10000L, ProductStatus.AVAILABLE).withId(1L),
-                Product.create(sellerId, "상품2", "설명2", 20000L, ProductStatus.AVAILABLE).withId(2L)
+                Product.create(sellerId, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(1L),
+                Product.create(sellerId, "상품2", "설명2", BigDecimal("20000"), ProductStatus.AVAILABLE).withId(2L)
             )
             val productPage = PageImpl(products, pageable, products.size.toLong())
 

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/CartItemFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/CartItemFixture.kt
@@ -1,12 +1,13 @@
 package com.hoppingmall.mall.support.fixture
 
 import com.hoppingmall.mall.cartItem.domain.CartItem
+import java.math.BigDecimal
 
 fun CartItem.Companion.fixture(
     buyerId: Long = 1L,
     productId: Long = 100L,
     productName: String = "테스트 상품",
-    productPrice: Long = 15000L,
+    productPrice: BigDecimal = BigDecimal("15000"),
     productImageUrl: String? = "https://example.com/image.jpg",
     quantity: Int = 2
 ): CartItem {

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/ProductFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/ProductFixture.kt
@@ -2,12 +2,13 @@ package com.hoppingmall.mall.support.fixture
 
 import com.hoppingmall.mall.global.enums.ProductStatus
 import com.hoppingmall.mall.product.domain.Product
+import java.math.BigDecimal
 
 fun Product.Companion.fixture(
     sellerId: Long = 1L,
     name: String = "테스트 상품",
     description: String = "테스트 상품 설명",
-    price: Long = 10000L,
+    price: BigDecimal = BigDecimal("10000"),
     status: ProductStatus = ProductStatus.AVAILABLE
 ): Product {
     return Product.create(sellerId, name, description, price, status)


### PR DESCRIPTION
Closes #49

## 📌 변경 사항

- Product 엔티티/DTO 가격 필드 `Long` → `BigDecimal` 변경 (`precision = 10, scale = 2`)
- CartItem 엔티티/DTO 가격 필드 `Long` → `BigDecimal` 변경 (`precision = 10, scale = 2`)
- CartItem.totalPrice 계산 로직 `BigDecimal.multiply` 방식으로 변경
- OrderCommandServiceImpl에서 불필요한 `BigDecimal()` 래핑 코드 제거

## ✅ 동작 확인

- 전체 테스트 통과
- Jacoco 커버리지 80% 검증 통과

## 🧪 테스트

- Product 관련 테스트 (도메인, 서비스, 컨트롤러) BigDecimal 전환 완료
- CartItem 관련 테스트 (도메인, 서비스, 컨트롤러) BigDecimal 전환 완료
- Order 관련 테스트 BigDecimal 변환 코드 제거 반영

## 📎 비고

- Order, OrderItem, Payment 도메인은 이미 BigDecimal을 사용하고 있으므로 변경 없음