### PR TITLE
feat: 환불 프로세스 고도화

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
@@ -66,6 +66,10 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/api/v1/shipping").hasRole("SELLER")
                 it.requestMatchers(HttpMethod.PATCH, "/api/v1/shipping/{shippingId}/status").hasRole("SELLER")
 
+                it.requestMatchers(HttpMethod.PATCH, "/api/v1/refunds/{refundId}/approve", "/api/v1/refunds/{refundId}/reject")
+                    .hasAnyRole("SELLER", "ADMIN")
+                it.requestMatchers(HttpMethod.GET, "/api/v1/refunds/seller").hasRole("SELLER")
+
                 it.requestMatchers("/api/v1/**").authenticated()
                 it.anyRequest().denyAll()
             }

--- a/src/main/kotlin/com/hoppingmall/mall/payment/enum/PaymentStatus.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/enum/PaymentStatus.kt
@@ -5,4 +5,5 @@ enum class PaymentStatus {
     SUCCESS,
     FAILED,
     CANCELLED,
+    REFUNDED,
 }

--- a/src/main/kotlin/com/hoppingmall/mall/point/service/PointCommandService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/service/PointCommandService.kt
@@ -2,7 +2,9 @@ package com.hoppingmall.mall.point.service
 
 import com.hoppingmall.mall.point.dto.request.PointUseRequest
 import com.hoppingmall.mall.point.dto.response.PointUseResponse
+import java.math.BigDecimal
 
 interface PointCommandService {
     fun usePoint(userId: Long, request: PointUseRequest): PointUseResponse
-} 
+    fun refundPoints(userId: Long, amount: BigDecimal, paymentId: Long, orderId: Long)
+}

--- a/src/main/kotlin/com/hoppingmall/mall/point/service/PointCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/service/PointCommandServiceImpl.kt
@@ -45,6 +45,28 @@ class PointCommandServiceImpl(
         )
     }
     
