### PR TITLE
feat: Membership-Payment 연동 이벤트 시스템 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,7 +110,9 @@ val jacocoExcludedDirs = listOf(
 	"**/com/hoppingmall/mall/global/common/repository/OutboxEventRepository*",
 	"**/com/hoppingmall/mall/point/service/PointEventConsumer*",
 	"**/com/hoppingmall/mall/payment/service/PaymentCompensationConsumer*",
-	"**/com/hoppingmall/mall/payment/service/PaymentEventConsumer*"
+	"**/com/hoppingmall/mall/payment/service/PaymentEventConsumer*",
+	"**/com/hoppingmall/mall/membership/service/MembershipEventConsumer*",
+	"**/com/hoppingmall/mall/membership/domain/MembershipEventLog*"
 )
 
 tasks.jacocoTestReport {

--- a/src/main/kotlin/com/hoppingmall/mall/membership/domain/MembershipEventLog.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/domain/MembershipEventLog.kt
@@ -1,0 +1,23 @@
+package com.hoppingmall.mall.membership.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "membership_event_logs",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["event_id"])]
+)
+class MembershipEventLog(
+    @Column(name = "event_id", nullable = false, unique = true)
+    val eventId: String,
+
+    @Column(nullable = false)
+    val paymentId: Long,
+
+    @Column(nullable = false)
+    val orderId: Long
+) : BaseEntity()

--- a/src/main/kotlin/com/hoppingmall/mall/membership/domain/repository/MembershipEventLogRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/domain/repository/MembershipEventLogRepository.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.mall.membership.domain.repository
+
+import com.hoppingmall.mall.membership.domain.MembershipEventLog
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MembershipEventLogRepository : JpaRepository<MembershipEventLog, Long> {
+    fun existsByEventId(eventId: String): Boolean
+}

