### PR TITLE
feat: 회원가입 시 Membership 자동 생성 연동

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/user/service/user/UserCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/user/service/user/UserCommandServiceImpl.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.user.service.user
 import com.hoppingmall.mall.global.vo.email.Email
 import com.hoppingmall.mall.global.vo.password.Password
 import com.hoppingmall.mall.global.vo.password.service.PasswordCreator
+import com.hoppingmall.mall.membership.service.MembershipCommandService
 import com.hoppingmall.mall.user.domain.User
 import com.hoppingmall.mall.user.domain.repository.UserRepository
 import com.hoppingmall.mall.user.dto.request.user.SignUpRequest
@@ -17,7 +18,8 @@ import org.springframework.transaction.annotation.Transactional
 class UserCommandServiceImpl(
     private val userRepository: UserRepository,
     private val passwordCreator: PasswordCreator,
-    private val userDomainService: UserDomainService
+    private val userDomainService: UserDomainService,
+    private val membershipCommandService: MembershipCommandService
 ) : UserCommandService {
 
     override fun signUp(request: SignUpRequest): SignUpResponse {
@@ -34,6 +36,7 @@ class UserCommandServiceImpl(
         )
 
         val saved = userRepository.save(user)
+        membershipCommandService.createMembership(saved.id!!)
 
         return SignUpResponse(
             id = saved.id!!,

--- a/src/test/kotlin/com/hoppingmall/mall/user/service/user/UserCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/user/service/user/UserCommandServiceImplTest.kt
@@ -4,6 +4,7 @@ import com.hoppingmall.mall.global.enums.Role
 import com.hoppingmall.mall.global.vo.email.Email
 import com.hoppingmall.mall.global.vo.password.Password
 import com.hoppingmall.mall.global.vo.password.service.PasswordCreator
+import com.hoppingmall.mall.membership.service.MembershipCommandService
 import com.hoppingmall.mall.support.fixture.fixture
 import com.hoppingmall.mall.support.withId
 import com.hoppingmall.mall.user.domain.User
@@ -25,7 +26,8 @@ class UserCommandServiceImplTest {
     private val userRepository: UserRepository = mock()
     private val passwordCreator: PasswordCreator = mock()
     private val userDomainService: UserDomainService = mock()
-    private val userCommandService = UserCommandServiceImpl(userRepository, passwordCreator, userDomainService)
+    private val membershipCommandService: MembershipCommandService = mock()
+    private val userCommandService = UserCommandServiceImpl(userRepository, passwordCreator, userDomainService, membershipCommandService)
 
     @Nested
     @DisplayName("signUp")
@@ -53,6 +55,7 @@ class UserCommandServiceImplTest {
             assertEquals(Role.SELLER, savedUser.getRole())
             assertEquals(1L, response.id)
             verify(userDomainService).validateNewUser(Email(request.email), request.password)
+            verify(membershipCommandService).createMembership(1L)
         }
 
         @Test


### PR DESCRIPTION
## 📌 개요
회원가입 시 BRONZE 등급 Membership을 자동 생성하도록 연동한다.

Closes #61

## ✅ 변경 사항
- `UserCommandServiceImpl`에 `MembershipCommandService` 의존성 추가
- `signUp()` 완료 후 `createMembership()` 호출

## 🧪 테스트
- 기존 회원가입 성공 테스트에 `createMembership` 호출 검증 추가
- `./gradlew test` 전체 통과
- `./gradlew jacocoTestVerification` 커버리지 80% 검증 통과

## 📎 참고
- Membership 등급 시스템(#56), Membership-Payment 연동(#58) 후속 작업