### PR TITLE
feat: Category 도메인 구현

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/category/controller/CategoryController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/controller/CategoryController.kt
@@ -1,0 +1,68 @@
+package com.hoppingmall.mall.category.controller
+
+import com.hoppingmall.mall.category.dto.request.CategoryCreateRequest
+import com.hoppingmall.mall.category.dto.request.CategoryUpdateRequest
+import com.hoppingmall.mall.category.dto.response.CategoryResponse
+import com.hoppingmall.mall.category.service.CategoryCommandService
+import com.hoppingmall.mall.category.service.CategoryQueryService
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/categories")
+class CategoryController(
+    private val categoryCommandService: CategoryCommandService,
+    private val categoryQueryService: CategoryQueryService
+) {
+
+    @PostMapping
+    fun createCategory(
+        @Valid @RequestBody request: CategoryCreateRequest
+    ): ResponseEntity<ApiResponse<CategoryResponse>> {
+        val response = categoryCommandService.createCategory(request)
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.success(response))
+    }
+
+    @GetMapping("/{categoryId}")
+    fun getCategory(
+        @PathVariable categoryId: Long
+    ): ResponseEntity<ApiResponse<CategoryResponse>> {
+        val response = categoryQueryService.getCategory(categoryId)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @GetMapping("/root")
+    fun getRootCategories(): ResponseEntity<ApiResponse<List<CategoryResponse>>> {
+        val response = categoryQueryService.getRootCategories()
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @GetMapping("/{categoryId}/sub")
+    fun getSubCategories(
+        @PathVariable categoryId: Long
+    ): ResponseEntity<ApiResponse<List<CategoryResponse>>> {
+        val response = categoryQueryService.getSubCategories(categoryId)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @PutMapping("/{categoryId}")
+    fun updateCategory(
+        @PathVariable categoryId: Long,
+        @Valid @RequestBody request: CategoryUpdateRequest
+    ): ResponseEntity<ApiResponse<CategoryResponse>> {
+        val response = categoryCommandService.updateCategory(categoryId, request)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @DeleteMapping("/{categoryId}")
+    fun deleteCategory(
+        @PathVariable categoryId: Long
+    ): ResponseEntity<Void> {
+        categoryCommandService.deleteCategory(categoryId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/category/domain/Category.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/domain/Category.kt
@@ -1,0 +1,36 @@
+package com.hoppingmall.mall.category.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import org.hibernate.annotations.Filter
+
+@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
+@Entity
+@Table(name = "categories")
+class Category private constructor(
+    @Column(nullable = false, unique = true)
+    var name: String,
+
+    @Column
+    val parentCategoryId: Long?,
+
+    @Column(nullable = false)
+    val depth: Int
+) : BaseEntity() {
+
+    fun update(name: String) {
+        this.name = name
+    }
+
+    fun isRootCategory(): Boolean {
+        return parentCategoryId == null
+    }
+
+    companion object {
+        fun create(name: String, parentCategoryId: Long?, depth: Int): Category {
+            return Category(name = name, parentCategoryId = parentCategoryId, depth = depth)
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/category/domain/repository/CategoryRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/domain/repository/CategoryRepository.kt
@@ -1,0 +1,15 @@
+package com.hoppingmall.mall.category.domain.repository
+
+import com.hoppingmall.mall.category.domain.Category
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CategoryRepository : JpaRepository<Category, Long> {
+    fun existsByName(name: String): Boolean
+    fun existsByNameAndIdNot(name: String, id: Long): Boolean
+    fun findByParentCategoryId(parentCategoryId: Long): List<Category>
+    fun existsByParentCategoryId(parentCategoryId: Long): Boolean
+    fun findNullableById(id: Long): Category?
+    fun findByParentCategoryIdIsNull(): List<Category>
+}

--- a/src/main/kotlin/com/hoppingmall/mall/category/dto/request/CategoryCreateRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/dto/request/CategoryCreateRequest.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.mall.category.dto.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class CategoryCreateRequest(
+    @field:NotBlank(message = "카테고리 이름은 필수입니다")
+    val name: String,
+
+    val parentCategoryId: Long? = null
+)

--- a/src/main/kotlin/com/hoppingmall/mall/category/dto/request/CategoryUpdateRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/dto/request/CategoryUpdateRequest.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.mall.category.dto.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class CategoryUpdateRequest(
+    @field:NotBlank(message = "카테고리 이름은 필수입니다")
+    val name: String
+)

--- a/src/main/kotlin/com/hoppingmall/mall/category/dto/response/CategoryResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/dto/response/CategoryResponse.kt
@@ -1,0 +1,26 @@
+package com.hoppingmall.mall.category.dto.response
+
+import com.hoppingmall.mall.category.domain.Category
+import java.time.LocalDateTime
+
+data class CategoryResponse(
+    val id: Long,
+    val name: String,
+    val parentCategoryId: Long?,
+    val depth: Int,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime?
+) {
+    companion object {
+        fun from(category: Category): CategoryResponse {
+            return CategoryResponse(
+                id = category.id!!,
+                name = category.name,
+                parentCategoryId = category.parentCategoryId,
+                depth = category.depth,
+                createdAt = category.createdAt,
+                updatedAt = category.updatedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/category/exception/CategoryAlreadyExistsException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/exception/CategoryAlreadyExistsException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.category.exception
+
+import com.hoppingmall.mall.category.exception.code.CategoryErrorCode
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+
+class CategoryAlreadyExistsException : BusinessException(CategoryErrorCode.CATEGORY_ALREADY_EXISTS)

--- a/src/main/kotlin/com/hoppingmall/mall/category/exception/CategoryHasChildrenException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/exception/CategoryHasChildrenException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.category.exception
+
+import com.hoppingmall.mall.category.exception.code.CategoryErrorCode
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+
+class CategoryHasChildrenException : BusinessException(CategoryErrorCode.CATEGORY_HAS_CHILDREN)

--- a/src/main/kotlin/com/hoppingmall/mall/category/exception/CategoryNotFoundException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/exception/CategoryNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.category.exception
+
+import com.hoppingmall.mall.category.exception.code.CategoryErrorCode
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+
+class CategoryNotFoundException : BusinessException(CategoryErrorCode.CATEGORY_NOT_FOUND)

--- a/src/main/kotlin/com/hoppingmall/mall/category/exception/code/CategoryErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/exception/code/CategoryErrorCode.kt
@@ -1,0 +1,14 @@
+package com.hoppingmall.mall.category.exception.code
+
+import com.hoppingmall.mall.global.common.error.code.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class CategoryErrorCode(
+    override val code: String,
+    override val message: String,
+    override val status: HttpStatus
+) : ErrorCode {
+    CATEGORY_NOT_FOUND("CAT001", "카테고리를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    CATEGORY_ALREADY_EXISTS("CAT002", "이미 존재하는 카테고리 이름입니다.", HttpStatus.CONFLICT),
+    CATEGORY_HAS_CHILDREN("CAT003", "하위 카테고리가 존재하여 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST),
+}

--- a/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryCommandService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryCommandService.kt
@@ -1,0 +1,11 @@
+package com.hoppingmall.mall.category.service
+
+import com.hoppingmall.mall.category.dto.request.CategoryCreateRequest
+import com.hoppingmall.mall.category.dto.request.CategoryUpdateRequest
+import com.hoppingmall.mall.category.dto.response.CategoryResponse
+
+interface CategoryCommandService {
+    fun createCategory(request: CategoryCreateRequest): CategoryResponse
+    fun updateCategory(categoryId: Long, request: CategoryUpdateRequest): CategoryResponse
+    fun deleteCategory(categoryId: Long)
+}

--- a/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryCommandServiceImpl.kt
@@ -1,0 +1,64 @@
+package com.hoppingmall.mall.category.service
+
+import com.hoppingmall.mall.category.domain.Category
+import com.hoppingmall.mall.category.domain.repository.CategoryRepository
+import com.hoppingmall.mall.category.dto.request.CategoryCreateRequest
+import com.hoppingmall.mall.category.dto.request.CategoryUpdateRequest
+import com.hoppingmall.mall.category.dto.response.CategoryResponse
+import com.hoppingmall.mall.category.exception.CategoryAlreadyExistsException
+import com.hoppingmall.mall.category.exception.CategoryHasChildrenException
+import com.hoppingmall.mall.category.exception.CategoryNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class CategoryCommandServiceImpl(
+    private val categoryRepository: CategoryRepository
+) : CategoryCommandService {
+
+    override fun createCategory(request: CategoryCreateRequest): CategoryResponse {
+        if (categoryRepository.existsByName(request.name)) {
+            throw CategoryAlreadyExistsException()
+        }
+
+        val depth = if (request.parentCategoryId != null) {
+            val parent = categoryRepository.findNullableById(request.parentCategoryId)
+                ?: throw CategoryNotFoundException()
+            parent.depth + 1
+        } else {
+            0
+        }
+
+        val category = Category.create(
+            name = request.name,
+            parentCategoryId = request.parentCategoryId,
+            depth = depth
+        )
+        val savedCategory = categoryRepository.save(category)
+        return CategoryResponse.from(savedCategory)
+    }
+
+    override fun updateCategory(categoryId: Long, request: CategoryUpdateRequest): CategoryResponse {
+        val category = categoryRepository.findNullableById(categoryId)
+            ?: throw CategoryNotFoundException()
+
+        if (categoryRepository.existsByNameAndIdNot(request.name, categoryId)) {
+            throw CategoryAlreadyExistsException()
+        }
+
+        category.update(request.name)
+        return CategoryResponse.from(category)
+    }
+
+    override fun deleteCategory(categoryId: Long) {
+        val category = categoryRepository.findNullableById(categoryId)
+            ?: throw CategoryNotFoundException()
+
+        if (categoryRepository.existsByParentCategoryId(category.id!!)) {
+            throw CategoryHasChildrenException()
+        }
+
+        categoryRepository.deleteById(category.id!!)
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryQueryService.kt
@@ -1,0 +1,9 @@
+package com.hoppingmall.mall.category.service
+
+import com.hoppingmall.mall.category.dto.response.CategoryResponse
+
+interface CategoryQueryService {
+    fun getCategory(categoryId: Long): CategoryResponse
+    fun getRootCategories(): List<CategoryResponse>
+    fun getSubCategories(parentCategoryId: Long): List<CategoryResponse>
+}

--- a/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryQueryServiceImpl.kt
@@ -1,0 +1,31 @@
+package com.hoppingmall.mall.category.service
+
+import com.hoppingmall.mall.category.domain.repository.CategoryRepository
+import com.hoppingmall.mall.category.dto.response.CategoryResponse
+import com.hoppingmall.mall.category.exception.CategoryNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class CategoryQueryServiceImpl(
+    private val categoryRepository: CategoryRepository
+) : CategoryQueryService {
+
+    override fun getCategory(categoryId: Long): CategoryResponse {
+        val category = categoryRepository.findNullableById(categoryId)
+            ?: throw CategoryNotFoundException()
+
+        return CategoryResponse.from(category)
+    }
+
+    override fun getRootCategories(): List<CategoryResponse> {
+        return categoryRepository.findByParentCategoryIdIsNull()
+            .map { CategoryResponse.from(it) }
+    }
+
+    override fun getSubCategories(parentCategoryId: Long): List<CategoryResponse> {
+        return categoryRepository.findByParentCategoryId(parentCategoryId)
+            .map { CategoryResponse.from(it) }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
@@ -40,9 +40,16 @@ class SecurityConfig(
                     "/api/v1/point-policies/{policyId}"
                 ).permitAll()
                 it.requestMatchers(HttpMethod.GET, "/api/v1/inventories/{productId}").permitAll()
+                it.requestMatchers(
+                    HttpMethod.GET,
+                    "/api/v1/categories/root",
+                    "/api/v1/categories/{categoryId}",
+                    "/api/v1/categories/{categoryId}/sub"
+                ).permitAll()
 
                 it.requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                 it.requestMatchers("/api/v1/point-policies/**").hasRole("ADMIN")
+                it.requestMatchers("/api/v1/categories/**").hasRole("ADMIN")
 
                 it.requestMatchers(
                     HttpMethod.POST,

--- a/src/test/kotlin/com/hoppingmall/mall/category/controller/CategoryControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/category/controller/CategoryControllerTest.kt
@@ -1,0 +1,171 @@
+package com.hoppingmall.mall.category.controller
+
+import com.hoppingmall.mall.category.dto.request.CategoryCreateRequest
+import com.hoppingmall.mall.category.dto.request.CategoryUpdateRequest
+import com.hoppingmall.mall.category.dto.response.CategoryResponse
+import com.hoppingmall.mall.category.service.CategoryCommandService
+import com.hoppingmall.mall.category.service.CategoryQueryService
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import java.time.LocalDateTime
+
+@DisplayName("CategoryController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class CategoryControllerTest {
+
+    private val categoryCommandService: CategoryCommandService = mock()
+    private val categoryQueryService: CategoryQueryService = mock()
+    private val controller = CategoryController(categoryCommandService, categoryQueryService)
+
+    private val now = LocalDateTime.of(2026, 1, 1, 0, 0, 0)
+
+    @Nested
+    @DisplayName("createCategory")
+    inner class CreateCategory {
+        @Test
+        fun 카테고리_생성_성공() {
+            // given
+            val request = CategoryCreateRequest(name = "전자제품")
+            val expectedResponse = CategoryResponse(
+                id = 1L, name = "전자제품", parentCategoryId = null, depth = 0,
+                createdAt = now, updatedAt = null
+            )
+
+            whenever(categoryCommandService.createCategory(request)).thenReturn(expectedResponse)
+
+            // when
+            val response: ResponseEntity<ApiResponse<CategoryResponse>> = controller.createCategory(request)
+
+            // then
+            assertEquals(HttpStatus.CREATED, response.statusCode)
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(expectedResponse, response.body?.data)
+            verify(categoryCommandService).createCategory(request)
+        }
+    }
+
+    @Nested
+    @DisplayName("getCategory")
+    inner class GetCategory {
+        @Test
+        fun 카테고리_조회_성공() {
+            // given
+            val expectedResponse = CategoryResponse(
+                id = 1L, name = "전자제품", parentCategoryId = null, depth = 0,
+                createdAt = now, updatedAt = null
+            )
+
+            whenever(categoryQueryService.getCategory(1L)).thenReturn(expectedResponse)
+
+            // when
+            val response: ResponseEntity<ApiResponse<CategoryResponse>> = controller.getCategory(1L)
+
+            // then
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(expectedResponse, response.body?.data)
+            verify(categoryQueryService).getCategory(1L)
+        }
+    }
+
+    @Nested
+    @DisplayName("getRootCategories")
+    inner class GetRootCategories {
+        @Test
+        fun 루트_카테고리_목록_조회_성공() {
+            // given
+            val expectedResponse = listOf(
+                CategoryResponse(
+                    id = 1L, name = "전자제품", parentCategoryId = null, depth = 0,
+                    createdAt = now, updatedAt = null
+                )
+            )
+
+            whenever(categoryQueryService.getRootCategories()).thenReturn(expectedResponse)
+
+            // when
+            val response: ResponseEntity<ApiResponse<List<CategoryResponse>>> = controller.getRootCategories()
+
+            // then
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(1, response.body?.data?.size)
+            verify(categoryQueryService).getRootCategories()
+        }
+    }
+
+    @Nested
+    @DisplayName("getSubCategories")
+    inner class GetSubCategories {
+        @Test
+        fun 하위_카테고리_목록_조회_성공() {
+            // given
+            val expectedResponse = listOf(
+                CategoryResponse(
+                    id = 2L, name = "노트북", parentCategoryId = 1L, depth = 1,
+                    createdAt = now, updatedAt = null
+                )
+            )
+
+            whenever(categoryQueryService.getSubCategories(1L)).thenReturn(expectedResponse)
+
+            // when
+            val response: ResponseEntity<ApiResponse<List<CategoryResponse>>> = controller.getSubCategories(1L)
+
+            // then
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(1, response.body?.data?.size)
+            verify(categoryQueryService).getSubCategories(1L)
+        }
+    }
+
+    @Nested
+    @DisplayName("updateCategory")
+    inner class UpdateCategory {
+        @Test
+        fun 카테고리_수정_성공() {
+            // given
+            val request = CategoryUpdateRequest(name = "가전제품")
+            val expectedResponse = CategoryResponse(
+                id = 1L, name = "가전제품", parentCategoryId = null, depth = 0,
+                createdAt = now, updatedAt = now
+            )
+
+            whenever(categoryCommandService.updateCategory(1L, request)).thenReturn(expectedResponse)
+
+            // when
+            val response: ResponseEntity<ApiResponse<CategoryResponse>> = controller.updateCategory(1L, request)
+
+            // then
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(expectedResponse, response.body?.data)
+            verify(categoryCommandService).updateCategory(1L, request)
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteCategory")
+    inner class DeleteCategory {
+        @Test
+        fun 카테고리_삭제_성공() {
+            // when
+            val response: ResponseEntity<Void> = controller.deleteCategory(1L)
+
+            // then
+            assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
+            verify(categoryCommandService).deleteCategory(1L)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/category/domain/CategoryTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/category/domain/CategoryTest.kt
@@ -1,0 +1,78 @@
+package com.hoppingmall.mall.category.domain
+
+import com.hoppingmall.mall.support.fixture.fixture
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("Category")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class CategoryTest {
+
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+        @Test
+        fun 루트_카테고리를_생성한다() {
+            // when
+            val category = Category.create(name = "전자제품", parentCategoryId = null, depth = 0)
+
+            // then
+            assertEquals("전자제품", category.name)
+            assertNull(category.parentCategoryId)
+            assertEquals(0, category.depth)
+        }
+
+        @Test
+        fun 하위_카테고리를_생성한다() {
+            // when
+            val category = Category.create(name = "노트북", parentCategoryId = 1L, depth = 1)
+
+            // then
+            assertEquals("노트북", category.name)
+            assertEquals(1L, category.parentCategoryId)
+            assertEquals(1, category.depth)
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    inner class Update {
+        @Test
+        fun 카테고리_이름을_변경한다() {
+            // given
+            val category = Category.fixture(name = "전자제품")
+
+            // when
+            category.update("가전제품")
+
+            // then
+            assertEquals("가전제품", category.name)
+        }
+    }
+
+    @Nested
+    @DisplayName("isRootCategory")
+    inner class IsRootCategory {
+        @Test
+        fun 루트_카테고리이면_true를_반환한다() {
+            // given
+            val category = Category.fixture(parentCategoryId = null)
+
+            // when & then
+            assertTrue(category.isRootCategory())
+        }
+
+        @Test
+        fun 하위_카테고리이면_false를_반환한다() {
+            // given
+            val category = Category.fixture(parentCategoryId = 1L, depth = 1)
+
+            // when & then
+            assertFalse(category.isRootCategory())
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/category/service/CategoryCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/category/service/CategoryCommandServiceImplTest.kt
@@ -1,0 +1,189 @@
+package com.hoppingmall.mall.category.service
+
+import com.hoppingmall.mall.category.domain.Category
+import com.hoppingmall.mall.category.domain.repository.CategoryRepository
+import com.hoppingmall.mall.category.dto.request.CategoryCreateRequest
+import com.hoppingmall.mall.category.dto.request.CategoryUpdateRequest
+import com.hoppingmall.mall.category.exception.CategoryAlreadyExistsException
+import com.hoppingmall.mall.category.exception.CategoryHasChildrenException
+import com.hoppingmall.mall.category.exception.CategoryNotFoundException
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.*
+
+@DisplayName("CategoryCommandServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class CategoryCommandServiceImplTest {
+
+    private val categoryRepository: CategoryRepository = mock()
+    private val categoryCommandService = CategoryCommandServiceImpl(categoryRepository)
+
+    @Nested
+    @DisplayName("createCategory")
+    inner class CreateCategory {
+        @Test
+        fun 루트_카테고리를_생성한다() {
+            // given
+            val request = CategoryCreateRequest(name = "전자제품")
+
+            whenever(categoryRepository.existsByName("전자제품")).thenReturn(false)
+            whenever(categoryRepository.save(any<Category>())).thenAnswer { invocation ->
+                invocation.getArgument<Category>(0).withId(1L)
+            }
+
+            // when
+            val response = categoryCommandService.createCategory(request)
+
+            // then
+            assertEquals(1L, response.id)
+            assertEquals("전자제품", response.name)
+            assertNull(response.parentCategoryId)
+            assertEquals(0, response.depth)
+        }
+
+        @Test
+        fun 하위_카테고리를_생성한다() {
+            // given
+            val request = CategoryCreateRequest(name = "노트북", parentCategoryId = 1L)
+            val parentCategory = Category.fixture(name = "전자제품").withId(1L)
+
+            whenever(categoryRepository.existsByName("노트북")).thenReturn(false)
+            whenever(categoryRepository.findNullableById(1L)).thenReturn(parentCategory)
+            whenever(categoryRepository.save(any<Category>())).thenAnswer { invocation ->
+                invocation.getArgument<Category>(0).withId(2L)
+            }
+
+            // when
+            val response = categoryCommandService.createCategory(request)
+
+            // then
+            assertEquals(2L, response.id)
+            assertEquals("노트북", response.name)
+            assertEquals(1L, response.parentCategoryId)
+            assertEquals(1, response.depth)
+        }
+
+        @Test
+        fun 이름이_중복되면_예외가_발생한다() {
+            // given
+            val request = CategoryCreateRequest(name = "전자제품")
+
+            whenever(categoryRepository.existsByName("전자제품")).thenReturn(true)
+
+            // when & then
+            assertThrows<CategoryAlreadyExistsException> {
+                categoryCommandService.createCategory(request)
+            }
+        }
+
+        @Test
+        fun 부모_카테고리가_존재하지_않으면_예외가_발생한다() {
+            // given
+            val request = CategoryCreateRequest(name = "노트북", parentCategoryId = 999L)
+
+            whenever(categoryRepository.existsByName("노트북")).thenReturn(false)
+            whenever(categoryRepository.findNullableById(999L)).thenReturn(null)
+
+            // when & then
+            assertThrows<CategoryNotFoundException> {
+                categoryCommandService.createCategory(request)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("updateCategory")
+    inner class UpdateCategory {
+        @Test
+        fun 카테고리_이름을_변경한다() {
+            // given
+            val category = Category.fixture(name = "전자제품").withId(1L)
+
+            whenever(categoryRepository.findNullableById(1L)).thenReturn(category)
+            whenever(categoryRepository.existsByNameAndIdNot("가전제품", 1L)).thenReturn(false)
+
+            // when
+            val response = categoryCommandService.updateCategory(1L, CategoryUpdateRequest(name = "가전제품"))
+
+            // then
+            assertEquals("가전제품", response.name)
+        }
+
+        @Test
+        fun 카테고리가_존재하지_않으면_예외가_발생한다() {
+            // given
+            whenever(categoryRepository.findNullableById(999L)).thenReturn(null)
+
+            // when & then
+            assertThrows<CategoryNotFoundException> {
+                categoryCommandService.updateCategory(999L, CategoryUpdateRequest(name = "가전제품"))
+            }
+        }
+
+        @Test
+        fun 변경하려는_이름이_이미_존재하면_예외가_발생한다() {
+            // given
+            val category = Category.fixture(name = "전자제품").withId(1L)
+
+            whenever(categoryRepository.findNullableById(1L)).thenReturn(category)
+            whenever(categoryRepository.existsByNameAndIdNot("의류", 1L)).thenReturn(true)
+
+            // when & then
+            assertThrows<CategoryAlreadyExistsException> {
+                categoryCommandService.updateCategory(1L, CategoryUpdateRequest(name = "의류"))
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteCategory")
+    inner class DeleteCategory {
+        @Test
+        fun 카테고리를_삭제한다() {
+            // given
+            val category = Category.fixture(name = "전자제품").withId(1L)
+
+            whenever(categoryRepository.findNullableById(1L)).thenReturn(category)
+            whenever(categoryRepository.existsByParentCategoryId(1L)).thenReturn(false)
+
+            // when
+            categoryCommandService.deleteCategory(1L)
+
+            // then
+            verify(categoryRepository).deleteById(1L)
+        }
+
+        @Test
+        fun 카테고리가_존재하지_않으면_예외가_발생한다() {
+            // given
+            whenever(categoryRepository.findNullableById(999L)).thenReturn(null)
+
+            // when & then
+            assertThrows<CategoryNotFoundException> {
+                categoryCommandService.deleteCategory(999L)
+            }
+        }
+
+        @Test
+        fun 하위_카테고리가_존재하면_예외가_발생한다() {
+            // given
+            val category = Category.fixture(name = "전자제품").withId(1L)
+
+            whenever(categoryRepository.findNullableById(1L)).thenReturn(category)
+            whenever(categoryRepository.existsByParentCategoryId(1L)).thenReturn(true)
+
+            // when & then
+            assertThrows<CategoryHasChildrenException> {
+                categoryCommandService.deleteCategory(1L)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/category/service/CategoryQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/category/service/CategoryQueryServiceImplTest.kt
@@ -1,0 +1,100 @@
+package com.hoppingmall.mall.category.service
+
+import com.hoppingmall.mall.category.domain.Category
+import com.hoppingmall.mall.category.domain.repository.CategoryRepository
+import com.hoppingmall.mall.category.exception.CategoryNotFoundException
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@DisplayName("CategoryQueryServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class CategoryQueryServiceImplTest {
+
+    private val categoryRepository: CategoryRepository = mock()
+    private val categoryQueryService = CategoryQueryServiceImpl(categoryRepository)
+
+    @Nested
+    @DisplayName("getCategory")
+    inner class GetCategory {
+        @Test
+        fun 카테고리를_조회한다() {
+            // given
+            val category = Category.fixture(name = "전자제품").withId(1L)
+
+            whenever(categoryRepository.findNullableById(1L)).thenReturn(category)
+
+            // when
+            val response = categoryQueryService.getCategory(1L)
+
+            // then
+            assertEquals(1L, response.id)
+            assertEquals("전자제품", response.name)
+        }
+
+        @Test
+        fun 카테고리가_존재하지_않으면_예외가_발생한다() {
+            // given
+            whenever(categoryRepository.findNullableById(999L)).thenReturn(null)
+
+            // when & then
+            assertThrows<CategoryNotFoundException> {
+                categoryQueryService.getCategory(999L)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getRootCategories")
+    inner class GetRootCategories {
+        @Test
+        fun 루트_카테고리_목록을_조회한다() {
+            // given
+            val categories = listOf(
+                Category.fixture(name = "전자제품").withId(1L),
+                Category.fixture(name = "의류").withId(2L)
+            )
+
+            whenever(categoryRepository.findByParentCategoryIdIsNull()).thenReturn(categories)
+
+            // when
+            val response = categoryQueryService.getRootCategories()
+
+            // then
+            assertEquals(2, response.size)
+            assertEquals("전자제품", response[0].name)
+            assertEquals("의류", response[1].name)
+        }
+    }
+
+    @Nested
+    @DisplayName("getSubCategories")
+    inner class GetSubCategories {
+        @Test
+        fun 하위_카테고리_목록을_조회한다() {
+            // given
+            val subCategories = listOf(
+                Category.fixture(name = "노트북", parentCategoryId = 1L, depth = 1).withId(2L),
+                Category.fixture(name = "스마트폰", parentCategoryId = 1L, depth = 1).withId(3L)
+            )
+
+            whenever(categoryRepository.findByParentCategoryId(1L)).thenReturn(subCategories)
+
+            // when
+            val response = categoryQueryService.getSubCategories(1L)
+
+            // then
+            assertEquals(2, response.size)
+            assertEquals("노트북", response[0].name)
+            assertEquals("스마트폰", response[1].name)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/CategoryFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/CategoryFixture.kt
@@ -1,0 +1,11 @@
+package com.hoppingmall.mall.support.fixture
+
+import com.hoppingmall.mall.category.domain.Category
+
+fun Category.Companion.fixture(
+    name: String = "전자제품",
+    parentCategoryId: Long? = null,
+    depth: Int = 0
+): Category {
+    return Category.create(name = name, parentCategoryId = parentCategoryId, depth = depth)
+}


### PR DESCRIPTION
## 📌 요약
Closes #51

- 계층 구조(대분류 > 중분류 > 소분류) 지원하는 Category 도메인 신규 구현
- CQRS 패턴 적용 (CategoryCommandService / CategoryQueryService)
- SecurityConfig에 카테고리 조회 공개, CUD는 ADMIN 권한 설정

## ✅ 변경 사항
- Category 엔티티 (parentCategoryId, depth로 계층 관리, soft delete)
- CategoryRepository (이름 중복 체크, 하위 카테고리 조회 등)
- CategoryErrorCode + 예외 클래스 3종 (NotFound, AlreadyExists, HasChildren)
- CategoryCreateRequest, CategoryUpdateRequest, CategoryResponse DTO
- CategoryCommandServiceImpl (생성/수정/삭제, 부모 검증/이름 중복/하위 존재 체크)
- CategoryQueryServiceImpl (단건 조회, 루트 목록, 하위 목록)
- CategoryController (6개 REST API 엔드포인트)

## 🧪 테스트
- CategoryTest: 엔티티 생성(루트/하위), 이름 수정, 루트 판별
- CategoryCommandServiceImplTest: 생성/수정/삭제 성공 및 예외 9케이스
- CategoryQueryServiceImplTest: 조회 성공/실패, 루트/하위 목록 4케이스
- CategoryControllerTest: 전 엔드포인트 성공 6케이스
- Jacoco 80% 커버리지 검증 통과

## 📎 참고
- Product 연동은 별도 이슈로 분리
- 기존 Inventory 도메인 패턴 참조하여 구현