+    override fun refundPoints(userId: Long, amount: BigDecimal, paymentId: Long, orderId: Long) {
+        if (amount <= BigDecimal.ZERO) return
+
+        val eventId = "refund-point-$paymentId-$orderId"
+        if (pointHistoryRepository.existsByEventId(eventId)) return
+
+        val point = findOrCreatePoint(userId)
+        point.balance = point.balance.add(amount)
+        pointRepository.save(point)
+
+        val pointHistory = PointHistory(
+            userId = userId,
+            amount = amount,
+            type = PointType.REFUND,
+            reason = "환불 포인트 반환",
+            orderId = orderId,
+            paymentId = paymentId,
+            eventId = eventId
+        )
+        pointHistoryRepository.save(pointHistory)
+    }
+
     private fun validateSufficientBalance(point: Point, useAmount: BigDecimal) {
         if (point.balance < useAmount) {
             throw PointInsufficientBalanceException()

--- a/src/main/kotlin/com/hoppingmall/mall/refund/controller/RefundController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/controller/RefundController.kt
@@ -1,0 +1,83 @@
+package com.hoppingmall.mall.refund.controller
+
+import com.hoppingmall.mall.refund.dto.request.RefundApprovalRequest
+import com.hoppingmall.mall.refund.dto.request.RefundCreateRequest
+import com.hoppingmall.mall.refund.dto.response.RefundResponse
+import com.hoppingmall.mall.refund.service.RefundCommandService
+import com.hoppingmall.mall.refund.service.RefundQueryService
+import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/refunds")
+class RefundController(
+    private val refundCommandService: RefundCommandService,
+    private val refundQueryService: RefundQueryService
+) {
+
+    @PostMapping
+    fun requestRefund(
+        @Valid @RequestBody request: RefundCreateRequest,
+        @AuthenticationPrincipal userDetails: UserDetails
+    ): ResponseEntity<RefundResponse> {
+        val buyerId = userDetails.username.toLong()
+        val response = refundCommandService.requestRefund(buyerId, request)
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/{refundId}")
+    fun getRefund(@PathVariable refundId: Long): ResponseEntity<RefundResponse> {
+        val response = refundQueryService.getRefund(refundId)
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/my")
+    fun getMyRefunds(
+        @AuthenticationPrincipal userDetails: UserDetails,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "10") size: Int
+    ): ResponseEntity<Page<RefundResponse>> {
+        val buyerId = userDetails.username.toLong()
+        val pageable = PageRequest.of(page, size)
+        val refunds = refundQueryService.getMyRefunds(buyerId, pageable)
+        return ResponseEntity.ok(refunds)
+    }
+
+    @GetMapping("/seller")
+    fun getSellerRefunds(
+        @AuthenticationPrincipal userDetails: UserDetails,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "10") size: Int
+    ): ResponseEntity<Page<RefundResponse>> {
+        val sellerId = userDetails.username.toLong()
+        val pageable = PageRequest.of(page, size)
+        val refunds = refundQueryService.getSellerRefunds(sellerId, pageable)
+        return ResponseEntity.ok(refunds)
+    }
+
+    @PatchMapping("/{refundId}/approve")
+    fun approveRefund(
+        @PathVariable refundId: Long,
+        @AuthenticationPrincipal userDetails: UserDetails
+    ): ResponseEntity<RefundResponse> {
+        val approverId = userDetails.username.toLong()
+        val response = refundCommandService.approveRefund(refundId, approverId)
+        return ResponseEntity.ok(response)
+    }
+
+    @PatchMapping("/{refundId}/reject")
+    fun rejectRefund(
+        @PathVariable refundId: Long,
+        @RequestBody request: RefundApprovalRequest,
+        @AuthenticationPrincipal userDetails: UserDetails
+    ): ResponseEntity<RefundResponse> {
+        val approverId = userDetails.username.toLong()
+        val response = refundCommandService.rejectRefund(refundId, approverId, request)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/domain/Refund.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/domain/Refund.kt
@@ -1,0 +1,111 @@
+package com.hoppingmall.mall.refund.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import com.hoppingmall.mall.refund.enum.RefundReason
+import com.hoppingmall.mall.refund.enum.RefundStatus
+import com.hoppingmall.mall.refund.exception.RefundInvalidStatusException
+import jakarta.persistence.*
+import org.hibernate.annotations.Filter
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "refunds")
+@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
+class Refund private constructor(
+    @Column(nullable = false)
+    val orderId: Long,
+
+    @Column(nullable = false)
+    val paymentId: Long,
+
+    @Column(nullable = false)
+    val buyerId: Long,
+
+    @Column(nullable = false)
+    val sellerId: Long,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var status: RefundStatus = RefundStatus.REQUESTED,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val reason: RefundReason,
+
+    @Column
+    val reasonDetail: String? = null,
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    val refundAmount: BigDecimal,
+
+    @Column(nullable = false)
+    val isFullRefund: Boolean,
+
+    @Column
+    var rejectionReason: String? = null,
+
+    @Column
+    var approvedBy: Long? = null,
+
+    @Column
+    var completedAt: LocalDateTime? = null
+) : BaseEntity() {
+
+    companion object {
+        private val allowedTransitions: Map<RefundStatus, Set<RefundStatus>> = mapOf(
+            RefundStatus.REQUESTED to setOf(RefundStatus.APPROVED, RefundStatus.REJECTED),
+            RefundStatus.APPROVED to setOf(RefundStatus.COMPLETED),
+            RefundStatus.COMPLETED to emptySet(),
+            RefundStatus.REJECTED to emptySet()
+        )
+
+        fun create(
+            orderId: Long,
+            paymentId: Long,
+            buyerId: Long,
+            sellerId: Long,
+            reason: RefundReason,
+            reasonDetail: String?,
+            refundAmount: BigDecimal,
+            isFullRefund: Boolean
+        ): Refund {
+            return Refund(
+                orderId = orderId,
+                paymentId = paymentId,
+                buyerId = buyerId,
+                sellerId = sellerId,
+                reason = reason,
+                reasonDetail = reasonDetail,
+                refundAmount = refundAmount,
+                isFullRefund = isFullRefund
+            )
+        }
+    }
+
+    fun approve(approvedBy: Long) {
+        validateTransition(RefundStatus.APPROVED)
+        this.status = RefundStatus.APPROVED
+        this.approvedBy = approvedBy
+    }
+
+    fun reject(reason: String, rejectedBy: Long) {
+        validateTransition(RefundStatus.REJECTED)
+        this.status = RefundStatus.REJECTED
+        this.rejectionReason = reason
+        this.approvedBy = rejectedBy
+    }
+
+    fun complete() {
+        validateTransition(RefundStatus.COMPLETED)
+        this.status = RefundStatus.COMPLETED
+        this.completedAt = LocalDateTime.now()
+    }
+
+    private fun validateTransition(newStatus: RefundStatus) {
+        val allowed = allowedTransitions[this.status] ?: emptySet()
+        if (newStatus !in allowed) {
+            throw RefundInvalidStatusException()
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/domain/RefundItem.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/domain/RefundItem.kt
@@ -1,0 +1,56 @@
+package com.hoppingmall.mall.refund.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import org.hibernate.annotations.Filter
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "refund_items")
+@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
+class RefundItem private constructor(
+    @Column(nullable = false)
+    val refundId: Long,
+
+    @Column(nullable = false)
+    val orderItemId: Long,
+
+    @Column(nullable = false)
+    val productId: Long,
+
+    @Column(nullable = false)
+    val productName: String,
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    val productPrice: BigDecimal,
+
+    @Column(nullable = false)
+    val quantity: Int,
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    val refundPrice: BigDecimal
+) : BaseEntity() {
+
+    companion object {
+        fun create(
+            refundId: Long,
+            orderItemId: Long,
+            productId: Long,
+            productName: String,
+            productPrice: BigDecimal,
+            quantity: Int
+        ): RefundItem {
+            return RefundItem(
+                refundId = refundId,
+                orderItemId = orderItemId,
+                productId = productId,
+                productName = productName,
+                productPrice = productPrice,
+                quantity = quantity,
+                refundPrice = productPrice.multiply(BigDecimal(quantity))
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/domain/repository/RefundItemRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/domain/repository/RefundItemRepository.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.mall.refund.domain.repository
+
+import com.hoppingmall.mall.refund.domain.RefundItem
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface RefundItemRepository : JpaRepository<RefundItem, Long> {
+    fun findByRefundId(refundId: Long): List<RefundItem>
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/domain/repository/RefundRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/domain/repository/RefundRepository.kt
@@ -1,0 +1,15 @@
+package com.hoppingmall.mall.refund.domain.repository
+
+import com.hoppingmall.mall.refund.domain.Refund
+import com.hoppingmall.mall.refund.enum.RefundStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface RefundRepository : JpaRepository<Refund, Long> {
+    fun findByOrderIdAndStatusNot(orderId: Long, status: RefundStatus): List<Refund>
+    fun findByBuyerId(buyerId: Long, pageable: Pageable): Page<Refund>
+    fun findBySellerId(sellerId: Long, pageable: Pageable): Page<Refund>
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/dto/request/RefundApprovalRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/dto/request/RefundApprovalRequest.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.refund.dto.request
+
+data class RefundApprovalRequest(
+    val rejectionReason: String? = null
+)

--- a/src/main/kotlin/com/hoppingmall/mall/refund/dto/request/RefundCreateRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/dto/request/RefundCreateRequest.kt
@@ -1,0 +1,33 @@
+package com.hoppingmall.mall.refund.dto.request
+
+import com.hoppingmall.mall.refund.enum.RefundReason
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.Size
+
+data class RefundCreateRequest(
+    @field:NotNull(message = "주문 ID는 필수입니다.")
+    @field:Positive(message = "주문 ID는 양수여야 합니다.")
+    val orderId: Long,
+
+    @field:NotNull(message = "환불 사유는 필수입니다.")
+    val reason: RefundReason,
+
+    val reasonDetail: String? = null,
+
+    @field:NotNull(message = "환불 아이템 목록은 필수입니다.")
+    @field:Size(min = 1, message = "환불 아이템은 최소 1개 이상이어야 합니다.")
+    @field:Valid
+    val items: List<RefundItemRequest>
+)
+
+data class RefundItemRequest(
+    @field:NotNull(message = "주문 아이템 ID는 필수입니다.")
+    @field:Positive(message = "주문 아이템 ID는 양수여야 합니다.")
+    val orderItemId: Long,
+
+    @field:NotNull(message = "환불 수량은 필수입니다.")
+    @field:Positive(message = "환불 수량은 양수여야 합니다.")
+    val quantity: Int
+)

--- a/src/main/kotlin/com/hoppingmall/mall/refund/dto/response/RefundItemResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/dto/response/RefundItemResponse.kt
@@ -1,0 +1,28 @@
+package com.hoppingmall.mall.refund.dto.response
+
+import com.hoppingmall.mall.refund.domain.RefundItem
+import java.math.BigDecimal
+
+data class RefundItemResponse(
+    val id: Long,
+    val orderItemId: Long,
+    val productId: Long,
+    val productName: String,
+    val productPrice: BigDecimal,
+    val quantity: Int,
+    val refundPrice: BigDecimal
+) {
+    companion object {
+        fun from(refundItem: RefundItem): RefundItemResponse {
+            return RefundItemResponse(
+                id = refundItem.id!!,
+                orderItemId = refundItem.orderItemId,
+                productId = refundItem.productId,
+                productName = refundItem.productName,
+                productPrice = refundItem.productPrice,
+                quantity = refundItem.quantity,
+                refundPrice = refundItem.refundPrice
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/dto/response/RefundResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/dto/response/RefundResponse.kt
@@ -1,0 +1,50 @@
+package com.hoppingmall.mall.refund.dto.response
+
+import com.hoppingmall.mall.refund.domain.Refund
+import com.hoppingmall.mall.refund.domain.RefundItem
+import com.hoppingmall.mall.refund.enum.RefundReason
+import com.hoppingmall.mall.refund.enum.RefundStatus
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+data class RefundResponse(
+    val id: Long,
+    val orderId: Long,
+    val paymentId: Long,
+    val buyerId: Long,
+    val sellerId: Long,
+    val status: RefundStatus,
+    val reason: RefundReason,
+    val reasonDetail: String?,
+    val refundAmount: BigDecimal,
+    val isFullRefund: Boolean,
+    val rejectionReason: String?,
+    val approvedBy: Long?,
+    val completedAt: LocalDateTime?,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+    val items: List<RefundItemResponse>
+) {
+    companion object {
+        fun from(refund: Refund, items: List<RefundItem>): RefundResponse {
+            return RefundResponse(
+                id = refund.id!!,
+                orderId = refund.orderId,
+                paymentId = refund.paymentId,
+                buyerId = refund.buyerId,
+                sellerId = refund.sellerId,
+                status = refund.status,
+                reason = refund.reason,
+                reasonDetail = refund.reasonDetail,
+                refundAmount = refund.refundAmount,
+                isFullRefund = refund.isFullRefund,
+                rejectionReason = refund.rejectionReason,
+                approvedBy = refund.approvedBy,
+                completedAt = refund.completedAt,
+                createdAt = refund.createdAt,
+                updatedAt = refund.updatedAt ?: refund.createdAt,
+                items = items.map { RefundItemResponse.from(it) }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/enum/RefundReason.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/enum/RefundReason.kt
@@ -1,0 +1,9 @@
+package com.hoppingmall.mall.refund.enum
+
+enum class RefundReason {
+    CHANGE_OF_MIND,
+    DEFECTIVE_PRODUCT,
+    WRONG_PRODUCT,
+    LATE_DELIVERY,
+    OTHER,
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/enum/RefundStatus.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/enum/RefundStatus.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.mall.refund.enum
+
+enum class RefundStatus {
+    REQUESTED,
+    APPROVED,
+    COMPLETED,
+    REJECTED,
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/exception/RefundAccessDeniedException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/exception/RefundAccessDeniedException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.refund.exception
+
+import com.hoppingmall.mall.refund.exception.code.RefundErrorCode
+
+class RefundAccessDeniedException : RefundException(RefundErrorCode.REFUND_ACCESS_DENIED)

--- a/src/main/kotlin/com/hoppingmall/mall/refund/exception/RefundAlreadyExistsException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/exception/RefundAlreadyExistsException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.refund.exception
+
+import com.hoppingmall.mall.refund.exception.code.RefundErrorCode
+
+class RefundAlreadyExistsException : RefundException(RefundErrorCode.REFUND_ALREADY_EXISTS)

--- a/src/main/kotlin/com/hoppingmall/mall/refund/exception/RefundException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/exception/RefundException.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.mall.refund.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.refund.exception.code.RefundErrorCode
+
+open class RefundException(
+    errorCode: RefundErrorCode
+) : BusinessException(errorCode)

--- a/src/main/kotlin/com/hoppingmall/mall/refund/exception/RefundInvalidStatusException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/exception/RefundInvalidStatusException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.refund.exception
+
+import com.hoppingmall.mall.refund.exception.code.RefundErrorCode
+
+class RefundInvalidStatusException : RefundException(RefundErrorCode.REFUND_INVALID_STATUS)

--- a/src/main/kotlin/com/hoppingmall/mall/refund/exception/RefundNotFoundException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/exception/RefundNotFoundException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.refund.exception
+
+import com.hoppingmall.mall.refund.exception.code.RefundErrorCode
+
+class RefundNotFoundException : RefundException(RefundErrorCode.REFUND_NOT_FOUND)

--- a/src/main/kotlin/com/hoppingmall/mall/refund/exception/code/RefundErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/exception/code/RefundErrorCode.kt
@@ -1,0 +1,18 @@
+package com.hoppingmall.mall.refund.exception.code
+
+import com.hoppingmall.mall.global.common.error.code.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class RefundErrorCode(
+    override val code: String,
+    override val message: String,
+    override val status: HttpStatus
+) : ErrorCode {
+    REFUND_NOT_FOUND("RFD001", "환불 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    REFUND_ACCESS_DENIED("RFD002", "환불에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    REFUND_INVALID_STATUS("RFD003", "환불 상태가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    REFUND_ALREADY_EXISTS("RFD004", "이미 진행 중인 환불 요청이 있습니다.", HttpStatus.CONFLICT),
+    REFUND_INVALID_ORDER_STATUS("RFD005", "현재 주문 상태에서는 환불을 요청할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    REFUND_INVALID_PAYMENT_STATUS("RFD006", "결제 상태가 유효하지 않아 환불을 요청할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    REFUND_INVALID_ITEM("RFD007", "환불 요청 아이템이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundCommandService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundCommandService.kt
@@ -1,0 +1,11 @@
+package com.hoppingmall.mall.refund.service
+
+import com.hoppingmall.mall.refund.dto.request.RefundApprovalRequest
+import com.hoppingmall.mall.refund.dto.request.RefundCreateRequest
+import com.hoppingmall.mall.refund.dto.response.RefundResponse
+
+interface RefundCommandService {
+    fun requestRefund(buyerId: Long, request: RefundCreateRequest): RefundResponse
+    fun approveRefund(refundId: Long, approverId: Long): RefundResponse
+    fun rejectRefund(refundId: Long, approverId: Long, request: RefundApprovalRequest): RefundResponse
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImpl.kt
@@ -1,0 +1,219 @@
+package com.hoppingmall.mall.refund.service
+
+import com.hoppingmall.mall.inventory.service.InventoryCommandService
+import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
+import com.hoppingmall.mall.order.domain.repository.OrderRepository
+import com.hoppingmall.mall.order.enum.OrderStatus
+import com.hoppingmall.mall.order.exception.OrderNotFoundException
+import com.hoppingmall.mall.payment.domain.repository.PaymentRepository
+import com.hoppingmall.mall.payment.enum.PaymentStatus
+import com.hoppingmall.mall.payment.exception.PaymentNotFoundException
+import com.hoppingmall.mall.point.service.PointCommandService
+import com.hoppingmall.mall.product.domain.repository.ProductRepository
+import com.hoppingmall.mall.refund.domain.Refund
+import com.hoppingmall.mall.refund.domain.RefundItem
+import com.hoppingmall.mall.refund.domain.repository.RefundItemRepository
+import com.hoppingmall.mall.refund.domain.repository.RefundRepository
+import com.hoppingmall.mall.refund.dto.request.RefundApprovalRequest
+import com.hoppingmall.mall.refund.dto.request.RefundCreateRequest
+import com.hoppingmall.mall.refund.dto.response.RefundResponse
+import com.hoppingmall.mall.refund.enum.RefundStatus
+import com.hoppingmall.mall.refund.exception.RefundAccessDeniedException
+import com.hoppingmall.mall.refund.exception.RefundAlreadyExistsException
+import com.hoppingmall.mall.refund.exception.RefundNotFoundException
+import com.hoppingmall.mall.shipping.domain.repository.ShippingRepository
+import com.hoppingmall.mall.shipping.enum.ShippingStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@Service
+@Transactional
+class RefundCommandServiceImpl(
+    private val refundRepository: RefundRepository,
+    private val refundItemRepository: RefundItemRepository,
+    private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository,
+    private val paymentRepository: PaymentRepository,
+    private val productRepository: ProductRepository,
+    private val shippingRepository: ShippingRepository,
+    private val inventoryCommandService: InventoryCommandService,
+    private val pointCommandService: PointCommandService
+) : RefundCommandService {
+
+    private val refundableOrderStatuses = setOf(OrderStatus.PAID, OrderStatus.SHIPPED, OrderStatus.DELIVERED)
+
+    override fun requestRefund(buyerId: Long, request: RefundCreateRequest): RefundResponse {
+        val order = orderRepository.findById(request.orderId)
+            .orElseThrow { OrderNotFoundException() }
+
+        if (order.buyerId != buyerId) {
+            throw RefundAccessDeniedException()
+        }
+
+        if (order.status !in refundableOrderStatuses) {
+            throw com.hoppingmall.mall.refund.exception.RefundException(
+                com.hoppingmall.mall.refund.exception.code.RefundErrorCode.REFUND_INVALID_ORDER_STATUS
+            )
+        }
+
+        val payment = paymentRepository.findByOrderId(request.orderId)
+            ?: throw PaymentNotFoundException()
+
+        if (!payment.isSuccess()) {
+            throw com.hoppingmall.mall.refund.exception.RefundException(
+                com.hoppingmall.mall.refund.exception.code.RefundErrorCode.REFUND_INVALID_PAYMENT_STATUS
+            )
+        }
+
+        val existingRefunds = refundRepository.findByOrderIdAndStatusNot(request.orderId, RefundStatus.REJECTED)
+        if (existingRefunds.isNotEmpty()) {
+            throw RefundAlreadyExistsException()
+        }
+
+        val orderItems = orderItemRepository.findByOrderId(request.orderId)
+        val orderItemMap = orderItems.associateBy { it.id!! }
+
+        request.items.forEach { item ->
+            val orderItem = orderItemMap[item.orderItemId]
+                ?: throw com.hoppingmall.mall.refund.exception.RefundException(
+                    com.hoppingmall.mall.refund.exception.code.RefundErrorCode.REFUND_INVALID_ITEM
+                )
+            if (item.quantity > orderItem.quantity) {
+                throw com.hoppingmall.mall.refund.exception.RefundException(
+                    com.hoppingmall.mall.refund.exception.code.RefundErrorCode.REFUND_INVALID_ITEM
+                )
+            }
+        }
+
+        val refundAmount = request.items.sumOf { item ->
+            val orderItem = orderItemMap[item.orderItemId]!!
+            orderItem.productPrice.multiply(BigDecimal(item.quantity))
+        }
+
+        val isFullRefund = request.items.size == orderItems.size &&
+            request.items.all { item ->
+                val orderItem = orderItemMap[item.orderItemId]!!
+                item.quantity == orderItem.quantity
+            }
+
+        val firstOrderItem = orderItemMap[request.items.first().orderItemId]!!
+        val product = productRepository.findById(firstOrderItem.productId).orElse(null)
+        val sellerId = product?.sellerId ?: 0L
+
+        val refund = Refund.create(
+            orderId = request.orderId,
+            paymentId = payment.id!!,
+            buyerId = buyerId,
+            sellerId = sellerId,
+            reason = request.reason,
+            reasonDetail = request.reasonDetail,
+            refundAmount = refundAmount,
+            isFullRefund = isFullRefund
+        )
+        val savedRefund = refundRepository.save(refund)
+
+        val refundItems = request.items.map { item ->
+            val orderItem = orderItemMap[item.orderItemId]!!
+            RefundItem.create(
+                refundId = savedRefund.id!!,
+                orderItemId = item.orderItemId,
+                productId = orderItem.productId,
+                productName = orderItem.productName,
+                productPrice = orderItem.productPrice,
+                quantity = item.quantity
+            )
+        }
+        val savedRefundItems = refundItemRepository.saveAll(refundItems)
+
+        val shipping = shippingRepository.findByOrderId(request.orderId)
+        val isAutoApprove = shipping == null || shipping.status == ShippingStatus.PREPARING
+
+        if (isAutoApprove) {
+            savedRefund.approve(buyerId)
+            processRefundCompletion(savedRefund, savedRefundItems, payment, order)
+            savedRefund.complete()
+            refundRepository.save(savedRefund)
+        }
+
+        return RefundResponse.from(savedRefund, savedRefundItems)
+    }
+
+    override fun approveRefund(refundId: Long, approverId: Long): RefundResponse {
+        val refund = refundRepository.findById(refundId)
+            .orElseThrow { RefundNotFoundException() }
+
+        if (refund.sellerId != approverId) {
+            throw RefundAccessDeniedException()
+        }
+
+        refund.approve(approverId)
+
+        val refundItems = refundItemRepository.findByRefundId(refundId)
+        val payment = paymentRepository.findById(refund.paymentId)
+            .orElseThrow { PaymentNotFoundException() }
+        val order = orderRepository.findById(refund.orderId)
+            .orElseThrow { OrderNotFoundException() }
+
+        processRefundCompletion(refund, refundItems, payment, order)
+        refund.complete()
+        refundRepository.save(refund)
+
+        return RefundResponse.from(refund, refundItems)
+    }
+
+    override fun rejectRefund(refundId: Long, approverId: Long, request: RefundApprovalRequest): RefundResponse {
+        val refund = refundRepository.findById(refundId)
+            .orElseThrow { RefundNotFoundException() }
+
+        if (refund.sellerId != approverId) {
+            throw RefundAccessDeniedException()
+        }
+
+        refund.reject(request.rejectionReason ?: "", approverId)
+        refundRepository.save(refund)
+
+        val refundItems = refundItemRepository.findByRefundId(refundId)
+        return RefundResponse.from(refund, refundItems)
+    }
+
+    private fun processRefundCompletion(
+        refund: Refund,
+        refundItems: List<RefundItem>,
+        payment: com.hoppingmall.mall.payment.domain.Payment,
+        order: com.hoppingmall.mall.order.domain.Order
+    ) {
+        refundItems.forEach { item ->
+            inventoryCommandService.increaseStock(item.productId, item.quantity)
+        }
+
+        val pointRefundAmount = if (refund.isFullRefund) {
+            payment.pointAmount
+        } else {
+            if (payment.amount > BigDecimal.ZERO) {
+                payment.pointAmount.multiply(refund.refundAmount)
+                    .divide(payment.amount, 0, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal.ZERO
+            }
+        }
+
+        pointCommandService.refundPoints(
+            userId = refund.buyerId,
+            amount = pointRefundAmount,
+            paymentId = payment.id!!,
+            orderId = refund.orderId
+        )
+
+        if (refund.isFullRefund) {
+            payment.updateStatus(PaymentStatus.REFUNDED)
+            paymentRepository.save(payment)
+
+            if (order.isCancellable()) {
+                order.updateStatus(OrderStatus.CANCELLED)
+                orderRepository.save(order)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundQueryService.kt
@@ -1,0 +1,11 @@
+package com.hoppingmall.mall.refund.service
+
+import com.hoppingmall.mall.refund.dto.response.RefundResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface RefundQueryService {
+    fun getRefund(refundId: Long): RefundResponse
+    fun getMyRefunds(buyerId: Long, pageable: Pageable): Page<RefundResponse>
+    fun getSellerRefunds(sellerId: Long, pageable: Pageable): Page<RefundResponse>
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundQueryServiceImpl.kt
@@ -1,0 +1,39 @@
+package com.hoppingmall.mall.refund.service
+
+import com.hoppingmall.mall.refund.domain.repository.RefundItemRepository
+import com.hoppingmall.mall.refund.domain.repository.RefundRepository
+import com.hoppingmall.mall.refund.dto.response.RefundResponse
+import com.hoppingmall.mall.refund.exception.RefundNotFoundException
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class RefundQueryServiceImpl(
+    private val refundRepository: RefundRepository,
+    private val refundItemRepository: RefundItemRepository
+) : RefundQueryService {
+
+    override fun getRefund(refundId: Long): RefundResponse {
+        val refund = refundRepository.findById(refundId)
+            .orElseThrow { RefundNotFoundException() }
+        val items = refundItemRepository.findByRefundId(refundId)
+        return RefundResponse.from(refund, items)
+    }
+
+    override fun getMyRefunds(buyerId: Long, pageable: Pageable): Page<RefundResponse> {
+        return refundRepository.findByBuyerId(buyerId, pageable).map { refund ->
+            val items = refundItemRepository.findByRefundId(refund.id!!)
+            RefundResponse.from(refund, items)
+        }
+    }
+
+    override fun getSellerRefunds(sellerId: Long, pageable: Pageable): Page<RefundResponse> {
+        return refundRepository.findBySellerId(sellerId, pageable).map { refund ->
+            val items = refundItemRepository.findByRefundId(refund.id!!)
+            RefundResponse.from(refund, items)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/point/service/PointCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/point/service/PointCommandServiceImplTest.kt
@@ -137,6 +137,100 @@ class PointCommandServiceImplTest {
     }
 
     @Nested
+    @DisplayName("refundPoints")
+    inner class RefundPoints {
+        @Test
+        fun `포인트 환불 성공`() {
+            // given
+            val userId = 1L
+            val amount = BigDecimal("500")
+            val paymentId = 1L
+            val orderId = 1L
+            val point = Point.fixture()
+            val savedPoint = Point.fixture(balance = BigDecimal("1500"))
+
+            whenever(pointHistoryRepository.existsByEventId("refund-point-$paymentId-$orderId")).thenReturn(false)
+            whenever(pointRepository.findByUserId(userId)).thenReturn(point)
+            whenever(pointRepository.save(any<Point>())).thenReturn(savedPoint)
+            whenever(pointHistoryRepository.save(any<PointHistory>())).thenReturn(
+                PointHistory.fixture(type = PointType.REFUND, amount = amount)
+            )
+
+            // when
+            pointCommandService.refundPoints(userId, amount, paymentId, orderId)
+
+            // then
+            verify(pointRepository).save(any())
+            verify(pointHistoryRepository).save(any())
+        }
+
+        @Test
+        fun `환불 금액이 0 이하이면 처리하지 않는다`() {
+            // given
+            val userId = 1L
+            val amount = BigDecimal.ZERO
+            val paymentId = 1L
+            val orderId = 1L
+
+            // when
+            pointCommandService.refundPoints(userId, amount, paymentId, orderId)
+
+            // then
+            verify(pointRepository, never()).findByUserId(any())
+            verify(pointHistoryRepository, never()).save(any())
+        }
+
+        @Test
+        fun `이미 처리된 환불은 중복 처리하지 않는다`() {
+            // given
+            val userId = 1L
+            val amount = BigDecimal("500")
+            val paymentId = 1L
+            val orderId = 1L
+
+            whenever(pointHistoryRepository.existsByEventId("refund-point-$paymentId-$orderId")).thenReturn(true)
+
+            // when
+            pointCommandService.refundPoints(userId, amount, paymentId, orderId)
+
+            // then
+            verify(pointRepository, never()).save(any())
+        }
+
+        @Test
+        fun `포인트 환불 내역이 정확히 기록된다`() {
+            // given
+            val userId = 1L
+            val amount = BigDecimal("500")
+            val paymentId = 1L
+            val orderId = 1L
+            val point = Point.fixture()
+
+            whenever(pointHistoryRepository.existsByEventId("refund-point-$paymentId-$orderId")).thenReturn(false)
+            whenever(pointRepository.findByUserId(userId)).thenReturn(point)
+            whenever(pointRepository.save(any<Point>())).thenReturn(point)
+            whenever(pointHistoryRepository.save(any<PointHistory>())).thenReturn(
+                PointHistory.fixture(type = PointType.REFUND, amount = amount)
+            )
+
+            val captor = argumentCaptor<PointHistory>()
+
+            // when
+            pointCommandService.refundPoints(userId, amount, paymentId, orderId)
+
+            // then
+            verify(pointHistoryRepository).save(captor.capture())
+            val savedHistory = captor.firstValue
+            assertEquals(userId, savedHistory.userId)
+            assertEquals(amount, savedHistory.amount)
+            assertEquals(PointType.REFUND, savedHistory.type)
+            assertEquals(orderId, savedHistory.orderId)
+            assertEquals(paymentId, savedHistory.paymentId)
+            assertEquals("refund-point-$paymentId-$orderId", savedHistory.eventId)
+        }
+    }
+
+    @Nested
     @DisplayName("validatePointUseRequest")
     inner class ValidatePointUseRequest {
         @Test

--- a/src/test/kotlin/com/hoppingmall/mall/refund/controller/RefundControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/refund/controller/RefundControllerTest.kt
@@ -1,0 +1,219 @@
+package com.hoppingmall.mall.refund.controller
+
+import com.hoppingmall.mall.refund.dto.request.RefundApprovalRequest
+import com.hoppingmall.mall.refund.dto.request.RefundCreateRequest
+import com.hoppingmall.mall.refund.dto.request.RefundItemRequest
+import com.hoppingmall.mall.refund.dto.response.RefundItemResponse
+import com.hoppingmall.mall.refund.dto.response.RefundResponse
+import com.hoppingmall.mall.refund.enum.RefundReason
+import com.hoppingmall.mall.refund.enum.RefundStatus
+import com.hoppingmall.mall.refund.service.RefundCommandService
+import com.hoppingmall.mall.refund.service.RefundQueryService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.userdetails.UserDetails
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@DisplayName("RefundController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class RefundControllerTest {
+
+    private val refundCommandService: RefundCommandService = mock()
+    private val refundQueryService: RefundQueryService = mock()
+    private val refundController = RefundController(refundCommandService, refundQueryService)
+
+    private fun createRefundResponse(
+        id: Long = 1L,
+        status: RefundStatus = RefundStatus.REQUESTED
+    ): RefundResponse {
+        return RefundResponse(
+            id = id,
+            orderId = 1L,
+            paymentId = 1L,
+            buyerId = 1L,
+            sellerId = 2L,
+            status = status,
+            reason = RefundReason.CHANGE_OF_MIND,
+            reasonDetail = null,
+            refundAmount = BigDecimal("30000"),
+            isFullRefund = true,
+            rejectionReason = null,
+            approvedBy = null,
+            completedAt = null,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
+            items = listOf(
+                RefundItemResponse(
+                    id = 1L,
+                    orderItemId = 1L,
+                    productId = 100L,
+                    productName = "테스트 상품",
+                    productPrice = BigDecimal("15000"),
+                    quantity = 2,
+                    refundPrice = BigDecimal("30000")
+                )
+            )
+        )
+    }
+
+    @Nested
+    @DisplayName("requestRefund")
+    inner class RequestRefund {
+        @Test
+        fun `환불_요청_성공`() {
+            // given
+            val userId = 1L
+            val request = RefundCreateRequest(
+                orderId = 1L,
+                reason = RefundReason.CHANGE_OF_MIND,
+                items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 2))
+            )
+            val response = createRefundResponse()
+            val userDetails: UserDetails = mock()
+
+            whenever(userDetails.username).thenReturn(userId.toString())
+            whenever(refundCommandService.requestRefund(userId, request)).thenReturn(response)
+
+            // when
+            val result = refundController.requestRefund(request, userDetails)
+
+            // then
+            assertEquals(HttpStatus.OK, result.statusCode)
+            assertEquals(response, result.body)
+            verify(refundCommandService).requestRefund(userId, request)
+        }
+    }
+
+    @Nested
+    @DisplayName("getRefund")
+    inner class GetRefund {
+        @Test
+        fun `환불_상세_조회_성공`() {
+            // given
+            val refundId = 1L
+            val response = createRefundResponse()
+
+            whenever(refundQueryService.getRefund(refundId)).thenReturn(response)
+
+            // when
+            val result = refundController.getRefund(refundId)
+
+            // then
+            assertEquals(HttpStatus.OK, result.statusCode)
+            assertEquals(response, result.body)
+            verify(refundQueryService).getRefund(refundId)
+        }
+    }
+
+    @Nested
+    @DisplayName("getMyRefunds")
+    inner class GetMyRefunds {
+        @Test
+        fun `내_환불_목록_조회_성공`() {
+            // given
+            val userId = 1L
+            val page = 0
+            val size = 10
+            val pageable = PageRequest.of(page, size)
+            val userDetails: UserDetails = mock()
+            val response = createRefundResponse()
+            val pageResponse = PageImpl(listOf(response), pageable, 1)
+
+            whenever(userDetails.username).thenReturn(userId.toString())
+            whenever(refundQueryService.getMyRefunds(userId, pageable)).thenReturn(pageResponse)
+
+            // when
+            val result = refundController.getMyRefunds(userDetails, page, size)
+
+            // then
+            assertEquals(HttpStatus.OK, result.statusCode)
+            assertEquals(pageResponse, result.body)
+            verify(refundQueryService).getMyRefunds(userId, pageable)
+        }
+    }
+
+    @Nested
+    @DisplayName("getSellerRefunds")
+    inner class GetSellerRefunds {
+        @Test
+        fun `판매자_환불_목록_조회_성공`() {
+            // given
+            val sellerId = 2L
+            val page = 0
+            val size = 10
+            val pageable = PageRequest.of(page, size)
+            val userDetails: UserDetails = mock()
+            val response = createRefundResponse()
+            val pageResponse = PageImpl(listOf(response), pageable, 1)
+
+            whenever(userDetails.username).thenReturn(sellerId.toString())
+            whenever(refundQueryService.getSellerRefunds(sellerId, pageable)).thenReturn(pageResponse)
+
+            // when
+            val result = refundController.getSellerRefunds(userDetails, page, size)
+
+            // then
+            assertEquals(HttpStatus.OK, result.statusCode)
+            assertEquals(pageResponse, result.body)
+            verify(refundQueryService).getSellerRefunds(sellerId, pageable)
+        }
+    }
+
+    @Nested
+    @DisplayName("approveRefund")
+    inner class ApproveRefund {
+        @Test
+        fun `환불_승인_성공`() {
+            // given
+            val refundId = 1L
+            val sellerId = 2L
+            val response = createRefundResponse(status = RefundStatus.COMPLETED)
+            val userDetails: UserDetails = mock()
+
+            whenever(userDetails.username).thenReturn(sellerId.toString())
+            whenever(refundCommandService.approveRefund(refundId, sellerId)).thenReturn(response)
+
+            // when
+            val result = refundController.approveRefund(refundId, userDetails)
+
+            // then
+            assertEquals(HttpStatus.OK, result.statusCode)
+            assertEquals(response, result.body)
+            verify(refundCommandService).approveRefund(refundId, sellerId)
+        }
+    }
+
+    @Nested
+    @DisplayName("rejectRefund")
+    inner class RejectRefund {
+        @Test
+        fun `환불_거절_성공`() {
+            // given
+            val refundId = 1L
+            val sellerId = 2L
+            val request = RefundApprovalRequest(rejectionReason = "반품 불가")
+            val response = createRefundResponse(status = RefundStatus.REJECTED)
+            val userDetails: UserDetails = mock()
+
+            whenever(userDetails.username).thenReturn(sellerId.toString())
+            whenever(refundCommandService.rejectRefund(refundId, sellerId, request)).thenReturn(response)
+
+            // when
+            val result = refundController.rejectRefund(refundId, request, userDetails)
+
+            // then
+            assertEquals(HttpStatus.OK, result.statusCode)
+            assertEquals(response, result.body)
+            verify(refundCommandService).rejectRefund(refundId, sellerId, request)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImplTest.kt
@@ -1,0 +1,441 @@
+package com.hoppingmall.mall.refund.service
+
+import com.hoppingmall.mall.inventory.service.InventoryCommandService
+import com.hoppingmall.mall.order.domain.Order
+import com.hoppingmall.mall.order.domain.OrderItem
+import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
+import com.hoppingmall.mall.order.domain.repository.OrderRepository
+import com.hoppingmall.mall.order.enum.OrderStatus
+import com.hoppingmall.mall.order.exception.OrderNotFoundException
+import com.hoppingmall.mall.payment.domain.Payment
+import com.hoppingmall.mall.payment.domain.repository.PaymentRepository
+import com.hoppingmall.mall.payment.exception.PaymentNotFoundException
+import com.hoppingmall.mall.point.service.PointCommandService
+import com.hoppingmall.mall.product.domain.Product
+import com.hoppingmall.mall.product.domain.repository.ProductRepository
+import com.hoppingmall.mall.refund.domain.Refund
+import com.hoppingmall.mall.refund.domain.RefundItem
+import com.hoppingmall.mall.refund.domain.repository.RefundItemRepository
+import com.hoppingmall.mall.refund.domain.repository.RefundRepository
+import com.hoppingmall.mall.refund.dto.request.RefundApprovalRequest
+import com.hoppingmall.mall.refund.dto.request.RefundCreateRequest
+import com.hoppingmall.mall.refund.dto.request.RefundItemRequest
+import com.hoppingmall.mall.refund.enum.RefundReason
+import com.hoppingmall.mall.refund.enum.RefundStatus
+import com.hoppingmall.mall.refund.exception.RefundAccessDeniedException
+import com.hoppingmall.mall.refund.exception.RefundAlreadyExistsException
+import com.hoppingmall.mall.refund.exception.RefundException
+import com.hoppingmall.mall.refund.exception.RefundNotFoundException
+import com.hoppingmall.mall.shipping.domain.Shipping
+import com.hoppingmall.mall.shipping.domain.repository.ShippingRepository
+import com.hoppingmall.mall.support.fixture.*
+import com.hoppingmall.mall.support.withId
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import java.math.BigDecimal
+import java.util.*
+
+@DisplayName("RefundCommandServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class RefundCommandServiceImplTest {
+
+    private val refundRepository: RefundRepository = mock()
+    private val refundItemRepository: RefundItemRepository = mock()
+    private val orderRepository: OrderRepository = mock()
+    private val orderItemRepository: OrderItemRepository = mock()
+    private val paymentRepository: PaymentRepository = mock()
+    private val productRepository: ProductRepository = mock()
+    private val shippingRepository: ShippingRepository = mock()
+    private val inventoryCommandService: InventoryCommandService = mock()
+    private val pointCommandService: PointCommandService = mock()
+
+    private val refundCommandService = RefundCommandServiceImpl(
+        refundRepository,
+        refundItemRepository,
+        orderRepository,
+        orderItemRepository,
+        paymentRepository,
+        productRepository,
+        shippingRepository,
+        inventoryCommandService,
+        pointCommandService
+    )
+
+    @Nested
+    @DisplayName("requestRefund")
+    inner class RequestRefund {
+
+        @Test
+        fun `배송_전_전체_환불_요청_시_자동_승인_및_완료`() {
+            // given
+            val buyerId = 1L
+            val orderId = 1L
+            val order = Order.paidFixture(buyerId = buyerId)
+            val payment = Payment.successFixture(orderId = orderId, pointAmount = BigDecimal("1000"))
+            val orderItem = OrderItem.fixture(orderId = orderId, productId = 100L, quantity = 2)
+            val product = Product.fixture(sellerId = 2L).withId(100L)
+
+            val request = RefundCreateRequest(
+                orderId = orderId,
+                reason = RefundReason.CHANGE_OF_MIND,
+                reasonDetail = null,
+                items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 2))
+            )
+
+            whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
+            whenever(paymentRepository.findByOrderId(orderId)).thenReturn(payment)
+            whenever(refundRepository.findByOrderIdAndStatusNot(orderId, RefundStatus.REJECTED)).thenReturn(emptyList())
+            whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(listOf(orderItem))
+            whenever(productRepository.findById(100L)).thenReturn(Optional.of(product))
+            whenever(shippingRepository.findByOrderId(orderId)).thenReturn(null)
+            whenever(refundRepository.save(any<Refund>())).thenAnswer { invocation ->
+                (invocation.arguments[0] as Refund).withId(1L)
+            }
+            whenever(refundItemRepository.saveAll(any<List<RefundItem>>())).thenAnswer { invocation ->
+                @Suppress("UNCHECKED_CAST")
+                (invocation.arguments[0] as List<RefundItem>).mapIndexed { index, item -> item.withId(index.toLong() + 1) }
+            }
+
+            // when
+            val response = refundCommandService.requestRefund(buyerId, request)
+
+            // then
+            assertEquals(RefundStatus.COMPLETED, response.status)
+            assertTrue(response.isFullRefund)
+            verify(inventoryCommandService).increaseStock(100L, 2)
+            verify(pointCommandService).refundPoints(eq(buyerId), eq(BigDecimal("1000")), eq(1L), eq(orderId))
+        }
+
+        @Test
+        fun `배송_중_환불_요청_시_REQUESTED_상태로_생성`() {
+            // given
+            val buyerId = 1L
+            val orderId = 1L
+            val order = Order.fixture(buyerId = buyerId, status = OrderStatus.SHIPPED)
+            val payment = Payment.successFixture(orderId = orderId)
+            val orderItem = OrderItem.fixture(orderId = orderId, productId = 100L, quantity = 2)
+            val product = Product.fixture(sellerId = 2L).withId(100L)
+            val shipping = Shipping.inTransitFixture(orderId = orderId)
+
+            val request = RefundCreateRequest(
+                orderId = orderId,
+                reason = RefundReason.DEFECTIVE_PRODUCT,
+                reasonDetail = "상품 파손",
+                items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 2))
+            )
+
+            whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
+            whenever(paymentRepository.findByOrderId(orderId)).thenReturn(payment)
+            whenever(refundRepository.findByOrderIdAndStatusNot(orderId, RefundStatus.REJECTED)).thenReturn(emptyList())
+            whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(listOf(orderItem))
+            whenever(productRepository.findById(100L)).thenReturn(Optional.of(product))
+            whenever(shippingRepository.findByOrderId(orderId)).thenReturn(shipping)
+            whenever(refundRepository.save(any<Refund>())).thenAnswer { invocation ->
+                (invocation.arguments[0] as Refund).withId(1L)
+            }
+            whenever(refundItemRepository.saveAll(any<List<RefundItem>>())).thenAnswer { invocation ->
+                @Suppress("UNCHECKED_CAST")
+                (invocation.arguments[0] as List<RefundItem>).mapIndexed { index, item -> item.withId(index.toLong() + 1) }
+            }
+
+            // when
+            val response = refundCommandService.requestRefund(buyerId, request)
+
+            // then
+            assertEquals(RefundStatus.REQUESTED, response.status)
+            verify(inventoryCommandService, never()).increaseStock(any(), any())
+            verify(pointCommandService, never()).refundPoints(any(), any(), any(), any())
+        }
+
+        @Test
+        fun `부분_환불_요청_성공`() {
+            // given
+            val buyerId = 1L
+            val orderId = 1L
+            val order = Order.paidFixture(buyerId = buyerId)
+            val payment = Payment.successFixture(orderId = orderId, amount = BigDecimal("50000"), pointAmount = BigDecimal("1000"))
+            val orderItem1 = OrderItem.fixture(orderId = orderId, productId = 100L, productPrice = BigDecimal("15000"), quantity = 2)
+            val orderItem2 = OrderItem.fixture(orderId = orderId, productId = 200L, productPrice = BigDecimal("20000"), quantity = 1).withId(2L)
+            val product = Product.fixture(sellerId = 2L).withId(100L)
+
+            val request = RefundCreateRequest(
+                orderId = orderId,
+                reason = RefundReason.CHANGE_OF_MIND,
+                items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 1))
+            )
+
+            whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
+            whenever(paymentRepository.findByOrderId(orderId)).thenReturn(payment)
+            whenever(refundRepository.findByOrderIdAndStatusNot(orderId, RefundStatus.REJECTED)).thenReturn(emptyList())
+            whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(listOf(orderItem1, orderItem2))
+            whenever(productRepository.findById(100L)).thenReturn(Optional.of(product))
+            whenever(shippingRepository.findByOrderId(orderId)).thenReturn(null)
+            whenever(refundRepository.save(any<Refund>())).thenAnswer { invocation ->
+                (invocation.arguments[0] as Refund).withId(1L)
+            }
+            whenever(refundItemRepository.saveAll(any<List<RefundItem>>())).thenAnswer { invocation ->
+                @Suppress("UNCHECKED_CAST")
+                (invocation.arguments[0] as List<RefundItem>).mapIndexed { index, item -> item.withId(index.toLong() + 1) }
+            }
+
+            // when
+            val response = refundCommandService.requestRefund(buyerId, request)
+
+            // then
+            assertFalse(response.isFullRefund)
+            assertEquals(BigDecimal("15000"), response.refundAmount)
+            verify(inventoryCommandService).increaseStock(100L, 1)
+        }
+
+        @Test
+        fun `다른_사용자의_주문에_환불_요청_시_예외_발생`() {
+            // given
+            val buyerId = 1L
+            val order = Order.paidFixture(buyerId = 999L)
+
+            val request = RefundCreateRequest(
+                orderId = 1L,
+                reason = RefundReason.CHANGE_OF_MIND,
+                items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 1))
+            )
+
+            whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+
+            // when & then
+            assertThrows(RefundAccessDeniedException::class.java) {
+                refundCommandService.requestRefund(buyerId, request)
+            }
+        }
+
+        @Test
+        fun `존재하지_않는_주문에_환불_요청_시_예외_발생`() {
+            // given
+            val request = RefundCreateRequest(
+                orderId = 999L,
+                reason = RefundReason.CHANGE_OF_MIND,
+                items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 1))
+            )
+
+            whenever(orderRepository.findById(999L)).thenReturn(Optional.empty())
+
+            // when & then
+            assertThrows(OrderNotFoundException::class.java) {
+                refundCommandService.requestRefund(1L, request)
+            }
+        }
+
+        @Test
+        fun `CREATED_상태_주문에_환불_요청_시_예외_발생`() {
+            // given
+            val buyerId = 1L
+            val order = Order.fixture(buyerId = buyerId, status = OrderStatus.CREATED)
+
+            val request = RefundCreateRequest(
+                orderId = 1L,
+                reason = RefundReason.CHANGE_OF_MIND,
+                items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 1))
+            )
+
+            whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+
+            // when & then
+            assertThrows(RefundException::class.java) {
+                refundCommandService.requestRefund(buyerId, request)
+            }
+        }
+
+        @Test
+        fun `결제가_성공_상태가_아닌_경우_예외_발생`() {
+            // given
+            val buyerId = 1L
+            val order = Order.paidFixture(buyerId = buyerId)
+            val payment = Payment.fixture(orderId = 1L, status = com.hoppingmall.mall.payment.enum.PaymentStatus.FAILED)
+
+            val request = RefundCreateRequest(
+                orderId = 1L,
+                reason = RefundReason.CHANGE_OF_MIND,
+                items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 1))
+            )
+
+            whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+            whenever(paymentRepository.findByOrderId(1L)).thenReturn(payment)
+
+            // when & then
+            assertThrows(RefundException::class.java) {
+                refundCommandService.requestRefund(buyerId, request)
+            }
+        }
+
+        @Test
+        fun `이미_진행_중인_환불이_있으면_예외_발생`() {
+            // given
+            val buyerId = 1L
+            val order = Order.paidFixture(buyerId = buyerId)
+            val payment = Payment.successFixture(orderId = 1L)
+            val existingRefund = Refund.fixture(status = RefundStatus.REQUESTED)
+
+            val request = RefundCreateRequest(
+                orderId = 1L,
+                reason = RefundReason.CHANGE_OF_MIND,
+                items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 1))
+            )
+
+            whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+            whenever(paymentRepository.findByOrderId(1L)).thenReturn(payment)
+            whenever(refundRepository.findByOrderIdAndStatusNot(1L, RefundStatus.REJECTED)).thenReturn(listOf(existingRefund))
+
+            // when & then
+            assertThrows(RefundAlreadyExistsException::class.java) {
+                refundCommandService.requestRefund(buyerId, request)
+            }
+        }
+
+        @Test
+        fun `환불_수량이_주문_수량을_초과하면_예외_발생`() {
+            // given
+            val buyerId = 1L
+            val order = Order.paidFixture(buyerId = buyerId)
+            val payment = Payment.successFixture(orderId = 1L)
+            val orderItem = OrderItem.fixture(orderId = 1L, quantity = 2)
+
+            val request = RefundCreateRequest(
+                orderId = 1L,
+                reason = RefundReason.CHANGE_OF_MIND,
+                items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 5))
+            )
+
+            whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+            whenever(paymentRepository.findByOrderId(1L)).thenReturn(payment)
+            whenever(refundRepository.findByOrderIdAndStatusNot(1L, RefundStatus.REJECTED)).thenReturn(emptyList())
+            whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(orderItem))
+
+            // when & then
+            assertThrows(RefundException::class.java) {
+                refundCommandService.requestRefund(buyerId, request)
+            }
+        }
+
+        @Test
+        fun `결제_정보가_없으면_예외_발생`() {
+            // given
+            val buyerId = 1L
+            val order = Order.paidFixture(buyerId = buyerId)
+
+            val request = RefundCreateRequest(
+                orderId = 1L,
+                reason = RefundReason.CHANGE_OF_MIND,
+                items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 1))
+            )
+
+            whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+            whenever(paymentRepository.findByOrderId(1L)).thenReturn(null)
+
+            // when & then
+            assertThrows(PaymentNotFoundException::class.java) {
+                refundCommandService.requestRefund(buyerId, request)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("approveRefund")
+    inner class ApproveRefund {
+
+        @Test
+        fun `판매자가_환불_승인_성공`() {
+            // given
+            val refundId = 1L
+            val sellerId = 2L
+            val refund = Refund.fixture(sellerId = sellerId, status = RefundStatus.REQUESTED)
+            val refundItem = RefundItem.fixture(refundId = refundId, productId = 100L, quantity = 2)
+            val payment = Payment.successFixture(pointAmount = BigDecimal("1000"))
+            val order = Order.paidFixture()
+
+            whenever(refundRepository.findById(refundId)).thenReturn(Optional.of(refund))
+            whenever(refundItemRepository.findByRefundId(refundId)).thenReturn(listOf(refundItem))
+            whenever(paymentRepository.findById(refund.paymentId)).thenReturn(Optional.of(payment))
+            whenever(orderRepository.findById(refund.orderId)).thenReturn(Optional.of(order))
+            whenever(refundRepository.save(any<Refund>())).thenAnswer { it.arguments[0] }
+
+            // when
+            val response = refundCommandService.approveRefund(refundId, sellerId)
+
+            // then
+            assertEquals(RefundStatus.COMPLETED, response.status)
+            verify(inventoryCommandService).increaseStock(100L, 2)
+            verify(pointCommandService).refundPoints(eq(1L), any(), eq(1L), eq(1L))
+        }
+
+        @Test
+        fun `다른_판매자가_승인_시도_시_예외_발생`() {
+            // given
+            val refundId = 1L
+            val refund = Refund.fixture(sellerId = 2L, status = RefundStatus.REQUESTED)
+
+            whenever(refundRepository.findById(refundId)).thenReturn(Optional.of(refund))
+
+            // when & then
+            assertThrows(RefundAccessDeniedException::class.java) {
+                refundCommandService.approveRefund(refundId, 999L)
+            }
+        }
+
+        @Test
+        fun `존재하지_않는_환불_승인_시_예외_발생`() {
+            // given
+            whenever(refundRepository.findById(999L)).thenReturn(Optional.empty())
+
+            // when & then
+            assertThrows(RefundNotFoundException::class.java) {
+                refundCommandService.approveRefund(999L, 2L)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("rejectRefund")
+    inner class RejectRefund {
+
+        @Test
+        fun `판매자가_환불_거절_성공`() {
+            // given
+            val refundId = 1L
+            val sellerId = 2L
+            val refund = Refund.fixture(sellerId = sellerId, status = RefundStatus.REQUESTED)
+            val refundItem = RefundItem.fixture(refundId = refundId)
+            val rejectionRequest = RefundApprovalRequest(rejectionReason = "반품 불가 상품")
+
+            whenever(refundRepository.findById(refundId)).thenReturn(Optional.of(refund))
+            whenever(refundItemRepository.findByRefundId(refundId)).thenReturn(listOf(refundItem))
+            whenever(refundRepository.save(any<Refund>())).thenAnswer { it.arguments[0] }
+
+            // when
+            val response = refundCommandService.rejectRefund(refundId, sellerId, rejectionRequest)
+
+            // then
+            assertEquals(RefundStatus.REJECTED, response.status)
+            assertEquals("반품 불가 상품", response.rejectionReason)
+            verify(inventoryCommandService, never()).increaseStock(any(), any())
+        }
+
+        @Test
+        fun `다른_판매자가_거절_시도_시_예외_발생`() {
+            // given
+            val refundId = 1L
+            val refund = Refund.fixture(sellerId = 2L, status = RefundStatus.REQUESTED)
+            val rejectionRequest = RefundApprovalRequest(rejectionReason = "거절")
+
+            whenever(refundRepository.findById(refundId)).thenReturn(Optional.of(refund))
+
+            // when & then
+            assertThrows(RefundAccessDeniedException::class.java) {
+                refundCommandService.rejectRefund(refundId, 999L, rejectionRequest)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/refund/service/RefundQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/refund/service/RefundQueryServiceImplTest.kt
@@ -1,0 +1,111 @@
+package com.hoppingmall.mall.refund.service
+
+import com.hoppingmall.mall.refund.domain.Refund
+import com.hoppingmall.mall.refund.domain.RefundItem
+import com.hoppingmall.mall.refund.domain.repository.RefundItemRepository
+import com.hoppingmall.mall.refund.domain.repository.RefundRepository
+import com.hoppingmall.mall.refund.exception.RefundNotFoundException
+import com.hoppingmall.mall.support.fixture.fixture
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.util.*
+
+@DisplayName("RefundQueryServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class RefundQueryServiceImplTest {
+
+    private val refundRepository: RefundRepository = mock()
+    private val refundItemRepository: RefundItemRepository = mock()
+    private val refundQueryService = RefundQueryServiceImpl(refundRepository, refundItemRepository)
+
+    @Nested
+    @DisplayName("getRefund")
+    inner class GetRefund {
+
+        @Test
+        fun `환불_상세_조회_성공`() {
+            // given
+            val refundId = 1L
+            val refund = Refund.fixture()
+            val refundItem = RefundItem.fixture(refundId = refundId)
+
+            whenever(refundRepository.findById(refundId)).thenReturn(Optional.of(refund))
+            whenever(refundItemRepository.findByRefundId(refundId)).thenReturn(listOf(refundItem))
+
+            // when
+            val response = refundQueryService.getRefund(refundId)
+
+            // then
+            assertEquals(refundId, response.id)
+            assertEquals(1, response.items.size)
+        }
+
+        @Test
+        fun `존재하지_않는_환불_조회_시_예외_발생`() {
+            // given
+            whenever(refundRepository.findById(999L)).thenReturn(Optional.empty())
+
+            // when & then
+            assertThrows(RefundNotFoundException::class.java) {
+                refundQueryService.getRefund(999L)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getMyRefunds")
+    inner class GetMyRefunds {
+
+        @Test
+        fun `내_환불_목록_조회_성공`() {
+            // given
+            val buyerId = 1L
+            val pageable = PageRequest.of(0, 10)
+            val refund = Refund.fixture(buyerId = buyerId)
+            val refundItem = RefundItem.fixture(refundId = 1L)
+
+            whenever(refundRepository.findByBuyerId(buyerId, pageable))
+                .thenReturn(PageImpl(listOf(refund), pageable, 1))
+            whenever(refundItemRepository.findByRefundId(1L)).thenReturn(listOf(refundItem))
+
+            // when
+            val response = refundQueryService.getMyRefunds(buyerId, pageable)
+
+            // then
+            assertEquals(1, response.totalElements)
+            assertEquals(buyerId, response.content.first().buyerId)
+        }
+    }
+
+    @Nested
+    @DisplayName("getSellerRefunds")
+    inner class GetSellerRefunds {
+
+        @Test
+        fun `판매자_환불_요청_목록_조회_성공`() {
+            // given
+            val sellerId = 2L
+            val pageable = PageRequest.of(0, 10)
+            val refund = Refund.fixture(sellerId = sellerId)
+            val refundItem = RefundItem.fixture(refundId = 1L)
+
+            whenever(refundRepository.findBySellerId(sellerId, pageable))
+                .thenReturn(PageImpl(listOf(refund), pageable, 1))
+            whenever(refundItemRepository.findByRefundId(1L)).thenReturn(listOf(refundItem))
+
+            // when
+            val response = refundQueryService.getSellerRefunds(sellerId, pageable)
+
+            // then
+            assertEquals(1, response.totalElements)
+            assertEquals(sellerId, response.content.first().sellerId)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/RefundFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/RefundFixture.kt
@@ -1,0 +1,51 @@
+package com.hoppingmall.mall.support.fixture
+
+import com.hoppingmall.mall.refund.domain.Refund
+import com.hoppingmall.mall.refund.enum.RefundReason
+import com.hoppingmall.mall.refund.enum.RefundStatus
+import com.hoppingmall.mall.support.withId
+import java.math.BigDecimal
+
+fun Refund.Companion.fixture(
+    orderId: Long = 1L,
+    paymentId: Long = 1L,
+    buyerId: Long = 1L,
+    sellerId: Long = 2L,
+    reason: RefundReason = RefundReason.CHANGE_OF_MIND,
+    reasonDetail: String? = null,
+    refundAmount: BigDecimal = BigDecimal("30000"),
+    isFullRefund: Boolean = true,
+    status: RefundStatus = RefundStatus.REQUESTED
+): Refund {
+    return Refund.create(
+        orderId = orderId,
+        paymentId = paymentId,
+        buyerId = buyerId,
+        sellerId = sellerId,
+        reason = reason,
+        reasonDetail = reasonDetail,
+        refundAmount = refundAmount,
+        isFullRefund = isFullRefund
+    ).apply {
+        this.status = status
+    }.withId(1L)
+}
+
+fun Refund.Companion.approvedFixture(
+    orderId: Long = 1L,
+    paymentId: Long = 1L,
+    buyerId: Long = 1L,
+    sellerId: Long = 2L,
+    refundAmount: BigDecimal = BigDecimal("30000"),
+    isFullRefund: Boolean = true
+): Refund {
+    return Refund.fixture(
+        orderId = orderId,
+        paymentId = paymentId,
+        buyerId = buyerId,
+        sellerId = sellerId,
+        refundAmount = refundAmount,
+        isFullRefund = isFullRefund,
+        status = RefundStatus.APPROVED
+    )
+}

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/RefundItemFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/RefundItemFixture.kt
@@ -1,0 +1,23 @@
+package com.hoppingmall.mall.support.fixture
+
+import com.hoppingmall.mall.refund.domain.RefundItem
+import com.hoppingmall.mall.support.withId
+import java.math.BigDecimal
+
+fun RefundItem.Companion.fixture(
+    refundId: Long = 1L,
+    orderItemId: Long = 1L,
+    productId: Long = 100L,
+    productName: String = "테스트 상품",
+    productPrice: BigDecimal = BigDecimal("15000"),
+    quantity: Int = 2
+): RefundItem {
+    return RefundItem.create(
+        refundId = refundId,
+        orderItemId = orderItemId,
+        productId = productId,
+        productName = productName,
+        productPrice = productPrice,
+        quantity = quantity
+    ).withId(1L)
+}


### PR DESCRIPTION
Closes #67

## 📌 요약
- 환불 도메인 신설 (Refund, RefundItem 엔티티)
- 환불 상태 흐름: REQUESTED → APPROVED → COMPLETED / REJECTED
- 배송 상태별 자동 승인 규칙 (배송 전: 자동 승인, 배송 중/완료: 판매자 승인)
- 부분/전체 환불 지원
- 재고 복구, 포인트 환불, 결제/주문 상태 변경 처리

## ✅ 변경 사항
- PaymentStatus에 REFUNDED 추가
- PointCommandService에 refundPoints() 메서드 추가
- Refund 도메인: 엔티티, enum, repository, exception, DTO
- RefundCommandService/Impl: 환불 요청/승인/거절 비즈니스 로직
- RefundQueryService/Impl: 환불 조회
- RefundController: REST API 6개 엔드포인트
- SecurityConfig: 환불 관련 권한 규칙 추가

## 🧪 테스트
- PointCommandServiceImplTest: 포인트 환불 테스트 4건 추가
- RefundCommandServiceImplTest: 환불 요청/승인/거절 테스트 12건
- RefundQueryServiceImplTest: 환불 조회 테스트 4건
- RefundControllerTest: 컨트롤러 테스트 6건
- Jacoco 커버리지 80% 검증 통과

## 📎 참고
- 기존 cancelPayment 비동기 보상 흐름은 하위 호환 유지
- 환불 처리는 동기 방식 (processRefundCompletion 내에서 직접 처리)