### PR TITLE
feat: 관리자 상품 통계 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,7 +112,8 @@ val jacocoExcludedDirs = listOf(
 	"**/com/hoppingmall/mall/payment/service/PaymentCompensationConsumer*",
 	"**/com/hoppingmall/mall/payment/service/PaymentEventConsumer*",
 	"**/com/hoppingmall/mall/membership/service/MembershipEventConsumer*",
-	"**/com/hoppingmall/mall/membership/domain/MembershipEventLog*"
+	"**/com/hoppingmall/mall/membership/domain/MembershipEventLog*",
+	"**/com/hoppingmall/mall/product/service/ProductStatisticsScheduler*"
 )
 
 tasks.jacocoTestReport {

--- a/src/main/kotlin/com/hoppingmall/mall/MallApplication.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/MallApplication.kt
@@ -3,9 +3,11 @@ package com.hoppingmall.mall
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 class MallApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/hoppingmall/mall/cartItem/domain/repository/CartItemRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/cartItem/domain/repository/CartItemRepository.kt
@@ -1,11 +1,25 @@
 package com.hoppingmall.mall.cartItem.domain.repository
 
 import com.hoppingmall.mall.cartItem.domain.CartItem
+import com.hoppingmall.mall.product.dto.CartAggregation
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
 interface CartItemRepository: JpaRepository<CartItem, Long> {
     fun findByBuyerId(buyerId: Long): List<CartItem>
     fun findByBuyerIdAndProductId(buyerId: Long, productId: Long): CartItem?
+
+    @Query(
+        value = """
+            SELECT ci.product_id AS productId,
+                   COUNT(DISTINCT ci.buyer_id) AS buyerCount
+            FROM cart_items ci
+            WHERE ci.deleted_at IS NULL
+            GROUP BY ci.product_id
+        """,
+        nativeQuery = true
+    )
+    fun aggregateCartByProduct(): List<CartAggregation>
 }

--- a/src/main/kotlin/com/hoppingmall/mall/order/domain/repository/OrderItemRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/domain/repository/OrderItemRepository.kt
@@ -1,10 +1,29 @@
 package com.hoppingmall.mall.order.domain.repository
 
 import com.hoppingmall.mall.order.domain.OrderItem
+import com.hoppingmall.mall.product.dto.SalesAggregation
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
 interface OrderItemRepository : JpaRepository<OrderItem, Long> {
     fun findByOrderId(orderId: Long): List<OrderItem>
+
+    @Query(
+        value = """
+            SELECT oi.product_id AS productId,
+                   SUM(oi.quantity) AS totalQuantity,
+                   SUM(oi.total_price) AS totalAmount
+            FROM order_items oi
+            JOIN orders o ON oi.order_id = o.id
+            WHERE o.status IN (:statuses)
+              AND oi.deleted_at IS NULL
+              AND o.deleted_at IS NULL
+            GROUP BY oi.product_id
+        """,
+        nativeQuery = true
+    )
+    fun aggregateSalesByProduct(@Param("statuses") statuses: List<String>): List<SalesAggregation>
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductStatisticsController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductStatisticsController.kt
@@ -1,0 +1,49 @@
+package com.hoppingmall.mall.product.controller
+
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.product.dto.response.ProductStatisticsResponse
+import com.hoppingmall.mall.product.dto.response.ProductStatisticsSummaryResponse
+import com.hoppingmall.mall.product.service.ProductStatisticsQueryService
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/admin/product-statistics")
+class ProductStatisticsController(
+    private val productStatisticsQueryService: ProductStatisticsQueryService
+) {
+    @GetMapping
+    fun getAll(pageable: Pageable): ApiResponse<Page<ProductStatisticsResponse>> {
+        return ApiResponse.success(productStatisticsQueryService.getAll(pageable))
+    }
+
+    @GetMapping("/{productId}")
+    fun getByProductId(@PathVariable productId: Long): ApiResponse<ProductStatisticsResponse> {
+        return ApiResponse.success(productStatisticsQueryService.getByProductId(productId))
+    }
+
+    @GetMapping("/seller/{sellerId}")
+    fun getBySellerId(
+        @PathVariable sellerId: Long,
+        pageable: Pageable
+    ): ApiResponse<Page<ProductStatisticsResponse>> {
+        return ApiResponse.success(productStatisticsQueryService.getBySellerId(sellerId, pageable))
+    }
+
+    @GetMapping("/category/{categoryId}")
+    fun getByCategoryId(
+        @PathVariable categoryId: Long,
+        pageable: Pageable
+    ): ApiResponse<Page<ProductStatisticsResponse>> {
+        return ApiResponse.success(productStatisticsQueryService.getByCategoryId(categoryId, pageable))
+    }
+
+    @GetMapping("/summary")
+    fun getSummary(): ApiResponse<ProductStatisticsSummaryResponse> {
+        return ApiResponse.success(productStatisticsQueryService.getSummary())
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/ProductStatistics.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/ProductStatistics.kt
@@ -1,0 +1,118 @@
+package com.hoppingmall.mall.product.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "product_statistics")
+class ProductStatistics private constructor(
+    @Column(unique = true, nullable = false)
+    val productId: Long,
+
+    @Column(nullable = false)
+    var productName: String,
+
+    @Column(nullable = false)
+    val sellerId: Long,
+
+    @Column(nullable = false)
+    var categoryId: Long,
+
+    @Column(nullable = false)
+    var totalSalesQuantity: Long = 0,
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    var totalSalesAmount: BigDecimal = BigDecimal.ZERO,
+
+    @Column(nullable = false)
+    var totalRefundQuantity: Long = 0,
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    var totalRefundAmount: BigDecimal = BigDecimal.ZERO,
+
+    @Column(nullable = false)
+    var currentCartCount: Long = 0,
+
+    @Column(nullable = false)
+    var currentStock: Int = 0,
+
+    @Column(nullable = false, precision = 5, scale = 4)
+    var refundRate: BigDecimal = BigDecimal.ZERO,
+
+    @Column(nullable = false, precision = 10, scale = 4)
+    var stockTurnoverRate: BigDecimal = BigDecimal.ZERO,
+
+    @Column(nullable = false)
+    var lastAggregatedAt: LocalDateTime = LocalDateTime.now()
+) : BaseEntity() {
+
+    fun update(
+        productName: String,
+        categoryId: Long,
+        totalSalesQuantity: Long,
+        totalSalesAmount: BigDecimal,
+        totalRefundQuantity: Long,
+        totalRefundAmount: BigDecimal,
+        currentCartCount: Long,
+        currentStock: Int
+    ) {
+        this.productName = productName
+        this.categoryId = categoryId
+        this.totalSalesQuantity = totalSalesQuantity
+        this.totalSalesAmount = totalSalesAmount
+        this.totalRefundQuantity = totalRefundQuantity
+        this.totalRefundAmount = totalRefundAmount
+        this.currentCartCount = currentCartCount
+        this.currentStock = currentStock
+        this.refundRate = calculateRefundRate(totalRefundQuantity, totalSalesQuantity)
+        this.stockTurnoverRate = calculateStockTurnoverRate(totalSalesQuantity, currentStock)
+        this.lastAggregatedAt = LocalDateTime.now()
+    }
+
+    companion object {
+        fun create(
+            productId: Long,
+            productName: String,
+            sellerId: Long,
+            categoryId: Long,
+            totalSalesQuantity: Long,
+            totalSalesAmount: BigDecimal,
+            totalRefundQuantity: Long,
+            totalRefundAmount: BigDecimal,
+            currentCartCount: Long,
+            currentStock: Int
+        ): ProductStatistics {
+            return ProductStatistics(
+                productId = productId,
+                productName = productName,
+                sellerId = sellerId,
+                categoryId = categoryId,
+                totalSalesQuantity = totalSalesQuantity,
+                totalSalesAmount = totalSalesAmount,
+                totalRefundQuantity = totalRefundQuantity,
+                totalRefundAmount = totalRefundAmount,
+                currentCartCount = currentCartCount,
+                currentStock = currentStock,
+                refundRate = calculateRefundRate(totalRefundQuantity, totalSalesQuantity),
+                stockTurnoverRate = calculateStockTurnoverRate(totalSalesQuantity, currentStock)
+            )
+        }
+
+        private fun calculateRefundRate(refundQuantity: Long, salesQuantity: Long): BigDecimal {
+            if (salesQuantity == 0L) return BigDecimal.ZERO
+            return BigDecimal(refundQuantity)
+                .divide(BigDecimal(salesQuantity), 4, RoundingMode.HALF_UP)
+        }
+
+        private fun calculateStockTurnoverRate(salesQuantity: Long, currentStock: Int): BigDecimal {
+            if (currentStock == 0) return BigDecimal.ZERO
+            return BigDecimal(salesQuantity)
+                .divide(BigDecimal(currentStock), 4, RoundingMode.HALF_UP)
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductStatisticsRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductStatisticsRepository.kt
@@ -1,0 +1,28 @@
+package com.hoppingmall.mall.product.domain.repository
+
+import com.hoppingmall.mall.product.domain.ProductStatistics
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import java.math.BigDecimal
+
+@Repository
+interface ProductStatisticsRepository : JpaRepository<ProductStatistics, Long> {
+    fun findByProductId(productId: Long): ProductStatistics?
+    fun findBySellerId(sellerId: Long, pageable: Pageable): Page<ProductStatistics>
+    fun findByCategoryId(categoryId: Long, pageable: Pageable): Page<ProductStatistics>
+
+    @Query("SELECT COUNT(ps) FROM ProductStatistics ps")
+    fun countAllProducts(): Long
+
+    @Query("SELECT COALESCE(SUM(ps.totalSalesAmount), 0) FROM ProductStatistics ps")
+    fun sumTotalSalesAmount(): BigDecimal
+
+    @Query("SELECT COALESCE(SUM(ps.totalRefundAmount), 0) FROM ProductStatistics ps")
+    fun sumTotalRefundAmount(): BigDecimal
+
+    @Query("SELECT COALESCE(AVG(ps.refundRate), 0) FROM ProductStatistics ps WHERE ps.totalSalesQuantity > 0")
+    fun avgRefundRate(): BigDecimal
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/CartAggregation.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/CartAggregation.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.product.dto
+
+interface CartAggregation {
+    fun getProductId(): Long
+    fun getBuyerCount(): Long
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/RefundAggregation.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/RefundAggregation.kt
@@ -1,0 +1,9 @@
+package com.hoppingmall.mall.product.dto
+
+import java.math.BigDecimal
+
+interface RefundAggregation {
+    fun getProductId(): Long
+    fun getTotalQuantity(): Long
+    fun getTotalAmount(): BigDecimal
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/SalesAggregation.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/SalesAggregation.kt
@@ -1,0 +1,9 @@
+package com.hoppingmall.mall.product.dto
+
+import java.math.BigDecimal
+
+interface SalesAggregation {
+    fun getProductId(): Long
+    fun getTotalQuantity(): Long
+    fun getTotalAmount(): BigDecimal
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/response/ProductStatisticsResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/response/ProductStatisticsResponse.kt
@@ -1,0 +1,41 @@
+package com.hoppingmall.mall.product.dto.response
+
+import com.hoppingmall.mall.product.domain.ProductStatistics
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+data class ProductStatisticsResponse(
+    val productId: Long,
+    val productName: String,
+    val sellerId: Long,
+    val categoryId: Long,
+    val totalSalesQuantity: Long,
+    val totalSalesAmount: BigDecimal,
+    val totalRefundQuantity: Long,
+    val totalRefundAmount: BigDecimal,
+    val currentCartCount: Long,
+    val currentStock: Int,
+    val refundRate: BigDecimal,
+    val stockTurnoverRate: BigDecimal,
+    val lastAggregatedAt: LocalDateTime
+) {
+    companion object {
+        fun from(entity: ProductStatistics): ProductStatisticsResponse {
+            return ProductStatisticsResponse(
+                productId = entity.productId,
+                productName = entity.productName,
+                sellerId = entity.sellerId,
+                categoryId = entity.categoryId,
+                totalSalesQuantity = entity.totalSalesQuantity,
+                totalSalesAmount = entity.totalSalesAmount,
+                totalRefundQuantity = entity.totalRefundQuantity,
+                totalRefundAmount = entity.totalRefundAmount,
+                currentCartCount = entity.currentCartCount,
+                currentStock = entity.currentStock,
+                refundRate = entity.refundRate,
+                stockTurnoverRate = entity.stockTurnoverRate,
+                lastAggregatedAt = entity.lastAggregatedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/response/ProductStatisticsSummaryResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/response/ProductStatisticsSummaryResponse.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.mall.product.dto.response
+
+import java.math.BigDecimal
+
+data class ProductStatisticsSummaryResponse(
+    val totalProductCount: Long,
+    val totalSalesAmount: BigDecimal,
+    val totalRefundAmount: BigDecimal,
+    val averageRefundRate: BigDecimal
+)

--- a/src/main/kotlin/com/hoppingmall/mall/product/exception/ProductStatisticsNotFoundException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/exception/ProductStatisticsNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.product.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.product.exception.code.ProductErrorCode
+
+class ProductStatisticsNotFoundException : BusinessException(ProductErrorCode.PRODUCT_STATISTICS_NOT_FOUND)

--- a/src/main/kotlin/com/hoppingmall/mall/product/exception/code/ProductErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/exception/code/ProductErrorCode.kt
@@ -12,5 +12,6 @@ enum class ProductErrorCode(
     PRODUCT_NOT_FOUND("P001", "상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     PRODUCT_ALREADY_EXISTS("P002", "이미 존재하는 상품입니다.", HttpStatus.CONFLICT),
     PRODUCT_INVALID_STATUS("P003", "유효하지 않은 상품 상태입니다.", HttpStatus.BAD_REQUEST),
-    PRODUCT_ACCESS_DENIED("P004", "상품에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN)
+    PRODUCT_ACCESS_DENIED("P004", "상품에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    PRODUCT_STATISTICS_NOT_FOUND("P005", "상품 통계를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryService.kt
@@ -1,0 +1,14 @@
+package com.hoppingmall.mall.product.service
+
+import com.hoppingmall.mall.product.dto.response.ProductStatisticsResponse
+import com.hoppingmall.mall.product.dto.response.ProductStatisticsSummaryResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface ProductStatisticsQueryService {
+    fun getAll(pageable: Pageable): Page<ProductStatisticsResponse>
+    fun getByProductId(productId: Long): ProductStatisticsResponse
+    fun getBySellerId(sellerId: Long, pageable: Pageable): Page<ProductStatisticsResponse>
+    fun getByCategoryId(categoryId: Long, pageable: Pageable): Page<ProductStatisticsResponse>
+    fun getSummary(): ProductStatisticsSummaryResponse
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryServiceImpl.kt
@@ -1,0 +1,47 @@
+package com.hoppingmall.mall.product.service
+
+import com.hoppingmall.mall.product.domain.repository.ProductStatisticsRepository
+import com.hoppingmall.mall.product.dto.response.ProductStatisticsResponse
+import com.hoppingmall.mall.product.dto.response.ProductStatisticsSummaryResponse
+import com.hoppingmall.mall.product.exception.ProductStatisticsNotFoundException
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class ProductStatisticsQueryServiceImpl(
+    private val productStatisticsRepository: ProductStatisticsRepository
+) : ProductStatisticsQueryService {
+
+    override fun getAll(pageable: Pageable): Page<ProductStatisticsResponse> {
+        return productStatisticsRepository.findAll(pageable)
+            .map { ProductStatisticsResponse.from(it) }
+    }
+
+    override fun getByProductId(productId: Long): ProductStatisticsResponse {
+        val statistics = productStatisticsRepository.findByProductId(productId)
+            ?: throw ProductStatisticsNotFoundException()
+        return ProductStatisticsResponse.from(statistics)
+    }
+
+    override fun getBySellerId(sellerId: Long, pageable: Pageable): Page<ProductStatisticsResponse> {
+        return productStatisticsRepository.findBySellerId(sellerId, pageable)
+            .map { ProductStatisticsResponse.from(it) }
+    }
+
+    override fun getByCategoryId(categoryId: Long, pageable: Pageable): Page<ProductStatisticsResponse> {
+        return productStatisticsRepository.findByCategoryId(categoryId, pageable)
+            .map { ProductStatisticsResponse.from(it) }
+    }
+
+    override fun getSummary(): ProductStatisticsSummaryResponse {
+        return ProductStatisticsSummaryResponse(
+            totalProductCount = productStatisticsRepository.countAllProducts(),
+            totalSalesAmount = productStatisticsRepository.sumTotalSalesAmount(),
+            totalRefundAmount = productStatisticsRepository.sumTotalRefundAmount(),
+            averageRefundRate = productStatisticsRepository.avgRefundRate()
+        )
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsScheduler.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsScheduler.kt
@@ -1,0 +1,106 @@
+package com.hoppingmall.mall.product.service
+
+import com.hoppingmall.mall.cartItem.domain.repository.CartItemRepository
+import com.hoppingmall.mall.inventory.domain.repository.InventoryRepository
+import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
+import com.hoppingmall.mall.product.domain.ProductStatistics
+import com.hoppingmall.mall.product.domain.repository.ProductRepository
+import com.hoppingmall.mall.product.domain.repository.ProductStatisticsRepository
+import com.hoppingmall.mall.refund.domain.repository.RefundItemRepository
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@Component
+@Profile("!test")
+class ProductStatisticsScheduler(
+    private val productRepository: ProductRepository,
+    private val productStatisticsRepository: ProductStatisticsRepository,
+    private val orderItemRepository: OrderItemRepository,
+    private val refundItemRepository: RefundItemRepository,
+    private val cartItemRepository: CartItemRepository,
+    private val inventoryRepository: InventoryRepository
+) {
+    private val logger = LoggerFactory.getLogger(ProductStatisticsScheduler::class.java)
+
+    @Scheduled(cron = "0 0 * * * *")
+    @Transactional
+    fun aggregateProductStatistics() {
+        logger.info("상품 통계 집계 시작")
+
+        val products = productRepository.findAll()
+        if (products.isEmpty()) {
+            logger.info("집계할 상품이 없습니다")
+            return
+        }
+
+        val salesMap = orderItemRepository
+            .aggregateSalesByProduct(listOf("PAID", "SHIPPED", "DELIVERED"))
+            .associateBy { it.getProductId() }
+
+        val refundMap = refundItemRepository
+            .aggregateRefundsByProduct("COMPLETED")
+            .associateBy { it.getProductId() }
+
+        val cartMap = cartItemRepository
+            .aggregateCartByProduct()
+            .associateBy { it.getProductId() }
+
+        val inventoryMap = inventoryRepository.findAll()
+            .associateBy { it.productId }
+
+        var createdCount = 0
+        var updatedCount = 0
+
+        for (product in products) {
+            val productId = product.id ?: continue
+            val sales = salesMap[productId]
+            val refund = refundMap[productId]
+            val cart = cartMap[productId]
+            val inventory = inventoryMap[productId]
+
+            val totalSalesQuantity = sales?.getTotalQuantity() ?: 0L
+            val totalSalesAmount = sales?.getTotalAmount() ?: BigDecimal.ZERO
+            val totalRefundQuantity = refund?.getTotalQuantity() ?: 0L
+            val totalRefundAmount = refund?.getTotalAmount() ?: BigDecimal.ZERO
+            val currentCartCount = cart?.getBuyerCount() ?: 0L
+            val currentStock = inventory?.stockQuantity ?: 0
+
+            val existing = productStatisticsRepository.findByProductId(productId)
+            if (existing != null) {
+                existing.update(
+                    productName = product.name,
+                    categoryId = product.categoryId,
+                    totalSalesQuantity = totalSalesQuantity,
+                    totalSalesAmount = totalSalesAmount,
+                    totalRefundQuantity = totalRefundQuantity,
+                    totalRefundAmount = totalRefundAmount,
+                    currentCartCount = currentCartCount,
+                    currentStock = currentStock
+                )
+                updatedCount++
+            } else {
+                productStatisticsRepository.save(
+                    ProductStatistics.create(
+                        productId = productId,
+                        productName = product.name,
+                        sellerId = product.sellerId,
+                        categoryId = product.categoryId,
+                        totalSalesQuantity = totalSalesQuantity,
+                        totalSalesAmount = totalSalesAmount,
+                        totalRefundQuantity = totalRefundQuantity,
+                        totalRefundAmount = totalRefundAmount,
+                        currentCartCount = currentCartCount,
+                        currentStock = currentStock
+                    )
+                )
+                createdCount++
+            }
+        }
+
+        logger.info("상품 통계 집계 완료 - 신규: ${createdCount}건, 갱신: ${updatedCount}건")
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/domain/repository/RefundItemRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/domain/repository/RefundItemRepository.kt
@@ -1,10 +1,29 @@
 package com.hoppingmall.mall.refund.domain.repository
 
+import com.hoppingmall.mall.product.dto.RefundAggregation
 import com.hoppingmall.mall.refund.domain.RefundItem
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
 interface RefundItemRepository : JpaRepository<RefundItem, Long> {
     fun findByRefundId(refundId: Long): List<RefundItem>
+
+    @Query(
+        value = """
+            SELECT ri.product_id AS productId,
+                   SUM(ri.quantity) AS totalQuantity,
+                   SUM(ri.refund_price) AS totalAmount
+            FROM refund_items ri
+            JOIN refunds r ON ri.refund_id = r.id
+            WHERE r.status = :status
+              AND ri.deleted_at IS NULL
+              AND r.deleted_at IS NULL
+            GROUP BY ri.product_id
+        """,
+        nativeQuery = true
+    )
+    fun aggregateRefundsByProduct(@Param("status") status: String): List<RefundAggregation>
 }

--- a/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductStatisticsControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductStatisticsControllerTest.kt
@@ -1,0 +1,165 @@
+package com.hoppingmall.mall.product.controller
+
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.product.dto.response.ProductStatisticsResponse
+import com.hoppingmall.mall.product.dto.response.ProductStatisticsSummaryResponse
+import com.hoppingmall.mall.product.exception.ProductStatisticsNotFoundException
+import com.hoppingmall.mall.product.service.ProductStatisticsQueryService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@DisplayName("ProductStatisticsController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class ProductStatisticsControllerTest {
+
+    private val productStatisticsQueryService: ProductStatisticsQueryService = mock()
+    private val controller = ProductStatisticsController(productStatisticsQueryService)
+
+    private fun createResponse(
+        productId: Long = 1L,
+        productName: String = "테스트 상품"
+    ) = ProductStatisticsResponse(
+        productId = productId,
+        productName = productName,
+        sellerId = 1L,
+        categoryId = 1L,
+        totalSalesQuantity = 100,
+        totalSalesAmount = BigDecimal("1000000"),
+        totalRefundQuantity = 5,
+        totalRefundAmount = BigDecimal("50000"),
+        currentCartCount = 10,
+        currentStock = 50,
+        refundRate = BigDecimal("0.0500"),
+        stockTurnoverRate = BigDecimal("2.0000"),
+        lastAggregatedAt = LocalDateTime.of(2026, 2, 17, 12, 0, 0)
+    )
+
+    @Nested
+    @DisplayName("getAll")
+    inner class GetAll {
+        @Test
+        fun 전체_통계_조회_성공() {
+            val pageable = PageRequest.of(0, 10)
+            val responses = listOf(createResponse(1L, "상품1"), createResponse(2L, "상품2"))
+            val page = PageImpl(responses, pageable, responses.size.toLong())
+
+            whenever(productStatisticsQueryService.getAll(any())).thenReturn(page)
+
+            val result: ApiResponse<Page<ProductStatisticsResponse>> = controller.getAll(pageable)
+
+            assertEquals("SUCCESS", result.code)
+            assertEquals(2, result.data!!.content.size)
+            verify(productStatisticsQueryService).getAll(pageable)
+        }
+    }
+
+    @Nested
+    @DisplayName("getByProductId")
+    inner class GetByProductId {
+        @Test
+        fun 상품별_통계_조회_성공() {
+            val productId = 1L
+            val response = createResponse(productId)
+
+            whenever(productStatisticsQueryService.getByProductId(productId)).thenReturn(response)
+
+            val result: ApiResponse<ProductStatisticsResponse> = controller.getByProductId(productId)
+
+            assertEquals("SUCCESS", result.code)
+            assertEquals(productId, result.data!!.productId)
+            verify(productStatisticsQueryService).getByProductId(productId)
+        }
+
+        @Test
+        fun 존재하지_않는_상품_통계_조회_시_예외_발생() {
+            val productId = 999L
+
+            whenever(productStatisticsQueryService.getByProductId(productId))
+                .thenThrow(ProductStatisticsNotFoundException())
+
+            assertThrows<ProductStatisticsNotFoundException> {
+                controller.getByProductId(productId)
+            }
+
+            verify(productStatisticsQueryService).getByProductId(productId)
+        }
+    }
+
+    @Nested
+    @DisplayName("getBySellerId")
+    inner class GetBySellerId {
+        @Test
+        fun 판매자별_통계_조회_성공() {
+            val sellerId = 1L
+            val pageable = PageRequest.of(0, 10)
+            val responses = listOf(createResponse(1L, "상품1"))
+            val page = PageImpl(responses, pageable, responses.size.toLong())
+
+            whenever(productStatisticsQueryService.getBySellerId(eq(sellerId), any())).thenReturn(page)
+
+            val result: ApiResponse<Page<ProductStatisticsResponse>> = controller.getBySellerId(sellerId, pageable)
+
+            assertEquals("SUCCESS", result.code)
+            assertEquals(1, result.data!!.content.size)
+            verify(productStatisticsQueryService).getBySellerId(sellerId, pageable)
+        }
+    }
+
+    @Nested
+    @DisplayName("getByCategoryId")
+    inner class GetByCategoryId {
+        @Test
+        fun 카테고리별_통계_조회_성공() {
+            val categoryId = 1L
+            val pageable = PageRequest.of(0, 10)
+            val responses = listOf(createResponse(1L, "상품1"))
+            val page = PageImpl(responses, pageable, responses.size.toLong())
+
+            whenever(productStatisticsQueryService.getByCategoryId(eq(categoryId), any())).thenReturn(page)
+
+            val result: ApiResponse<Page<ProductStatisticsResponse>> = controller.getByCategoryId(categoryId, pageable)
+
+            assertEquals("SUCCESS", result.code)
+            assertEquals(1, result.data!!.content.size)
+            verify(productStatisticsQueryService).getByCategoryId(categoryId, pageable)
+        }
+    }
+
+    @Nested
+    @DisplayName("getSummary")
+    inner class GetSummary {
+        @Test
+        fun 전체_요약_조회_성공() {
+            val summary = ProductStatisticsSummaryResponse(
+                totalProductCount = 10,
+                totalSalesAmount = BigDecimal("5000000"),
+                totalRefundAmount = BigDecimal("250000"),
+                averageRefundRate = BigDecimal("0.0500")
+            )
+
+            whenever(productStatisticsQueryService.getSummary()).thenReturn(summary)
+
+            val result: ApiResponse<ProductStatisticsSummaryResponse> = controller.getSummary()
+
+            assertEquals("SUCCESS", result.code)
+            assertEquals(10L, result.data!!.totalProductCount)
+            assertEquals(BigDecimal("5000000"), result.data!!.totalSalesAmount)
+            verify(productStatisticsQueryService).getSummary()
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/product/domain/ProductStatisticsTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/domain/ProductStatisticsTest.kt
@@ -1,0 +1,127 @@
+package com.hoppingmall.mall.product.domain
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("ProductStatistics")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class ProductStatisticsTest {
+
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+        @Test
+        fun 통계_생성_시_환불률이_올바르게_계산된다() {
+            val stats = ProductStatistics.create(
+                productId = 1L,
+                productName = "테스트 상품",
+                sellerId = 1L,
+                categoryId = 1L,
+                totalSalesQuantity = 100,
+                totalSalesAmount = BigDecimal("1000000"),
+                totalRefundQuantity = 5,
+                totalRefundAmount = BigDecimal("50000"),
+                currentCartCount = 10,
+                currentStock = 50
+            )
+
+            assertEquals(BigDecimal("0.0500"), stats.refundRate)
+        }
+
+        @Test
+        fun 통계_생성_시_재고_회전율이_올바르게_계산된다() {
+            val stats = ProductStatistics.create(
+                productId = 1L,
+                productName = "테스트 상품",
+                sellerId = 1L,
+                categoryId = 1L,
+                totalSalesQuantity = 100,
+                totalSalesAmount = BigDecimal("1000000"),
+                totalRefundQuantity = 5,
+                totalRefundAmount = BigDecimal("50000"),
+                currentCartCount = 10,
+                currentStock = 50
+            )
+
+            assertEquals(BigDecimal("2.0000"), stats.stockTurnoverRate)
+        }
+
+        @Test
+        fun 판매수량이_0이면_환불률은_0이다() {
+            val stats = ProductStatistics.create(
+                productId = 1L,
+                productName = "테스트 상품",
+                sellerId = 1L,
+                categoryId = 1L,
+                totalSalesQuantity = 0,
+                totalSalesAmount = BigDecimal.ZERO,
+                totalRefundQuantity = 0,
+                totalRefundAmount = BigDecimal.ZERO,
+                currentCartCount = 0,
+                currentStock = 50
+            )
+
+            assertEquals(BigDecimal.ZERO, stats.refundRate)
+        }
+
+        @Test
+        fun 재고가_0이면_재고_회전율은_0이다() {
+            val stats = ProductStatistics.create(
+                productId = 1L,
+                productName = "테스트 상품",
+                sellerId = 1L,
+                categoryId = 1L,
+                totalSalesQuantity = 100,
+                totalSalesAmount = BigDecimal("1000000"),
+                totalRefundQuantity = 5,
+                totalRefundAmount = BigDecimal("50000"),
+                currentCartCount = 10,
+                currentStock = 0
+            )
+
+            assertEquals(BigDecimal.ZERO, stats.stockTurnoverRate)
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    inner class Update {
+        @Test
+        fun 통계_갱신_시_환불률과_재고_회전율이_재계산된다() {
+            val stats = ProductStatistics.create(
+                productId = 1L,
+                productName = "테스트 상품",
+                sellerId = 1L,
+                categoryId = 1L,
+                totalSalesQuantity = 100,
+                totalSalesAmount = BigDecimal("1000000"),
+                totalRefundQuantity = 5,
+                totalRefundAmount = BigDecimal("50000"),
+                currentCartCount = 10,
+                currentStock = 50
+            )
+
+            stats.update(
+                productName = "수정된 상품",
+                categoryId = 2L,
+                totalSalesQuantity = 200,
+                totalSalesAmount = BigDecimal("2000000"),
+                totalRefundQuantity = 20,
+                totalRefundAmount = BigDecimal("200000"),
+                currentCartCount = 15,
+                currentStock = 100
+            )
+
+            assertEquals("수정된 상품", stats.productName)
+            assertEquals(2L, stats.categoryId)
+            assertEquals(200, stats.totalSalesQuantity)
+            assertEquals(BigDecimal("0.1000"), stats.refundRate)
+            assertEquals(BigDecimal("2.0000"), stats.stockTurnoverRate)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryServiceImplTest.kt
@@ -1,0 +1,152 @@
+package com.hoppingmall.mall.product.service
+
+import com.hoppingmall.mall.product.domain.ProductStatistics
+import com.hoppingmall.mall.product.domain.repository.ProductStatisticsRepository
+import com.hoppingmall.mall.product.exception.ProductStatisticsNotFoundException
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.math.BigDecimal
+
+@DisplayName("ProductStatisticsQueryServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class ProductStatisticsQueryServiceImplTest {
+
+    private val productStatisticsRepository: ProductStatisticsRepository = mock()
+    private val service = ProductStatisticsQueryServiceImpl(productStatisticsRepository)
+
+    @Nested
+    @DisplayName("getAll")
+    inner class GetAll {
+        @Test
+        fun 전체_통계_조회_성공() {
+            val pageable = PageRequest.of(0, 10)
+            val stats = listOf(
+                ProductStatistics.fixture(productId = 1L, productName = "상품1").withId(1L),
+                ProductStatistics.fixture(productId = 2L, productName = "상품2", sellerId = 2L).withId(2L)
+            )
+            val page = PageImpl(stats, pageable, stats.size.toLong())
+
+            whenever(productStatisticsRepository.findAll(pageable)).thenReturn(page)
+
+            val result = service.getAll(pageable)
+
+            assertEquals(2, result.content.size)
+            assertEquals("상품1", result.content[0].productName)
+            assertEquals("상품2", result.content[1].productName)
+            verify(productStatisticsRepository).findAll(pageable)
+        }
+    }
+
+    @Nested
+    @DisplayName("getByProductId")
+    inner class GetByProductId {
+        @Test
+        fun 상품별_통계_조회_성공() {
+            val productId = 1L
+            val stats = ProductStatistics.fixture(productId = productId, productName = "테스트 상품").withId(1L)
+
+            whenever(productStatisticsRepository.findByProductId(productId)).thenReturn(stats)
+
+            val result = service.getByProductId(productId)
+
+            assertEquals(productId, result.productId)
+            assertEquals("테스트 상품", result.productName)
+            assertEquals(100, result.totalSalesQuantity)
+            verify(productStatisticsRepository).findByProductId(productId)
+        }
+
+        @Test
+        fun 존재하지_않는_상품_통계_조회_시_예외_발생() {
+            val productId = 999L
+
+            whenever(productStatisticsRepository.findByProductId(productId)).thenReturn(null)
+
+            assertThrows(ProductStatisticsNotFoundException::class.java) {
+                service.getByProductId(productId)
+            }
+
+            verify(productStatisticsRepository).findByProductId(productId)
+        }
+    }
+
+    @Nested
+    @DisplayName("getBySellerId")
+    inner class GetBySellerId {
+        @Test
+        fun 판매자별_통계_조회_성공() {
+            val sellerId = 1L
+            val pageable = PageRequest.of(0, 10)
+            val stats = listOf(
+                ProductStatistics.fixture(productId = 1L, sellerId = sellerId, productName = "상품1").withId(1L),
+                ProductStatistics.fixture(productId = 2L, sellerId = sellerId, productName = "상품2").withId(2L)
+            )
+            val page = PageImpl(stats, pageable, stats.size.toLong())
+
+            whenever(productStatisticsRepository.findBySellerId(sellerId, pageable)).thenReturn(page)
+
+            val result = service.getBySellerId(sellerId, pageable)
+
+            assertEquals(2, result.content.size)
+            assertEquals(sellerId, result.content[0].sellerId)
+            assertEquals(sellerId, result.content[1].sellerId)
+            verify(productStatisticsRepository).findBySellerId(sellerId, pageable)
+        }
+    }
+
+    @Nested
+    @DisplayName("getByCategoryId")
+    inner class GetByCategoryId {
+        @Test
+        fun 카테고리별_통계_조회_성공() {
+            val categoryId = 1L
+            val pageable = PageRequest.of(0, 10)
+            val stats = listOf(
+                ProductStatistics.fixture(productId = 1L, categoryId = categoryId, productName = "상품1").withId(1L)
+            )
+            val page = PageImpl(stats, pageable, stats.size.toLong())
+
+            whenever(productStatisticsRepository.findByCategoryId(categoryId, pageable)).thenReturn(page)
+
+            val result = service.getByCategoryId(categoryId, pageable)
+
+            assertEquals(1, result.content.size)
+            assertEquals(categoryId, result.content[0].categoryId)
+            verify(productStatisticsRepository).findByCategoryId(categoryId, pageable)
+        }
+    }
+
+    @Nested
+    @DisplayName("getSummary")
+    inner class GetSummary {
+        @Test
+        fun 전체_요약_조회_성공() {
+            whenever(productStatisticsRepository.countAllProducts()).thenReturn(10L)
+            whenever(productStatisticsRepository.sumTotalSalesAmount()).thenReturn(BigDecimal("5000000"))
+            whenever(productStatisticsRepository.sumTotalRefundAmount()).thenReturn(BigDecimal("250000"))
+            whenever(productStatisticsRepository.avgRefundRate()).thenReturn(BigDecimal("0.0500"))
+
+            val result = service.getSummary()
+
+            assertEquals(10L, result.totalProductCount)
+            assertEquals(BigDecimal("5000000"), result.totalSalesAmount)
+            assertEquals(BigDecimal("250000"), result.totalRefundAmount)
+            assertEquals(BigDecimal("0.0500"), result.averageRefundRate)
+            verify(productStatisticsRepository).countAllProducts()
+            verify(productStatisticsRepository).sumTotalSalesAmount()
+            verify(productStatisticsRepository).sumTotalRefundAmount()
+            verify(productStatisticsRepository).avgRefundRate()
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/ProductStatisticsFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/ProductStatisticsFixture.kt
@@ -1,0 +1,30 @@
+package com.hoppingmall.mall.support.fixture
+
+import com.hoppingmall.mall.product.domain.ProductStatistics
+import java.math.BigDecimal
+
+fun ProductStatistics.Companion.fixture(
+    productId: Long = 1L,
+    productName: String = "테스트 상품",
+    sellerId: Long = 1L,
+    categoryId: Long = 1L,
+    totalSalesQuantity: Long = 100,
+    totalSalesAmount: BigDecimal = BigDecimal("1000000"),
+    totalRefundQuantity: Long = 5,
+    totalRefundAmount: BigDecimal = BigDecimal("50000"),
+    currentCartCount: Long = 10,
+    currentStock: Int = 50
+): ProductStatistics {
+    return ProductStatistics.create(
+        productId = productId,
+        productName = productName,
+        sellerId = sellerId,
+        categoryId = categoryId,
+        totalSalesQuantity = totalSalesQuantity,
+        totalSalesAmount = totalSalesAmount,
+        totalRefundQuantity = totalRefundQuantity,
+        totalRefundAmount = totalRefundAmount,
+        currentCartCount = currentCartCount,
+        currentStock = currentStock
+    )
+}


### PR DESCRIPTION
Closes #69

## 📌 변경 사항
- `ProductStatistics` 엔티티 (상품당 1행, 판매/환불/장바구니/재고 통계)
- 매 1시간 스케줄러 배치 집계 (`@Scheduled`, `@Profile("!test")`)
- Admin API (`/api/v1/admin/product-statistics`) - 전체/상품별/판매자별/카테고리별/요약 조회
- `@EnableScheduling` 활성화

## ✅ 주요 설계
- 4개 네이티브 SQL 집계 쿼리 (판매, 환불, 장바구니, 재고) → 상품별 Map → UPSERT
- 환불률(refundRate), 재고 회전율(stockTurnoverRate) 자동 계산
- 기존 `/api/v1/admin/**` → `hasRole("ADMIN")` 규칙에 포함되어 SecurityConfig 변경 없음

## 🧪 테스트
- ProductStatisticsTest (엔티티 단위 테스트)
- ProductStatisticsQueryServiceImplTest
- ProductStatisticsControllerTest
- `./gradlew test` ✅
- `./gradlew jacocoTestVerification` ✅

## 📎 참고
- Jacoco 제외 대상에 `ProductStatisticsScheduler` 추가