### PR TITLE
feat: Membership 등급 시스템 구현

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
@@ -51,6 +51,7 @@ class SecurityConfig(
                 it.requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                 it.requestMatchers("/api/v1/point-policies/**").hasRole("ADMIN")
                 it.requestMatchers("/api/v1/categories/**").hasRole("ADMIN")
+                it.requestMatchers(HttpMethod.GET, "/api/v1/memberships/users/{userId}").hasRole("ADMIN")
 
                 it.requestMatchers(
                     HttpMethod.POST,

--- a/src/main/kotlin/com/hoppingmall/mall/membership/controller/MembershipController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/controller/MembershipController.kt
@@ -1,0 +1,44 @@
+package com.hoppingmall.mall.membership.controller
+
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.membership.dto.response.MembershipResponse
+import com.hoppingmall.mall.membership.service.MembershipCommandService
+import com.hoppingmall.mall.membership.service.MembershipQueryService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/memberships")
+class MembershipController(
+    private val membershipCommandService: MembershipCommandService,
+    private val membershipQueryService: MembershipQueryService
+) {
+
+    @PostMapping
+    fun createMembership(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ): ResponseEntity<ApiResponse<MembershipResponse>> {
+        val response = membershipCommandService.createMembership(userPrincipal.getUserId())
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.success(response))
+    }
+
+    @GetMapping("/me")
+    fun getMyMembership(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ): ResponseEntity<ApiResponse<MembershipResponse>> {
+        val response = membershipQueryService.getMembershipByUserId(userPrincipal.getUserId())
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @GetMapping("/users/{userId}")
+    fun getMembershipByUserId(
+        @PathVariable userId: Long
+    ): ResponseEntity<ApiResponse<MembershipResponse>> {
+        val response = membershipQueryService.getMembershipByUserId(userId)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/membership/domain/Membership.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/domain/Membership.kt
@@ -1,0 +1,40 @@
+package com.hoppingmall.mall.membership.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import com.hoppingmall.mall.membership.enum.MembershipGrade
+import jakarta.persistence.*
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "memberships")
+class Membership(
+    @Column(nullable = false, unique = true)
+    val userId: Long,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var grade: MembershipGrade = MembershipGrade.BRONZE,
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    var totalSpent: BigDecimal = BigDecimal.ZERO
+) : BaseEntity() {
+
+    companion object {
+        fun create(userId: Long): Membership {
+            return Membership(userId = userId)
+        }
+    }
+
+    fun addPurchaseAmount(amount: BigDecimal) {
+        require(amount > BigDecimal.ZERO) { "구매 금액은 0보다 커야 합니다" }
+        this.totalSpent = this.totalSpent.add(amount)
+        upgradeGradeIfEligible()
+    }
+
+    fun upgradeGradeIfEligible() {
+        val newGrade = MembershipGrade.fromTotalSpent(totalSpent)
+        if (newGrade.ordinal > this.grade.ordinal) {
+            this.grade = newGrade
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/membership/domain/repository/MembershipRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/domain/repository/MembershipRepository.kt
@@ -1,0 +1,11 @@
+package com.hoppingmall.mall.membership.domain.repository
+
+import com.hoppingmall.mall.membership.domain.Membership
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MembershipRepository : JpaRepository<Membership, Long> {
+    fun findByUserId(userId: Long): Membership?
+    fun existsByUserId(userId: Long): Boolean
+}

--- a/src/main/kotlin/com/hoppingmall/mall/membership/dto/response/MembershipResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/dto/response/MembershipResponse.kt
@@ -1,0 +1,43 @@
+package com.hoppingmall.mall.membership.dto.response
+
+import com.hoppingmall.mall.membership.domain.Membership
+import com.hoppingmall.mall.membership.enum.MembershipGrade
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+data class MembershipResponse(
+    val id: Long,
+    val userId: Long,
+    val grade: MembershipGrade,
+    val gradeName: String,
+    val totalSpent: BigDecimal,
+    val pointEarningRate: BigDecimal,
+    val discountRate: BigDecimal,
+    val nextGrade: MembershipGrade?,
+    val amountToNextGrade: BigDecimal?,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime?
+) {
+    companion object {
+        fun from(membership: Membership): MembershipResponse {
+            val nextGrade = membership.grade.nextGrade()
+            val amountToNextGrade = nextGrade?.let {
+                it.requiredAmount.subtract(membership.totalSpent).coerceAtLeast(BigDecimal.ZERO)
+            }
+
+            return MembershipResponse(
+                id = membership.id!!,
+                userId = membership.userId,
+                grade = membership.grade,
+                gradeName = membership.grade.gradeName,
+                totalSpent = membership.totalSpent,
+                pointEarningRate = membership.grade.pointEarningRate,
+                discountRate = membership.grade.discountRate,
+                nextGrade = nextGrade,
+                amountToNextGrade = amountToNextGrade,
+                createdAt = membership.createdAt,
+                updatedAt = membership.updatedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/membership/enum/MembershipGrade.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/enum/MembershipGrade.kt
@@ -1,0 +1,28 @@
+package com.hoppingmall.mall.membership.enum
+
+import java.math.BigDecimal
+
+enum class MembershipGrade(
+    val gradeName: String,
+    val requiredAmount: BigDecimal,
+    val pointEarningRate: BigDecimal,
+    val discountRate: BigDecimal
+) {
+    BRONZE("브론즈", BigDecimal.ZERO, BigDecimal("0.01"), BigDecimal.ZERO),
+    SILVER("실버", BigDecimal("100000"), BigDecimal("0.02"), BigDecimal("0.01")),
+    GOLD("골드", BigDecimal("500000"), BigDecimal("0.03"), BigDecimal("0.02")),
+    PLATINUM("플래티넘", BigDecimal("1000000"), BigDecimal("0.05"), BigDecimal("0.03")),
+    DIAMOND("다이아몬드", BigDecimal("5000000"), BigDecimal("0.07"), BigDecimal("0.05"));
+
+    fun nextGrade(): MembershipGrade? {
+        val grades = entries
+        val currentIndex = grades.indexOf(this)
+        return if (currentIndex < grades.size - 1) grades[currentIndex + 1] else null
+    }
+
+    companion object {
+        fun fromTotalSpent(totalSpent: BigDecimal): MembershipGrade {
+            return entries.reversed().first { totalSpent >= it.requiredAmount }
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/membership/exception/MembershipAlreadyExistsException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/exception/MembershipAlreadyExistsException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.membership.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.membership.exception.code.MembershipErrorCode
+
+class MembershipAlreadyExistsException : BusinessException(MembershipErrorCode.MEMBERSHIP_ALREADY_EXISTS)

--- a/src/main/kotlin/com/hoppingmall/mall/membership/exception/MembershipNotFoundException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/exception/MembershipNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.membership.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.membership.exception.code.MembershipErrorCode
+
+class MembershipNotFoundException : BusinessException(MembershipErrorCode.MEMBERSHIP_NOT_FOUND)

--- a/src/main/kotlin/com/hoppingmall/mall/membership/exception/code/MembershipErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/exception/code/MembershipErrorCode.kt
@@ -1,0 +1,21 @@
+package com.hoppingmall.mall.membership.exception.code
+
+import com.hoppingmall.mall.global.common.error.code.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class MembershipErrorCode(
+    override val code: String,
+    override val message: String,
+    override val status: HttpStatus
+) : ErrorCode {
+    MEMBERSHIP_NOT_FOUND(
+        code = "MEMBERSHIP_NOT_FOUND",
+        message = "멤버십 정보를 찾을 수 없습니다",
+        status = HttpStatus.NOT_FOUND
+    ),
+    MEMBERSHIP_ALREADY_EXISTS(
+        code = "MEMBERSHIP_ALREADY_EXISTS",
+        message = "이미 멤버십이 존재합니다",
+        status = HttpStatus.CONFLICT
+    )
+}

--- a/src/main/kotlin/com/hoppingmall/mall/membership/service/MembershipCommandService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/service/MembershipCommandService.kt
@@ -1,0 +1,9 @@
+package com.hoppingmall.mall.membership.service
+
+import com.hoppingmall.mall.membership.dto.response.MembershipResponse
+import java.math.BigDecimal
+
+interface MembershipCommandService {
+    fun createMembership(userId: Long): MembershipResponse
+    fun addPurchaseAmount(userId: Long, amount: BigDecimal): MembershipResponse
+}

--- a/src/main/kotlin/com/hoppingmall/mall/membership/service/MembershipCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/service/MembershipCommandServiceImpl.kt
@@ -1,0 +1,33 @@
+package com.hoppingmall.mall.membership.service
+
+import com.hoppingmall.mall.membership.domain.Membership
+import com.hoppingmall.mall.membership.domain.repository.MembershipRepository
+import com.hoppingmall.mall.membership.dto.response.MembershipResponse
+import com.hoppingmall.mall.membership.exception.MembershipAlreadyExistsException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@Service
+@Transactional
+class MembershipCommandServiceImpl(
+    private val membershipRepository: MembershipRepository
+) : MembershipCommandService {
+
+    override fun createMembership(userId: Long): MembershipResponse {
+        if (membershipRepository.existsByUserId(userId)) {
+            throw MembershipAlreadyExistsException()
+        }
+        val membership = Membership.create(userId)
+        val saved = membershipRepository.save(membership)
+        return MembershipResponse.from(saved)
+    }
+
+    override fun addPurchaseAmount(userId: Long, amount: BigDecimal): MembershipResponse {
+        val membership = membershipRepository.findByUserId(userId)
+            ?: membershipRepository.save(Membership.create(userId))
+        membership.addPurchaseAmount(amount)
+        val saved = membershipRepository.save(membership)
+        return MembershipResponse.from(saved)
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/membership/service/MembershipQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/service/MembershipQueryService.kt
@@ -1,0 +1,7 @@
+package com.hoppingmall.mall.membership.service
+
+import com.hoppingmall.mall.membership.dto.response.MembershipResponse
+
+interface MembershipQueryService {
+    fun getMembershipByUserId(userId: Long): MembershipResponse
+}

--- a/src/main/kotlin/com/hoppingmall/mall/membership/service/MembershipQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/service/MembershipQueryServiceImpl.kt
@@ -1,0 +1,20 @@
+package com.hoppingmall.mall.membership.service
+
+import com.hoppingmall.mall.membership.domain.repository.MembershipRepository
+import com.hoppingmall.mall.membership.dto.response.MembershipResponse
+import com.hoppingmall.mall.membership.exception.MembershipNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class MembershipQueryServiceImpl(
+    private val membershipRepository: MembershipRepository
+) : MembershipQueryService {
+
+    override fun getMembershipByUserId(userId: Long): MembershipResponse {
+        val membership = membershipRepository.findByUserId(userId)
+            ?: throw MembershipNotFoundException()
+        return MembershipResponse.from(membership)
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/membership/controller/MembershipControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/membership/controller/MembershipControllerTest.kt
@@ -1,0 +1,102 @@
+package com.hoppingmall.mall.membership.controller
+
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.membership.dto.response.MembershipResponse
+import com.hoppingmall.mall.membership.enum.MembershipGrade
+import com.hoppingmall.mall.membership.service.MembershipCommandService
+import com.hoppingmall.mall.membership.service.MembershipQueryService
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.mockito.kotlin.*
+import org.springframework.http.ResponseEntity
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@DisplayName("MembershipController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class MembershipControllerTest {
+
+    private val membershipCommandService: MembershipCommandService = mock()
+    private val membershipQueryService: MembershipQueryService = mock()
+    private val controller = MembershipController(membershipCommandService, membershipQueryService)
+
+    private val now = LocalDateTime.now()
+
+    private fun createMembershipResponse(
+        userId: Long = 1L,
+        grade: MembershipGrade = MembershipGrade.BRONZE,
+        totalSpent: BigDecimal = BigDecimal.ZERO
+    ) = MembershipResponse(
+        id = 1L,
+        userId = userId,
+        grade = grade,
+        gradeName = grade.gradeName,
+        totalSpent = totalSpent,
+        pointEarningRate = grade.pointEarningRate,
+        discountRate = grade.discountRate,
+        nextGrade = grade.nextGrade(),
+        amountToNextGrade = grade.nextGrade()?.requiredAmount?.subtract(totalSpent)?.coerceAtLeast(BigDecimal.ZERO),
+        createdAt = now,
+        updatedAt = null
+    )
+
+    @Nested
+    @DisplayName("createMembership")
+    inner class CreateMembership {
+        @Test
+        fun 멤버십_생성_성공() {
+            val userPrincipal = UserPrincipal(1L, "test@example.com", "BUYER")
+            val expectedResponse = createMembershipResponse()
+
+            whenever(membershipCommandService.createMembership(userPrincipal.getUserId())).thenReturn(expectedResponse)
+
+            val response: ResponseEntity<ApiResponse<MembershipResponse>> = controller.createMembership(userPrincipal)
+
+            assertEquals(201, response.statusCode.value())
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals("성공", response.body?.message)
+            assertEquals(expectedResponse, response.body?.data)
+            verify(membershipCommandService).createMembership(userPrincipal.getUserId())
+        }
+    }
+
+    @Nested
+    @DisplayName("getMyMembership")
+    inner class GetMyMembership {
+        @Test
+        fun 본인_멤버십_조회_성공() {
+            val userPrincipal = UserPrincipal(1L, "test@example.com", "BUYER")
+            val expectedResponse = createMembershipResponse(grade = MembershipGrade.SILVER, totalSpent = BigDecimal("150000"))
+
+            whenever(membershipQueryService.getMembershipByUserId(userPrincipal.getUserId())).thenReturn(expectedResponse)
+
+            val response: ResponseEntity<ApiResponse<MembershipResponse>> = controller.getMyMembership(userPrincipal)
+
+            assertEquals(200, response.statusCode.value())
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(expectedResponse, response.body?.data)
+            verify(membershipQueryService).getMembershipByUserId(userPrincipal.getUserId())
+        }
+    }
+
+    @Nested
+    @DisplayName("getMembershipByUserId")
+    inner class GetMembershipByUserId {
+        @Test
+        fun 관리자_멤버십_조회_성공() {
+            val userId = 2L
+            val expectedResponse = createMembershipResponse(userId = userId, grade = MembershipGrade.GOLD, totalSpent = BigDecimal("600000"))
+
+            whenever(membershipQueryService.getMembershipByUserId(userId)).thenReturn(expectedResponse)
+
+            val response: ResponseEntity<ApiResponse<MembershipResponse>> = controller.getMembershipByUserId(userId)
+
+            assertEquals(200, response.statusCode.value())
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(expectedResponse, response.body?.data)
+            verify(membershipQueryService).getMembershipByUserId(userId)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/membership/domain/MembershipTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/membership/domain/MembershipTest.kt
@@ -1,0 +1,122 @@
+package com.hoppingmall.mall.membership.domain
+
+import com.hoppingmall.mall.membership.enum.MembershipGrade
+import com.hoppingmall.mall.support.fixture.fixture
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("Membership")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class MembershipTest {
+
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+        @Test
+        fun 멤버십_생성_성공() {
+            val membership = Membership.create(userId = 1L)
+
+            assertEquals(1L, membership.userId)
+            assertEquals(MembershipGrade.BRONZE, membership.grade)
+            assertEquals(BigDecimal.ZERO, membership.totalSpent)
+        }
+    }
+
+    @Nested
+    @DisplayName("addPurchaseAmount")
+    inner class AddPurchaseAmount {
+        @Test
+        fun 구매_금액_추가_성공() {
+            val membership = Membership.Companion.fixture()
+
+            membership.addPurchaseAmount(BigDecimal("50000"))
+
+            assertEquals(BigDecimal("50000"), membership.totalSpent)
+        }
+
+        @Test
+        fun 구매_금액_누적_성공() {
+            val membership = Membership.Companion.fixture(totalSpent = BigDecimal("50000"))
+
+            membership.addPurchaseAmount(BigDecimal("30000"))
+
+            assertEquals(BigDecimal("80000"), membership.totalSpent)
+        }
+
+        @Test
+        fun 음수_금액_추가_시_예외_발생() {
+            val membership = Membership.Companion.fixture()
+
+            assertThrows(IllegalArgumentException::class.java) {
+                membership.addPurchaseAmount(BigDecimal("-1000"))
+            }
+        }
+
+        @Test
+        fun 영_금액_추가_시_예외_발생() {
+            val membership = Membership.Companion.fixture()
+
+            assertThrows(IllegalArgumentException::class.java) {
+                membership.addPurchaseAmount(BigDecimal.ZERO)
+            }
+        }
+
+        @Test
+        fun 구매_금액_추가_시_자동_등급_승급() {
+            val membership = Membership.Companion.fixture()
+
+            membership.addPurchaseAmount(BigDecimal("100000"))
+
+            assertEquals(MembershipGrade.SILVER, membership.grade)
+            assertEquals(BigDecimal("100000"), membership.totalSpent)
+        }
+
+        @Test
+        fun BRONZE에서_GOLD로_한번에_승급() {
+            val membership = Membership.Companion.fixture()
+
+            membership.addPurchaseAmount(BigDecimal("500000"))
+
+            assertEquals(MembershipGrade.GOLD, membership.grade)
+        }
+    }
+
+    @Nested
+    @DisplayName("upgradeGradeIfEligible")
+    inner class UpgradeGradeIfEligible {
+        @Test
+        fun 등급_조건_미충족_시_유지() {
+            val membership = Membership.Companion.fixture(totalSpent = BigDecimal("50000"))
+
+            membership.upgradeGradeIfEligible()
+
+            assertEquals(MembershipGrade.BRONZE, membership.grade)
+        }
+
+        @Test
+        fun 등급_조건_충족_시_승급() {
+            val membership = Membership.Companion.fixture(totalSpent = BigDecimal("100000"))
+
+            membership.upgradeGradeIfEligible()
+
+            assertEquals(MembershipGrade.SILVER, membership.grade)
+        }
+
+        @Test
+        fun 이미_높은_등급이면_강등되지_않음() {
+            val membership = Membership.Companion.fixture(
+                grade = MembershipGrade.GOLD,
+                totalSpent = BigDecimal("100000")
+            )
+
+            membership.upgradeGradeIfEligible()
+
+            assertEquals(MembershipGrade.GOLD, membership.grade)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/membership/enum/MembershipGradeTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/membership/enum/MembershipGradeTest.kt
@@ -1,0 +1,123 @@
+package com.hoppingmall.mall.membership.enum
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("MembershipGrade")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class MembershipGradeTest {
+
+    @Nested
+    @DisplayName("fromTotalSpent")
+    inner class FromTotalSpent {
+        @Test
+        fun 누적_금액_0원이면_BRONZE() {
+            val grade = MembershipGrade.fromTotalSpent(BigDecimal.ZERO)
+            assertEquals(MembershipGrade.BRONZE, grade)
+        }
+
+        @Test
+        fun 누적_금액_99999원이면_BRONZE() {
+            val grade = MembershipGrade.fromTotalSpent(BigDecimal("99999"))
+            assertEquals(MembershipGrade.BRONZE, grade)
+        }
+
+        @Test
+        fun 누적_금액_100000원이면_SILVER() {
+            val grade = MembershipGrade.fromTotalSpent(BigDecimal("100000"))
+            assertEquals(MembershipGrade.SILVER, grade)
+        }
+
+        @Test
+        fun 누적_금액_499999원이면_SILVER() {
+            val grade = MembershipGrade.fromTotalSpent(BigDecimal("499999"))
+            assertEquals(MembershipGrade.SILVER, grade)
+        }
+
+        @Test
+        fun 누적_금액_500000원이면_GOLD() {
+            val grade = MembershipGrade.fromTotalSpent(BigDecimal("500000"))
+            assertEquals(MembershipGrade.GOLD, grade)
+        }
+
+        @Test
+        fun 누적_금액_1000000원이면_PLATINUM() {
+            val grade = MembershipGrade.fromTotalSpent(BigDecimal("1000000"))
+            assertEquals(MembershipGrade.PLATINUM, grade)
+        }
+
+        @Test
+        fun 누적_금액_5000000원이면_DIAMOND() {
+            val grade = MembershipGrade.fromTotalSpent(BigDecimal("5000000"))
+            assertEquals(MembershipGrade.DIAMOND, grade)
+        }
+
+        @Test
+        fun 누적_금액_10000000원이면_DIAMOND() {
+            val grade = MembershipGrade.fromTotalSpent(BigDecimal("10000000"))
+            assertEquals(MembershipGrade.DIAMOND, grade)
+        }
+    }
+
+    @Nested
+    @DisplayName("nextGrade")
+    inner class NextGrade {
+        @Test
+        fun BRONZE의_다음_등급은_SILVER() {
+            assertEquals(MembershipGrade.SILVER, MembershipGrade.BRONZE.nextGrade())
+        }
+
+        @Test
+        fun SILVER의_다음_등급은_GOLD() {
+            assertEquals(MembershipGrade.GOLD, MembershipGrade.SILVER.nextGrade())
+        }
+
+        @Test
+        fun GOLD의_다음_등급은_PLATINUM() {
+            assertEquals(MembershipGrade.PLATINUM, MembershipGrade.GOLD.nextGrade())
+        }
+
+        @Test
+        fun PLATINUM의_다음_등급은_DIAMOND() {
+            assertEquals(MembershipGrade.DIAMOND, MembershipGrade.PLATINUM.nextGrade())
+        }
+
+        @Test
+        fun DIAMOND의_다음_등급은_없음() {
+            assertNull(MembershipGrade.DIAMOND.nextGrade())
+        }
+    }
+
+    @Nested
+    @DisplayName("등급별 혜택")
+    inner class GradeBenefits {
+        @Test
+        fun BRONZE_혜택_검증() {
+            val grade = MembershipGrade.BRONZE
+            assertEquals("브론즈", grade.gradeName)
+            assertEquals(BigDecimal("0.01"), grade.pointEarningRate)
+            assertEquals(BigDecimal.ZERO, grade.discountRate)
+        }
+
+        @Test
+        fun SILVER_혜택_검증() {
+            val grade = MembershipGrade.SILVER
+            assertEquals("실버", grade.gradeName)
+            assertEquals(BigDecimal("0.02"), grade.pointEarningRate)
+            assertEquals(BigDecimal("0.01"), grade.discountRate)
+        }
+
+        @Test
+        fun DIAMOND_혜택_검증() {
+            val grade = MembershipGrade.DIAMOND
+            assertEquals("다이아몬드", grade.gradeName)
+            assertEquals(BigDecimal("0.07"), grade.pointEarningRate)
+            assertEquals(BigDecimal("0.05"), grade.discountRate)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/membership/service/MembershipCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/membership/service/MembershipCommandServiceImplTest.kt
@@ -1,0 +1,107 @@
+package com.hoppingmall.mall.membership.service
+
+import com.hoppingmall.mall.membership.domain.Membership
+import com.hoppingmall.mall.membership.domain.repository.MembershipRepository
+import com.hoppingmall.mall.membership.enum.MembershipGrade
+import com.hoppingmall.mall.membership.exception.MembershipAlreadyExistsException
+import com.hoppingmall.mall.support.fixture.fixture
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import java.math.BigDecimal
+
+@DisplayName("MembershipCommandServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class MembershipCommandServiceImplTest {
+
+    private val membershipRepository: MembershipRepository = mock()
+    private val membershipCommandService = MembershipCommandServiceImpl(membershipRepository)
+
+    @Nested
+    @DisplayName("createMembership")
+    inner class CreateMembership {
+        @Test
+        fun 멤버십_생성_성공() {
+            val userId = 1L
+            val membership = Membership.Companion.fixture(userId = userId)
+
+            whenever(membershipRepository.existsByUserId(userId)).thenReturn(false)
+            whenever(membershipRepository.save(any<Membership>())).thenReturn(membership)
+
+            val response = membershipCommandService.createMembership(userId)
+
+            assertEquals(userId, response.userId)
+            assertEquals(MembershipGrade.BRONZE, response.grade)
+            verify(membershipRepository).existsByUserId(userId)
+            verify(membershipRepository).save(any())
+        }
+
+        @Test
+        fun 이미_멤버십이_존재하면_예외_발생() {
+            val userId = 1L
+
+            whenever(membershipRepository.existsByUserId(userId)).thenReturn(true)
+
+            assertThrows(MembershipAlreadyExistsException::class.java) {
+                membershipCommandService.createMembership(userId)
+            }
+
+            verify(membershipRepository, never()).save(any())
+        }
+    }
+
+    @Nested
+    @DisplayName("addPurchaseAmount")
+    inner class AddPurchaseAmount {
+        @Test
+        fun 기존_멤버십에_구매_금액_추가_성공() {
+            val userId = 1L
+            val amount = BigDecimal("50000")
+            val membership = Membership.Companion.fixture(userId = userId)
+
+            whenever(membershipRepository.findByUserId(userId)).thenReturn(membership)
+            whenever(membershipRepository.save(any<Membership>())).thenReturn(membership)
+
+            val response = membershipCommandService.addPurchaseAmount(userId, amount)
+
+            assertEquals(BigDecimal("50000"), response.totalSpent)
+            verify(membershipRepository).findByUserId(userId)
+            verify(membershipRepository).save(any())
+        }
+
+        @Test
+        fun 멤버십이_없으면_자동_생성_후_금액_추가() {
+            val userId = 1L
+            val amount = BigDecimal("50000")
+            val newMembership = Membership.Companion.fixture(userId = userId)
+
+            whenever(membershipRepository.findByUserId(userId)).thenReturn(null)
+            whenever(membershipRepository.save(any<Membership>())).thenReturn(newMembership)
+
+            val response = membershipCommandService.addPurchaseAmount(userId, amount)
+
+            assertEquals(userId, response.userId)
+            verify(membershipRepository).findByUserId(userId)
+            verify(membershipRepository, times(2)).save(any())
+        }
+
+        @Test
+        fun 구매_금액_추가_시_등급_승급() {
+            val userId = 1L
+            val amount = BigDecimal("100000")
+            val membership = Membership.Companion.fixture(userId = userId)
+
+            whenever(membershipRepository.findByUserId(userId)).thenReturn(membership)
+            whenever(membershipRepository.save(any<Membership>())).thenAnswer { it.arguments[0] }
+
+            val response = membershipCommandService.addPurchaseAmount(userId, amount)
+
+            assertEquals(MembershipGrade.SILVER, response.grade)
+            assertEquals(BigDecimal("100000"), response.totalSpent)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/membership/service/MembershipQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/membership/service/MembershipQueryServiceImplTest.kt
@@ -1,0 +1,84 @@
+package com.hoppingmall.mall.membership.service
+
+import com.hoppingmall.mall.membership.domain.Membership
+import com.hoppingmall.mall.membership.domain.repository.MembershipRepository
+import com.hoppingmall.mall.membership.enum.MembershipGrade
+import com.hoppingmall.mall.membership.exception.MembershipNotFoundException
+import com.hoppingmall.mall.support.fixture.fixture
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import java.math.BigDecimal
+
+@DisplayName("MembershipQueryServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class MembershipQueryServiceImplTest {
+
+    private val membershipRepository: MembershipRepository = mock()
+    private val membershipQueryService = MembershipQueryServiceImpl(membershipRepository)
+
+    @Nested
+    @DisplayName("getMembershipByUserId")
+    inner class GetMembershipByUserId {
+        @Test
+        fun 멤버십_조회_성공() {
+            val userId = 1L
+            val membership = Membership.Companion.fixture(userId = userId, grade = MembershipGrade.SILVER, totalSpent = BigDecimal("150000"))
+
+            whenever(membershipRepository.findByUserId(userId)).thenReturn(membership)
+
+            val response = membershipQueryService.getMembershipByUserId(userId)
+
+            assertEquals(userId, response.userId)
+            assertEquals(MembershipGrade.SILVER, response.grade)
+            assertEquals("실버", response.gradeName)
+            assertEquals(BigDecimal("150000"), response.totalSpent)
+            assertEquals(BigDecimal("0.02"), response.pointEarningRate)
+            assertEquals(BigDecimal("0.01"), response.discountRate)
+            verify(membershipRepository).findByUserId(userId)
+        }
+
+        @Test
+        fun 멤버십이_없으면_예외_발생() {
+            val userId = 1L
+
+            whenever(membershipRepository.findByUserId(userId)).thenReturn(null)
+
+            assertThrows(MembershipNotFoundException::class.java) {
+                membershipQueryService.getMembershipByUserId(userId)
+            }
+
+            verify(membershipRepository).findByUserId(userId)
+        }
+
+        @Test
+        fun 다음_등급까지_남은_금액_계산() {
+            val userId = 1L
+            val membership = Membership.Companion.fixture(userId = userId, grade = MembershipGrade.SILVER, totalSpent = BigDecimal("150000"))
+
+            whenever(membershipRepository.findByUserId(userId)).thenReturn(membership)
+
+            val response = membershipQueryService.getMembershipByUserId(userId)
+
+            assertEquals(MembershipGrade.GOLD, response.nextGrade)
+            assertEquals(BigDecimal("350000"), response.amountToNextGrade)
+        }
+
+        @Test
+        fun DIAMOND_등급은_다음_등급_없음() {
+            val userId = 1L
+            val membership = Membership.Companion.fixture(userId = userId, grade = MembershipGrade.DIAMOND, totalSpent = BigDecimal("5000000"))
+
+            whenever(membershipRepository.findByUserId(userId)).thenReturn(membership)
+
+            val response = membershipQueryService.getMembershipByUserId(userId)
+
+            assertNull(response.nextGrade)
+            assertNull(response.amountToNextGrade)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/MembershipFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/MembershipFixture.kt
@@ -1,0 +1,14 @@
+package com.hoppingmall.mall.support.fixture
+
+import com.hoppingmall.mall.membership.domain.Membership
+import com.hoppingmall.mall.membership.enum.MembershipGrade
+import com.hoppingmall.mall.support.withId
+import java.math.BigDecimal
+
+fun Membership.Companion.fixture(
+    userId: Long = 1L,
+    grade: MembershipGrade = MembershipGrade.BRONZE,
+    totalSpent: BigDecimal = BigDecimal.ZERO
+): Membership {
+    return Membership(userId = userId, grade = grade, totalSpent = totalSpent).withId(1L)
+}


### PR DESCRIPTION
Closes #55

## 📌 작업 내용
- MembershipGrade enum (BRONZE~DIAMOND 5등급, 적립률/할인율/승급 기준)
- Membership 엔티티 (userId 1:1, 누적 구매액 기반 자동 등급 승급)
- MembershipRepository, MembershipErrorCode, 커스텀 예외
- MembershipResponse DTO (등급 정보 + 다음 등급까지 남은 금액)
- MembershipCommandService/Impl (생성, 구매 금액 추가)
- MembershipQueryService/Impl (userId 기반 조회)
- MembershipController (POST 생성, GET /me 본인, GET /users/{userId} 관리자)
- SecurityConfig에 관리자 전용 멤버십 조회 권한 추가

## ✅ 등급 체계

| 등급 | 누적 구매액 | 포인트 적립률 | 할인율 |
|------|-----------|-------------|--------|
| BRONZE | 0 | 1% | 0% |
| SILVER | 100,000 | 2% | 1% |
| GOLD | 500,000 | 3% | 2% |
| PLATINUM | 1,000,000 | 5% | 3% |
| DIAMOND | 5,000,000 | 7% | 5% |

## 🧪 테스트
- MembershipGradeTest: fromTotalSpent 경계값, nextGrade, 등급별 혜택
- MembershipTest: create, addPurchaseAmount, upgradeGradeIfEligible, 음수 금액 예외
- MembershipCommandServiceImplTest: 생성, 중복 예외, 금액 추가, 자동 생성, 등급 승급
- MembershipQueryServiceImplTest: 조회 성공, 미존재 예외, amountToNextGrade 계산
- MembershipControllerTest: 생성/본인조회/관리자조회 엔드포인트

## 📎 기타
- 승급만 가능, 강등 없음
- CQRS 패턴 적용 (CommandService / QueryService 분리)
- Jacoco 커버리지 80% 검증 통과