### PR TITLE
feat: 상품 통계 고도화 - 실시간 + 일별 히스토리

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,7 +113,9 @@ val jacocoExcludedDirs = listOf(
 	"**/com/hoppingmall/mall/payment/service/PaymentEventConsumer*",
 	"**/com/hoppingmall/mall/membership/service/MembershipEventConsumer*",
 	"**/com/hoppingmall/mall/membership/domain/MembershipEventLog*",
-	"**/com/hoppingmall/mall/product/service/ProductStatisticsScheduler*"
+	"**/com/hoppingmall/mall/product/service/ProductStatisticsScheduler*",
+	"**/com/hoppingmall/mall/product/service/StatisticsEventConsumer*",
+	"**/com/hoppingmall/mall/product/domain/StatisticsEventLog*"
 )
 
 tasks.jacocoTestReport {

--- a/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductStatisticsController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductStatisticsController.kt
@@ -1,15 +1,13 @@
 package com.hoppingmall.mall.product.controller
 
 import com.hoppingmall.mall.global.common.response.ApiResponse
-import com.hoppingmall.mall.product.dto.response.ProductStatisticsResponse
-import com.hoppingmall.mall.product.dto.response.ProductStatisticsSummaryResponse
+import com.hoppingmall.mall.product.dto.response.*
 import com.hoppingmall.mall.product.service.ProductStatisticsQueryService
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.web.bind.annotation.*
+import java.time.LocalDate
 
 @RestController
 @RequestMapping("/api/v1/admin/product-statistics")
@@ -45,5 +43,35 @@ class ProductStatisticsController(
     @GetMapping("/summary")
     fun getSummary(): ApiResponse<ProductStatisticsSummaryResponse> {
         return ApiResponse.success(productStatisticsQueryService.getSummary())
+    }
+
+    @GetMapping("/realtime/today")
+    fun getTodaySummary(): ApiResponse<TodaySummaryResponse> {
+        return ApiResponse.success(productStatisticsQueryService.getTodaySummary())
+    }
+
+    @GetMapping("/daily")
+    fun getDailyStatistics(
+        @RequestParam productId: Long,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate
+    ): ApiResponse<List<ProductDailyStatisticsResponse>> {
+        return ApiResponse.success(productStatisticsQueryService.getDailyStatistics(productId, startDate, endDate))
+    }
+
+    @GetMapping("/top-selling")
+    fun getTopSellingProducts(
+        @RequestParam(defaultValue = "7") days: Int,
+        @RequestParam(defaultValue = "10") limit: Int
+    ): ApiResponse<List<TopProductResponse>> {
+        return ApiResponse.success(productStatisticsQueryService.getTopSellingProducts(days, limit))
+    }
+
+    @GetMapping("/top-refund")
+    fun getTopRefundProducts(
+        @RequestParam(defaultValue = "7") days: Int,
+        @RequestParam(defaultValue = "10") limit: Int
+    ): ApiResponse<List<TopProductResponse>> {
+        return ApiResponse.success(productStatisticsQueryService.getTopRefundProducts(days, limit))
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/ProductDailyStatistics.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/ProductDailyStatistics.kt
@@ -1,0 +1,74 @@
+package com.hoppingmall.mall.product.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@Entity
+@Table(
+    name = "product_daily_statistics",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["product_id", "statistics_date"])]
+)
+class ProductDailyStatistics private constructor(
+    @Column(name = "product_id", nullable = false)
+    val productId: Long,
+
+    @Column(name = "statistics_date", nullable = false)
+    val statisticsDate: LocalDate,
+
+    @Column(nullable = false)
+    var dailySalesQuantity: Long = 0,
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    var dailySalesAmount: BigDecimal = BigDecimal.ZERO,
+
+    @Column(nullable = false)
+    var dailyOrderCount: Long = 0,
+
+    @Column(nullable = false)
+    var dailyRefundQuantity: Long = 0,
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    var dailyRefundAmount: BigDecimal = BigDecimal.ZERO,
+
+    @Column(nullable = false)
+    var endOfDayStock: Int = 0
+) : BaseEntity() {
+
+    fun updateFromStatistics(stats: ProductStatistics) {
+        this.dailySalesQuantity = stats.todaySalesQuantity
+        this.dailySalesAmount = stats.todaySalesAmount
+        this.dailyOrderCount = stats.todayOrderCount
+        this.dailyRefundQuantity = stats.todayRefundQuantity
+        this.dailyRefundAmount = stats.todayRefundAmount
+        this.endOfDayStock = stats.currentStock
+    }
+
+    companion object {
+        fun create(
+            productId: Long,
+            statisticsDate: LocalDate,
+            dailySalesQuantity: Long = 0,
+            dailySalesAmount: BigDecimal = BigDecimal.ZERO,
+            dailyOrderCount: Long = 0,
+            dailyRefundQuantity: Long = 0,
+            dailyRefundAmount: BigDecimal = BigDecimal.ZERO,
+            endOfDayStock: Int = 0
+        ): ProductDailyStatistics {
+            return ProductDailyStatistics(
+                productId = productId,
+                statisticsDate = statisticsDate,
+                dailySalesQuantity = dailySalesQuantity,
+                dailySalesAmount = dailySalesAmount,
+                dailyOrderCount = dailyOrderCount,
+                dailyRefundQuantity = dailyRefundQuantity,
+                dailyRefundAmount = dailyRefundAmount,
+                endOfDayStock = endOfDayStock
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/ProductStatistics.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/ProductStatistics.kt
@@ -48,6 +48,39 @@ class ProductStatistics private constructor(
     var stockTurnoverRate: BigDecimal = BigDecimal.ZERO,
 
     @Column(nullable = false)
+    var todaySalesQuantity: Long = 0,
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    var todaySalesAmount: BigDecimal = BigDecimal.ZERO,
+
+    @Column(nullable = false)
+    var todayOrderCount: Long = 0,
+
+    @Column(nullable = false)
+    var todayRefundQuantity: Long = 0,
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    var todayRefundAmount: BigDecimal = BigDecimal.ZERO,
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    var last7DaysSalesAmount: BigDecimal = BigDecimal.ZERO,
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    var last30DaysSalesAmount: BigDecimal = BigDecimal.ZERO,
+
+    @Column(nullable = false, precision = 10, scale = 4)
+    var salesGrowthRate: BigDecimal = BigDecimal.ZERO,
+
+    @Column(nullable = false)
+    var orderCount: Long = 0,
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    var netRevenue: BigDecimal = BigDecimal.ZERO,
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    var averageOrderAmount: BigDecimal = BigDecimal.ZERO,
+
+    @Column(nullable = false)
     var lastAggregatedAt: LocalDateTime = LocalDateTime.now()
 ) : BaseEntity() {
 
@@ -71,6 +104,73 @@ class ProductStatistics private constructor(
         this.currentStock = currentStock
         this.refundRate = calculateRefundRate(totalRefundQuantity, totalSalesQuantity)
         this.stockTurnoverRate = calculateStockTurnoverRate(totalSalesQuantity, currentStock)
+        this.netRevenue = totalSalesAmount.subtract(totalRefundAmount)
+        this.averageOrderAmount = calculateAverageOrderAmount(totalSalesAmount, orderCount)
+        this.lastAggregatedAt = LocalDateTime.now()
+    }
+
+    fun incrementSales(quantity: Long, amount: BigDecimal) {
+        this.totalSalesQuantity += quantity
+        this.totalSalesAmount = this.totalSalesAmount.add(amount)
+        this.todaySalesQuantity += quantity
+        this.todaySalesAmount = this.todaySalesAmount.add(amount)
+        this.todayOrderCount++
+        this.orderCount++
+        this.refundRate = calculateRefundRate(this.totalRefundQuantity, this.totalSalesQuantity)
+        this.stockTurnoverRate = calculateStockTurnoverRate(this.totalSalesQuantity, this.currentStock)
+        this.netRevenue = this.totalSalesAmount.subtract(this.totalRefundAmount)
+        this.averageOrderAmount = calculateAverageOrderAmount(this.totalSalesAmount, this.orderCount)
+        this.lastAggregatedAt = LocalDateTime.now()
+    }
+
+    fun decrementSales(quantity: Long, amount: BigDecimal) {
+        this.totalSalesQuantity = maxOf(0, this.totalSalesQuantity - quantity)
+        this.totalSalesAmount = this.totalSalesAmount.subtract(amount).coerceAtLeast(BigDecimal.ZERO)
+        this.todaySalesQuantity = maxOf(0, this.todaySalesQuantity - quantity)
+        this.todaySalesAmount = this.todaySalesAmount.subtract(amount).coerceAtLeast(BigDecimal.ZERO)
+        this.todayOrderCount = maxOf(0, this.todayOrderCount - 1)
+        this.orderCount = maxOf(0, this.orderCount - 1)
+        this.refundRate = calculateRefundRate(this.totalRefundQuantity, this.totalSalesQuantity)
+        this.stockTurnoverRate = calculateStockTurnoverRate(this.totalSalesQuantity, this.currentStock)
+        this.netRevenue = this.totalSalesAmount.subtract(this.totalRefundAmount)
+        this.averageOrderAmount = calculateAverageOrderAmount(this.totalSalesAmount, this.orderCount)
+        this.lastAggregatedAt = LocalDateTime.now()
+    }
+
+    fun incrementRefund(quantity: Long, amount: BigDecimal) {
+        this.totalRefundQuantity += quantity
+        this.totalRefundAmount = this.totalRefundAmount.add(amount)
+        this.todayRefundQuantity += quantity
+        this.todayRefundAmount = this.todayRefundAmount.add(amount)
+        this.refundRate = calculateRefundRate(this.totalRefundQuantity, this.totalSalesQuantity)
+        this.netRevenue = this.totalSalesAmount.subtract(this.totalRefundAmount)
+        this.lastAggregatedAt = LocalDateTime.now()
+    }
+
+    fun resetToday() {
+        this.todaySalesQuantity = 0
+        this.todaySalesAmount = BigDecimal.ZERO
+        this.todayOrderCount = 0
+        this.todayRefundQuantity = 0
+        this.todayRefundAmount = BigDecimal.ZERO
+    }
+
+    fun updatePeriodMetrics(last7Days: BigDecimal, last30Days: BigDecimal, previousWeekAmount: BigDecimal) {
+        this.last7DaysSalesAmount = last7Days
+        this.last30DaysSalesAmount = last30Days
+        this.salesGrowthRate = if (previousWeekAmount > BigDecimal.ZERO) {
+            last7Days.subtract(previousWeekAmount)
+                .divide(previousWeekAmount, 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal("100"))
+        } else {
+            BigDecimal.ZERO
+        }
+    }
+
+    fun updateCartAndInventory(cartCount: Long, stock: Int) {
+        this.currentCartCount = cartCount
+        this.currentStock = stock
+        this.stockTurnoverRate = calculateStockTurnoverRate(this.totalSalesQuantity, stock)
         this.lastAggregatedAt = LocalDateTime.now()
     }
 
@@ -80,12 +180,12 @@ class ProductStatistics private constructor(
             productName: String,
             sellerId: Long,
             categoryId: Long,
-            totalSalesQuantity: Long,
-            totalSalesAmount: BigDecimal,
-            totalRefundQuantity: Long,
-            totalRefundAmount: BigDecimal,
-            currentCartCount: Long,
-            currentStock: Int
+            totalSalesQuantity: Long = 0,
+            totalSalesAmount: BigDecimal = BigDecimal.ZERO,
+            totalRefundQuantity: Long = 0,
+            totalRefundAmount: BigDecimal = BigDecimal.ZERO,
+            currentCartCount: Long = 0,
+            currentStock: Int = 0
         ): ProductStatistics {
             return ProductStatistics(
                 productId = productId,
@@ -99,7 +199,9 @@ class ProductStatistics private constructor(
                 currentCartCount = currentCartCount,
                 currentStock = currentStock,
                 refundRate = calculateRefundRate(totalRefundQuantity, totalSalesQuantity),
-                stockTurnoverRate = calculateStockTurnoverRate(totalSalesQuantity, currentStock)
+                stockTurnoverRate = calculateStockTurnoverRate(totalSalesQuantity, currentStock),
+                netRevenue = totalSalesAmount.subtract(totalRefundAmount),
+                averageOrderAmount = BigDecimal.ZERO
             )
         }
 
@@ -113,6 +215,11 @@ class ProductStatistics private constructor(
             if (currentStock == 0) return BigDecimal.ZERO
             return BigDecimal(salesQuantity)
                 .divide(BigDecimal(currentStock), 4, RoundingMode.HALF_UP)
+        }
+
+        private fun calculateAverageOrderAmount(totalAmount: BigDecimal, orderCount: Long): BigDecimal {
+            if (orderCount == 0L) return BigDecimal.ZERO
+            return totalAmount.divide(BigDecimal(orderCount), 2, RoundingMode.HALF_UP)
         }
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/StatisticsEventLog.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/StatisticsEventLog.kt
@@ -1,0 +1,23 @@
+package com.hoppingmall.mall.product.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "statistics_event_logs",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["event_id"])]
+)
+class StatisticsEventLog(
+    @Column(name = "event_id", nullable = false, unique = true)
+    val eventId: String,
+
+    @Column(nullable = false)
+    val eventType: String,
+
+    @Column(nullable = false)
+    val orderId: Long
+) : BaseEntity()

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductDailyStatisticsRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductDailyStatisticsRepository.kt
@@ -1,0 +1,72 @@
+package com.hoppingmall.mall.product.domain.repository
+
+import com.hoppingmall.mall.product.domain.ProductDailyStatistics
+import com.hoppingmall.mall.product.dto.TopProductProjection
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@Repository
+interface ProductDailyStatisticsRepository : JpaRepository<ProductDailyStatistics, Long> {
+
+    fun findByProductIdAndStatisticsDate(productId: Long, statisticsDate: LocalDate): ProductDailyStatistics?
+
+    fun findByProductIdAndStatisticsDateBetweenOrderByStatisticsDateAsc(
+        productId: Long,
+        startDate: LocalDate,
+        endDate: LocalDate
+    ): List<ProductDailyStatistics>
+
+    @Query(
+        """
+        SELECT COALESCE(SUM(d.dailySalesAmount), 0)
+        FROM ProductDailyStatistics d
+        WHERE d.productId = :productId
+          AND d.statisticsDate BETWEEN :startDate AND :endDate
+        """
+    )
+    fun sumSalesAmountByProductIdAndDateRange(
+        @Param("productId") productId: Long,
+        @Param("startDate") startDate: LocalDate,
+        @Param("endDate") endDate: LocalDate
+    ): BigDecimal
+
+    @Query(
+        """
+        SELECT d.productId AS productId,
+               SUM(d.dailySalesAmount) AS totalAmount,
+               SUM(d.dailySalesQuantity) AS totalQuantity
+        FROM ProductDailyStatistics d
+        WHERE d.statisticsDate BETWEEN :startDate AND :endDate
+        GROUP BY d.productId
+        ORDER BY SUM(d.dailySalesAmount) DESC
+        LIMIT :limit
+        """
+    )
+    fun findTopSellingProducts(
+        @Param("startDate") startDate: LocalDate,
+        @Param("endDate") endDate: LocalDate,
+        @Param("limit") limit: Int
+    ): List<TopProductProjection>
+
+    @Query(
+        """
+        SELECT d.productId AS productId,
+               SUM(d.dailyRefundAmount) AS totalAmount,
+               SUM(d.dailyRefundQuantity) AS totalQuantity
+        FROM ProductDailyStatistics d
+        WHERE d.statisticsDate BETWEEN :startDate AND :endDate
+        GROUP BY d.productId
+        ORDER BY SUM(d.dailyRefundAmount) DESC
+        LIMIT :limit
+        """
+    )
+    fun findTopRefundProducts(
+        @Param("startDate") startDate: LocalDate,
+        @Param("endDate") endDate: LocalDate,
+        @Param("limit") limit: Int
+    ): List<TopProductProjection>
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductStatisticsRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductStatisticsRepository.kt
@@ -1,10 +1,13 @@
 package com.hoppingmall.mall.product.domain.repository
 
 import com.hoppingmall.mall.product.domain.ProductStatistics
+import jakarta.persistence.LockModeType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.math.BigDecimal
 
@@ -13,6 +16,10 @@ interface ProductStatisticsRepository : JpaRepository<ProductStatistics, Long> {
     fun findByProductId(productId: Long): ProductStatistics?
     fun findBySellerId(sellerId: Long, pageable: Pageable): Page<ProductStatistics>
     fun findByCategoryId(categoryId: Long, pageable: Pageable): Page<ProductStatistics>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT ps FROM ProductStatistics ps WHERE ps.productId = :productId")
+    fun findByProductIdForUpdate(@Param("productId") productId: Long): ProductStatistics?
 
     @Query("SELECT COUNT(ps) FROM ProductStatistics ps")
     fun countAllProducts(): Long
@@ -25,4 +32,13 @@ interface ProductStatisticsRepository : JpaRepository<ProductStatistics, Long> {
 
     @Query("SELECT COALESCE(AVG(ps.refundRate), 0) FROM ProductStatistics ps WHERE ps.totalSalesQuantity > 0")
     fun avgRefundRate(): BigDecimal
+
+    @Query("SELECT COALESCE(SUM(ps.todaySalesAmount), 0) FROM ProductStatistics ps")
+    fun sumTodaySalesAmount(): BigDecimal
+
+    @Query("SELECT COALESCE(SUM(ps.todayOrderCount), 0) FROM ProductStatistics ps")
+    fun sumTodayOrderCount(): Long
+
+    @Query("SELECT COALESCE(SUM(ps.todayRefundAmount), 0) FROM ProductStatistics ps")
+    fun sumTodayRefundAmount(): BigDecimal
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/StatisticsEventLogRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/StatisticsEventLogRepository.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.mall.product.domain.repository
+
+import com.hoppingmall.mall.product.domain.StatisticsEventLog
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface StatisticsEventLogRepository : JpaRepository<StatisticsEventLog, Long> {
+    fun existsByEventId(eventId: String): Boolean
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/TopProductProjection.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/TopProductProjection.kt
@@ -1,0 +1,9 @@
+package com.hoppingmall.mall.product.dto
+
+import java.math.BigDecimal
+
+interface TopProductProjection {
+    fun getProductId(): Long
+    fun getTotalAmount(): BigDecimal
+    fun getTotalQuantity(): Long
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/response/ProductDailyStatisticsResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/response/ProductDailyStatisticsResponse.kt
@@ -1,0 +1,31 @@
+package com.hoppingmall.mall.product.dto.response
+
+import com.hoppingmall.mall.product.domain.ProductDailyStatistics
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class ProductDailyStatisticsResponse(
+    val productId: Long,
+    val statisticsDate: LocalDate,
+    val dailySalesQuantity: Long,
+    val dailySalesAmount: BigDecimal,
+    val dailyOrderCount: Long,
+    val dailyRefundQuantity: Long,
+    val dailyRefundAmount: BigDecimal,
+    val endOfDayStock: Int
+) {
+    companion object {
+        fun from(entity: ProductDailyStatistics): ProductDailyStatisticsResponse {
+            return ProductDailyStatisticsResponse(
+                productId = entity.productId,
+                statisticsDate = entity.statisticsDate,
+                dailySalesQuantity = entity.dailySalesQuantity,
+                dailySalesAmount = entity.dailySalesAmount,
+                dailyOrderCount = entity.dailyOrderCount,
+                dailyRefundQuantity = entity.dailyRefundQuantity,
+                dailyRefundAmount = entity.dailyRefundAmount,
+                endOfDayStock = entity.endOfDayStock
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/response/ProductStatisticsResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/response/ProductStatisticsResponse.kt
@@ -17,6 +17,17 @@ data class ProductStatisticsResponse(
     val currentStock: Int,
     val refundRate: BigDecimal,
     val stockTurnoverRate: BigDecimal,
+    val todaySalesQuantity: Long,
+    val todaySalesAmount: BigDecimal,
+    val todayOrderCount: Long,
+    val todayRefundQuantity: Long,
+    val todayRefundAmount: BigDecimal,
+    val last7DaysSalesAmount: BigDecimal,
+    val last30DaysSalesAmount: BigDecimal,
+    val salesGrowthRate: BigDecimal,
+    val orderCount: Long,
+    val netRevenue: BigDecimal,
+    val averageOrderAmount: BigDecimal,
     val lastAggregatedAt: LocalDateTime
 ) {
     companion object {
@@ -34,6 +45,17 @@ data class ProductStatisticsResponse(
                 currentStock = entity.currentStock,
                 refundRate = entity.refundRate,
                 stockTurnoverRate = entity.stockTurnoverRate,
+                todaySalesQuantity = entity.todaySalesQuantity,
+                todaySalesAmount = entity.todaySalesAmount,
+                todayOrderCount = entity.todayOrderCount,
+                todayRefundQuantity = entity.todayRefundQuantity,
+                todayRefundAmount = entity.todayRefundAmount,
+                last7DaysSalesAmount = entity.last7DaysSalesAmount,
+                last30DaysSalesAmount = entity.last30DaysSalesAmount,
+                salesGrowthRate = entity.salesGrowthRate,
+                orderCount = entity.orderCount,
+                netRevenue = entity.netRevenue,
+                averageOrderAmount = entity.averageOrderAmount,
                 lastAggregatedAt = entity.lastAggregatedAt
             )
         }

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/response/TodaySummaryResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/response/TodaySummaryResponse.kt
@@ -1,0 +1,9 @@
+package com.hoppingmall.mall.product.dto.response
+
+import java.math.BigDecimal
+
+data class TodaySummaryResponse(
+    val todaySalesAmount: BigDecimal,
+    val todayOrderCount: Long,
+    val todayRefundAmount: BigDecimal
+)

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/response/TopProductResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/response/TopProductResponse.kt
@@ -1,0 +1,20 @@
+package com.hoppingmall.mall.product.dto.response
+
+import com.hoppingmall.mall.product.dto.TopProductProjection
+import java.math.BigDecimal
+
+data class TopProductResponse(
+    val productId: Long,
+    val totalAmount: BigDecimal,
+    val totalQuantity: Long
+) {
+    companion object {
+        fun from(projection: TopProductProjection): TopProductResponse {
+            return TopProductResponse(
+                productId = projection.getProductId(),
+                totalAmount = projection.getTotalAmount(),
+                totalQuantity = projection.getTotalQuantity()
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsCommandService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsCommandService.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.mall.product.service
+
+import java.math.BigDecimal
+
+interface ProductStatisticsCommandService {
+    fun incrementSalesStats(productId: Long, quantity: Long, amount: BigDecimal)
+    fun decrementSalesStats(productId: Long, quantity: Long, amount: BigDecimal)
+    fun incrementRefundStats(productId: Long, quantity: Long, amount: BigDecimal)
+    fun flushDailySnapshot()
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsCommandServiceImpl.kt
@@ -1,0 +1,91 @@
+package com.hoppingmall.mall.product.service
+
+import com.hoppingmall.mall.product.domain.ProductDailyStatistics
+import com.hoppingmall.mall.product.domain.ProductStatistics
+import com.hoppingmall.mall.product.domain.repository.ProductDailyStatisticsRepository
+import com.hoppingmall.mall.product.domain.repository.ProductRepository
+import com.hoppingmall.mall.product.domain.repository.ProductStatisticsRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@Service
+@Transactional
+class ProductStatisticsCommandServiceImpl(
+    private val productStatisticsRepository: ProductStatisticsRepository,
+    private val productDailyStatisticsRepository: ProductDailyStatisticsRepository,
+    private val productRepository: ProductRepository
+) : ProductStatisticsCommandService {
+
+    private val logger = LoggerFactory.getLogger(ProductStatisticsCommandServiceImpl::class.java)
+
+    override fun incrementSalesStats(productId: Long, quantity: Long, amount: BigDecimal) {
+        val stats = getOrCreateStatistics(productId)
+        stats.incrementSales(quantity, amount)
+        productStatisticsRepository.save(stats)
+    }
+
+    override fun decrementSalesStats(productId: Long, quantity: Long, amount: BigDecimal) {
+        val stats = productStatisticsRepository.findByProductId(productId) ?: return
+        stats.decrementSales(quantity, amount)
+        productStatisticsRepository.save(stats)
+    }
+
+    override fun incrementRefundStats(productId: Long, quantity: Long, amount: BigDecimal) {
+        val stats = getOrCreateStatistics(productId)
+        stats.incrementRefund(quantity, amount)
+        productStatisticsRepository.save(stats)
+    }
+
+    override fun flushDailySnapshot() {
+        val today = LocalDate.now()
+        val allStats = productStatisticsRepository.findAll()
+
+        for (stats in allStats) {
+            val existing = productDailyStatisticsRepository
+                .findByProductIdAndStatisticsDate(stats.productId, today)
+
+            val daily = existing ?: ProductDailyStatistics.create(
+                productId = stats.productId,
+                statisticsDate = today
+            )
+            daily.updateFromStatistics(stats)
+            productDailyStatisticsRepository.save(daily)
+
+            val last7Days = productDailyStatisticsRepository.sumSalesAmountByProductIdAndDateRange(
+                stats.productId, today.minusDays(6), today
+            )
+            val last30Days = productDailyStatisticsRepository.sumSalesAmountByProductIdAndDateRange(
+                stats.productId, today.minusDays(29), today
+            )
+            val previousWeek = productDailyStatisticsRepository.sumSalesAmountByProductIdAndDateRange(
+                stats.productId, today.minusDays(13), today.minusDays(7)
+            )
+
+            stats.updatePeriodMetrics(last7Days, last30Days, previousWeek)
+            stats.resetToday()
+            productStatisticsRepository.save(stats)
+        }
+
+        logger.info("일별 통계 스냅샷 완료: ${allStats.size}건")
+    }
+
+    private fun getOrCreateStatistics(productId: Long): ProductStatistics {
+        val existing = productStatisticsRepository.findByProductId(productId)
+        if (existing != null) return existing
+
+        val product = productRepository.findById(productId).orElse(null)
+            ?: throw IllegalArgumentException("상품을 찾을 수 없습니다: $productId")
+
+        return productStatisticsRepository.save(
+            ProductStatistics.create(
+                productId = productId,
+                productName = product.name,
+                sellerId = product.sellerId,
+                categoryId = product.categoryId
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryService.kt
@@ -1,9 +1,9 @@
 package com.hoppingmall.mall.product.service
 
-import com.hoppingmall.mall.product.dto.response.ProductStatisticsResponse
-import com.hoppingmall.mall.product.dto.response.ProductStatisticsSummaryResponse
+import com.hoppingmall.mall.product.dto.response.*
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import java.time.LocalDate
 
 interface ProductStatisticsQueryService {
     fun getAll(pageable: Pageable): Page<ProductStatisticsResponse>
@@ -11,4 +11,8 @@ interface ProductStatisticsQueryService {
     fun getBySellerId(sellerId: Long, pageable: Pageable): Page<ProductStatisticsResponse>
     fun getByCategoryId(categoryId: Long, pageable: Pageable): Page<ProductStatisticsResponse>
     fun getSummary(): ProductStatisticsSummaryResponse
+    fun getTodaySummary(): TodaySummaryResponse
+    fun getDailyStatistics(productId: Long, startDate: LocalDate, endDate: LocalDate): List<ProductDailyStatisticsResponse>
+    fun getTopSellingProducts(days: Int, limit: Int): List<TopProductResponse>
+    fun getTopRefundProducts(days: Int, limit: Int): List<TopProductResponse>
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryServiceImpl.kt
@@ -1,18 +1,20 @@
 package com.hoppingmall.mall.product.service
 
+import com.hoppingmall.mall.product.domain.repository.ProductDailyStatisticsRepository
 import com.hoppingmall.mall.product.domain.repository.ProductStatisticsRepository
-import com.hoppingmall.mall.product.dto.response.ProductStatisticsResponse
-import com.hoppingmall.mall.product.dto.response.ProductStatisticsSummaryResponse
+import com.hoppingmall.mall.product.dto.response.*
 import com.hoppingmall.mall.product.exception.ProductStatisticsNotFoundException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 
 @Service
 @Transactional(readOnly = true)
 class ProductStatisticsQueryServiceImpl(
-    private val productStatisticsRepository: ProductStatisticsRepository
+    private val productStatisticsRepository: ProductStatisticsRepository,
+    private val productDailyStatisticsRepository: ProductDailyStatisticsRepository
 ) : ProductStatisticsQueryService {
 
     override fun getAll(pageable: Pageable): Page<ProductStatisticsResponse> {
@@ -43,5 +45,39 @@ class ProductStatisticsQueryServiceImpl(
             totalRefundAmount = productStatisticsRepository.sumTotalRefundAmount(),
             averageRefundRate = productStatisticsRepository.avgRefundRate()
         )
+    }
+
+    override fun getTodaySummary(): TodaySummaryResponse {
+        return TodaySummaryResponse(
+            todaySalesAmount = productStatisticsRepository.sumTodaySalesAmount(),
+            todayOrderCount = productStatisticsRepository.sumTodayOrderCount(),
+            todayRefundAmount = productStatisticsRepository.sumTodayRefundAmount()
+        )
+    }
+
+    override fun getDailyStatistics(
+        productId: Long,
+        startDate: LocalDate,
+        endDate: LocalDate
+    ): List<ProductDailyStatisticsResponse> {
+        return productDailyStatisticsRepository
+            .findByProductIdAndStatisticsDateBetweenOrderByStatisticsDateAsc(productId, startDate, endDate)
+            .map { ProductDailyStatisticsResponse.from(it) }
+    }
+
+    override fun getTopSellingProducts(days: Int, limit: Int): List<TopProductResponse> {
+        val endDate = LocalDate.now()
+        val startDate = endDate.minusDays(days.toLong() - 1)
+        return productDailyStatisticsRepository
+            .findTopSellingProducts(startDate, endDate, limit)
+            .map { TopProductResponse.from(it) }
+    }
+
+    override fun getTopRefundProducts(days: Int, limit: Int): List<TopProductResponse> {
+        val endDate = LocalDate.now()
+        val startDate = endDate.minusDays(days.toLong() - 1)
+        return productDailyStatisticsRepository
+            .findTopRefundProducts(startDate, endDate, limit)
+            .map { TopProductResponse.from(it) }
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsScheduler.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsScheduler.kt
@@ -2,48 +2,33 @@ package com.hoppingmall.mall.product.service
 
 import com.hoppingmall.mall.cartItem.domain.repository.CartItemRepository
 import com.hoppingmall.mall.inventory.domain.repository.InventoryRepository
-import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
-import com.hoppingmall.mall.product.domain.ProductStatistics
-import com.hoppingmall.mall.product.domain.repository.ProductRepository
 import com.hoppingmall.mall.product.domain.repository.ProductStatisticsRepository
-import com.hoppingmall.mall.refund.domain.repository.RefundItemRepository
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.math.BigDecimal
 
 @Component
 @Profile("!test")
 class ProductStatisticsScheduler(
-    private val productRepository: ProductRepository,
     private val productStatisticsRepository: ProductStatisticsRepository,
-    private val orderItemRepository: OrderItemRepository,
-    private val refundItemRepository: RefundItemRepository,
     private val cartItemRepository: CartItemRepository,
-    private val inventoryRepository: InventoryRepository
+    private val inventoryRepository: InventoryRepository,
+    private val productStatisticsCommandService: ProductStatisticsCommandService
 ) {
     private val logger = LoggerFactory.getLogger(ProductStatisticsScheduler::class.java)
 
     @Scheduled(cron = "0 0 * * * *")
     @Transactional
-    fun aggregateProductStatistics() {
-        logger.info("상품 통계 집계 시작")
+    fun syncCartAndInventory() {
+        logger.info("장바구니/재고 동기화 시작")
 
-        val products = productRepository.findAll()
-        if (products.isEmpty()) {
-            logger.info("집계할 상품이 없습니다")
+        val allStats = productStatisticsRepository.findAll()
+        if (allStats.isEmpty()) {
+            logger.info("동기화할 통계가 없습니다")
             return
         }
-
-        val salesMap = orderItemRepository
-            .aggregateSalesByProduct(listOf("PAID", "SHIPPED", "DELIVERED"))
-            .associateBy { it.getProductId() }
-
-        val refundMap = refundItemRepository
-            .aggregateRefundsByProduct("COMPLETED")
-            .associateBy { it.getProductId() }
 
         val cartMap = cartItemRepository
             .aggregateCartByProduct()
@@ -52,55 +37,26 @@ class ProductStatisticsScheduler(
         val inventoryMap = inventoryRepository.findAll()
             .associateBy { it.productId }
 
-        var createdCount = 0
         var updatedCount = 0
 
-        for (product in products) {
-            val productId = product.id ?: continue
-            val sales = salesMap[productId]
-            val refund = refundMap[productId]
-            val cart = cartMap[productId]
-            val inventory = inventoryMap[productId]
+        for (stats in allStats) {
+            val cart = cartMap[stats.productId]
+            val inventory = inventoryMap[stats.productId]
 
-            val totalSalesQuantity = sales?.getTotalQuantity() ?: 0L
-            val totalSalesAmount = sales?.getTotalAmount() ?: BigDecimal.ZERO
-            val totalRefundQuantity = refund?.getTotalQuantity() ?: 0L
-            val totalRefundAmount = refund?.getTotalAmount() ?: BigDecimal.ZERO
-            val currentCartCount = cart?.getBuyerCount() ?: 0L
-            val currentStock = inventory?.stockQuantity ?: 0
+            val cartCount = cart?.getBuyerCount() ?: 0L
+            val stock = inventory?.stockQuantity ?: 0
 
-            val existing = productStatisticsRepository.findByProductId(productId)
-            if (existing != null) {
-                existing.update(
-                    productName = product.name,
-                    categoryId = product.categoryId,
-                    totalSalesQuantity = totalSalesQuantity,
-                    totalSalesAmount = totalSalesAmount,
-                    totalRefundQuantity = totalRefundQuantity,
-                    totalRefundAmount = totalRefundAmount,
-                    currentCartCount = currentCartCount,
-                    currentStock = currentStock
-                )
-                updatedCount++
-            } else {
-                productStatisticsRepository.save(
-                    ProductStatistics.create(
-                        productId = productId,
-                        productName = product.name,
-                        sellerId = product.sellerId,
-                        categoryId = product.categoryId,
-                        totalSalesQuantity = totalSalesQuantity,
-                        totalSalesAmount = totalSalesAmount,
-                        totalRefundQuantity = totalRefundQuantity,
-                        totalRefundAmount = totalRefundAmount,
-                        currentCartCount = currentCartCount,
-                        currentStock = currentStock
-                    )
-                )
-                createdCount++
-            }
+            stats.updateCartAndInventory(cartCount, stock)
+            updatedCount++
         }
 
-        logger.info("상품 통계 집계 완료 - 신규: ${createdCount}건, 갱신: ${updatedCount}건")
+        logger.info("장바구니/재고 동기화 완료: ${updatedCount}건")
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    fun flushDailyStatistics() {
+        logger.info("일별 통계 마감 시작")
+        productStatisticsCommandService.flushDailySnapshot()
+        logger.info("일별 통계 마감 완료")
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/StatisticsEventConsumer.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/StatisticsEventConsumer.kt
@@ -1,0 +1,111 @@
+package com.hoppingmall.mall.product.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
+import com.hoppingmall.mall.payment.dto.event.PaymentCancelledEvent
+import com.hoppingmall.mall.payment.dto.event.PaymentCompletedEvent
+import com.hoppingmall.mall.product.domain.StatisticsEventLog
+import com.hoppingmall.mall.product.domain.repository.StatisticsEventLogRepository
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@Service
+class StatisticsEventConsumer(
+    private val statisticsEventLogRepository: StatisticsEventLogRepository,
+    private val orderItemRepository: OrderItemRepository,
+    private val productStatisticsCommandService: ProductStatisticsCommandService,
+    private val objectMapper: ObjectMapper
+) {
+
+    private val logger = LoggerFactory.getLogger(StatisticsEventConsumer::class.java)
+
+    @KafkaListener(topics = ["payment"], groupId = "statistics-service")
+    @Transactional
+    fun handlePaymentCompleted(event: PaymentCompletedEvent) {
+        try {
+            if (statisticsEventLogRepository.existsByEventId(event.transactionId)) {
+                logger.info("이미 처리된 통계 이벤트: ${event.transactionId}")
+                return
+            }
+
+            val orderItems = orderItemRepository.findByOrderId(event.orderId)
+            orderItems.forEach { item ->
+                productStatisticsCommandService.incrementSalesStats(
+                    item.productId,
+                    item.quantity.toLong(),
+                    item.totalPrice
+                )
+            }
+
+            try {
+                statisticsEventLogRepository.save(
+                    StatisticsEventLog(
+                        eventId = event.transactionId,
+                        eventType = "PaymentCompleted",
+                        orderId = event.orderId
+                    )
+                )
+            } catch (e: DataIntegrityViolationException) {
+                logger.info("이미 처리된 통계 이벤트: ${event.transactionId}")
+                return
+            }
+
+            logger.info("결제 완료 통계 반영: orderId=${event.orderId}")
+        } catch (e: Exception) {
+            logger.error("결제 완료 통계 처리 실패: ${event.transactionId}, 오류: ${e.message}")
+            throw e
+        }
+    }
+
+    @KafkaListener(topics = ["payment-compensation"], groupId = "statistics-compensation-service")
+    @Transactional
+    fun handleCompensationEvent(message: String) {
+        val node = objectMapper.readTree(message)
+        val eventType = node.get("eventType")?.asText()
+
+        if (eventType != "PaymentCancelled") return
+
+        val event = objectMapper.treeToValue(node, PaymentCancelledEvent::class.java)
+        handlePaymentCancelled(event)
+    }
+
+    private fun handlePaymentCancelled(event: PaymentCancelledEvent) {
+        try {
+            if (statisticsEventLogRepository.existsByEventId(event.eventId)) {
+                logger.info("이미 처리된 통계 보상 이벤트: ${event.eventId}")
+                return
+            }
+
+            val orderItems = orderItemRepository.findByOrderId(event.orderId)
+            orderItems.forEach { item ->
+                productStatisticsCommandService.decrementSalesStats(
+                    item.productId,
+                    item.quantity.toLong(),
+                    item.totalPrice
+                )
+            }
+
+            try {
+                statisticsEventLogRepository.save(
+                    StatisticsEventLog(
+                        eventId = event.eventId,
+                        eventType = "PaymentCancelled",
+                        orderId = event.orderId
+                    )
+                )
+            } catch (e: DataIntegrityViolationException) {
+                logger.info("이미 처리된 통계 보상 이벤트: ${event.eventId}")
+                return
+            }
+
+            logger.info("결제 취소 통계 반영: orderId=${event.orderId}")
+        } catch (e: Exception) {
+            logger.error("결제 취소 통계 처리 실패: ${event.eventId}, 오류: ${e.message}")
+            throw e
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImpl.kt
@@ -10,6 +10,7 @@ import com.hoppingmall.mall.payment.enum.PaymentStatus
 import com.hoppingmall.mall.payment.exception.PaymentNotFoundException
 import com.hoppingmall.mall.point.service.PointCommandService
 import com.hoppingmall.mall.product.domain.repository.ProductRepository
+import com.hoppingmall.mall.product.service.ProductStatisticsCommandService
 import com.hoppingmall.mall.refund.domain.Refund
 import com.hoppingmall.mall.refund.domain.RefundItem
 import com.hoppingmall.mall.refund.domain.repository.RefundItemRepository
@@ -39,7 +40,8 @@ class RefundCommandServiceImpl(
     private val productRepository: ProductRepository,
     private val shippingRepository: ShippingRepository,
     private val inventoryCommandService: InventoryCommandService,
-    private val pointCommandService: PointCommandService
+    private val pointCommandService: PointCommandService,
+    private val productStatisticsCommandService: ProductStatisticsCommandService
 ) : RefundCommandService {
 
     private val refundableOrderStatuses = setOf(OrderStatus.PAID, OrderStatus.SHIPPED, OrderStatus.DELIVERED)
@@ -205,6 +207,14 @@ class RefundCommandServiceImpl(
             paymentId = payment.id!!,
             orderId = refund.orderId
         )
+
+        refundItems.forEach { item ->
+            productStatisticsCommandService.incrementRefundStats(
+                item.productId,
+                item.quantity.toLong(),
+                item.refundPrice
+            )
+        }
 
         if (refund.isFullRefund) {
             payment.updateStatus(PaymentStatus.REFUNDED)

--- a/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductStatisticsControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductStatisticsControllerTest.kt
@@ -1,8 +1,7 @@
 package com.hoppingmall.mall.product.controller
 
 import com.hoppingmall.mall.global.common.response.ApiResponse
-import com.hoppingmall.mall.product.dto.response.ProductStatisticsResponse
-import com.hoppingmall.mall.product.dto.response.ProductStatisticsSummaryResponse
+import com.hoppingmall.mall.product.dto.response.*
 import com.hoppingmall.mall.product.exception.ProductStatisticsNotFoundException
 import com.hoppingmall.mall.product.service.ProductStatisticsQueryService
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -12,15 +11,12 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import org.mockito.kotlin.*
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import java.math.BigDecimal
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @DisplayName("ProductStatisticsController")
@@ -46,6 +42,17 @@ class ProductStatisticsControllerTest {
         currentStock = 50,
         refundRate = BigDecimal("0.0500"),
         stockTurnoverRate = BigDecimal("2.0000"),
+        todaySalesQuantity = 10,
+        todaySalesAmount = BigDecimal("100000"),
+        todayOrderCount = 5,
+        todayRefundQuantity = 1,
+        todayRefundAmount = BigDecimal("10000"),
+        last7DaysSalesAmount = BigDecimal("700000"),
+        last30DaysSalesAmount = BigDecimal("3000000"),
+        salesGrowthRate = BigDecimal("20.0000"),
+        orderCount = 50,
+        netRevenue = BigDecimal("950000"),
+        averageOrderAmount = BigDecimal("20000.00"),
         lastAggregatedAt = LocalDateTime.of(2026, 2, 17, 12, 0, 0)
     )
 
@@ -160,6 +167,102 @@ class ProductStatisticsControllerTest {
             assertEquals(10L, result.data!!.totalProductCount)
             assertEquals(BigDecimal("5000000"), result.data!!.totalSalesAmount)
             verify(productStatisticsQueryService).getSummary()
+        }
+    }
+
+    @Nested
+    @DisplayName("getTodaySummary")
+    inner class GetTodaySummary {
+        @Test
+        fun 오늘_실시간_요약_조회_성공() {
+            val todaySummary = TodaySummaryResponse(
+                todaySalesAmount = BigDecimal("1000000"),
+                todayOrderCount = 50,
+                todayRefundAmount = BigDecimal("50000")
+            )
+
+            whenever(productStatisticsQueryService.getTodaySummary()).thenReturn(todaySummary)
+
+            val result: ApiResponse<TodaySummaryResponse> = controller.getTodaySummary()
+
+            assertEquals("SUCCESS", result.code)
+            assertEquals(BigDecimal("1000000"), result.data!!.todaySalesAmount)
+            assertEquals(50L, result.data!!.todayOrderCount)
+            verify(productStatisticsQueryService).getTodaySummary()
+        }
+    }
+
+    @Nested
+    @DisplayName("getDailyStatistics")
+    inner class GetDailyStatistics {
+        @Test
+        fun 일별_통계_조회_성공() {
+            val productId = 1L
+            val startDate = LocalDate.of(2026, 2, 10)
+            val endDate = LocalDate.of(2026, 2, 18)
+            val dailyList = listOf(
+                ProductDailyStatisticsResponse(
+                    productId = productId,
+                    statisticsDate = startDate,
+                    dailySalesQuantity = 50,
+                    dailySalesAmount = BigDecimal("500000"),
+                    dailyOrderCount = 10,
+                    dailyRefundQuantity = 2,
+                    dailyRefundAmount = BigDecimal("20000"),
+                    endOfDayStock = 100
+                )
+            )
+
+            whenever(productStatisticsQueryService.getDailyStatistics(productId, startDate, endDate))
+                .thenReturn(dailyList)
+
+            val result: ApiResponse<List<ProductDailyStatisticsResponse>> =
+                controller.getDailyStatistics(productId, startDate, endDate)
+
+            assertEquals("SUCCESS", result.code)
+            assertEquals(1, result.data!!.size)
+            assertEquals(startDate, result.data!![0].statisticsDate)
+            verify(productStatisticsQueryService).getDailyStatistics(productId, startDate, endDate)
+        }
+    }
+
+    @Nested
+    @DisplayName("getTopSellingProducts")
+    inner class GetTopSellingProducts {
+        @Test
+        fun TOP_판매_조회_성공() {
+            val topList = listOf(
+                TopProductResponse(productId = 1L, totalAmount = BigDecimal("500000"), totalQuantity = 50)
+            )
+
+            whenever(productStatisticsQueryService.getTopSellingProducts(7, 10)).thenReturn(topList)
+
+            val result: ApiResponse<List<TopProductResponse>> = controller.getTopSellingProducts(7, 10)
+
+            assertEquals("SUCCESS", result.code)
+            assertEquals(1, result.data!!.size)
+            assertEquals(1L, result.data!![0].productId)
+            verify(productStatisticsQueryService).getTopSellingProducts(7, 10)
+        }
+    }
+
+    @Nested
+    @DisplayName("getTopRefundProducts")
+    inner class GetTopRefundProducts {
+        @Test
+        fun TOP_환불_조회_성공() {
+            val topList = listOf(
+                TopProductResponse(productId = 2L, totalAmount = BigDecimal("100000"), totalQuantity = 10)
+            )
+
+            whenever(productStatisticsQueryService.getTopRefundProducts(30, 5)).thenReturn(topList)
+
+            val result: ApiResponse<List<TopProductResponse>> = controller.getTopRefundProducts(30, 5)
+
+            assertEquals("SUCCESS", result.code)
+            assertEquals(1, result.data!!.size)
+            assertEquals(2L, result.data!![0].productId)
+            verify(productStatisticsQueryService).getTopRefundProducts(30, 5)
         }
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/product/domain/ProductDailyStatisticsTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/domain/ProductDailyStatisticsTest.kt
@@ -1,0 +1,88 @@
+package com.hoppingmall.mall.product.domain
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@DisplayName("ProductDailyStatistics")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class ProductDailyStatisticsTest {
+
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+        @Test
+        fun 일별_통계가_기본값으로_생성된다() {
+            val daily = ProductDailyStatistics.create(
+                productId = 1L,
+                statisticsDate = LocalDate.of(2026, 2, 18)
+            )
+
+            assertEquals(1L, daily.productId)
+            assertEquals(LocalDate.of(2026, 2, 18), daily.statisticsDate)
+            assertEquals(0, daily.dailySalesQuantity)
+            assertEquals(BigDecimal.ZERO, daily.dailySalesAmount)
+            assertEquals(0, daily.dailyOrderCount)
+            assertEquals(0, daily.dailyRefundQuantity)
+            assertEquals(BigDecimal.ZERO, daily.dailyRefundAmount)
+            assertEquals(0, daily.endOfDayStock)
+        }
+
+        @Test
+        fun 일별_통계가_지정된_값으로_생성된다() {
+            val daily = ProductDailyStatistics.create(
+                productId = 1L,
+                statisticsDate = LocalDate.of(2026, 2, 18),
+                dailySalesQuantity = 50,
+                dailySalesAmount = BigDecimal("500000"),
+                dailyOrderCount = 10,
+                dailyRefundQuantity = 2,
+                dailyRefundAmount = BigDecimal("20000"),
+                endOfDayStock = 100
+            )
+
+            assertEquals(50, daily.dailySalesQuantity)
+            assertEquals(BigDecimal("500000"), daily.dailySalesAmount)
+            assertEquals(10, daily.dailyOrderCount)
+            assertEquals(2, daily.dailyRefundQuantity)
+            assertEquals(BigDecimal("20000"), daily.dailyRefundAmount)
+            assertEquals(100, daily.endOfDayStock)
+        }
+    }
+
+    @Nested
+    @DisplayName("updateFromStatistics")
+    inner class UpdateFromStatistics {
+        @Test
+        fun ProductStatistics에서_오늘_데이터를_복사한다() {
+            val stats = ProductStatistics.create(
+                productId = 1L,
+                productName = "테스트 상품",
+                sellerId = 1L,
+                categoryId = 1L,
+                currentStock = 80
+            )
+            stats.incrementSales(10, BigDecimal("100000"))
+            stats.incrementRefund(1, BigDecimal("10000"))
+
+            val daily = ProductDailyStatistics.create(
+                productId = 1L,
+                statisticsDate = LocalDate.of(2026, 2, 18)
+            )
+
+            daily.updateFromStatistics(stats)
+
+            assertEquals(10, daily.dailySalesQuantity)
+            assertEquals(BigDecimal("100000"), daily.dailySalesAmount)
+            assertEquals(1, daily.dailyOrderCount)
+            assertEquals(1, daily.dailyRefundQuantity)
+            assertEquals(BigDecimal("10000"), daily.dailyRefundAmount)
+            assertEquals(80, daily.endOfDayStock)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/product/domain/ProductStatisticsTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/domain/ProductStatisticsTest.kt
@@ -86,6 +86,24 @@ class ProductStatisticsTest {
 
             assertEquals(BigDecimal.ZERO, stats.stockTurnoverRate)
         }
+
+        @Test
+        fun 생성_시_순매출이_올바르게_계산된다() {
+            val stats = ProductStatistics.create(
+                productId = 1L,
+                productName = "테스트 상품",
+                sellerId = 1L,
+                categoryId = 1L,
+                totalSalesQuantity = 100,
+                totalSalesAmount = BigDecimal("1000000"),
+                totalRefundQuantity = 5,
+                totalRefundAmount = BigDecimal("50000"),
+                currentCartCount = 10,
+                currentStock = 50
+            )
+
+            assertEquals(BigDecimal("950000"), stats.netRevenue)
+        }
     }
 
     @Nested
@@ -122,6 +140,202 @@ class ProductStatisticsTest {
             assertEquals(200, stats.totalSalesQuantity)
             assertEquals(BigDecimal("0.1000"), stats.refundRate)
             assertEquals(BigDecimal("2.0000"), stats.stockTurnoverRate)
+            assertEquals(BigDecimal("1800000"), stats.netRevenue)
+        }
+    }
+
+    @Nested
+    @DisplayName("incrementSales")
+    inner class IncrementSales {
+        @Test
+        fun 판매_증가_시_수량_금액_주문수가_증가한다() {
+            val stats = ProductStatistics.create(
+                productId = 1L,
+                productName = "테스트 상품",
+                sellerId = 1L,
+                categoryId = 1L
+            )
+
+            stats.incrementSales(3, BigDecimal("30000"))
+
+            assertEquals(3, stats.totalSalesQuantity)
+            assertEquals(BigDecimal("30000"), stats.totalSalesAmount)
+            assertEquals(3, stats.todaySalesQuantity)
+            assertEquals(BigDecimal("30000"), stats.todaySalesAmount)
+            assertEquals(1, stats.todayOrderCount)
+            assertEquals(1, stats.orderCount)
+            assertEquals(BigDecimal("30000"), stats.netRevenue)
+            assertEquals(BigDecimal("30000.00"), stats.averageOrderAmount)
+        }
+
+        @Test
+        fun 연속_판매_증가_시_누적된다() {
+            val stats = ProductStatistics.create(
+                productId = 1L,
+                productName = "테스트 상품",
+                sellerId = 1L,
+                categoryId = 1L
+            )
+
+            stats.incrementSales(2, BigDecimal("20000"))
+            stats.incrementSales(3, BigDecimal("45000"))
+
+            assertEquals(5, stats.totalSalesQuantity)
+            assertEquals(BigDecimal("65000"), stats.totalSalesAmount)
+            assertEquals(2, stats.orderCount)
+            assertEquals(BigDecimal("32500.00"), stats.averageOrderAmount)
+        }
+    }
+
+    @Nested
+    @DisplayName("decrementSales")
+    inner class DecrementSales {
+        @Test
+        fun 판매_차감_시_수량과_금액이_감소한다() {
+            val stats = ProductStatistics.create(
+                productId = 1L,
+                productName = "테스트 상품",
+                sellerId = 1L,
+                categoryId = 1L,
+                totalSalesQuantity = 10,
+                totalSalesAmount = BigDecimal("100000")
+            )
+
+            stats.decrementSales(3, BigDecimal("30000"))
+
+            assertEquals(7, stats.totalSalesQuantity)
+            assertEquals(BigDecimal("70000"), stats.totalSalesAmount)
+        }
+
+        @Test
+        fun 판매_차감_시_0_미만이_되지_않는다() {
+            val stats = ProductStatistics.create(
+                productId = 1L,
+                productName = "테스트 상품",
+                sellerId = 1L,
+                categoryId = 1L,
+                totalSalesQuantity = 2,
+                totalSalesAmount = BigDecimal("20000")
+            )
+
+            stats.decrementSales(5, BigDecimal("50000"))
+
+            assertEquals(0, stats.totalSalesQuantity)
+            assertEquals(BigDecimal.ZERO, stats.totalSalesAmount)
+        }
+    }
+
+    @Nested
+    @DisplayName("incrementRefund")
+    inner class IncrementRefund {
+        @Test
+        fun 환불_증가_시_환불_수량_금액이_증가한다() {
+            val stats = ProductStatistics.create(
+                productId = 1L,
+                productName = "테스트 상품",
+                sellerId = 1L,
+                categoryId = 1L,
+                totalSalesQuantity = 100,
+                totalSalesAmount = BigDecimal("1000000")
+            )
+
+            stats.incrementRefund(2, BigDecimal("20000"))
+
+            assertEquals(2, stats.totalRefundQuantity)
+            assertEquals(BigDecimal("20000"), stats.totalRefundAmount)
+            assertEquals(2, stats.todayRefundQuantity)
+            assertEquals(BigDecimal("20000"), stats.todayRefundAmount)
+            assertEquals(BigDecimal("980000"), stats.netRevenue)
+            assertEquals(BigDecimal("0.0200"), stats.refundRate)
+        }
+    }
+
+    @Nested
+    @DisplayName("resetToday")
+    inner class ResetToday {
+        @Test
+        fun 오늘_지표가_모두_초기화된다() {
+            val stats = ProductStatistics.create(
+                productId = 1L,
+                productName = "테스트 상품",
+                sellerId = 1L,
+                categoryId = 1L
+            )
+            stats.incrementSales(5, BigDecimal("50000"))
+            stats.incrementRefund(1, BigDecimal("10000"))
+
+            stats.resetToday()
+
+            assertEquals(0, stats.todaySalesQuantity)
+            assertEquals(BigDecimal.ZERO, stats.todaySalesAmount)
+            assertEquals(0, stats.todayOrderCount)
+            assertEquals(0, stats.todayRefundQuantity)
+            assertEquals(BigDecimal.ZERO, stats.todayRefundAmount)
+            assertEquals(5, stats.totalSalesQuantity)
+            assertEquals(1, stats.totalRefundQuantity)
+        }
+    }
+
+    @Nested
+    @DisplayName("updatePeriodMetrics")
+    inner class UpdatePeriodMetrics {
+        @Test
+        fun 기간_지표와_성장률이_올바르게_계산된다() {
+            val stats = ProductStatistics.create(
+                productId = 1L,
+                productName = "테스트 상품",
+                sellerId = 1L,
+                categoryId = 1L
+            )
+
+            stats.updatePeriodMetrics(
+                last7Days = BigDecimal("700000"),
+                last30Days = BigDecimal("3000000"),
+                previousWeekAmount = BigDecimal("500000")
+            )
+
+            assertEquals(BigDecimal("700000"), stats.last7DaysSalesAmount)
+            assertEquals(BigDecimal("3000000"), stats.last30DaysSalesAmount)
+            assertEquals(BigDecimal("40.0000"), stats.salesGrowthRate)
+        }
+
+        @Test
+        fun 전주_매출이_0이면_성장률은_0이다() {
+            val stats = ProductStatistics.create(
+                productId = 1L,
+                productName = "테스트 상품",
+                sellerId = 1L,
+                categoryId = 1L
+            )
+
+            stats.updatePeriodMetrics(
+                last7Days = BigDecimal("700000"),
+                last30Days = BigDecimal("3000000"),
+                previousWeekAmount = BigDecimal.ZERO
+            )
+
+            assertEquals(BigDecimal.ZERO, stats.salesGrowthRate)
+        }
+    }
+
+    @Nested
+    @DisplayName("updateCartAndInventory")
+    inner class UpdateCartAndInventory {
+        @Test
+        fun 장바구니와_재고가_갱신된다() {
+            val stats = ProductStatistics.create(
+                productId = 1L,
+                productName = "테스트 상품",
+                sellerId = 1L,
+                categoryId = 1L,
+                totalSalesQuantity = 100
+            )
+
+            stats.updateCartAndInventory(cartCount = 15, stock = 25)
+
+            assertEquals(15, stats.currentCartCount)
+            assertEquals(25, stats.currentStock)
+            assertEquals(BigDecimal("4.0000"), stats.stockTurnoverRate)
         }
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsCommandServiceImplTest.kt
@@ -1,0 +1,170 @@
+package com.hoppingmall.mall.product.service
+
+import com.hoppingmall.mall.product.domain.ProductDailyStatistics
+import com.hoppingmall.mall.product.domain.ProductStatistics
+import com.hoppingmall.mall.product.domain.repository.ProductDailyStatisticsRepository
+import com.hoppingmall.mall.product.domain.repository.ProductRepository
+import com.hoppingmall.mall.product.domain.repository.ProductStatisticsRepository
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.*
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.*
+
+@DisplayName("ProductStatisticsCommandServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class ProductStatisticsCommandServiceImplTest {
+
+    private val productStatisticsRepository: ProductStatisticsRepository = mock()
+    private val productDailyStatisticsRepository: ProductDailyStatisticsRepository = mock()
+    private val productRepository: ProductRepository = mock()
+
+    private val service = ProductStatisticsCommandServiceImpl(
+        productStatisticsRepository,
+        productDailyStatisticsRepository,
+        productRepository
+    )
+
+    @Nested
+    @DisplayName("incrementSalesStats")
+    inner class IncrementSalesStats {
+        @Test
+        fun 기존_통계가_있으면_판매_증분한다() {
+            val stats = ProductStatistics.fixture(productId = 1L).withId(1L)
+            whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(stats)
+            whenever(productStatisticsRepository.save(any<ProductStatistics>())).thenAnswer { it.arguments[0] }
+
+            service.incrementSalesStats(1L, 5, BigDecimal("50000"))
+
+            assertEquals(105, stats.totalSalesQuantity)
+            assertEquals(BigDecimal("1050000"), stats.totalSalesAmount)
+            verify(productStatisticsRepository).save(stats)
+        }
+
+        @Test
+        fun 기존_통계가_없으면_새로_생성_후_증분한다() {
+            whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(null)
+            val product = com.hoppingmall.mall.product.domain.Product.fixture(sellerId = 2L, categoryId = 3L).withId(1L)
+            whenever(productRepository.findById(1L)).thenReturn(Optional.of(product))
+            whenever(productStatisticsRepository.save(any<ProductStatistics>())).thenAnswer { invocation ->
+                (invocation.arguments[0] as ProductStatistics).withId(1L)
+            }
+
+            service.incrementSalesStats(1L, 5, BigDecimal("50000"))
+
+            verify(productStatisticsRepository, times(2)).save(any<ProductStatistics>())
+        }
+
+        @Test
+        fun 상품이_존재하지_않으면_예외_발생() {
+            whenever(productStatisticsRepository.findByProductId(999L)).thenReturn(null)
+            whenever(productRepository.findById(999L)).thenReturn(Optional.empty())
+
+            assertThrows<IllegalArgumentException> {
+                service.incrementSalesStats(999L, 1, BigDecimal("10000"))
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("decrementSalesStats")
+    inner class DecrementSalesStats {
+        @Test
+        fun 기존_통계가_있으면_판매_차감한다() {
+            val stats = ProductStatistics.fixture(productId = 1L, totalSalesQuantity = 100, totalSalesAmount = BigDecimal("1000000")).withId(1L)
+            whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(stats)
+            whenever(productStatisticsRepository.save(any<ProductStatistics>())).thenAnswer { it.arguments[0] }
+
+            service.decrementSalesStats(1L, 3, BigDecimal("30000"))
+
+            assertEquals(97, stats.totalSalesQuantity)
+            assertEquals(BigDecimal("970000"), stats.totalSalesAmount)
+            verify(productStatisticsRepository).save(stats)
+        }
+
+        @Test
+        fun 기존_통계가_없으면_아무_작업도_하지_않는다() {
+            whenever(productStatisticsRepository.findByProductId(999L)).thenReturn(null)
+
+            service.decrementSalesStats(999L, 3, BigDecimal("30000"))
+
+            verify(productStatisticsRepository, never()).save(any<ProductStatistics>())
+        }
+    }
+
+    @Nested
+    @DisplayName("incrementRefundStats")
+    inner class IncrementRefundStats {
+        @Test
+        fun 환불_통계가_증가한다() {
+            val stats = ProductStatistics.fixture(productId = 1L).withId(1L)
+            whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(stats)
+            whenever(productStatisticsRepository.save(any<ProductStatistics>())).thenAnswer { it.arguments[0] }
+
+            service.incrementRefundStats(1L, 2, BigDecimal("20000"))
+
+            assertEquals(7, stats.totalRefundQuantity)
+            assertEquals(BigDecimal("70000"), stats.totalRefundAmount)
+            verify(productStatisticsRepository).save(stats)
+        }
+    }
+
+    @Nested
+    @DisplayName("flushDailySnapshot")
+    inner class FlushDailySnapshot {
+        @Test
+        fun 일별_스냅샷을_저장하고_오늘_지표를_리셋한다() {
+            val stats = ProductStatistics.fixture(productId = 1L).withId(1L)
+            stats.incrementSales(5, BigDecimal("50000"))
+
+            whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
+            whenever(productDailyStatisticsRepository.findByProductIdAndStatisticsDate(eq(1L), any()))
+                .thenReturn(null)
+            whenever(productDailyStatisticsRepository.save(any<ProductDailyStatistics>()))
+                .thenAnswer { it.arguments[0] }
+            whenever(productDailyStatisticsRepository.sumSalesAmountByProductIdAndDateRange(eq(1L), any(), any()))
+                .thenReturn(BigDecimal("300000"))
+            whenever(productStatisticsRepository.save(any<ProductStatistics>())).thenAnswer { it.arguments[0] }
+
+            service.flushDailySnapshot()
+
+            assertEquals(0, stats.todaySalesQuantity)
+            assertEquals(BigDecimal.ZERO, stats.todaySalesAmount)
+            verify(productDailyStatisticsRepository).save(any<ProductDailyStatistics>())
+            verify(productStatisticsRepository).save(stats)
+        }
+
+        @Test
+        fun 기존_일별_통계가_있으면_업데이트한다() {
+            val stats = ProductStatistics.fixture(productId = 1L).withId(1L)
+            stats.incrementSales(3, BigDecimal("30000"))
+
+            val existingDaily = ProductDailyStatistics.create(
+                productId = 1L,
+                statisticsDate = LocalDate.now()
+            ).withId(1L)
+
+            whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
+            whenever(productDailyStatisticsRepository.findByProductIdAndStatisticsDate(eq(1L), any()))
+                .thenReturn(existingDaily)
+            whenever(productDailyStatisticsRepository.save(any<ProductDailyStatistics>()))
+                .thenAnswer { it.arguments[0] }
+            whenever(productDailyStatisticsRepository.sumSalesAmountByProductIdAndDateRange(eq(1L), any(), any()))
+                .thenReturn(BigDecimal("200000"))
+            whenever(productStatisticsRepository.save(any<ProductStatistics>())).thenAnswer { it.arguments[0] }
+
+            service.flushDailySnapshot()
+
+            assertEquals(3, existingDaily.dailySalesQuantity)
+            verify(productDailyStatisticsRepository).save(existingDaily)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryServiceImplTest.kt
@@ -1,7 +1,10 @@
 package com.hoppingmall.mall.product.service
 
+import com.hoppingmall.mall.product.domain.ProductDailyStatistics
 import com.hoppingmall.mall.product.domain.ProductStatistics
+import com.hoppingmall.mall.product.domain.repository.ProductDailyStatisticsRepository
 import com.hoppingmall.mall.product.domain.repository.ProductStatisticsRepository
+import com.hoppingmall.mall.product.dto.TopProductProjection
 import com.hoppingmall.mall.product.exception.ProductStatisticsNotFoundException
 import com.hoppingmall.mall.support.fixture.fixture
 import com.hoppingmall.mall.support.withId
@@ -12,19 +15,19 @@ import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import org.mockito.kotlin.*
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import java.math.BigDecimal
+import java.time.LocalDate
 
 @DisplayName("ProductStatisticsQueryServiceImpl")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class ProductStatisticsQueryServiceImplTest {
 
     private val productStatisticsRepository: ProductStatisticsRepository = mock()
-    private val service = ProductStatisticsQueryServiceImpl(productStatisticsRepository)
+    private val productDailyStatisticsRepository: ProductDailyStatisticsRepository = mock()
+    private val service = ProductStatisticsQueryServiceImpl(productStatisticsRepository, productDailyStatisticsRepository)
 
     @Nested
     @DisplayName("getAll")
@@ -147,6 +150,92 @@ class ProductStatisticsQueryServiceImplTest {
             verify(productStatisticsRepository).sumTotalSalesAmount()
             verify(productStatisticsRepository).sumTotalRefundAmount()
             verify(productStatisticsRepository).avgRefundRate()
+        }
+    }
+
+    @Nested
+    @DisplayName("getTodaySummary")
+    inner class GetTodaySummary {
+        @Test
+        fun 오늘_실시간_요약_조회_성공() {
+            whenever(productStatisticsRepository.sumTodaySalesAmount()).thenReturn(BigDecimal("1000000"))
+            whenever(productStatisticsRepository.sumTodayOrderCount()).thenReturn(50L)
+            whenever(productStatisticsRepository.sumTodayRefundAmount()).thenReturn(BigDecimal("50000"))
+
+            val result = service.getTodaySummary()
+
+            assertEquals(BigDecimal("1000000"), result.todaySalesAmount)
+            assertEquals(50L, result.todayOrderCount)
+            assertEquals(BigDecimal("50000"), result.todayRefundAmount)
+        }
+    }
+
+    @Nested
+    @DisplayName("getDailyStatistics")
+    inner class GetDailyStatistics {
+        @Test
+        fun 상품별_일별_추이_조회_성공() {
+            val productId = 1L
+            val startDate = LocalDate.of(2026, 2, 10)
+            val endDate = LocalDate.of(2026, 2, 18)
+            val dailyList = listOf(
+                ProductDailyStatistics.fixture(productId = productId, statisticsDate = startDate).withId(1L),
+                ProductDailyStatistics.fixture(productId = productId, statisticsDate = endDate).withId(2L)
+            )
+
+            whenever(
+                productDailyStatisticsRepository
+                    .findByProductIdAndStatisticsDateBetweenOrderByStatisticsDateAsc(productId, startDate, endDate)
+            ).thenReturn(dailyList)
+
+            val result = service.getDailyStatistics(productId, startDate, endDate)
+
+            assertEquals(2, result.size)
+            assertEquals(startDate, result[0].statisticsDate)
+            assertEquals(endDate, result[1].statisticsDate)
+        }
+    }
+
+    @Nested
+    @DisplayName("getTopSellingProducts")
+    inner class GetTopSellingProducts {
+        @Test
+        fun 기간별_판매_TOP_N_조회_성공() {
+            val projection = mock<TopProductProjection>()
+            whenever(projection.getProductId()).thenReturn(1L)
+            whenever(projection.getTotalAmount()).thenReturn(BigDecimal("500000"))
+            whenever(projection.getTotalQuantity()).thenReturn(50L)
+
+            whenever(productDailyStatisticsRepository.findTopSellingProducts(any(), any(), eq(10)))
+                .thenReturn(listOf(projection))
+
+            val result = service.getTopSellingProducts(7, 10)
+
+            assertEquals(1, result.size)
+            assertEquals(1L, result[0].productId)
+            assertEquals(BigDecimal("500000"), result[0].totalAmount)
+            assertEquals(50L, result[0].totalQuantity)
+        }
+    }
+
+    @Nested
+    @DisplayName("getTopRefundProducts")
+    inner class GetTopRefundProducts {
+        @Test
+        fun 기간별_환불_TOP_N_조회_성공() {
+            val projection = mock<TopProductProjection>()
+            whenever(projection.getProductId()).thenReturn(2L)
+            whenever(projection.getTotalAmount()).thenReturn(BigDecimal("100000"))
+            whenever(projection.getTotalQuantity()).thenReturn(10L)
+
+            whenever(productDailyStatisticsRepository.findTopRefundProducts(any(), any(), eq(5)))
+                .thenReturn(listOf(projection))
+
+            val result = service.getTopRefundProducts(30, 5)
+
+            assertEquals(1, result.size)
+            assertEquals(2L, result[0].productId)
+            assertEquals(BigDecimal("100000"), result[0].totalAmount)
         }
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImplTest.kt
@@ -13,6 +13,7 @@ import com.hoppingmall.mall.payment.exception.PaymentNotFoundException
 import com.hoppingmall.mall.point.service.PointCommandService
 import com.hoppingmall.mall.product.domain.Product
 import com.hoppingmall.mall.product.domain.repository.ProductRepository
+import com.hoppingmall.mall.product.service.ProductStatisticsCommandService
 import com.hoppingmall.mall.refund.domain.Refund
 import com.hoppingmall.mall.refund.domain.RefundItem
 import com.hoppingmall.mall.refund.domain.repository.RefundItemRepository
@@ -53,6 +54,7 @@ class RefundCommandServiceImplTest {
     private val shippingRepository: ShippingRepository = mock()
     private val inventoryCommandService: InventoryCommandService = mock()
     private val pointCommandService: PointCommandService = mock()
+    private val productStatisticsCommandService: ProductStatisticsCommandService = mock()
 
     private val refundCommandService = RefundCommandServiceImpl(
         refundRepository,
@@ -63,7 +65,8 @@ class RefundCommandServiceImplTest {
         productRepository,
         shippingRepository,
         inventoryCommandService,
-        pointCommandService
+        pointCommandService,
+        productStatisticsCommandService
     )
 
     @Nested
@@ -109,6 +112,7 @@ class RefundCommandServiceImplTest {
             assertTrue(response.isFullRefund)
             verify(inventoryCommandService).increaseStock(100L, 2)
             verify(pointCommandService).refundPoints(eq(buyerId), eq(BigDecimal("1000")), eq(1L), eq(orderId))
+            verify(productStatisticsCommandService).incrementRefundStats(eq(100L), eq(2L), any())
         }
 
         @Test
@@ -369,6 +373,7 @@ class RefundCommandServiceImplTest {
             assertEquals(RefundStatus.COMPLETED, response.status)
             verify(inventoryCommandService).increaseStock(100L, 2)
             verify(pointCommandService).refundPoints(eq(1L), any(), eq(1L), eq(1L))
+            verify(productStatisticsCommandService).incrementRefundStats(eq(100L), eq(2L), any())
         }
 
         @Test

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/ProductDailyStatisticsFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/ProductDailyStatisticsFixture.kt
@@ -1,0 +1,27 @@
+package com.hoppingmall.mall.support.fixture
+
+import com.hoppingmall.mall.product.domain.ProductDailyStatistics
+import java.math.BigDecimal
+import java.time.LocalDate
+
+fun ProductDailyStatistics.Companion.fixture(
+    productId: Long = 1L,
+    statisticsDate: LocalDate = LocalDate.of(2026, 2, 18),
+    dailySalesQuantity: Long = 50,
+    dailySalesAmount: BigDecimal = BigDecimal("500000"),
+    dailyOrderCount: Long = 10,
+    dailyRefundQuantity: Long = 2,
+    dailyRefundAmount: BigDecimal = BigDecimal("20000"),
+    endOfDayStock: Int = 100
+): ProductDailyStatistics {
+    return ProductDailyStatistics.create(
+        productId = productId,
+        statisticsDate = statisticsDate,
+        dailySalesQuantity = dailySalesQuantity,
+        dailySalesAmount = dailySalesAmount,
+        dailyOrderCount = dailyOrderCount,
+        dailyRefundQuantity = dailyRefundQuantity,
+        dailyRefundAmount = dailyRefundAmount,
+        endOfDayStock = endOfDayStock
+    )
+}


### PR DESCRIPTION
## 📌 관련 이슈
Closes #71

## ✅ 변경 사항
- **ProductStatistics 실시간 필드 확장**: today/period/derived 필드 + 증분 메서드 (incrementSales, decrementSales, incrementRefund 등)
- **ProductDailyStatistics 엔티티 추가**: 일별 스냅샷 저장, 기간별 집계 쿼리
- **StatisticsEventLog 멱등성 로그**: Kafka Consumer 중복 처리 방지
- **ProductStatisticsCommandService**: 증분 판매/환불 통계 갱신, 일별 flush
- **StatisticsEventConsumer**: payment/payment-compensation 토픽 구독으로 실시간 통계 반영
- **환불 완료 시 통계 반영**: RefundCommandServiceImpl에서 환불 완료 시 통계 증분
- **스케줄러 증분 방식 전환**: 전체 재집계 → 장바구니/재고 동기화 + 자정 일별 마감
- **4개 신규 API 엔드포인트**: /realtime/today, /daily, /top-selling, /top-refund

## 🧪 테스트
- ProductStatisticsTest: 신규 메서드 (increment/decrement/refund/resetToday/updatePeriod) 테스트
- ProductDailyStatisticsTest: 엔티티 생성/갱신 테스트
- ProductStatisticsCommandServiceImplTest: 증분 판매/환불/flush 서비스 테스트
- ProductStatisticsQueryServiceImplTest: 4개 신규 쿼리 메서드 테스트 추가
- ProductStatisticsControllerTest: 4개 신규 엔드포인트 테스트 추가
- RefundCommandServiceImplTest: 환불 시 통계 호출 검증 추가
- `./gradlew test` 전체 통과
- `./gradlew jacocoTestCoverageVerification` 80% 이상 통과

## 📎 참고
- 기존 5개 API 엔드포인트 유지 (하위 호환)
- Kafka Consumer 멱등성 패턴 (StatisticsEventLog + DataIntegrityViolationException)
- PaymentFailed는 통계에 반영하지 않음 (아직 판매 집계에 미반영 상태)