### PR TITLE
feat: 위시리스트(찜) 기능 구현

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/wishlist/controller/WishlistController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/wishlist/controller/WishlistController.kt
@@ -1,0 +1,61 @@
+package com.hoppingmall.mall.wishlist.controller
+
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.wishlist.dto.request.WishlistCreateRequest
+import com.hoppingmall.mall.wishlist.dto.response.WishlistResponse
+import com.hoppingmall.mall.wishlist.service.WishlistCommandService
+import com.hoppingmall.mall.wishlist.service.WishlistQueryService
+import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/wishlists")
+class WishlistController(
+    private val wishlistCommandService: WishlistCommandService,
+    private val wishlistQueryService: WishlistQueryService
+) {
+
+    @PostMapping
+    fun addWishlist(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @Valid @RequestBody request: WishlistCreateRequest
+    ): ResponseEntity<ApiResponse<WishlistResponse>> {
+        val wishlist = wishlistCommandService.addWishlist(userPrincipal.getUserId(), request)
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.success(wishlist))
+    }
+
+    @DeleteMapping("/{wishlistId}")
+    fun removeWishlist(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PathVariable wishlistId: Long
+    ): ResponseEntity<ApiResponse<Unit>> {
+        wishlistCommandService.removeWishlist(userPrincipal.getUserId(), wishlistId)
+        return ResponseEntity.ok(ApiResponse.success(Unit))
+    }
+
+    @GetMapping
+    fun getWishlists(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PageableDefault(size = 20) pageable: Pageable
+    ): ResponseEntity<ApiResponse<Page<WishlistResponse>>> {
+        val wishlists = wishlistQueryService.getWishlists(userPrincipal.getUserId(), pageable)
+        return ResponseEntity.ok(ApiResponse.success(wishlists))
+    }
+
+    @GetMapping("/check/{productId}")
+    fun isWishlisted(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PathVariable productId: Long
+    ): ResponseEntity<ApiResponse<Boolean>> {
+        val wishlisted = wishlistQueryService.isWishlisted(userPrincipal.getUserId(), productId)
+        return ResponseEntity.ok(ApiResponse.success(wishlisted))
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/wishlist/domain/Wishlist.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/wishlist/domain/Wishlist.kt
@@ -1,0 +1,26 @@
+package com.hoppingmall.mall.wishlist.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "wishlists",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["buyer_id", "product_id"])]
+)
+class Wishlist private constructor(
+    @Column
+    val buyerId: Long,
+
+    @Column
+    val productId: Long,
+) : BaseEntity() {
+    companion object {
+        fun create(buyerId: Long, productId: Long): Wishlist {
+            return Wishlist(buyerId, productId)
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/wishlist/domain/repository/WishlistRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/wishlist/domain/repository/WishlistRepository.kt
@@ -1,0 +1,13 @@
+package com.hoppingmall.mall.wishlist.domain.repository
+
+import com.hoppingmall.mall.wishlist.domain.Wishlist
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface WishlistRepository : JpaRepository<Wishlist, Long> {
+    fun findByBuyerId(buyerId: Long, pageable: Pageable): Page<Wishlist>
+    fun existsByBuyerIdAndProductId(buyerId: Long, productId: Long): Boolean
+}

--- a/src/main/kotlin/com/hoppingmall/mall/wishlist/dto/request/WishlistCreateRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/wishlist/dto/request/WishlistCreateRequest.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.mall.wishlist.dto.request
+
+import jakarta.validation.constraints.NotNull
+
+data class WishlistCreateRequest(
+    @field:NotNull(message = "상품 ID는 필수입니다")
+    val productId: Long
+)

--- a/src/main/kotlin/com/hoppingmall/mall/wishlist/dto/response/WishlistResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/wishlist/dto/response/WishlistResponse.kt
@@ -1,0 +1,20 @@
+package com.hoppingmall.mall.wishlist.dto.response
+
+import com.hoppingmall.mall.wishlist.domain.Wishlist
+import java.time.LocalDateTime
+
+data class WishlistResponse(
+    val id: Long,
+    val productId: Long,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(wishlist: Wishlist): WishlistResponse {
+            return WishlistResponse(
+                id = wishlist.id!!,
+                productId = wishlist.productId,
+                createdAt = wishlist.createdAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/wishlist/exception/WishlistAlreadyExistsException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/wishlist/exception/WishlistAlreadyExistsException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.wishlist.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.wishlist.exception.code.WishlistErrorCode
+
+class WishlistAlreadyExistsException : BusinessException(WishlistErrorCode.WISHLIST_ALREADY_EXISTS)

--- a/src/main/kotlin/com/hoppingmall/mall/wishlist/exception/WishlistNotFoundException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/wishlist/exception/WishlistNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.wishlist.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.wishlist.exception.code.WishlistErrorCode
+
+class WishlistNotFoundException : BusinessException(WishlistErrorCode.WISHLIST_NOT_FOUND)

--- a/src/main/kotlin/com/hoppingmall/mall/wishlist/exception/code/WishlistErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/wishlist/exception/code/WishlistErrorCode.kt
@@ -1,0 +1,13 @@
+package com.hoppingmall.mall.wishlist.exception.code
+
+import com.hoppingmall.mall.global.common.error.code.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class WishlistErrorCode(
+    override val code: String,
+    override val message: String,
+    override val status: HttpStatus
+) : ErrorCode {
+    WISHLIST_NOT_FOUND("WISH001", "찜 항목을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    WISHLIST_ALREADY_EXISTS("WISH002", "이미 찜한 상품입니다.", HttpStatus.CONFLICT),
+}

--- a/src/main/kotlin/com/hoppingmall/mall/wishlist/service/WishlistCommandService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/wishlist/service/WishlistCommandService.kt
@@ -1,0 +1,9 @@
+package com.hoppingmall.mall.wishlist.service
+
+import com.hoppingmall.mall.wishlist.dto.request.WishlistCreateRequest
+import com.hoppingmall.mall.wishlist.dto.response.WishlistResponse
+
+interface WishlistCommandService {
+    fun addWishlist(buyerId: Long, request: WishlistCreateRequest): WishlistResponse
+    fun removeWishlist(buyerId: Long, wishlistId: Long)
+}

--- a/src/main/kotlin/com/hoppingmall/mall/wishlist/service/WishlistCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/wishlist/service/WishlistCommandServiceImpl.kt
@@ -1,0 +1,45 @@
+package com.hoppingmall.mall.wishlist.service
+
+import com.hoppingmall.mall.product.domain.repository.ProductRepository
+import com.hoppingmall.mall.product.exception.ProductNotFoundException
+import com.hoppingmall.mall.wishlist.domain.Wishlist
+import com.hoppingmall.mall.wishlist.domain.repository.WishlistRepository
+import com.hoppingmall.mall.wishlist.dto.request.WishlistCreateRequest
+import com.hoppingmall.mall.wishlist.dto.response.WishlistResponse
+import com.hoppingmall.mall.wishlist.exception.WishlistAlreadyExistsException
+import com.hoppingmall.mall.wishlist.exception.WishlistNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class WishlistCommandServiceImpl(
+    private val wishlistRepository: WishlistRepository,
+    private val productRepository: ProductRepository
+) : WishlistCommandService {
+
+    override fun addWishlist(buyerId: Long, request: WishlistCreateRequest): WishlistResponse {
+        productRepository.findById(request.productId)
+            .orElseThrow { ProductNotFoundException() }
+
+        if (wishlistRepository.existsByBuyerIdAndProductId(buyerId, request.productId)) {
+            throw WishlistAlreadyExistsException()
+        }
+
+        val wishlist = Wishlist.create(buyerId, request.productId)
+        val savedWishlist = wishlistRepository.save(wishlist)
+
+        return WishlistResponse.from(savedWishlist)
+    }
+
+    override fun removeWishlist(buyerId: Long, wishlistId: Long) {
+        val wishlist = wishlistRepository.findById(wishlistId)
+            .orElseThrow { WishlistNotFoundException() }
+
+        if (wishlist.buyerId != buyerId) {
+            throw WishlistNotFoundException()
+        }
+
+        wishlistRepository.deleteById(wishlistId)
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/wishlist/service/WishlistQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/wishlist/service/WishlistQueryService.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.mall.wishlist.service
+
+import com.hoppingmall.mall.wishlist.dto.response.WishlistResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface WishlistQueryService {
+    fun getWishlists(buyerId: Long, pageable: Pageable): Page<WishlistResponse>
+    fun isWishlisted(buyerId: Long, productId: Long): Boolean
+}

--- a/src/main/kotlin/com/hoppingmall/mall/wishlist/service/WishlistQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/wishlist/service/WishlistQueryServiceImpl.kt
@@ -1,0 +1,24 @@
+package com.hoppingmall.mall.wishlist.service
+
+import com.hoppingmall.mall.wishlist.domain.repository.WishlistRepository
+import com.hoppingmall.mall.wishlist.dto.response.WishlistResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class WishlistQueryServiceImpl(
+    private val wishlistRepository: WishlistRepository
+) : WishlistQueryService {
+
+    override fun getWishlists(buyerId: Long, pageable: Pageable): Page<WishlistResponse> {
+        return wishlistRepository.findByBuyerId(buyerId, pageable)
+            .map { WishlistResponse.from(it) }
+    }
+
+    override fun isWishlisted(buyerId: Long, productId: Long): Boolean {
+        return wishlistRepository.existsByBuyerIdAndProductId(buyerId, productId)
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/WishlistFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/WishlistFixture.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.mall.support.fixture
+
+import com.hoppingmall.mall.wishlist.domain.Wishlist
+
+fun Wishlist.Companion.fixture(
+    buyerId: Long = 1L,
+    productId: Long = 100L,
+): Wishlist {
+    return Wishlist.create(buyerId, productId)
+}

--- a/src/test/kotlin/com/hoppingmall/mall/wishlist/controller/WishlistControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/wishlist/controller/WishlistControllerTest.kt
@@ -1,0 +1,136 @@
+package com.hoppingmall.mall.wishlist.controller
+
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.wishlist.dto.request.WishlistCreateRequest
+import com.hoppingmall.mall.wishlist.dto.response.WishlistResponse
+import com.hoppingmall.mall.wishlist.service.WishlistCommandService
+import com.hoppingmall.mall.wishlist.service.WishlistQueryService
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.mockito.kotlin.*
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.http.ResponseEntity
+import java.time.LocalDateTime
+
+@DisplayName("WishlistController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class WishlistControllerTest {
+
+    private val wishlistCommandService: WishlistCommandService = mock()
+    private val wishlistQueryService: WishlistQueryService = mock()
+    private val controller = WishlistController(wishlistCommandService, wishlistQueryService)
+
+    @Nested
+    @DisplayName("addWishlist")
+    inner class AddWishlist {
+        @Test
+        fun 찜_추가_성공() {
+            // Data
+            val userPrincipal = UserPrincipal(1L, "test@example.com", "ROLE_USER")
+            val request = WishlistCreateRequest(productId = 100L)
+            val expectedResponse = WishlistResponse(
+                id = 1L,
+                productId = 100L,
+                createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+            )
+
+            // Context
+            whenever(wishlistCommandService.addWishlist(userPrincipal.getUserId(), request)).thenReturn(expectedResponse)
+
+            // Interaction
+            val response: ResponseEntity<ApiResponse<WishlistResponse>> = controller.addWishlist(userPrincipal, request)
+
+            // Assertions
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals("성공", response.body?.message)
+            assertEquals(expectedResponse, response.body?.data)
+            verify(wishlistCommandService).addWishlist(userPrincipal.getUserId(), request)
+        }
+    }
+
+    @Nested
+    @DisplayName("removeWishlist")
+    inner class RemoveWishlist {
+        @Test
+        fun 찜_삭제_성공() {
+            // Data
+            val userPrincipal = UserPrincipal(1L, "test@example.com", "ROLE_USER")
+            val wishlistId = 1L
+
+            // Context
+            doNothing().whenever(wishlistCommandService).removeWishlist(userPrincipal.getUserId(), wishlistId)
+
+            // Interaction
+            val response: ResponseEntity<ApiResponse<Unit>> = controller.removeWishlist(userPrincipal, wishlistId)
+
+            // Assertions
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals("성공", response.body?.message)
+            assertEquals(Unit, response.body?.data)
+            verify(wishlistCommandService).removeWishlist(userPrincipal.getUserId(), wishlistId)
+        }
+    }
+
+    @Nested
+    @DisplayName("getWishlists")
+    inner class GetWishlists {
+        @Test
+        fun 찜_목록_조회_성공() {
+            // Data
+            val userPrincipal = UserPrincipal(1L, "test@example.com", "ROLE_USER")
+            val pageable = PageRequest.of(0, 20)
+            val expectedResponses = listOf(
+                WishlistResponse(
+                    id = 1L,
+                    productId = 100L,
+                    createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+                ),
+                WishlistResponse(
+                    id = 2L,
+                    productId = 200L,
+                    createdAt = LocalDateTime.of(2026, 1, 2, 0, 0)
+                )
+            )
+            val expectedPage: Page<WishlistResponse> = PageImpl(expectedResponses, pageable, 2)
+
+            // Context
+            whenever(wishlistQueryService.getWishlists(userPrincipal.getUserId(), pageable)).thenReturn(expectedPage)
+
+            // Interaction
+            val response: ResponseEntity<ApiResponse<Page<WishlistResponse>>> = controller.getWishlists(userPrincipal, pageable)
+
+            // Assertions
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals("성공", response.body?.message)
+            assertEquals(expectedPage, response.body?.data)
+            verify(wishlistQueryService).getWishlists(userPrincipal.getUserId(), pageable)
+        }
+    }
+
+    @Nested
+    @DisplayName("isWishlisted")
+    inner class IsWishlisted {
+        @Test
+        fun 찜_여부_확인_성공() {
+            // Data
+            val userPrincipal = UserPrincipal(1L, "test@example.com", "ROLE_USER")
+            val productId = 100L
+
+            // Context
+            whenever(wishlistQueryService.isWishlisted(userPrincipal.getUserId(), productId)).thenReturn(true)
+
+            // Interaction
+            val response: ResponseEntity<ApiResponse<Boolean>> = controller.isWishlisted(userPrincipal, productId)
+
+            // Assertions
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals("성공", response.body?.message)
+            assertEquals(true, response.body?.data)
+            verify(wishlistQueryService).isWishlisted(userPrincipal.getUserId(), productId)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/wishlist/domain/WishlistTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/wishlist/domain/WishlistTest.kt
@@ -1,0 +1,26 @@
+package com.hoppingmall.mall.wishlist.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("Wishlist")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class WishlistTest {
+
+    @Test
+    fun 위시리스트_생성_성공() {
+        // Data
+        val buyerId = 1L
+        val productId = 100L
+
+        // Interaction
+        val wishlist = Wishlist.create(buyerId, productId)
+
+        // Assertions
+        assertThat(wishlist.buyerId).isEqualTo(buyerId)
+        assertThat(wishlist.productId).isEqualTo(productId)
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/wishlist/service/WishlistCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/wishlist/service/WishlistCommandServiceImplTest.kt
@@ -1,0 +1,155 @@
+package com.hoppingmall.mall.wishlist.service
+
+import com.hoppingmall.mall.product.domain.Product
+import com.hoppingmall.mall.product.domain.repository.ProductRepository
+import com.hoppingmall.mall.product.exception.ProductNotFoundException
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
+import com.hoppingmall.mall.wishlist.domain.Wishlist
+import com.hoppingmall.mall.wishlist.domain.repository.WishlistRepository
+import com.hoppingmall.mall.wishlist.dto.request.WishlistCreateRequest
+import com.hoppingmall.mall.wishlist.exception.WishlistAlreadyExistsException
+import com.hoppingmall.mall.wishlist.exception.WishlistNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.*
+
+@DisplayName("WishlistCommandServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class WishlistCommandServiceImplTest {
+
+    @Mock
+    private lateinit var wishlistRepository: WishlistRepository
+
+    @Mock
+    private lateinit var productRepository: ProductRepository
+
+    private lateinit var wishlistCommandService: WishlistCommandServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        wishlistCommandService = WishlistCommandServiceImpl(wishlistRepository, productRepository)
+    }
+
+    @Nested
+    @DisplayName("addWishlist")
+    inner class AddWishlist {
+
+        @Test
+        fun 찜_추가_성공() {
+            // Data
+            val buyerId = 1L
+            val request = WishlistCreateRequest(productId = 100L)
+            val product = Product.fixture().withId(100L)
+
+            // Context
+            whenever(productRepository.findById(request.productId)).thenReturn(java.util.Optional.of(product))
+            whenever(wishlistRepository.existsByBuyerIdAndProductId(buyerId, request.productId)).thenReturn(false)
+            whenever(wishlistRepository.save(any<Wishlist>())).thenAnswer { invocation ->
+                val wishlist = invocation.getArgument<Wishlist>(0)
+                wishlist.withId(1L)
+            }
+
+            // Interaction
+            val result = wishlistCommandService.addWishlist(buyerId, request)
+
+            // Assertions
+            assertThat(result).isNotNull()
+            assertThat(result.productId).isEqualTo(request.productId)
+
+            verify(wishlistRepository).save(any())
+        }
+
+        @Test
+        fun 존재하지_않는_상품_찜_추가_시_예외_발생() {
+            // Data
+            val buyerId = 1L
+            val request = WishlistCreateRequest(productId = 999L)
+
+            // Context
+            whenever(productRepository.findById(request.productId)).thenReturn(java.util.Optional.empty())
+
+            // Interaction & Assertions
+            assertThatThrownBy { wishlistCommandService.addWishlist(buyerId, request) }
+                .isInstanceOf(ProductNotFoundException::class.java)
+        }
+
+        @Test
+        fun 이미_찜한_상품_추가_시_예외_발생() {
+            // Data
+            val buyerId = 1L
+            val request = WishlistCreateRequest(productId = 100L)
+            val product = Product.fixture().withId(100L)
+
+            // Context
+            whenever(productRepository.findById(request.productId)).thenReturn(java.util.Optional.of(product))
+            whenever(wishlistRepository.existsByBuyerIdAndProductId(buyerId, request.productId)).thenReturn(true)
+
+            // Interaction & Assertions
+            assertThatThrownBy { wishlistCommandService.addWishlist(buyerId, request) }
+                .isInstanceOf(WishlistAlreadyExistsException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("removeWishlist")
+    inner class RemoveWishlist {
+
+        @Test
+        fun 찜_삭제_성공() {
+            // Data
+            val buyerId = 1L
+            val wishlistId = 1L
+            val wishlist = Wishlist.fixture(buyerId = buyerId, productId = 100L).withId(wishlistId)
+
+            // Context
+            whenever(wishlistRepository.findById(wishlistId)).thenReturn(java.util.Optional.of(wishlist))
+            doNothing().`when`(wishlistRepository).deleteById(wishlistId)
+
+            // Interaction
+            wishlistCommandService.removeWishlist(buyerId, wishlistId)
+
+            // Assertions
+            verify(wishlistRepository).deleteById(wishlistId)
+        }
+
+        @Test
+        fun 존재하지_않는_찜_삭제_시_예외_발생() {
+            // Data
+            val buyerId = 1L
+            val wishlistId = 999L
+
+            // Context
+            whenever(wishlistRepository.findById(wishlistId)).thenReturn(java.util.Optional.empty())
+
+            // Interaction & Assertions
+            assertThatThrownBy { wishlistCommandService.removeWishlist(buyerId, wishlistId) }
+                .isInstanceOf(WishlistNotFoundException::class.java)
+        }
+
+        @Test
+        fun 다른_사용자의_찜_삭제_시_예외_발생() {
+            // Data
+            val buyerId = 1L
+            val wishlistId = 1L
+            val wishlist = Wishlist.fixture(buyerId = 2L, productId = 100L).withId(wishlistId)
+
+            // Context
+            whenever(wishlistRepository.findById(wishlistId)).thenReturn(java.util.Optional.of(wishlist))
+
+            // Interaction & Assertions
+            assertThatThrownBy { wishlistCommandService.removeWishlist(buyerId, wishlistId) }
+                .isInstanceOf(WishlistNotFoundException::class.java)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/wishlist/service/WishlistQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/wishlist/service/WishlistQueryServiceImplTest.kt
@@ -1,0 +1,127 @@
+package com.hoppingmall.mall.wishlist.service
+
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
+import com.hoppingmall.mall.wishlist.domain.Wishlist
+import com.hoppingmall.mall.wishlist.domain.repository.WishlistRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.*
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+
+@DisplayName("WishlistQueryServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class WishlistQueryServiceImplTest {
+
+    @Mock
+    private lateinit var wishlistRepository: WishlistRepository
+
+    private lateinit var wishlistQueryService: WishlistQueryServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        wishlistQueryService = WishlistQueryServiceImpl(wishlistRepository)
+    }
+
+    @Nested
+    @DisplayName("getWishlists")
+    inner class GetWishlists {
+
+        @Test
+        fun 빈_찜_목록_조회_성공() {
+            // Data
+            val buyerId = 1L
+            val pageable = PageRequest.of(0, 20)
+
+            // Context
+            whenever(wishlistRepository.findByBuyerId(buyerId, pageable))
+                .thenReturn(PageImpl(emptyList(), pageable, 0))
+
+            // Interaction
+            val result = wishlistQueryService.getWishlists(buyerId, pageable)
+
+            // Assertions
+            assertThat(result.content).isEmpty()
+            assertThat(result.totalElements).isEqualTo(0)
+
+            verify(wishlistRepository).findByBuyerId(buyerId, pageable)
+        }
+
+        @Test
+        fun 찜_목록_조회_성공() {
+            // Data
+            val buyerId = 1L
+            val pageable = PageRequest.of(0, 20)
+            val wishlists = listOf(
+                Wishlist.fixture(buyerId = buyerId, productId = 100L).withId(1L),
+                Wishlist.fixture(buyerId = buyerId, productId = 200L).withId(2L)
+            )
+
+            // Context
+            whenever(wishlistRepository.findByBuyerId(buyerId, pageable))
+                .thenReturn(PageImpl(wishlists, pageable, 2))
+
+            // Interaction
+            val result = wishlistQueryService.getWishlists(buyerId, pageable)
+
+            // Assertions
+            assertThat(result.content).hasSize(2)
+            assertThat(result.content[0].productId).isEqualTo(100L)
+            assertThat(result.content[1].productId).isEqualTo(200L)
+            assertThat(result.totalElements).isEqualTo(2)
+
+            verify(wishlistRepository).findByBuyerId(buyerId, pageable)
+        }
+    }
+
+    @Nested
+    @DisplayName("isWishlisted")
+    inner class IsWishlisted {
+
+        @Test
+        fun 찜한_상품_확인_true() {
+            // Data
+            val buyerId = 1L
+            val productId = 100L
+
+            // Context
+            whenever(wishlistRepository.existsByBuyerIdAndProductId(buyerId, productId)).thenReturn(true)
+
+            // Interaction
+            val result = wishlistQueryService.isWishlisted(buyerId, productId)
+
+            // Assertions
+            assertThat(result).isTrue()
+
+            verify(wishlistRepository).existsByBuyerIdAndProductId(buyerId, productId)
+        }
+
+        @Test
+        fun 찜하지_않은_상품_확인_false() {
+            // Data
+            val buyerId = 1L
+            val productId = 100L
+
+            // Context
+            whenever(wishlistRepository.existsByBuyerIdAndProductId(buyerId, productId)).thenReturn(false)
+
+            // Interaction
+            val result = wishlistQueryService.isWishlisted(buyerId, productId)
+
+            // Assertions
+            assertThat(result).isFalse()
+
+            verify(wishlistRepository).existsByBuyerIdAndProductId(buyerId, productId)
+        }
+    }
+}


### PR DESCRIPTION
Closes #75

## 📌 작업 내용
- Wishlist 도메인 신규 구현 (Entity, Repository, DTO, ErrorCode, Exception)
- CQRS 패턴 적용 (CommandService / QueryService 분리)
- RESTful API 4개 엔드포인트 구현

## ✅ 주요 변경사항
- `POST /api/v1/wishlists` - 찜 추가 (201)
- `DELETE /api/v1/wishlists/{wishlistId}` - 찜 삭제
- `GET /api/v1/wishlists` - 내 찜 목록 (페이징)
- `GET /api/v1/wishlists/check/{productId}` - 찜 여부 확인
- 물리 삭제 사용 (soft delete X)
- `buyer_id + product_id` 복합 유니크 제약조건

## 🧪 테스트
- Domain, CommandService, QueryService, Controller 단위 테스트
- Jacoco 커버리지 80% 검증 통과

## 📎 참고
- CartItem 도메인과 유사한 패턴 적용