### PR TITLE
refactor: 환불 완료 처리 비동기 전환

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,7 +115,10 @@ val jacocoExcludedDirs = listOf(
 	"**/com/hoppingmall/mall/membership/domain/MembershipEventLog*",
 	"**/com/hoppingmall/mall/product/service/ProductStatisticsScheduler*",
 	"**/com/hoppingmall/mall/product/service/StatisticsEventConsumer*",
-	"**/com/hoppingmall/mall/product/domain/StatisticsEventLog*"
+	"**/com/hoppingmall/mall/product/domain/StatisticsEventLog*",
+	"**/com/hoppingmall/mall/refund/service/RefundCompletionConsumer*",
+	"**/com/hoppingmall/mall/refund/service/KafkaRefundEventPublisher*",
+	"**/com/hoppingmall/mall/refund/domain/RefundEventLog*"
 )
 
 tasks.jacocoTestReport {

--- a/src/main/kotlin/com/hoppingmall/mall/refund/domain/RefundEventLog.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/domain/RefundEventLog.kt
@@ -1,0 +1,26 @@
+package com.hoppingmall.mall.refund.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "refund_event_logs",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["event_id"])]
+)
+class RefundEventLog(
+    @Column(name = "event_id", nullable = false, unique = true)
+    val eventId: String,
+
+    @Column(nullable = false)
+    val eventType: String,
+
+    @Column(nullable = false)
+    val refundId: Long,
+
+    @Column(nullable = false)
+    val orderId: Long
+) : BaseEntity()