--- a/src/main/kotlin/com/hoppingmall/mall/membership/service/MembershipEventConsumer.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/service/MembershipEventConsumer.kt
@@ -1,0 +1,38 @@
+package com.hoppingmall.mall.membership.service
+
+import com.hoppingmall.mall.membership.domain.MembershipEventLog
+import com.hoppingmall.mall.membership.domain.repository.MembershipEventLogRepository
+import com.hoppingmall.mall.payment.dto.event.MembershipUpdateRequestEvent
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class MembershipEventConsumer(
+    private val membershipCommandService: MembershipCommandService,
+    private val membershipEventLogRepository: MembershipEventLogRepository
+) {
+
+    @KafkaListener(topics = ["membership-update-request"], groupId = "membership-service")
+    fun handleMembershipUpdateRequest(event: MembershipUpdateRequestEvent) {
+        try {
+            if (membershipEventLogRepository.existsByEventId(event.eventId)) {
+                return
+            }
+
+            membershipCommandService.addPurchaseAmount(event.userId, event.amount)
+
+            membershipEventLogRepository.save(
+                MembershipEventLog(
+                    eventId = event.eventId,
+                    paymentId = event.paymentId,
+                    orderId = event.orderId
+                )
+            )
+        } catch (e: DataIntegrityViolationException) {
+            return
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/payment/dto/event/MembershipUpdateRequestEvent.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/dto/event/MembershipUpdateRequestEvent.kt
@@ -1,0 +1,11 @@
+package com.hoppingmall.mall.payment.dto.event
+
+import java.math.BigDecimal
+
+data class MembershipUpdateRequestEvent(
+    val eventId: String,
+    val userId: Long,
+    val orderId: Long,
+    val paymentId: Long,
+    val amount: BigDecimal
+)

--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/KafkaPaymentEventPublisher.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/KafkaPaymentEventPublisher.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.mall.payment.service
 
+import com.hoppingmall.mall.payment.dto.event.MembershipUpdateRequestEvent
 import com.hoppingmall.mall.payment.dto.event.PaymentCancelledEvent
 import com.hoppingmall.mall.payment.dto.event.PaymentCompletedEvent
 import com.hoppingmall.mall.payment.dto.event.PaymentFailedEvent
@@ -47,6 +48,23 @@ class KafkaPaymentEventPublisher(
                 "reason" to (event.reason ?: "결제 완료 적립")
             ),
             topic = "point-earn-request",
+            partitionKey = event.userId.toString()
+        )
+    }
+
+    override fun publishMembershipUpdateEvent(event: MembershipUpdateRequestEvent) {
+        transactionalEventPublisher.publishEvent(
+            aggregateType = "Payment",
+            aggregateId = event.paymentId.toString(),
+            eventType = "MembershipUpdateRequested",
+            eventData = mapOf(
+                "eventId" to event.eventId,
+                "userId" to event.userId,
+                "orderId" to event.orderId,
+                "paymentId" to event.paymentId,
+                "amount" to event.amount
+            ),
+            topic = "membership-update-request",
             partitionKey = event.userId.toString()
         )
     }

--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentCommandServiceImpl.kt
@@ -86,9 +86,10 @@ class PaymentCommandServiceImpl(
     
     private fun publishPaymentEvents(payment: Payment) {
         paymentEventService.publishPaymentCompletedEvent(payment)
-        
+
         if (payment.amount > BigDecimal.ZERO) {
             paymentEventService.publishPointEarnRequestEvent(payment)
+            paymentEventService.publishMembershipUpdateEvent(payment)
         }
         paymentEventService.publishPaymentCompletedNotification(payment)
     }

--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentEventPublisher.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentEventPublisher.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.mall.payment.service
 
+import com.hoppingmall.mall.payment.dto.event.MembershipUpdateRequestEvent
 import com.hoppingmall.mall.payment.dto.event.PaymentCancelledEvent
 import com.hoppingmall.mall.payment.dto.event.PaymentCompletedEvent
 import com.hoppingmall.mall.payment.dto.event.PaymentFailedEvent
@@ -8,6 +9,7 @@ import com.hoppingmall.mall.payment.dto.event.PointEarnRequestEvent
 interface PaymentEventPublisher {
     fun publishPaymentCompletedEvent(event: PaymentCompletedEvent)
     fun publishPointEarnRequestEvent(event: PointEarnRequestEvent)
+    fun publishMembershipUpdateEvent(event: MembershipUpdateRequestEvent)
     fun publishPaymentFailedEvent(event: PaymentFailedEvent)
     fun publishPaymentCancelledEvent(event: PaymentCancelledEvent)
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentEventService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentEventService.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.payment.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.hoppingmall.mall.payment.domain.Payment
+import com.hoppingmall.mall.payment.dto.event.MembershipUpdateRequestEvent
 import com.hoppingmall.mall.payment.dto.event.PaymentCancelledEvent
 import com.hoppingmall.mall.payment.dto.event.PaymentCompletedEvent
 import com.hoppingmall.mall.payment.dto.event.PaymentFailedEvent
@@ -51,6 +52,19 @@ class PaymentEventService(
         paymentEventPublisher.publishPointEarnRequestEvent(event)
     }
     
+    fun publishMembershipUpdateEvent(payment: Payment) {
+        val eventId = "membership-${payment.transactionId ?: "payment-${payment.id}"}"
+
+        val event = MembershipUpdateRequestEvent(
+            eventId = eventId,
+            userId = payment.userId,
+            orderId = payment.orderId,
+            paymentId = payment.id!!,
+            amount = payment.amount
+        )
+        paymentEventPublisher.publishMembershipUpdateEvent(event)
+    }
+
     fun publishPaymentCompletedNotification(payment: Payment) {
         val eventId = payment.transactionId ?: "payment-${payment.id}"
         val metadata = objectMapper.writeValueAsString(

--- a/src/test/kotlin/com/hoppingmall/mall/membership/service/MembershipEventConsumerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/membership/service/MembershipEventConsumerTest.kt
@@ -1,0 +1,102 @@
+package com.hoppingmall.mall.membership.service
+
+import com.hoppingmall.mall.membership.domain.MembershipEventLog
+import com.hoppingmall.mall.membership.domain.repository.MembershipEventLogRepository
+import com.hoppingmall.mall.membership.dto.response.MembershipResponse
+import com.hoppingmall.mall.membership.enum.MembershipGrade
+import com.hoppingmall.mall.payment.dto.event.MembershipUpdateRequestEvent
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.dao.DataIntegrityViolationException
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("MembershipEventConsumer 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class MembershipEventConsumerTest {
+
+    @Mock
+    private lateinit var membershipCommandService: MembershipCommandService
+
+    @Mock
+    private lateinit var membershipEventLogRepository: MembershipEventLogRepository
+
+    @InjectMocks
+    private lateinit var membershipEventConsumer: MembershipEventConsumer
+
+    private fun createEvent(
+        eventId: String = "membership-TXN_123456",
+        userId: Long = 1L,
+        orderId: Long = 1L,
+        paymentId: Long = 1L,
+        amount: BigDecimal = BigDecimal("50000")
+    ) = MembershipUpdateRequestEvent(eventId, userId, orderId, paymentId, amount)
+
+    private fun membershipResponse() = MembershipResponse(
+        id = 1L,
+        userId = 1L,
+        grade = MembershipGrade.BRONZE,
+        gradeName = MembershipGrade.BRONZE.gradeName,
+        totalSpent = BigDecimal("50000"),
+        pointEarningRate = MembershipGrade.BRONZE.pointEarningRate,
+        discountRate = MembershipGrade.BRONZE.discountRate,
+        nextGrade = MembershipGrade.SILVER,
+        amountToNextGrade = BigDecimal("50000"),
+        createdAt = LocalDateTime.now(),
+        updatedAt = null
+    )
+
+    @Test
+    fun 멤버십_구매금액_업데이트_정상_처리() {
+        val event = createEvent()
+
+        whenever(membershipEventLogRepository.existsByEventId(event.eventId)).thenReturn(false)
+        whenever(membershipCommandService.addPurchaseAmount(event.userId, event.amount))
+            .thenReturn(membershipResponse())
+        whenever(membershipEventLogRepository.save(any<MembershipEventLog>()))
+            .thenAnswer { it.arguments[0] }
+
+        membershipEventConsumer.handleMembershipUpdateRequest(event)
+
+        verify(membershipCommandService).addPurchaseAmount(event.userId, event.amount)
+        verify(membershipEventLogRepository).save(any<MembershipEventLog>())
+    }
+
+    @Test
+    fun 중복_이벤트는_처리를_건너뛴다() {
+        val event = createEvent()
+
+        whenever(membershipEventLogRepository.existsByEventId(event.eventId)).thenReturn(true)
+
+        membershipEventConsumer.handleMembershipUpdateRequest(event)
+
+        verify(membershipCommandService, never()).addPurchaseAmount(any(), any())
+        verify(membershipEventLogRepository, never()).save(any<MembershipEventLog>())
+    }
+
+    @Test
+    fun DataIntegrityViolationException_발생_시_정상_종료() {
+        val event = createEvent()
+
+        whenever(membershipEventLogRepository.existsByEventId(event.eventId)).thenReturn(false)
+        whenever(membershipCommandService.addPurchaseAmount(event.userId, event.amount))
+            .thenReturn(membershipResponse())
+        whenever(membershipEventLogRepository.save(any<MembershipEventLog>()))
+            .thenThrow(DataIntegrityViolationException("duplicate"))
+
+        membershipEventConsumer.handleMembershipUpdateRequest(event)
+
+        verify(membershipCommandService).addPurchaseAmount(event.userId, event.amount)
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentCommandServiceImplTest.kt
@@ -72,6 +72,7 @@ class PaymentCommandServiceImplTest {
             assertEquals("TXN_123456", response.transactionId)
             verify(paymentEventService).publishPaymentCompletedEvent(any())
             verify(paymentEventService).publishPointEarnRequestEvent(any())
+            verify(paymentEventService).publishMembershipUpdateEvent(any())
             verify(paymentEventService).publishPaymentCompletedNotification(any())
         }
 
@@ -104,6 +105,7 @@ class PaymentCommandServiceImplTest {
             assertEquals("잔액 부족", response.errorMessage)
             verify(paymentEventService, never()).publishPaymentCompletedEvent(any())
             verify(paymentEventService, never()).publishPointEarnRequestEvent(any())
+            verify(paymentEventService, never()).publishMembershipUpdateEvent(any())
             verify(paymentEventService, never()).publishPaymentCompletedNotification(any())
             verify(paymentEventService).publishPaymentFailedEvent(any())
             verify(paymentEventService).publishPaymentFailedNotification(any())

--- a/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentEventServiceTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentEventServiceTest.kt
@@ -126,6 +126,18 @@ class PaymentEventServiceTest {
     }
 
     @Test
+    fun `멤버십 업데이트 요청 이벤트를 발행한다`() {
+        // given
+        val payment = Payment.fixture()
+
+        // when
+        paymentEventService.publishMembershipUpdateEvent(payment)
+
+        // then
+        verify(paymentEventPublisher).publishMembershipUpdateEvent(any())
+    }
+
+    @Test
     fun `결제 실패 이벤트를 발행한다`() {
         // given
         val payment = Payment.failedFixture()


### PR DESCRIPTION
## 📌 개요
결제 완료 시 Membership에 구매 금액을 반영하여 누적 구매액 갱신 및 자동 등급 승급을 구현한다.

Closes #57

## ✅ 변경 사항
- `MembershipUpdateRequestEvent` DTO 추가
- `MembershipEventLog` 엔티티 및 Repository 추가 (멱등성 보장)
- `MembershipEventConsumer` Kafka Consumer 구현
- `PaymentEventPublisher`/`KafkaPaymentEventPublisher`에 멤버십 이벤트 발행 추가
- `PaymentEventService`에 `publishMembershipUpdateEvent` 추가
- `PaymentCommandServiceImpl` 결제 성공 시 멤버십 업데이트 이벤트 발행
- Jacoco 제외 설정 추가

## 🧪 테스트
- `MembershipEventConsumerTest` 단위 테스트 (정상 처리, 멱등성, 예외 처리)
- `PaymentEventServiceTest`에 멤버십 업데이트 이벤트 발행 테스트 추가
- `PaymentCommandServiceImplTest`에 멤버십 이벤트 발행 검증 추가
- `./gradlew test` 전체 통과
- `./gradlew jacocoTestVerification` 커버리지 80% 검증 통과

## 📎 참고
- 기존 포인트 적립 흐름(`PointEarnRequestEvent` → `PointEventConsumer`)과 동일한 Kafka + Outbox 패턴 적용
- Consumer 멱등성: `eventId` 기반 중복 체크 + `DataIntegrityViolationException` catch