### PR TITLE
feat: Product-Category 연동

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
@@ -32,7 +32,8 @@ class SecurityConfig(
                     HttpMethod.GET,
                     "/api/v1/products",
                     "/api/v1/products/{productId}",
-                    "/api/v1/products/seller/{sellerId}"
+                    "/api/v1/products/seller/{sellerId}",
+                    "/api/v1/products/category/{categoryId}"
                 ).permitAll()
                 it.requestMatchers(
                     HttpMethod.GET,

--- a/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductController.kt
@@ -43,6 +43,15 @@ class ProductController(
         return ApiResponse.success(products)
     }
 
+    @GetMapping("/category/{categoryId}")
+    fun getProductsByCategory(
+        @PathVariable categoryId: Long,
+        pageable: Pageable
+    ): ApiResponse<Page<ProductResponse>> {
+        val products = productQueryService.getProductsByCategoryId(categoryId, pageable)
+        return ApiResponse.success(products)
+    }
+
     @PostMapping
     fun createProduct(@Valid @RequestBody request: ProductCreateRequest): ApiResponse<ProductResponse> {
         val productResponse = productCommandService.createProduct(request)

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/Product.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/Product.kt
@@ -15,6 +15,9 @@ class Product private constructor(
     val sellerId: Long,
 
     @Column(nullable = false)
+    var categoryId: Long,
+
+    @Column(nullable = false)
     var name: String,
 
     @Column(columnDefinition = "TEXT")
@@ -32,12 +35,13 @@ class Product private constructor(
     companion object {
         fun create(
             sellerId: Long,
+            categoryId: Long,
             name: String,
             description: String,
             price: BigDecimal,
             status: ProductStatus
-        ): Product{
-            return Product(sellerId, name, description, price, status)
+        ): Product {
+            return Product(sellerId, categoryId, name, description, price, status)
         }
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductRepository.kt
@@ -11,5 +11,7 @@ interface ProductRepository: JpaRepository<Product, Long> {
 
     fun findBySellerId(sellerId: Long, pageable: Pageable): Page<Product>
 
+    fun findByCategoryId(categoryId: Long, pageable: Pageable): Page<Product>
+
     fun findNullableById(id: Long): Product?
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/request/ProductCreateRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/request/ProductCreateRequest.kt
@@ -9,7 +9,10 @@ import java.math.BigDecimal
 data class ProductCreateRequest(
     @field:NotNull(message = "판매자 ID는 필수입니다.")
     val sellerId: Long,
-    
+
+    @field:NotNull(message = "카테고리 ID는 필수입니다.")
+    val categoryId: Long,
+
     @field:NotBlank(message = "상품명은 필수입니다.")
     val name: String,
     

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/request/ProductUpdateRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/request/ProductUpdateRequest.kt
@@ -2,10 +2,14 @@ package com.hoppingmall.mall.product.dto.request
 
 import com.hoppingmall.mall.global.enums.ProductStatus
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Positive
 import java.math.BigDecimal
 
 data class ProductUpdateRequest(
+    @field:NotNull(message = "카테고리 ID는 필수입니다.")
+    val categoryId: Long,
+
     @field:NotBlank(message = "상품명은 필수입니다.")
     val name: String,
     

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/response/ProductWithImageResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/response/ProductWithImageResponse.kt
@@ -9,6 +9,7 @@ import java.time.LocalDateTime
 data class ProductResponse(
     val id: Long,
     val sellerId: Long,
+    val categoryId: Long,
     val name: String,
     val description: String,
     val price: BigDecimal,
@@ -22,6 +23,7 @@ data class ProductResponse(
             return ProductResponse(
                 id = product.id!!,
                 sellerId = product.sellerId,
+                categoryId = product.categoryId,
                 name = product.name,
                 description = product.description,
                 price = product.price,

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImpl.kt
@@ -1,5 +1,7 @@
 package com.hoppingmall.mall.product.service
 
+import com.hoppingmall.mall.category.domain.repository.CategoryRepository
+import com.hoppingmall.mall.category.exception.CategoryNotFoundException
 import com.hoppingmall.mall.product.domain.Product
 import com.hoppingmall.mall.product.domain.ProductImage
 import com.hoppingmall.mall.product.domain.repository.ProductImageRepository
@@ -15,7 +17,8 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 class ProductCommandServiceImpl(
     private val productRepository: ProductRepository,
-    private val productImageRepository: ProductImageRepository
+    private val productImageRepository: ProductImageRepository,
+    private val categoryRepository: CategoryRepository
 ) : ProductCommandService {
 
     companion object {
@@ -23,8 +26,13 @@ class ProductCommandServiceImpl(
     }
 
     override fun createProduct(request: ProductCreateRequest): ProductResponse {
+        if (!categoryRepository.existsById(request.categoryId)) {
+            throw CategoryNotFoundException()
+        }
+
         val product = Product.create(
             sellerId = request.sellerId,
+            categoryId = request.categoryId,
             name = request.name,
             description = request.description,
             price = request.price,
@@ -43,9 +51,14 @@ class ProductCommandServiceImpl(
     }
 
     override fun updateProduct(productId: Long, request: ProductUpdateRequest): ProductResponse {
+        if (!categoryRepository.existsById(request.categoryId)) {
+            throw CategoryNotFoundException()
+        }
+
         val product = productRepository.findById(productId)
             .orElseThrow { ProductNotFoundException() }
 
+        product.categoryId = request.categoryId
         product.name = request.name
         product.description = request.description
         product.price = request.price

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryService.kt
@@ -10,4 +10,6 @@ interface ProductQueryService {
     fun getProductById(productId: Long): ProductResponse
     
     fun getProductsBySellerId(sellerId: Long, pageable: Pageable): Page<ProductResponse>
+
+    fun getProductsByCategoryId(categoryId: Long, pageable: Pageable): Page<ProductResponse>
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImpl.kt
@@ -46,12 +46,30 @@ class ProductQueryServiceImpl(
         pageable: Pageable
     ): Page<ProductResponse> {
         val productPage = productRepository.findBySellerId(sellerId, pageable)
-        
+
         val productResponses = productPage.content.map { product ->
             val image = productImageRepository.findByProductId(product.id!!)
             ProductResponse.from(product, image)
         }
-        
+
+        return PageImpl(
+            productResponses,
+            pageable,
+            productPage.totalElements
+        )
+    }
+
+    override fun getProductsByCategoryId(
+        categoryId: Long,
+        pageable: Pageable
+    ): Page<ProductResponse> {
+        val productPage = productRepository.findByCategoryId(categoryId, pageable)
+
+        val productResponses = productPage.content.map { product ->
+            val image = productImageRepository.findByProductId(product.id!!)
+            ProductResponse.from(product, image)
+        }
+
         return PageImpl(
             productResponses,
             pageable,

--- a/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductControllerTest.kt
@@ -39,6 +39,7 @@ class ProductControllerTest {
                 ProductResponse(
                     id = 1L,
                     sellerId = 1L,
+                    categoryId = 1L,
                     name = "상품1",
                     description = "설명1",
                     price = BigDecimal("10000"),
@@ -50,6 +51,7 @@ class ProductControllerTest {
                 ProductResponse(
                     id = 2L,
                     sellerId = 2L,
+                    categoryId = 1L,
                     name = "상품2",
                     description = "설명2",
                     price = BigDecimal("20000"),
@@ -81,6 +83,7 @@ class ProductControllerTest {
             val productResponse = ProductResponse(
                 id = productId,
                 sellerId = 1L,
+                categoryId = 1L,
                 name = "상품1",
                 description = "설명1",
                 price = BigDecimal("10000"),
@@ -127,6 +130,7 @@ class ProductControllerTest {
                 ProductResponse(
                     id = 1L,
                     sellerId = sellerId,
+                    categoryId = 1L,
                     name = "상품1",
                     description = "설명1",
                     price = BigDecimal("10000"),
@@ -138,6 +142,7 @@ class ProductControllerTest {
                 ProductResponse(
                     id = 2L,
                     sellerId = sellerId,
+                    categoryId = 1L,
                     name = "상품2",
                     description = "설명2",
                     price = BigDecimal("20000"),
@@ -161,12 +166,59 @@ class ProductControllerTest {
     }
 
     @Nested
+    @DisplayName("getProductsByCategory")
+    inner class GetProductsByCategory {
+        @Test
+        fun 카테고리별_상품_목록_조회_성공() {
+            val categoryId = 1L
+            val pageable = PageRequest.of(0, 10)
+            val productResponses = listOf(
+                ProductResponse(
+                    id = 1L,
+                    sellerId = 1L,
+                    categoryId = categoryId,
+                    name = "상품1",
+                    description = "설명1",
+                    price = BigDecimal("10000"),
+                    status = ProductStatus.AVAILABLE,
+                    imageUrl = "https://example.com/image1.jpg",
+                    createdAt = LocalDateTime.now(),
+                    updatedAt = null
+                ),
+                ProductResponse(
+                    id = 2L,
+                    sellerId = 2L,
+                    categoryId = categoryId,
+                    name = "상품2",
+                    description = "설명2",
+                    price = BigDecimal("20000"),
+                    status = ProductStatus.AVAILABLE,
+                    imageUrl = "https://example.com/image2.jpg",
+                    createdAt = LocalDateTime.now(),
+                    updatedAt = null
+                )
+            )
+            val productResponsePage = PageImpl(productResponses, pageable, productResponses.size.toLong())
+
+            whenever(productQueryService.getProductsByCategoryId(eq(categoryId), any())).thenReturn(productResponsePage)
+
+            val response: ApiResponse<Page<ProductResponse>> = controller.getProductsByCategory(categoryId, pageable)
+
+            assertEquals("SUCCESS", response.code)
+            assertEquals("성공", response.message)
+            assertEquals(productResponsePage, response.data)
+            verify(productQueryService).getProductsByCategoryId(categoryId, pageable)
+        }
+    }
+
+    @Nested
     @DisplayName("createProduct")
     inner class CreateProduct {
         @Test
         fun 상품_생성_성공() {
             val request = ProductCreateRequest(
                 sellerId = 1L,
+                categoryId = 1L,
                 name = "새 상품",
                 description = "새 상품 설명",
                 price = BigDecimal("15000"),
@@ -177,6 +229,7 @@ class ProductControllerTest {
             val expectedResponse = ProductResponse(
                 id = 1L,
                 sellerId = 1L,
+                categoryId = 1L,
                 name = "새 상품",
                 description = "새 상품 설명",
                 price = BigDecimal("15000"),
@@ -204,6 +257,7 @@ class ProductControllerTest {
         fun 상품_수정_성공() {
             val productId = 1L
             val request = ProductUpdateRequest(
+                categoryId = 1L,
                 name = "수정된 상품",
                 description = "수정된 상품 설명",
                 price = BigDecimal("20000"),
@@ -214,6 +268,7 @@ class ProductControllerTest {
             val expectedResponse = ProductResponse(
                 id = productId,
                 sellerId = 1L,
+                categoryId = 1L,
                 name = "수정된 상품",
                 description = "수정된 상품 설명",
                 price = BigDecimal("20000"),
@@ -281,4 +336,4 @@ class ProductControllerTest {
             verify(productImageService).uploadProductImage(imageFile)
         }
     }
-} 
+}

--- a/src/test/kotlin/com/hoppingmall/mall/product/domain/ProductTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/domain/ProductTest.kt
@@ -19,14 +19,16 @@ class ProductTest {
         @Test
         fun 상품_생성_성공() {
             val sellerId = 1L
+            val categoryId = 1L
             val name = "테스트 상품"
             val description = "테스트 상품 설명"
             val price = BigDecimal("10000")
             val status = ProductStatus.AVAILABLE
 
-            val product = Product.create(sellerId, name, description, price, status)
+            val product = Product.create(sellerId, categoryId, name, description, price, status)
 
             assertEquals(sellerId, product.sellerId)
+            assertEquals(categoryId, product.categoryId)
             assertEquals(name, product.name)
             assertEquals(description, product.description)
             assertEquals(price, product.price)
@@ -36,11 +38,12 @@ class ProductTest {
         @Test
         fun 기본_상태로_상품_생성_성공() {
             val sellerId = 1L
+            val categoryId = 1L
             val name = "테스트 상품"
             val description = "테스트 상품 설명"
             val price = BigDecimal("10000")
 
-            val product = Product.create(sellerId, name, description, price, ProductStatus.AVAILABLE)
+            val product = Product.create(sellerId, categoryId, name, description, price, ProductStatus.AVAILABLE)
 
             assertEquals(ProductStatus.AVAILABLE, product.status)
         }
@@ -48,11 +51,12 @@ class ProductTest {
         @Test
         fun 품절_상태로_상품_생성_성공() {
             val sellerId = 1L
+            val categoryId = 1L
             val name = "테스트 상품"
             val description = "테스트 상품 설명"
             val price = BigDecimal("10000")
 
-            val product = Product.create(sellerId, name, description, price, ProductStatus.SOLD_OUT)
+            val product = Product.create(sellerId, categoryId, name, description, price, ProductStatus.SOLD_OUT)
 
             assertEquals(ProductStatus.SOLD_OUT, product.status)
         }

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImplTest.kt
@@ -1,5 +1,7 @@
 package com.hoppingmall.mall.product.service
 
+import com.hoppingmall.mall.category.domain.repository.CategoryRepository
+import com.hoppingmall.mall.category.exception.CategoryNotFoundException
 import com.hoppingmall.mall.global.enums.ProductStatus
 import com.hoppingmall.mall.product.domain.Product
 import java.math.BigDecimal
@@ -26,7 +28,8 @@ class ProductCommandServiceImplTest {
 
     private val productRepository: ProductRepository = mock()
     private val productImageRepository: ProductImageRepository = mock()
-    private val productCommandService = ProductCommandServiceImpl(productRepository, productImageRepository)
+    private val categoryRepository: CategoryRepository = mock()
+    private val productCommandService = ProductCommandServiceImpl(productRepository, productImageRepository, categoryRepository)
 
     @Nested
     @DisplayName("createProduct")
@@ -36,17 +39,19 @@ class ProductCommandServiceImplTest {
             // Data
             val request = ProductCreateRequest(
                 sellerId = 1L,
+                categoryId = 1L,
                 name = "테스트 상품",
                 description = "테스트 상품 설명",
                 price = BigDecimal("10000"),
                 imageUrl = "https://example.com/image.jpg",
                 status = ProductStatus.AVAILABLE
             )
-            
+
             val productCaptor = argumentCaptor<Product>()
             val imageCaptor = argumentCaptor<ProductImage>()
 
             // Context
+            whenever(categoryRepository.existsById(request.categoryId)).thenReturn(true)
             whenever(productRepository.save(productCaptor.capture())).thenAnswer {
                 productCaptor.firstValue.withId(1L)
             }
@@ -60,20 +65,23 @@ class ProductCommandServiceImplTest {
             // Assertions
             assertThat(result).isNotNull()
             assertThat(result.id).isEqualTo(1L)
+            assertThat(result.categoryId).isEqualTo(request.categoryId)
             assertThat(result.name).isEqualTo(request.name)
             assertThat(result.description).isEqualTo(request.description)
             assertThat(result.price).isEqualTo(request.price)
             assertThat(result.status).isEqualTo(request.status)
             assertThat(result.imageUrl).isEqualTo(request.imageUrl)
-            
+
             // 저장된 객체 검증
             val savedProduct = productCaptor.firstValue
             assertThat(savedProduct.name).isEqualTo(request.name)
             assertThat(savedProduct.sellerId).isEqualTo(request.sellerId)
-            
+            assertThat(savedProduct.categoryId).isEqualTo(request.categoryId)
+
             val savedImage = imageCaptor.firstValue
             assertThat(savedImage.imageUrl).isEqualTo(request.imageUrl)
-            
+
+            verify(categoryRepository).existsById(request.categoryId)
             verify(productRepository).save(any())
             verify(productImageRepository).save(any())
         }
@@ -83,17 +91,19 @@ class ProductCommandServiceImplTest {
             // Data
             val request = ProductCreateRequest(
                 sellerId = 1L,
+                categoryId = 1L,
                 name = "테스트 상품",
                 description = "테스트 상품 설명",
                 price = BigDecimal("10000"),
                 imageUrl = null,
                 status = ProductStatus.AVAILABLE
             )
-            
+
             val productCaptor = argumentCaptor<Product>()
             val imageCaptor = argumentCaptor<ProductImage>()
 
             // Context
+            whenever(categoryRepository.existsById(request.categoryId)).thenReturn(true)
             whenever(productRepository.save(productCaptor.capture())).thenAnswer {
                 productCaptor.firstValue.withId(1L)
             }
@@ -109,17 +119,41 @@ class ProductCommandServiceImplTest {
             assertThat(result.id).isEqualTo(1L)
             assertThat(result.name).isEqualTo(request.name)
             assertThat(result.imageUrl).isEqualTo("D:/hoppingmall/product/images/default-product.jpg")
-            
+
             // 저장된 객체 검증
             val savedProduct = productCaptor.firstValue
             assertThat(savedProduct.name).isEqualTo(request.name)
             assertThat(savedProduct.sellerId).isEqualTo(request.sellerId)
-            
+
             val savedImage = imageCaptor.firstValue
             assertThat(savedImage.imageUrl).isEqualTo("D:/hoppingmall/product/images/default-product.jpg")
-            
+
+            verify(categoryRepository).existsById(request.categoryId)
             verify(productRepository).save(any())
             verify(productImageRepository).save(any())
+        }
+
+        @Test
+        fun 존재하지_않는_카테고리로_상품_생성_시_예외_발생() {
+            // Data
+            val request = ProductCreateRequest(
+                sellerId = 1L,
+                categoryId = 999L,
+                name = "테스트 상품",
+                description = "테스트 상품 설명",
+                price = BigDecimal("10000"),
+                status = ProductStatus.AVAILABLE
+            )
+
+            // Context
+            whenever(categoryRepository.existsById(request.categoryId)).thenReturn(false)
+
+            // Interaction & Assertions
+            assertThatThrownBy { productCommandService.createProduct(request) }
+                .isInstanceOf(CategoryNotFoundException::class.java)
+
+            verify(categoryRepository).existsById(request.categoryId)
+            verify(productRepository, never()).save(any())
         }
     }
 
@@ -131,19 +165,21 @@ class ProductCommandServiceImplTest {
             // Data
             val productId = 1L
             val request = ProductUpdateRequest(
+                categoryId = 2L,
                 name = "수정된 상품명",
                 description = "수정된 상품 설명",
                 price = BigDecimal("20000"),
                 imageUrl = "https://example.com/updated-image.jpg",
                 status = ProductStatus.SOLD_OUT
             )
-            
+
             val existingProduct = Product.fixture().withId(productId)
             val productCaptor = argumentCaptor<Product>()
             val imageCaptor = argumentCaptor<ProductImage>()
-            
+
             val existingImage = ProductImage.fixture(productId = productId)
             // Context
+            whenever(categoryRepository.existsById(request.categoryId)).thenReturn(true)
             whenever(productRepository.findById(productId)).thenReturn(java.util.Optional.of(existingProduct))
             whenever(productRepository.save(productCaptor.capture())).thenAnswer {
                 productCaptor.firstValue.withId(productId)
@@ -159,12 +195,14 @@ class ProductCommandServiceImplTest {
             // Assertions
             assertThat(result).isNotNull()
             assertThat(result.id).isEqualTo(productId)
+            assertThat(result.categoryId).isEqualTo(request.categoryId)
             assertThat(result.name).isEqualTo(request.name)
             assertThat(result.description).isEqualTo(request.description)
             assertThat(result.price).isEqualTo(request.price)
             assertThat(result.status).isEqualTo(request.status)
             assertThat(result.imageUrl).isEqualTo(request.imageUrl)
-            
+
+            verify(categoryRepository).existsById(request.categoryId)
             verify(productRepository).findById(productId)
             verify(productRepository).save(any())
             verify(productImageRepository).findByProductId(productId)
@@ -176,6 +214,7 @@ class ProductCommandServiceImplTest {
             // Data
             val productId = 999L
             val request = ProductUpdateRequest(
+                categoryId = 1L,
                 name = "수정된 상품명",
                 description = "수정된 상품 설명",
                 price = BigDecimal("20000"),
@@ -184,15 +223,39 @@ class ProductCommandServiceImplTest {
             )
 
             // Context
+            whenever(categoryRepository.existsById(request.categoryId)).thenReturn(true)
             whenever(productRepository.findById(productId)).thenReturn(java.util.Optional.empty())
 
             // Interaction & Assertions
             assertThatThrownBy { productCommandService.updateProduct(productId, request) }
                 .isInstanceOf(ProductNotFoundException::class.java)
-            
+
             verify(productRepository).findById(productId)
             verify(productImageRepository, never()).findByProductId(any())
             verify(productImageRepository, never()).save(any())
+        }
+
+        @Test
+        fun 존재하지_않는_카테고리로_상품_수정_시_예외_발생() {
+            // Data
+            val productId = 1L
+            val request = ProductUpdateRequest(
+                categoryId = 999L,
+                name = "수정된 상품명",
+                description = "수정된 상품 설명",
+                price = BigDecimal("20000"),
+                status = ProductStatus.AVAILABLE
+            )
+
+            // Context
+            whenever(categoryRepository.existsById(request.categoryId)).thenReturn(false)
+
+            // Interaction & Assertions
+            assertThatThrownBy { productCommandService.updateProduct(productId, request) }
+                .isInstanceOf(CategoryNotFoundException::class.java)
+
+            verify(categoryRepository).existsById(request.categoryId)
+            verify(productRepository, never()).findById(any())
         }
 
         @Test
@@ -200,19 +263,20 @@ class ProductCommandServiceImplTest {
             // Data
             val productId = 1L
             val request = ProductUpdateRequest(
+                categoryId = 1L,
                 name = "수정된 상품명",
                 description = "수정된 상품 설명",
                 price = BigDecimal("20000"),
                 imageUrl = "https://example.com/new-image.jpg",
                 status = ProductStatus.AVAILABLE
             )
-            
+
             val existingProduct = Product.fixture().withId(productId)
             val productCaptor = argumentCaptor<Product>()
             val imageCaptor = argumentCaptor<ProductImage>()
-            
 
             // Context
+            whenever(categoryRepository.existsById(request.categoryId)).thenReturn(true)
             whenever(productRepository.findById(productId)).thenReturn(java.util.Optional.of(existingProduct))
             whenever(productRepository.save(productCaptor.capture())).thenAnswer {
                 productCaptor.firstValue.withId(productId)
@@ -230,7 +294,7 @@ class ProductCommandServiceImplTest {
             assertThat(result.id).isEqualTo(productId)
             assertThat(result.name).isEqualTo(request.name)
             assertThat(result.imageUrl).isEqualTo(request.imageUrl)
-            
+
             verify(productRepository).findById(productId)
             verify(productRepository).save(any())
             verify(productImageRepository).findByProductId(productId)
@@ -242,19 +306,20 @@ class ProductCommandServiceImplTest {
             // Data
             val productId = 1L
             val request = ProductUpdateRequest(
+                categoryId = 1L,
                 name = "수정된 상품명",
                 description = "수정된 상품 설명",
                 price = BigDecimal("20000"),
                 imageUrl = null,
                 status = ProductStatus.AVAILABLE
             )
-            
+
             val existingProduct = Product.fixture().withId(productId)
             val productCaptor = argumentCaptor<Product>()
             val imageCaptor = argumentCaptor<ProductImage>()
-            
 
             // Context
+            whenever(categoryRepository.existsById(request.categoryId)).thenReturn(true)
             whenever(productRepository.findById(productId)).thenReturn(java.util.Optional.of(existingProduct))
             whenever(productRepository.save(productCaptor.capture())).thenAnswer {
                 productCaptor.firstValue.withId(productId)
@@ -272,7 +337,7 @@ class ProductCommandServiceImplTest {
             assertThat(result.id).isEqualTo(productId)
             assertThat(result.name).isEqualTo(request.name)
             assertThat(result.imageUrl).isEqualTo("D:/hoppingmall/product/images/default-product.jpg")
-            
+
             verify(productRepository).findById(productId)
             verify(productRepository).save(any())
             verify(productImageRepository).findByProductId(productId)

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImplTest.kt
@@ -36,8 +36,8 @@ class ProductQueryServiceImplTest {
         fun 상품_목록_조회_성공() {
             val pageable = PageRequest.of(0, 10)
             val products = listOf(
-                Product.create(1L, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(1L),
-                Product.create(2L, "상품2", "설명2", BigDecimal("20000"), ProductStatus.AVAILABLE).withId(2L)
+                Product.create(1L, 1L, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(1L),
+                Product.create(2L, 1L, "상품2", "설명2", BigDecimal("20000"), ProductStatus.AVAILABLE).withId(2L)
             )
             val productPage = PageImpl(products, pageable, products.size.toLong())
 
@@ -62,7 +62,7 @@ class ProductQueryServiceImplTest {
         @Test
         fun 상품_상세_조회_성공() {
             val productId = 1L
-            val product = Product.create(1L, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(productId)
+            val product = Product.create(1L, 1L, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(productId)
             val image = ProductImage.create(productId, "https://example.com/image.jpg")
 
             whenever(productRepository.findNullableById(productId)).thenReturn(product)
@@ -93,7 +93,7 @@ class ProductQueryServiceImplTest {
         @Test
         fun 이미지가_없는_상품_조회_성공() {
             val productId = 1L
-            val product = Product.create(1L, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(productId)
+            val product = Product.create(1L, 1L, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(productId)
 
             whenever(productRepository.findNullableById(productId)).thenReturn(product)
             whenever(productImageRepository.findByProductId(productId)).thenReturn(null)
@@ -116,8 +116,8 @@ class ProductQueryServiceImplTest {
             val sellerId = 1L
             val pageable = PageRequest.of(0, 10)
             val products = listOf(
-                Product.create(sellerId, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(1L),
-                Product.create(sellerId, "상품2", "설명2", BigDecimal("20000"), ProductStatus.AVAILABLE).withId(2L)
+                Product.create(sellerId, 1L, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(1L),
+                Product.create(sellerId, 1L, "상품2", "설명2", BigDecimal("20000"), ProductStatus.AVAILABLE).withId(2L)
             )
             val productPage = PageImpl(products, pageable, products.size.toLong())
 
@@ -135,6 +135,36 @@ class ProductQueryServiceImplTest {
             assertEquals("상품2", result.content[1].name)
             assertEquals("https://example.com/image2.jpg", result.content[1].imageUrl)
             verify(productRepository).findBySellerId(sellerId, pageable)
+        }
+    }
+
+    @Nested
+    @DisplayName("getProductsByCategoryId")
+    inner class GetProductsByCategoryId {
+        @Test
+        fun 카테고리별_상품_목록_조회_성공() {
+            val categoryId = 1L
+            val pageable = PageRequest.of(0, 10)
+            val products = listOf(
+                Product.create(1L, categoryId, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(1L),
+                Product.create(2L, categoryId, "상품2", "설명2", BigDecimal("20000"), ProductStatus.AVAILABLE).withId(2L)
+            )
+            val productPage = PageImpl(products, pageable, products.size.toLong())
+
+            whenever(productRepository.findByCategoryId(categoryId, pageable)).thenReturn(productPage)
+            whenever(productImageRepository.findByProductId(1L)).thenReturn(ProductImage.create(1L, "https://example.com/image1.jpg"))
+            whenever(productImageRepository.findByProductId(2L)).thenReturn(ProductImage.create(2L, "https://example.com/image2.jpg"))
+
+            val result = productQueryService.getProductsByCategoryId(categoryId, pageable)
+
+            assertEquals(2, result.content.size)
+            assertEquals(categoryId, result.content[0].categoryId)
+            assertEquals("상품1", result.content[0].name)
+            assertEquals("https://example.com/image1.jpg", result.content[0].imageUrl)
+            assertEquals(categoryId, result.content[1].categoryId)
+            assertEquals("상품2", result.content[1].name)
+            assertEquals("https://example.com/image2.jpg", result.content[1].imageUrl)
+            verify(productRepository).findByCategoryId(categoryId, pageable)
         }
     }
 } 

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/ProductFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/ProductFixture.kt
@@ -6,10 +6,11 @@ import java.math.BigDecimal
 
 fun Product.Companion.fixture(
     sellerId: Long = 1L,
+    categoryId: Long = 1L,
     name: String = "테스트 상품",
     description: String = "테스트 상품 설명",
     price: BigDecimal = BigDecimal("10000"),
     status: ProductStatus = ProductStatus.AVAILABLE
 ): Product {
-    return Product.create(sellerId, name, description, price, status)
+    return Product.create(sellerId, categoryId, name, description, price, status)
 } 


### PR DESCRIPTION
## 📌 관련 이슈
Closes #53

## ✅ 작업 내용
- Product 엔티티에 `categoryId` 필드 추가 (not null)
- ProductCreateRequest, ProductUpdateRequest, ProductResponse에 `categoryId` 반영
- 상품 생성/수정 시 카테고리 존재 여부 검증 (CategoryNotFoundException)
- `GET /api/v1/products/category/{categoryId}` 카테고리별 상품 조회 API 추가
- SecurityConfig에 해당 엔드포인트 permitAll 설정

## 🧪 테스트
- ProductTest: `Product.create()` categoryId 검증 추가
- ProductCommandServiceImplTest: 카테고리 미존재 시 예외 테스트 추가
- ProductQueryServiceImplTest: 카테고리별 조회 테스트 추가
- ProductControllerTest: 카테고리별 조회 엔드포인트 테스트 추가
- `./gradlew test` 전체 통과
- `./gradlew jacocoTestVerification` 커버리지 80% 이상 확인

## 📎 참고 사항
- Category 도메인은 #52 에서 구현 완료
- Product → Category는 ID 참조 방식 (JPA 연관관계 없음)