--- a/src/main/kotlin/com/hoppingmall/mall/refund/domain/repository/RefundEventLogRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/domain/repository/RefundEventLogRepository.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.mall.refund.domain.repository
+
+import com.hoppingmall.mall.refund.domain.RefundEventLog
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface RefundEventLogRepository : JpaRepository<RefundEventLog, Long> {
+    fun existsByEventId(eventId: String): Boolean
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/dto/event/RefundCompletedEvent.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/dto/event/RefundCompletedEvent.kt
@@ -1,0 +1,22 @@
+package com.hoppingmall.mall.refund.dto.event
+
+import java.math.BigDecimal
+import java.util.UUID
+
+data class RefundCompletedEvent(
+    val eventId: String = UUID.randomUUID().toString(),
+    val refundId: Long,
+    val orderId: Long,
+    val paymentId: Long,
+    val buyerId: Long,
+    val refundAmount: BigDecimal,
+    val pointRefundAmount: BigDecimal,
+    val isFullRefund: Boolean,
+    val items: List<RefundItemEvent>
+)
+
+data class RefundItemEvent(
+    val productId: Long,
+    val quantity: Int,
+    val refundPrice: BigDecimal
+)

--- a/src/main/kotlin/com/hoppingmall/mall/refund/service/KafkaRefundEventPublisher.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/service/KafkaRefundEventPublisher.kt
@@ -1,0 +1,38 @@
+package com.hoppingmall.mall.refund.service
+
+import com.hoppingmall.mall.global.common.service.TransactionalEventPublisher
+import com.hoppingmall.mall.refund.dto.event.RefundCompletedEvent
+import org.springframework.stereotype.Service
+
+@Service
+class KafkaRefundEventPublisher(
+    private val transactionalEventPublisher: TransactionalEventPublisher
+) : RefundEventPublisher {
+
+    override fun publishRefundCompletedEvent(event: RefundCompletedEvent) {
+        transactionalEventPublisher.publishEvent(
+            aggregateType = "Refund",
+            aggregateId = event.refundId.toString(),
+            eventType = "RefundCompleted",
+            eventData = mapOf(
+                "eventId" to event.eventId,
+                "refundId" to event.refundId,
+                "orderId" to event.orderId,
+                "paymentId" to event.paymentId,
+                "buyerId" to event.buyerId,
+                "refundAmount" to event.refundAmount,
+                "pointRefundAmount" to event.pointRefundAmount,
+                "isFullRefund" to event.isFullRefund,
+                "items" to event.items.map { item ->
+                    mapOf(
+                        "productId" to item.productId,
+                        "quantity" to item.quantity,
+                        "refundPrice" to item.refundPrice
+                    )
+                }
+            ),
+            topic = "refund-completion",
+            partitionKey = event.orderId.toString()
+        )
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImpl.kt
@@ -1,20 +1,19 @@
 package com.hoppingmall.mall.refund.service
 
-import com.hoppingmall.mall.inventory.service.InventoryCommandService
 import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
 import com.hoppingmall.mall.order.domain.repository.OrderRepository
 import com.hoppingmall.mall.order.enum.OrderStatus
 import com.hoppingmall.mall.order.exception.OrderNotFoundException
+import com.hoppingmall.mall.payment.domain.Payment
 import com.hoppingmall.mall.payment.domain.repository.PaymentRepository
-import com.hoppingmall.mall.payment.enum.PaymentStatus
 import com.hoppingmall.mall.payment.exception.PaymentNotFoundException
-import com.hoppingmall.mall.point.service.PointCommandService
 import com.hoppingmall.mall.product.domain.repository.ProductRepository
-import com.hoppingmall.mall.product.service.ProductStatisticsCommandService
 import com.hoppingmall.mall.refund.domain.Refund
 import com.hoppingmall.mall.refund.domain.RefundItem
 import com.hoppingmall.mall.refund.domain.repository.RefundItemRepository
 import com.hoppingmall.mall.refund.domain.repository.RefundRepository
+import com.hoppingmall.mall.refund.dto.event.RefundCompletedEvent
+import com.hoppingmall.mall.refund.dto.event.RefundItemEvent
 import com.hoppingmall.mall.refund.dto.request.RefundApprovalRequest
 import com.hoppingmall.mall.refund.dto.request.RefundCreateRequest
 import com.hoppingmall.mall.refund.dto.response.RefundResponse
@@ -39,9 +38,7 @@ class RefundCommandServiceImpl(
     private val paymentRepository: PaymentRepository,
     private val productRepository: ProductRepository,
     private val shippingRepository: ShippingRepository,
-    private val inventoryCommandService: InventoryCommandService,
-    private val pointCommandService: PointCommandService,
-    private val productStatisticsCommandService: ProductStatisticsCommandService
+    private val refundEventPublisher: RefundEventPublisher
 ) : RefundCommandService {
 
     private val refundableOrderStatuses = setOf(OrderStatus.PAID, OrderStatus.SHIPPED, OrderStatus.DELIVERED)
@@ -134,7 +131,7 @@ class RefundCommandServiceImpl(
 
         if (isAutoApprove) {
             savedRefund.approve(buyerId)
-            processRefundCompletion(savedRefund, savedRefundItems, payment, order)
+            publishRefundCompletedEvent(savedRefund, savedRefundItems, payment)
             savedRefund.complete()
             refundRepository.save(savedRefund)
         }
@@ -155,10 +152,8 @@ class RefundCommandServiceImpl(
         val refundItems = refundItemRepository.findByRefundId(refundId)
         val payment = paymentRepository.findById(refund.paymentId)
             .orElseThrow { PaymentNotFoundException() }
-        val order = orderRepository.findById(refund.orderId)
-            .orElseThrow { OrderNotFoundException() }
 
-        processRefundCompletion(refund, refundItems, payment, order)
+        publishRefundCompletedEvent(refund, refundItems, payment)
         refund.complete()
         refundRepository.save(refund)
 
@@ -180,16 +175,11 @@ class RefundCommandServiceImpl(
         return RefundResponse.from(refund, refundItems)
     }
 
-    private fun processRefundCompletion(
+    private fun publishRefundCompletedEvent(
         refund: Refund,
         refundItems: List<RefundItem>,
-        payment: com.hoppingmall.mall.payment.domain.Payment,
-        order: com.hoppingmall.mall.order.domain.Order
+        payment: Payment
     ) {
-        refundItems.forEach { item ->
-            inventoryCommandService.increaseStock(item.productId, item.quantity)
-        }
-
         val pointRefundAmount = if (refund.isFullRefund) {
             payment.pointAmount
         } else {
@@ -201,29 +191,23 @@ class RefundCommandServiceImpl(
             }
         }
 
-        pointCommandService.refundPoints(
-            userId = refund.buyerId,
-            amount = pointRefundAmount,
-            paymentId = payment.id!!,
-            orderId = refund.orderId
-        )
-
-        refundItems.forEach { item ->
-            productStatisticsCommandService.incrementRefundStats(
-                item.productId,
-                item.quantity.toLong(),
-                item.refundPrice
+        refundEventPublisher.publishRefundCompletedEvent(
+            RefundCompletedEvent(
+                refundId = refund.id!!,
+                orderId = refund.orderId,
+                paymentId = payment.id!!,
+                buyerId = refund.buyerId,
+                refundAmount = refund.refundAmount,
+                pointRefundAmount = pointRefundAmount,
+                isFullRefund = refund.isFullRefund,
+                items = refundItems.map { item ->
+                    RefundItemEvent(
+                        productId = item.productId,
+                        quantity = item.quantity,
+                        refundPrice = item.refundPrice
+                    )
+                }
             )
-        }
-
-        if (refund.isFullRefund) {
-            payment.updateStatus(PaymentStatus.REFUNDED)
-            paymentRepository.save(payment)
-
-            if (order.isCancellable()) {
-                order.updateStatus(OrderStatus.CANCELLED)
-                orderRepository.save(order)
-            }
-        }
+        )
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundCompletionConsumer.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundCompletionConsumer.kt
@@ -1,0 +1,133 @@
+package com.hoppingmall.mall.refund.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.mall.inventory.service.InventoryCommandService
+import com.hoppingmall.mall.order.domain.repository.OrderRepository
+import com.hoppingmall.mall.order.enum.OrderStatus
+import com.hoppingmall.mall.payment.domain.repository.PaymentRepository
+import com.hoppingmall.mall.payment.enum.PaymentStatus
+import com.hoppingmall.mall.point.service.PointCommandService
+import com.hoppingmall.mall.product.service.ProductStatisticsCommandService
+import com.hoppingmall.mall.refund.domain.RefundEventLog
+import com.hoppingmall.mall.refund.domain.repository.RefundEventLogRepository
+import com.hoppingmall.mall.refund.dto.event.RefundCompletedEvent
+import com.hoppingmall.mall.refund.dto.event.RefundItemEvent
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@Service
+class RefundCompletionConsumer(
+    private val refundEventLogRepository: RefundEventLogRepository,
+    private val inventoryCommandService: InventoryCommandService,
+    private val pointCommandService: PointCommandService,
+    private val productStatisticsCommandService: ProductStatisticsCommandService,
+    private val paymentRepository: PaymentRepository,
+    private val orderRepository: OrderRepository,
+    private val objectMapper: ObjectMapper
+) {
+
+    private val logger = LoggerFactory.getLogger(RefundCompletionConsumer::class.java)
+
+    @KafkaListener(topics = ["refund-completion"], groupId = "refund-completion-service")
+    fun handleRefundCompletionEvent(message: String) {
+        val node = objectMapper.readTree(message)
+        val eventType = node.get("eventType")?.asText()
+
+        when (eventType) {
+            "RefundCompleted" -> {
+                val eventData = node.get("eventData") ?: node
+                val event = parseRefundCompletedEvent(eventData)
+                processRefundCompletion(event)
+            }
+            else -> logger.warn("알 수 없는 환불 이벤트 타입: $eventType")
+        }
+    }
+
+    private fun parseRefundCompletedEvent(node: com.fasterxml.jackson.databind.JsonNode): RefundCompletedEvent {
+        val items = node.get("items")?.map { itemNode ->
+            RefundItemEvent(
+                productId = itemNode.get("productId").asLong(),
+                quantity = itemNode.get("quantity").asInt(),
+                refundPrice = BigDecimal(itemNode.get("refundPrice").asText())
+            )
+        } ?: emptyList()
+
+        return RefundCompletedEvent(
+            eventId = node.get("eventId").asText(),
+            refundId = node.get("refundId").asLong(),
+            orderId = node.get("orderId").asLong(),
+            paymentId = node.get("paymentId").asLong(),
+            buyerId = node.get("buyerId").asLong(),
+            refundAmount = BigDecimal(node.get("refundAmount").asText()),
+            pointRefundAmount = BigDecimal(node.get("pointRefundAmount").asText()),
+            isFullRefund = node.get("isFullRefund").asBoolean(),
+            items = items
+        )
+    }
+
+    @Transactional
+    fun processRefundCompletion(event: RefundCompletedEvent) {
+        try {
+            if (refundEventLogRepository.existsByEventId(event.eventId)) {
+                logger.info("이미 처리된 환불 완료 이벤트: ${event.eventId}")
+                return
+            }
+
+            event.items.forEach { item ->
+                inventoryCommandService.increaseStock(item.productId, item.quantity)
+            }
+
+            pointCommandService.refundPoints(
+                userId = event.buyerId,
+                amount = event.pointRefundAmount,
+                paymentId = event.paymentId,
+                orderId = event.orderId
+            )
+
+            event.items.forEach { item ->
+                productStatisticsCommandService.incrementRefundStats(
+                    item.productId,
+                    item.quantity.toLong(),
+                    item.refundPrice
+                )
+            }
+
+            if (event.isFullRefund) {
+                val payment = paymentRepository.findById(event.paymentId).orElse(null)
+                if (payment != null) {
+                    payment.updateStatus(PaymentStatus.REFUNDED)
+                    paymentRepository.save(payment)
+                }
+
+                val order = orderRepository.findById(event.orderId).orElse(null)
+                if (order != null && order.isCancellable()) {
+                    order.updateStatus(OrderStatus.CANCELLED)
+                    orderRepository.save(order)
+                }
+            }
+
+            try {
+                refundEventLogRepository.save(
+                    RefundEventLog(
+                        eventId = event.eventId,
+                        eventType = "REFUND_COMPLETED",
+                        refundId = event.refundId,
+                        orderId = event.orderId
+                    )
+                )
+            } catch (e: DataIntegrityViolationException) {
+                logger.info("이미 처리된 환불 완료 이벤트: ${event.eventId}")
+                return
+            }
+
+            logger.info("환불 완료 처리 성공: refundId=${event.refundId}, orderId=${event.orderId}")
+        } catch (e: Exception) {
+            logger.error("환불 완료 처리 실패: ${event.eventId}, 오류: ${e.message}")
+            throw e
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundEventPublisher.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundEventPublisher.kt
@@ -1,0 +1,7 @@
+package com.hoppingmall.mall.refund.service
+
+import com.hoppingmall.mall.refund.dto.event.RefundCompletedEvent
+
+interface RefundEventPublisher {
+    fun publishRefundCompletedEvent(event: RefundCompletedEvent)
+}

--- a/src/test/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImplTest.kt
@@ -1,6 +1,5 @@
 package com.hoppingmall.mall.refund.service
 
-import com.hoppingmall.mall.inventory.service.InventoryCommandService
 import com.hoppingmall.mall.order.domain.Order
 import com.hoppingmall.mall.order.domain.OrderItem
 import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
@@ -10,14 +9,13 @@ import com.hoppingmall.mall.order.exception.OrderNotFoundException
 import com.hoppingmall.mall.payment.domain.Payment
 import com.hoppingmall.mall.payment.domain.repository.PaymentRepository
 import com.hoppingmall.mall.payment.exception.PaymentNotFoundException
-import com.hoppingmall.mall.point.service.PointCommandService
 import com.hoppingmall.mall.product.domain.Product
 import com.hoppingmall.mall.product.domain.repository.ProductRepository
-import com.hoppingmall.mall.product.service.ProductStatisticsCommandService
 import com.hoppingmall.mall.refund.domain.Refund
 import com.hoppingmall.mall.refund.domain.RefundItem
 import com.hoppingmall.mall.refund.domain.repository.RefundItemRepository
 import com.hoppingmall.mall.refund.domain.repository.RefundRepository
+import com.hoppingmall.mall.refund.dto.event.RefundCompletedEvent
 import com.hoppingmall.mall.refund.dto.request.RefundApprovalRequest
 import com.hoppingmall.mall.refund.dto.request.RefundCreateRequest
 import com.hoppingmall.mall.refund.dto.request.RefundItemRequest
@@ -52,9 +50,7 @@ class RefundCommandServiceImplTest {
     private val paymentRepository: PaymentRepository = mock()
     private val productRepository: ProductRepository = mock()
     private val shippingRepository: ShippingRepository = mock()
-    private val inventoryCommandService: InventoryCommandService = mock()
-    private val pointCommandService: PointCommandService = mock()
-    private val productStatisticsCommandService: ProductStatisticsCommandService = mock()
+    private val refundEventPublisher: RefundEventPublisher = mock()
 
     private val refundCommandService = RefundCommandServiceImpl(
         refundRepository,
@@ -64,9 +60,7 @@ class RefundCommandServiceImplTest {
         paymentRepository,
         productRepository,
         shippingRepository,
-        inventoryCommandService,
-        pointCommandService,
-        productStatisticsCommandService
+        refundEventPublisher
     )
 
     @Nested
@@ -110,9 +104,7 @@ class RefundCommandServiceImplTest {
             // then
             assertEquals(RefundStatus.COMPLETED, response.status)
             assertTrue(response.isFullRefund)
-            verify(inventoryCommandService).increaseStock(100L, 2)
-            verify(pointCommandService).refundPoints(eq(buyerId), eq(BigDecimal("1000")), eq(1L), eq(orderId))
-            verify(productStatisticsCommandService).incrementRefundStats(eq(100L), eq(2L), any())
+            verify(refundEventPublisher).publishRefundCompletedEvent(any())
         }
 
         @Test
@@ -152,8 +144,7 @@ class RefundCommandServiceImplTest {
 
             // then
             assertEquals(RefundStatus.REQUESTED, response.status)
-            verify(inventoryCommandService, never()).increaseStock(any(), any())
-            verify(pointCommandService, never()).refundPoints(any(), any(), any(), any())
+            verify(refundEventPublisher, never()).publishRefundCompletedEvent(any())
         }
 
         @Test
@@ -193,7 +184,7 @@ class RefundCommandServiceImplTest {
             // then
             assertFalse(response.isFullRefund)
             assertEquals(BigDecimal("15000"), response.refundAmount)
-            verify(inventoryCommandService).increaseStock(100L, 1)
+            verify(refundEventPublisher).publishRefundCompletedEvent(any())
         }
 
         @Test
@@ -358,12 +349,10 @@ class RefundCommandServiceImplTest {
             val refund = Refund.fixture(sellerId = sellerId, status = RefundStatus.REQUESTED)
             val refundItem = RefundItem.fixture(refundId = refundId, productId = 100L, quantity = 2)
             val payment = Payment.successFixture(pointAmount = BigDecimal("1000"))
-            val order = Order.paidFixture()
 
             whenever(refundRepository.findById(refundId)).thenReturn(Optional.of(refund))
             whenever(refundItemRepository.findByRefundId(refundId)).thenReturn(listOf(refundItem))
             whenever(paymentRepository.findById(refund.paymentId)).thenReturn(Optional.of(payment))
-            whenever(orderRepository.findById(refund.orderId)).thenReturn(Optional.of(order))
             whenever(refundRepository.save(any<Refund>())).thenAnswer { it.arguments[0] }
 
             // when
@@ -371,9 +360,7 @@ class RefundCommandServiceImplTest {
 
             // then
             assertEquals(RefundStatus.COMPLETED, response.status)
-            verify(inventoryCommandService).increaseStock(100L, 2)
-            verify(pointCommandService).refundPoints(eq(1L), any(), eq(1L), eq(1L))
-            verify(productStatisticsCommandService).incrementRefundStats(eq(100L), eq(2L), any())
+            verify(refundEventPublisher).publishRefundCompletedEvent(any())
         }
 
         @Test
@@ -425,7 +412,7 @@ class RefundCommandServiceImplTest {
             // then
             assertEquals(RefundStatus.REJECTED, response.status)
             assertEquals("반품 불가 상품", response.rejectionReason)
-            verify(inventoryCommandService, never()).increaseStock(any(), any())
+            verify(refundEventPublisher, never()).publishRefundCompletedEvent(any())
         }
 
         @Test

--- a/src/test/kotlin/com/hoppingmall/mall/refund/service/RefundCompletionConsumerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/refund/service/RefundCompletionConsumerTest.kt
@@ -1,0 +1,146 @@
+package com.hoppingmall.mall.refund.service
+
+import com.hoppingmall.mall.inventory.service.InventoryCommandService
+import com.hoppingmall.mall.order.domain.Order
+import com.hoppingmall.mall.order.domain.repository.OrderRepository
+import com.hoppingmall.mall.order.enum.OrderStatus
+import com.hoppingmall.mall.payment.domain.Payment
+import com.hoppingmall.mall.payment.domain.repository.PaymentRepository
+import com.hoppingmall.mall.payment.enum.PaymentStatus
+import com.hoppingmall.mall.point.service.PointCommandService
+import com.hoppingmall.mall.product.service.ProductStatisticsCommandService
+import com.hoppingmall.mall.refund.domain.RefundEventLog
+import com.hoppingmall.mall.refund.domain.repository.RefundEventLogRepository
+import com.hoppingmall.mall.refund.dto.event.RefundCompletedEvent
+import com.hoppingmall.mall.refund.dto.event.RefundItemEvent
+import com.hoppingmall.mall.support.fixture.paidFixture
+import com.hoppingmall.mall.support.fixture.successFixture
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import java.math.BigDecimal
+import java.util.*
+
+@DisplayName("RefundCompletionConsumer")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class RefundCompletionConsumerTest {
+
+    private val refundEventLogRepository: RefundEventLogRepository = mock()
+    private val inventoryCommandService: InventoryCommandService = mock()
+    private val pointCommandService: PointCommandService = mock()
+    private val productStatisticsCommandService: ProductStatisticsCommandService = mock()
+    private val paymentRepository: PaymentRepository = mock()
+    private val orderRepository: OrderRepository = mock()
+    private val objectMapper = com.fasterxml.jackson.databind.ObjectMapper()
+
+    private val consumer = RefundCompletionConsumer(
+        refundEventLogRepository,
+        inventoryCommandService,
+        pointCommandService,
+        productStatisticsCommandService,
+        paymentRepository,
+        orderRepository,
+        objectMapper
+    )
+
+    @Test
+    fun `환불_완료_이벤트_정상_처리`() {
+        // given
+        val event = RefundCompletedEvent(
+            eventId = "test-event-1",
+            refundId = 1L,
+            orderId = 1L,
+            paymentId = 1L,
+            buyerId = 1L,
+            refundAmount = BigDecimal("30000"),
+            pointRefundAmount = BigDecimal("1000"),
+            isFullRefund = true,
+            items = listOf(
+                RefundItemEvent(productId = 100L, quantity = 2, refundPrice = BigDecimal("30000"))
+            )
+        )
+
+        val payment = Payment.successFixture(orderId = 1L)
+        val order = Order.paidFixture(buyerId = 1L)
+
+        whenever(refundEventLogRepository.existsByEventId(event.eventId)).thenReturn(false)
+        whenever(paymentRepository.findById(1L)).thenReturn(Optional.of(payment))
+        whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+        whenever(refundEventLogRepository.save(any<RefundEventLog>())).thenAnswer { it.arguments[0] }
+
+        // when
+        consumer.processRefundCompletion(event)
+
+        // then
+        verify(inventoryCommandService).increaseStock(100L, 2)
+        verify(pointCommandService).refundPoints(eq(1L), eq(BigDecimal("1000")), eq(1L), eq(1L))
+        verify(productStatisticsCommandService).incrementRefundStats(eq(100L), eq(2L), eq(BigDecimal("30000")))
+        verify(paymentRepository).save(any())
+        verify(orderRepository).save(any())
+        verify(refundEventLogRepository).save(any<RefundEventLog>())
+    }
+
+    @Test
+    fun `이미_처리된_이벤트는_스킵`() {
+        // given
+        val event = RefundCompletedEvent(
+            eventId = "already-processed",
+            refundId = 1L,
+            orderId = 1L,
+            paymentId = 1L,
+            buyerId = 1L,
+            refundAmount = BigDecimal("30000"),
+            pointRefundAmount = BigDecimal("1000"),
+            isFullRefund = true,
+            items = listOf(
+                RefundItemEvent(productId = 100L, quantity = 2, refundPrice = BigDecimal("30000"))
+            )
+        )
+
+        whenever(refundEventLogRepository.existsByEventId(event.eventId)).thenReturn(true)
+
+        // when
+        consumer.processRefundCompletion(event)
+
+        // then
+        verify(inventoryCommandService, never()).increaseStock(any(), any())
+        verify(pointCommandService, never()).refundPoints(any(), any(), any(), any())
+        verify(productStatisticsCommandService, never()).incrementRefundStats(any(), any(), any())
+        verify(refundEventLogRepository, never()).save(any<RefundEventLog>())
+    }
+
+    @Test
+    fun `부분_환불_시_결제_주문_상태_미변경`() {
+        // given
+        val event = RefundCompletedEvent(
+            eventId = "partial-refund-event",
+            refundId = 1L,
+            orderId = 1L,
+            paymentId = 1L,
+            buyerId = 1L,
+            refundAmount = BigDecimal("15000"),
+            pointRefundAmount = BigDecimal("500"),
+            isFullRefund = false,
+            items = listOf(
+                RefundItemEvent(productId = 100L, quantity = 1, refundPrice = BigDecimal("15000"))
+            )
+        )
+
+        whenever(refundEventLogRepository.existsByEventId(event.eventId)).thenReturn(false)
+        whenever(refundEventLogRepository.save(any<RefundEventLog>())).thenAnswer { it.arguments[0] }
+
+        // when
+        consumer.processRefundCompletion(event)
+
+        // then
+        verify(inventoryCommandService).increaseStock(100L, 1)
+        verify(pointCommandService).refundPoints(eq(1L), eq(BigDecimal("500")), eq(1L), eq(1L))
+        verify(productStatisticsCommandService).incrementRefundStats(eq(100L), eq(1L), eq(BigDecimal("15000")))
+        verify(paymentRepository, never()).findById(any())
+        verify(paymentRepository, never()).save(any())
+        verify(orderRepository, never()).findById(any())
+        verify(orderRepository, never()).save(any())
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/support/IntegrationTestBase.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/IntegrationTestBase.kt
@@ -18,7 +18,7 @@ import java.time.Duration
 @Import(TestKafkaConfig::class)
 @EmbeddedKafka(
     partitions = 1,
-    topics = ["notification", "point-earn-request", "payment", "payment-compensation"],
+    topics = ["notification", "point-earn-request", "payment", "payment-compensation", "refund-completion"],
     brokerProperties = ["listeners=PLAINTEXT://localhost:0", "port=0"]
 )
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)


### PR DESCRIPTION
Closes #73

## 📌 변경 사항
- 환불 완료 처리(`processRefundCompletion`)를 동기 → 비동기(Kafka + Outbox Pattern) 방식으로 전환
- `RefundCompletedEvent` DTO 및 `RefundEventPublisher` 인터페이스 + `KafkaRefundEventPublisher` 구현
- `RefundCompletionConsumer` 구현 (재고 복구, 포인트 반환, 통계 갱신, 결제/주문 상태 변경)
- `RefundEventLog` 엔티티 기반 멱등성 보장 (unique constraint + DataIntegrityViolationException)
- `RefundCommandServiceImpl`에서 `InventoryCommandService`, `PointCommandService`, `ProductStatisticsCommandService` 의존성 제거

## ✅ 주요 포인트
- 기존 `PaymentCompensationConsumer` 패턴을 그대로 따름
- Transactional Outbox Pattern으로 이벤트 발행 원자성 보장
- 부분 환불 시 결제/주문 상태 미변경, 전체 환불 시만 상태 변경
- `pointRefundAmount` 사전 계산 후 이벤트에 포함

## 🧪 테스트
- `RefundCompletionConsumerTest`: 정상 처리 / 멱등성 스킵 / 부분 환불 검증
- `RefundCommandServiceImplTest`: mock 대상 교체 + 이벤트 발행 검증으로 업데이트
- Jacoco 커버리지 80% 검증 통과

## 📎 참고
- `PaymentCompensationConsumer` 패턴 참조
- `KafkaPaymentEventPublisher` 패턴 참조