### PR TITLE
feat: 포인트 적립률 Strategy 패턴 적용

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentEventService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentEventService.kt
@@ -8,17 +8,16 @@ import com.hoppingmall.mall.payment.dto.event.PaymentCompletedEvent
 import com.hoppingmall.mall.payment.dto.event.PaymentFailedEvent
 import com.hoppingmall.mall.payment.dto.event.PointEarnRequestEvent
 import com.hoppingmall.mall.notification.enum.NotificationType
-import com.hoppingmall.mall.point.service.PointPolicyService
+import com.hoppingmall.mall.point.service.strategy.PointEarnRateStrategy
 import com.hoppingmall.mall.global.common.service.TransactionalEventPublisher
 import org.springframework.stereotype.Service
-import java.math.BigDecimal
 import java.time.LocalDateTime
 
 @Service
 class PaymentEventService(
     private val paymentEventPublisher: PaymentEventPublisher,
     private val transactionalEventPublisher: TransactionalEventPublisher,
-    private val pointPolicyService: PointPolicyService,
+    private val pointEarnRateStrategy: PointEarnRateStrategy,
     private val objectMapper: ObjectMapper
 ) {
     
@@ -38,7 +37,7 @@ class PaymentEventService(
     }
     
     fun publishPointEarnRequestEvent(payment: Payment) {
-        val earnRate = getCurrentEarnRate()
+        val earnRate = pointEarnRateStrategy.getEarnRate(payment.userId)
         val earnAmount = payment.amount.multiply(earnRate)
         val eventId = payment.transactionId ?: "payment-${payment.id}"
         
@@ -174,10 +173,5 @@ class PaymentEventService(
             topic = "notification",
             partitionKey = payment.userId.toString()
         )
-    }
-
-    private fun getCurrentEarnRate(): BigDecimal {
-        val currentPolicy = pointPolicyService.getCurrentPolicy()
-        return currentPolicy?.earnRate ?: BigDecimal("0.01")
     }
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/point/service/strategy/MembershipBasedRateStrategy.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/service/strategy/MembershipBasedRateStrategy.kt
@@ -1,0 +1,17 @@
+package com.hoppingmall.mall.point.service.strategy
+
+import com.hoppingmall.mall.membership.domain.repository.MembershipRepository
+import com.hoppingmall.mall.membership.enum.MembershipGrade
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+
+@Component
+class MembershipBasedRateStrategy(
+    private val membershipRepository: MembershipRepository
+) : PointEarnRateStrategy {
+
+    override fun getEarnRate(userId: Long): BigDecimal {
+        val membership = membershipRepository.findByUserId(userId)
+        return membership?.grade?.pointEarningRate ?: MembershipGrade.BRONZE.pointEarningRate
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/point/service/strategy/PointEarnRateStrategy.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/service/strategy/PointEarnRateStrategy.kt
@@ -1,0 +1,7 @@
+package com.hoppingmall.mall.point.service.strategy
+
+import java.math.BigDecimal
+
+fun interface PointEarnRateStrategy {
+    fun getEarnRate(userId: Long): BigDecimal
+}

--- a/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentEventServiceTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentEventServiceTest.kt
@@ -3,12 +3,11 @@ package com.hoppingmall.mall.payment.service
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.hoppingmall.mall.payment.domain.Payment
 import com.hoppingmall.mall.payment.dto.event.PointEarnRequestEvent
-import com.hoppingmall.mall.point.service.PointPolicyService
+import com.hoppingmall.mall.point.service.strategy.PointEarnRateStrategy
 import com.hoppingmall.mall.support.fixture.failedFixture
 import com.hoppingmall.mall.support.fixture.fixture
 import com.hoppingmall.mall.support.fixture.successFixture
 import com.hoppingmall.mall.global.common.service.TransactionalEventPublisher
-import com.hoppingmall.mall.point.dto.response.PointPolicyResponse
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
 import java.math.BigDecimal
@@ -18,12 +17,12 @@ class PaymentEventServiceTest {
     
     private val paymentEventPublisher: PaymentEventPublisher = mock()
     private val transactionalEventPublisher: TransactionalEventPublisher = mock()
-    private val pointPolicyService: PointPolicyService = mock()
+    private val pointEarnRateStrategy: PointEarnRateStrategy = mock()
     private val objectMapper = ObjectMapper()
     private val paymentEventService = PaymentEventService(
         paymentEventPublisher,
         transactionalEventPublisher,
-        pointPolicyService,
+        pointEarnRateStrategy,
         objectMapper
     )
     
@@ -43,10 +42,11 @@ class PaymentEventServiceTest {
     fun `포인트 적립 요청 이벤트를 발행한다`() {
         // given
         val payment = Payment.fixture()
-        
+        whenever(pointEarnRateStrategy.getEarnRate(payment.userId)).thenReturn(BigDecimal("0.01"))
+
         // when
         paymentEventService.publishPointEarnRequestEvent(payment)
-        
+
         // then
         verify(paymentEventPublisher).publishPointEarnRequestEvent(any())
     }
@@ -74,24 +74,13 @@ class PaymentEventServiceTest {
     fun `포인트 적립 요청 이벤트의 금액이 정확히 계산된다`() {
         // given
         val payment = Payment.fixture(amount = BigDecimal("10000"))
-        whenever(pointPolicyService.getCurrentPolicy()).thenReturn(
-            PointPolicyResponse(
-                id = 1L,
-                policyName = "기본 정책",
-                earnRate = BigDecimal("0.01"),
-                maxEarnRate = BigDecimal("0.05"),
-                minUseAmount = BigDecimal("1000"),
-                maxUseAmount = BigDecimal("100000"),
-                isActive = true,
-                description = "1% 적립"
-            )
-        )
-        
+        whenever(pointEarnRateStrategy.getEarnRate(payment.userId)).thenReturn(BigDecimal("0.01"))
+
         val captor = argumentCaptor<PointEarnRequestEvent>()
-        
+
         // when
         paymentEventService.publishPointEarnRequestEvent(payment)
-        
+
         // then
         verify(paymentEventPublisher).publishPointEarnRequestEvent(captor.capture())
         assertEquals(BigDecimal("100.00"), captor.firstValue.earnAmount)

--- a/src/test/kotlin/com/hoppingmall/mall/point/service/strategy/MembershipBasedRateStrategyTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/point/service/strategy/MembershipBasedRateStrategyTest.kt
@@ -1,0 +1,87 @@
+package com.hoppingmall.mall.point.service.strategy
+
+import com.hoppingmall.mall.membership.domain.Membership
+import com.hoppingmall.mall.membership.domain.repository.MembershipRepository
+import com.hoppingmall.mall.membership.enum.MembershipGrade
+import com.hoppingmall.mall.support.fixture.fixture
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+
+@DisplayName("MembershipBasedRateStrategy")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class MembershipBasedRateStrategyTest {
+
+    @Mock
+    private lateinit var membershipRepository: MembershipRepository
+
+    @InjectMocks
+    private lateinit var strategy: MembershipBasedRateStrategy
+
+    @Test
+    fun BRONZE_등급은_1퍼센트_적립률을_반환한다() {
+        val membership = Membership.fixture(grade = MembershipGrade.BRONZE)
+        whenever(membershipRepository.findByUserId(1L)).thenReturn(membership)
+
+        val earnRate = strategy.getEarnRate(1L)
+
+        assertEquals(MembershipGrade.BRONZE.pointEarningRate, earnRate)
+    }
+
+    @Test
+    fun SILVER_등급은_2퍼센트_적립률을_반환한다() {
+        val membership = Membership.fixture(grade = MembershipGrade.SILVER)
+        whenever(membershipRepository.findByUserId(1L)).thenReturn(membership)
+
+        val earnRate = strategy.getEarnRate(1L)
+
+        assertEquals(MembershipGrade.SILVER.pointEarningRate, earnRate)
+    }
+
+    @Test
+    fun GOLD_등급은_3퍼센트_적립률을_반환한다() {
+        val membership = Membership.fixture(grade = MembershipGrade.GOLD)
+        whenever(membershipRepository.findByUserId(1L)).thenReturn(membership)
+
+        val earnRate = strategy.getEarnRate(1L)
+
+        assertEquals(MembershipGrade.GOLD.pointEarningRate, earnRate)
+    }
+
+    @Test
+    fun PLATINUM_등급은_5퍼센트_적립률을_반환한다() {
+        val membership = Membership.fixture(grade = MembershipGrade.PLATINUM)
+        whenever(membershipRepository.findByUserId(1L)).thenReturn(membership)
+
+        val earnRate = strategy.getEarnRate(1L)
+
+        assertEquals(MembershipGrade.PLATINUM.pointEarningRate, earnRate)
+    }
+
+    @Test
+    fun DIAMOND_등급은_7퍼센트_적립률을_반환한다() {
+        val membership = Membership.fixture(grade = MembershipGrade.DIAMOND)
+        whenever(membershipRepository.findByUserId(1L)).thenReturn(membership)
+
+        val earnRate = strategy.getEarnRate(1L)
+
+        assertEquals(MembershipGrade.DIAMOND.pointEarningRate, earnRate)
+    }
+
+    @Test
+    fun Membership이_없으면_BRONZE_적립률을_반환한다() {
+        whenever(membershipRepository.findByUserId(999L)).thenReturn(null)
+
+        val earnRate = strategy.getEarnRate(999L)
+
+        assertEquals(MembershipGrade.BRONZE.pointEarningRate, earnRate)
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
Closes #63

## ✅ 변경 사항
- `PointEarnRateStrategy` fun interface 추가 (적립률 계산 추상화)
- `MembershipBasedRateStrategy` 구현 (등급별 적립률: BRONZE 1% ~ DIAMOND 7%)
- `PaymentEventService`에서 `PointPolicyService` → `PointEarnRateStrategy`로 의존성 교체
- Membership 미보유 사용자는 BRONZE 적립률(1%) 폴백

## 🧪 테스트
- `MembershipBasedRateStrategyTest`: 등급별 적립률 반환 + 폴백 검증 (6개)
- `PaymentEventServiceTest`: Strategy mock 교체 및 금액 계산 테스트 수정
- `./gradlew test` 전체 통과, `jacocoTestVerification` 커버리지 80% 이상 확인

## 📎 참고
- 기존 `PointPolicyService`는 포인트 정책 관리(CRUD) 용도로 유지
- 향후 프로모션 적립률 등 새 Strategy 구현체 확장 가능