### PR TITLE
config: ddl-auto create-drop → update 전환

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     open-in-view: false
     properties:
       hibernate:


### PR DESCRIPTION
## 📌 개요
서버 재시작 시 데이터 유실을 방지하기 위해 ddl-auto 설정을 변경한다.

Closes #59

## ✅ 변경 사항
- `application.yml`: `ddl-auto: create-drop` → `update`

## 🧪 테스트
- `./gradlew test` 전체 통과

## 📎 참고
- 테스트 프로필(`application-test.yml`)은 `create-drop` 유지 (테스트마다 클린 상태 보장)
- 추후 운영 환경에서는 `validate` + Flyway 마이그레이션 적용 권장