### PR TITLE
feat: 리뷰/평점 기능 구현

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
@@ -48,6 +48,11 @@ class SecurityConfig(
                     "/api/v1/categories/{categoryId}",
                     "/api/v1/categories/{categoryId}/sub"
                 ).permitAll()
+                it.requestMatchers(
+                    HttpMethod.GET,
+                    "/api/v1/reviews/{reviewId}",
+                    "/api/v1/products/{productId}/reviews"
+                ).permitAll()
 
                 it.requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                 it.requestMatchers("/api/v1/point-policies/**").hasRole("ADMIN")

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/ProductStatistics.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/ProductStatistics.kt
@@ -80,6 +80,12 @@ class ProductStatistics private constructor(
     @Column(nullable = false, precision = 15, scale = 2)
     var averageOrderAmount: BigDecimal = BigDecimal.ZERO,
 
+    @Column(nullable = false, precision = 3, scale = 2)
+    var averageRating: BigDecimal = BigDecimal.ZERO,
+
+    @Column(nullable = false)
+    var reviewCount: Long = 0,
+
     @Column(nullable = false)
     var lastAggregatedAt: LocalDateTime = LocalDateTime.now()
 ) : BaseEntity() {
@@ -165,6 +171,11 @@ class ProductStatistics private constructor(
         } else {
             BigDecimal.ZERO
         }
+    }
+
+    fun updateReviewStats(averageRating: BigDecimal, reviewCount: Long) {
+        this.averageRating = averageRating
+        this.reviewCount = reviewCount
     }
 
     fun updateCartAndInventory(cartCount: Long, stock: Int) {

--- a/src/main/kotlin/com/hoppingmall/mall/review/controller/ReviewController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/controller/ReviewController.kt
@@ -1,0 +1,80 @@
+package com.hoppingmall.mall.review.controller
+
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.review.dto.request.ReviewCreateRequest
+import com.hoppingmall.mall.review.dto.request.ReviewUpdateRequest
+import com.hoppingmall.mall.review.dto.response.ReviewResponse
+import com.hoppingmall.mall.review.service.ReviewCommandService
+import com.hoppingmall.mall.review.service.ReviewQueryService
+import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1")
+class ReviewController(
+    private val reviewCommandService: ReviewCommandService,
+    private val reviewQueryService: ReviewQueryService
+) {
+
+    @PostMapping("/reviews")
+    fun createReview(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @Valid @RequestBody request: ReviewCreateRequest
+    ): ResponseEntity<ApiResponse<ReviewResponse>> {
+        val response = reviewCommandService.createReview(userPrincipal.getUserId(), request)
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.success(response))
+    }
+
+    @GetMapping("/reviews/{reviewId}")
+    fun getReview(
+        @PathVariable reviewId: Long
+    ): ResponseEntity<ApiResponse<ReviewResponse>> {
+        val response = reviewQueryService.getReview(reviewId)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @GetMapping("/products/{productId}/reviews")
+    fun getProductReviews(
+        @PathVariable productId: Long,
+        @PageableDefault(size = 10) pageable: Pageable
+    ): ResponseEntity<ApiResponse<Page<ReviewResponse>>> {
+        val response = reviewQueryService.getReviewsByProductId(productId, pageable)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @GetMapping("/reviews/my")
+    fun getMyReviews(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PageableDefault(size = 10) pageable: Pageable
+    ): ResponseEntity<ApiResponse<Page<ReviewResponse>>> {
+        val response = reviewQueryService.getMyReviews(userPrincipal.getUserId(), pageable)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @PutMapping("/reviews/{reviewId}")
+    fun updateReview(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PathVariable reviewId: Long,
+        @Valid @RequestBody request: ReviewUpdateRequest
+    ): ResponseEntity<ApiResponse<ReviewResponse>> {
+        val response = reviewCommandService.updateReview(reviewId, userPrincipal.getUserId(), request)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @DeleteMapping("/reviews/{reviewId}")
+    fun deleteReview(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PathVariable reviewId: Long
+    ): ResponseEntity<ApiResponse<Unit>> {
+        reviewCommandService.deleteReview(reviewId, userPrincipal.getUserId())
+        return ResponseEntity.ok(ApiResponse.success(Unit))
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/review/domain/Review.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/domain/Review.kt
@@ -1,0 +1,58 @@
+package com.hoppingmall.mall.review.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import jakarta.persistence.*
+import org.hibernate.annotations.Filter
+
+@Entity
+@Table(
+    name = "reviews",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["order_item_id"])]
+)
+@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
+class Review private constructor(
+    @Column(nullable = false)
+    val buyerId: Long,
+
+    @Column(nullable = false)
+    val orderItemId: Long,
+
+    @Column(nullable = false)
+    val productId: Long,
+
+    @Column(nullable = false)
+    var rating: Int,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    var content: String,
+
+    @Column
+    var imageUrl: String? = null
+) : BaseEntity() {
+
+    companion object {
+        fun create(
+            buyerId: Long,
+            orderItemId: Long,
+            productId: Long,
+            rating: Int,
+            content: String,
+            imageUrl: String? = null
+        ): Review {
+            return Review(
+                buyerId = buyerId,
+                orderItemId = orderItemId,
+                productId = productId,
+                rating = rating,
+                content = content,
+                imageUrl = imageUrl
+            )
+        }
+    }
+
+    fun update(rating: Int, content: String, imageUrl: String?) {
+        this.rating = rating
+        this.content = content
+        this.imageUrl = imageUrl
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/review/domain/repository/ReviewRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/domain/repository/ReviewRepository.kt
@@ -1,0 +1,23 @@
+package com.hoppingmall.mall.review.domain.repository
+
+import com.hoppingmall.mall.review.domain.Review
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ReviewRepository : JpaRepository<Review, Long> {
+    fun findByProductId(productId: Long, pageable: Pageable): Page<Review>
+    fun findByBuyerId(buyerId: Long, pageable: Pageable): Page<Review>
+    fun existsByOrderItemId(orderItemId: Long): Boolean
+    fun findNullableById(id: Long): Review?
+
+    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.productId = :productId AND r.deletedAt IS NULL")
+    fun averageRatingByProductId(@Param("productId") productId: Long): Double?
+
+    @Query("SELECT COUNT(r) FROM Review r WHERE r.productId = :productId AND r.deletedAt IS NULL")
+    fun countByProductId(@Param("productId") productId: Long): Long
+}

--- a/src/main/kotlin/com/hoppingmall/mall/review/dto/request/ReviewCreateRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/dto/request/ReviewCreateRequest.kt
@@ -1,0 +1,25 @@
+package com.hoppingmall.mall.review.dto.request
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.Size
+
+data class ReviewCreateRequest(
+    @field:NotNull(message = "주문 상품 ID는 필수입니다.")
+    @field:Positive(message = "주문 상품 ID는 양수여야 합니다.")
+    val orderItemId: Long,
+
+    @field:NotNull(message = "평점은 필수입니다.")
+    @field:Min(value = 1, message = "평점은 1 이상이어야 합니다.")
+    @field:Max(value = 5, message = "평점은 5 이하여야 합니다.")
+    val rating: Int,
+
+    @field:NotBlank(message = "리뷰 내용은 필수입니다.")
+    @field:Size(min = 10, max = 2000, message = "리뷰 내용은 10자 이상 2000자 이하여야 합니다.")
+    val content: String,
+
+    val imageUrl: String? = null
+)

--- a/src/main/kotlin/com/hoppingmall/mall/review/dto/request/ReviewUpdateRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/dto/request/ReviewUpdateRequest.kt
@@ -1,0 +1,20 @@
+package com.hoppingmall.mall.review.dto.request
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+data class ReviewUpdateRequest(
+    @field:NotNull(message = "평점은 필수입니다.")
+    @field:Min(value = 1, message = "평점은 1 이상이어야 합니다.")
+    @field:Max(value = 5, message = "평점은 5 이하여야 합니다.")
+    val rating: Int,
+
+    @field:NotBlank(message = "리뷰 내용은 필수입니다.")
+    @field:Size(min = 10, max = 2000, message = "리뷰 내용은 10자 이상 2000자 이하여야 합니다.")
+    val content: String,
+
+    val imageUrl: String? = null
+)

--- a/src/main/kotlin/com/hoppingmall/mall/review/dto/response/ReviewResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/dto/response/ReviewResponse.kt
@@ -1,0 +1,32 @@
+package com.hoppingmall.mall.review.dto.response
+
+import com.hoppingmall.mall.review.domain.Review
+import java.time.LocalDateTime
+
+data class ReviewResponse(
+    val id: Long,
+    val buyerId: Long,
+    val orderItemId: Long,
+    val productId: Long,
+    val rating: Int,
+    val content: String,
+    val imageUrl: String?,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime
+) {
+    companion object {
+        fun from(review: Review): ReviewResponse {
+            return ReviewResponse(
+                id = review.id!!,
+                buyerId = review.buyerId,
+                orderItemId = review.orderItemId,
+                productId = review.productId,
+                rating = review.rating,
+                content = review.content,
+                imageUrl = review.imageUrl,
+                createdAt = review.createdAt,
+                updatedAt = review.updatedAt ?: review.createdAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/review/exception/ReviewAccessDeniedException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/exception/ReviewAccessDeniedException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.review.exception
+
+import com.hoppingmall.mall.review.exception.code.ReviewErrorCode
+
+class ReviewAccessDeniedException : ReviewException(ReviewErrorCode.REVIEW_ACCESS_DENIED)

--- a/src/main/kotlin/com/hoppingmall/mall/review/exception/ReviewAlreadyExistsException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/exception/ReviewAlreadyExistsException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.review.exception
+
+import com.hoppingmall.mall.review.exception.code.ReviewErrorCode
+
+class ReviewAlreadyExistsException : ReviewException(ReviewErrorCode.REVIEW_ALREADY_EXISTS)

--- a/src/main/kotlin/com/hoppingmall/mall/review/exception/ReviewException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/exception/ReviewException.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.mall.review.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.review.exception.code.ReviewErrorCode
+
+open class ReviewException(
+    errorCode: ReviewErrorCode
+) : BusinessException(errorCode)

--- a/src/main/kotlin/com/hoppingmall/mall/review/exception/ReviewNotFoundException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/exception/ReviewNotFoundException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.review.exception
+
+import com.hoppingmall.mall.review.exception.code.ReviewErrorCode
+
+class ReviewNotFoundException : ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND)

--- a/src/main/kotlin/com/hoppingmall/mall/review/exception/code/ReviewErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/exception/code/ReviewErrorCode.kt
@@ -1,0 +1,16 @@
+package com.hoppingmall.mall.review.exception.code
+
+import com.hoppingmall.mall.global.common.error.code.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class ReviewErrorCode(
+    override val code: String,
+    override val message: String,
+    override val status: HttpStatus
+) : ErrorCode {
+    REVIEW_NOT_FOUND("REV001", "리뷰를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    REVIEW_ALREADY_EXISTS("REV002", "이미 해당 주문 상품에 대한 리뷰가 존재합니다.", HttpStatus.CONFLICT),
+    REVIEW_ORDER_NOT_DELIVERED("REV003", "배송 완료된 주문에만 리뷰를 작성할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    REVIEW_ACCESS_DENIED("REV004", "리뷰에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    REVIEW_INVALID_ORDER_ITEM("REV005", "유효하지 않은 주문 상품입니다.", HttpStatus.BAD_REQUEST),
+}

--- a/src/main/kotlin/com/hoppingmall/mall/review/service/ReviewCommandService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/service/ReviewCommandService.kt
@@ -1,0 +1,11 @@
+package com.hoppingmall.mall.review.service
+
+import com.hoppingmall.mall.review.dto.request.ReviewCreateRequest
+import com.hoppingmall.mall.review.dto.request.ReviewUpdateRequest
+import com.hoppingmall.mall.review.dto.response.ReviewResponse
+
+interface ReviewCommandService {
+    fun createReview(buyerId: Long, request: ReviewCreateRequest): ReviewResponse
+    fun updateReview(reviewId: Long, buyerId: Long, request: ReviewUpdateRequest): ReviewResponse
+    fun deleteReview(reviewId: Long, buyerId: Long)
+}

--- a/src/main/kotlin/com/hoppingmall/mall/review/service/ReviewCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/service/ReviewCommandServiceImpl.kt
@@ -1,0 +1,107 @@
+package com.hoppingmall.mall.review.service
+
+import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
+import com.hoppingmall.mall.order.domain.repository.OrderRepository
+import com.hoppingmall.mall.order.enum.OrderStatus
+import com.hoppingmall.mall.product.domain.repository.ProductStatisticsRepository
+import com.hoppingmall.mall.review.domain.Review
+import com.hoppingmall.mall.review.domain.repository.ReviewRepository
+import com.hoppingmall.mall.review.dto.request.ReviewCreateRequest
+import com.hoppingmall.mall.review.dto.request.ReviewUpdateRequest
+import com.hoppingmall.mall.review.dto.response.ReviewResponse
+import com.hoppingmall.mall.review.exception.ReviewAccessDeniedException
+import com.hoppingmall.mall.review.exception.ReviewAlreadyExistsException
+import com.hoppingmall.mall.review.exception.ReviewException
+import com.hoppingmall.mall.review.exception.ReviewNotFoundException
+import com.hoppingmall.mall.review.exception.code.ReviewErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@Service
+@Transactional
+class ReviewCommandServiceImpl(
+    private val reviewRepository: ReviewRepository,
+    private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository,
+    private val productStatisticsRepository: ProductStatisticsRepository
+) : ReviewCommandService {
+
+    override fun createReview(buyerId: Long, request: ReviewCreateRequest): ReviewResponse {
+        val orderItem = orderItemRepository.findById(request.orderItemId)
+            .orElseThrow { ReviewException(ReviewErrorCode.REVIEW_INVALID_ORDER_ITEM) }
+
+        val order = orderRepository.findById(orderItem.orderId)
+            .orElseThrow { ReviewException(ReviewErrorCode.REVIEW_INVALID_ORDER_ITEM) }
+
+        if (order.status != OrderStatus.DELIVERED) {
+            throw ReviewException(ReviewErrorCode.REVIEW_ORDER_NOT_DELIVERED)
+        }
+
+        if (order.buyerId != buyerId) {
+            throw ReviewAccessDeniedException()
+        }
+
+        if (reviewRepository.existsByOrderItemId(request.orderItemId)) {
+            throw ReviewAlreadyExistsException()
+        }
+
+        val review = Review.create(
+            buyerId = buyerId,
+            orderItemId = request.orderItemId,
+            productId = orderItem.productId,
+            rating = request.rating,
+            content = request.content,
+            imageUrl = request.imageUrl
+        )
+        val savedReview = reviewRepository.save(review)
+
+        updateProductReviewStats(orderItem.productId)
+
+        return ReviewResponse.from(savedReview)
+    }
+
+    override fun updateReview(reviewId: Long, buyerId: Long, request: ReviewUpdateRequest): ReviewResponse {
+        val review = reviewRepository.findNullableById(reviewId)
+            ?: throw ReviewNotFoundException()
+
+        if (review.buyerId != buyerId) {
+            throw ReviewAccessDeniedException()
+        }
+
+        review.update(
+            rating = request.rating,
+            content = request.content,
+            imageUrl = request.imageUrl
+        )
+
+        updateProductReviewStats(review.productId)
+
+        return ReviewResponse.from(review)
+    }
+
+    override fun deleteReview(reviewId: Long, buyerId: Long) {
+        val review = reviewRepository.findNullableById(reviewId)
+            ?: throw ReviewNotFoundException()
+
+        if (review.buyerId != buyerId) {
+            throw ReviewAccessDeniedException()
+        }
+
+        review.softDelete()
+
+        updateProductReviewStats(review.productId)
+    }
+
+    private fun updateProductReviewStats(productId: Long) {
+        val stats = productStatisticsRepository.findByProductIdForUpdate(productId) ?: return
+
+        val avgRating = reviewRepository.averageRatingByProductId(productId)
+            ?.let { BigDecimal(it).setScale(2, RoundingMode.HALF_UP) }
+            ?: BigDecimal.ZERO
+        val reviewCount = reviewRepository.countByProductId(productId)
+
+        stats.updateReviewStats(avgRating, reviewCount)
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/review/service/ReviewQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/service/ReviewQueryService.kt
@@ -1,0 +1,11 @@
+package com.hoppingmall.mall.review.service
+
+import com.hoppingmall.mall.review.dto.response.ReviewResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface ReviewQueryService {
+    fun getReview(reviewId: Long): ReviewResponse
+    fun getReviewsByProductId(productId: Long, pageable: Pageable): Page<ReviewResponse>
+    fun getMyReviews(buyerId: Long, pageable: Pageable): Page<ReviewResponse>
+}

--- a/src/main/kotlin/com/hoppingmall/mall/review/service/ReviewQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/service/ReviewQueryServiceImpl.kt
@@ -1,0 +1,32 @@
+package com.hoppingmall.mall.review.service
+
+import com.hoppingmall.mall.review.domain.repository.ReviewRepository
+import com.hoppingmall.mall.review.dto.response.ReviewResponse
+import com.hoppingmall.mall.review.exception.ReviewNotFoundException
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class ReviewQueryServiceImpl(
+    private val reviewRepository: ReviewRepository
+) : ReviewQueryService {
+
+    override fun getReview(reviewId: Long): ReviewResponse {
+        val review = reviewRepository.findNullableById(reviewId)
+            ?: throw ReviewNotFoundException()
+        return ReviewResponse.from(review)
+    }
+
+    override fun getReviewsByProductId(productId: Long, pageable: Pageable): Page<ReviewResponse> {
+        return reviewRepository.findByProductId(productId, pageable)
+            .map { ReviewResponse.from(it) }
+    }
+
+    override fun getMyReviews(buyerId: Long, pageable: Pageable): Page<ReviewResponse> {
+        return reviewRepository.findByBuyerId(buyerId, pageable)
+            .map { ReviewResponse.from(it) }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/review/controller/ReviewControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/review/controller/ReviewControllerTest.kt
@@ -1,0 +1,205 @@
+package com.hoppingmall.mall.review.controller
+
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.review.dto.request.ReviewCreateRequest
+import com.hoppingmall.mall.review.dto.request.ReviewUpdateRequest
+import com.hoppingmall.mall.review.dto.response.ReviewResponse
+import com.hoppingmall.mall.review.service.ReviewCommandService
+import com.hoppingmall.mall.review.service.ReviewQueryService
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.mockito.kotlin.*
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import java.time.LocalDateTime
+
+@DisplayName("ReviewController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class ReviewControllerTest {
+
+    private val reviewCommandService: ReviewCommandService = mock()
+    private val reviewQueryService: ReviewQueryService = mock()
+    private val controller = ReviewController(reviewCommandService, reviewQueryService)
+
+    private fun createReviewResponse(
+        id: Long = 1L,
+        buyerId: Long = 1L,
+        orderItemId: Long = 1L,
+        productId: Long = 100L,
+        rating: Int = 5,
+        content: String = "정말 좋은 상품입니다. 배송도 빠르고 품질도 만족합니다."
+    ): ReviewResponse {
+        return ReviewResponse(
+            id = id,
+            buyerId = buyerId,
+            orderItemId = orderItemId,
+            productId = productId,
+            rating = rating,
+            content = content,
+            imageUrl = null,
+            createdAt = LocalDateTime.of(2026, 1, 1, 0, 0),
+            updatedAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+        )
+    }
+
+    @Nested
+    @DisplayName("createReview")
+    inner class CreateReview {
+        @Test
+        fun 리뷰_생성_성공() {
+            // Data
+            val userPrincipal = UserPrincipal(1L, "test@example.com", "BUYER")
+            val request = ReviewCreateRequest(
+                orderItemId = 1L,
+                rating = 5,
+                content = "정말 좋은 상품입니다. 배송도 빠르고 품질도 만족합니다."
+            )
+            val expectedResponse = createReviewResponse()
+
+            // Context
+            whenever(reviewCommandService.createReview(userPrincipal.getUserId(), request))
+                .thenReturn(expectedResponse)
+
+            // Interaction
+            val response: ResponseEntity<ApiResponse<ReviewResponse>> =
+                controller.createReview(userPrincipal, request)
+
+            // Assertions
+            assertEquals(HttpStatus.CREATED, response.statusCode)
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(expectedResponse, response.body?.data)
+            verify(reviewCommandService).createReview(userPrincipal.getUserId(), request)
+        }
+    }
+
+    @Nested
+    @DisplayName("getReview")
+    inner class GetReview {
+        @Test
+        fun 리뷰_단건_조회_성공() {
+            // Data
+            val expectedResponse = createReviewResponse()
+
+            // Context
+            whenever(reviewQueryService.getReview(1L)).thenReturn(expectedResponse)
+
+            // Interaction
+            val response: ResponseEntity<ApiResponse<ReviewResponse>> = controller.getReview(1L)
+
+            // Assertions
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(expectedResponse, response.body?.data)
+            verify(reviewQueryService).getReview(1L)
+        }
+    }
+
+    @Nested
+    @DisplayName("getProductReviews")
+    inner class GetProductReviews {
+        @Test
+        fun 상품별_리뷰_목록_조회_성공() {
+            // Data
+            val pageable = PageRequest.of(0, 10)
+            val reviews = listOf(createReviewResponse(id = 1L), createReviewResponse(id = 2L, orderItemId = 2L))
+            val expectedPage: Page<ReviewResponse> = PageImpl(reviews, pageable, 2)
+
+            // Context
+            whenever(reviewQueryService.getReviewsByProductId(100L, pageable)).thenReturn(expectedPage)
+
+            // Interaction
+            val response: ResponseEntity<ApiResponse<Page<ReviewResponse>>> =
+                controller.getProductReviews(100L, pageable)
+
+            // Assertions
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(expectedPage, response.body?.data)
+            verify(reviewQueryService).getReviewsByProductId(100L, pageable)
+        }
+    }
+
+    @Nested
+    @DisplayName("getMyReviews")
+    inner class GetMyReviews {
+        @Test
+        fun 내_리뷰_목록_조회_성공() {
+            // Data
+            val userPrincipal = UserPrincipal(1L, "test@example.com", "BUYER")
+            val pageable = PageRequest.of(0, 10)
+            val reviews = listOf(createReviewResponse())
+            val expectedPage: Page<ReviewResponse> = PageImpl(reviews, pageable, 1)
+
+            // Context
+            whenever(reviewQueryService.getMyReviews(userPrincipal.getUserId(), pageable))
+                .thenReturn(expectedPage)
+
+            // Interaction
+            val response: ResponseEntity<ApiResponse<Page<ReviewResponse>>> =
+                controller.getMyReviews(userPrincipal, pageable)
+
+            // Assertions
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(expectedPage, response.body?.data)
+            verify(reviewQueryService).getMyReviews(userPrincipal.getUserId(), pageable)
+        }
+    }
+
+    @Nested
+    @DisplayName("updateReview")
+    inner class UpdateReview {
+        @Test
+        fun 리뷰_수정_성공() {
+            // Data
+            val userPrincipal = UserPrincipal(1L, "test@example.com", "BUYER")
+            val request = ReviewUpdateRequest(
+                rating = 3,
+                content = "다시 생각해보니 보통인 것 같습니다. 괜찮은 수준이에요."
+            )
+            val expectedResponse = createReviewResponse(rating = 3, content = "다시 생각해보니 보통인 것 같습니다. 괜찮은 수준이에요.")
+
+            // Context
+            whenever(reviewCommandService.updateReview(1L, userPrincipal.getUserId(), request))
+                .thenReturn(expectedResponse)
+
+            // Interaction
+            val response: ResponseEntity<ApiResponse<ReviewResponse>> =
+                controller.updateReview(userPrincipal, 1L, request)
+
+            // Assertions
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(expectedResponse, response.body?.data)
+            verify(reviewCommandService).updateReview(1L, userPrincipal.getUserId(), request)
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteReview")
+    inner class DeleteReview {
+        @Test
+        fun 리뷰_삭제_성공() {
+            // Data
+            val userPrincipal = UserPrincipal(1L, "test@example.com", "BUYER")
+
+            // Context
+            doNothing().whenever(reviewCommandService).deleteReview(1L, userPrincipal.getUserId())
+
+            // Interaction
+            val response: ResponseEntity<ApiResponse<Unit>> =
+                controller.deleteReview(userPrincipal, 1L)
+
+            // Assertions
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(Unit, response.body?.data)
+            verify(reviewCommandService).deleteReview(1L, userPrincipal.getUserId())
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/review/domain/ReviewTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/review/domain/ReviewTest.kt
@@ -1,0 +1,93 @@
+package com.hoppingmall.mall.review.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("Review")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class ReviewTest {
+
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+
+        @Test
+        fun 리뷰_생성_성공() {
+            // Data
+            val buyerId = 1L
+            val orderItemId = 1L
+            val productId = 100L
+            val rating = 5
+            val content = "정말 좋은 상품입니다. 배송도 빠르고 품질도 만족합니다."
+
+            // Interaction
+            val review = Review.create(
+                buyerId = buyerId,
+                orderItemId = orderItemId,
+                productId = productId,
+                rating = rating,
+                content = content
+            )
+
+            // Assertions
+            assertThat(review.buyerId).isEqualTo(buyerId)
+            assertThat(review.orderItemId).isEqualTo(orderItemId)
+            assertThat(review.productId).isEqualTo(productId)
+            assertThat(review.rating).isEqualTo(rating)
+            assertThat(review.content).isEqualTo(content)
+            assertThat(review.imageUrl).isNull()
+        }
+
+        @Test
+        fun 이미지_포함_리뷰_생성_성공() {
+            // Data
+            val imageUrl = "https://example.com/image.jpg"
+
+            // Interaction
+            val review = Review.create(
+                buyerId = 1L,
+                orderItemId = 1L,
+                productId = 100L,
+                rating = 4,
+                content = "이미지 포함 리뷰 테스트입니다. 상품이 좋습니다.",
+                imageUrl = imageUrl
+            )
+
+            // Assertions
+            assertThat(review.imageUrl).isEqualTo(imageUrl)
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    inner class Update {
+
+        @Test
+        fun 리뷰_수정_성공() {
+            // Data
+            val review = Review.create(
+                buyerId = 1L,
+                orderItemId = 1L,
+                productId = 100L,
+                rating = 3,
+                content = "보통입니다. 그냥 그런 상품이에요."
+            )
+
+            // Interaction
+            review.update(
+                rating = 5,
+                content = "다시 사용해보니 정말 좋은 상품입니다. 강력 추천합니다.",
+                imageUrl = "https://example.com/updated.jpg"
+            )
+
+            // Assertions
+            assertThat(review.rating).isEqualTo(5)
+            assertThat(review.content).isEqualTo("다시 사용해보니 정말 좋은 상품입니다. 강력 추천합니다.")
+            assertThat(review.imageUrl).isEqualTo("https://example.com/updated.jpg")
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/review/service/ReviewCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/review/service/ReviewCommandServiceImplTest.kt
@@ -1,0 +1,318 @@
+package com.hoppingmall.mall.review.service
+
+import com.hoppingmall.mall.order.domain.Order
+import com.hoppingmall.mall.order.domain.OrderItem
+import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
+import com.hoppingmall.mall.order.domain.repository.OrderRepository
+import com.hoppingmall.mall.product.domain.ProductStatistics
+import com.hoppingmall.mall.product.domain.repository.ProductStatisticsRepository
+import com.hoppingmall.mall.review.domain.Review
+import com.hoppingmall.mall.review.domain.repository.ReviewRepository
+import com.hoppingmall.mall.review.dto.request.ReviewCreateRequest
+import com.hoppingmall.mall.review.dto.request.ReviewUpdateRequest
+import com.hoppingmall.mall.review.exception.ReviewAccessDeniedException
+import com.hoppingmall.mall.review.exception.ReviewAlreadyExistsException
+import com.hoppingmall.mall.review.exception.ReviewException
+import com.hoppingmall.mall.review.exception.ReviewNotFoundException
+import com.hoppingmall.mall.support.fixture.deliveredFixture
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.*
+import java.util.*
+
+@DisplayName("ReviewCommandServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ReviewCommandServiceImplTest {
+
+    @Mock
+    private lateinit var reviewRepository: ReviewRepository
+
+    @Mock
+    private lateinit var orderRepository: OrderRepository
+
+    @Mock
+    private lateinit var orderItemRepository: OrderItemRepository
+
+    @Mock
+    private lateinit var productStatisticsRepository: ProductStatisticsRepository
+
+    private lateinit var reviewCommandService: ReviewCommandServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        reviewCommandService = ReviewCommandServiceImpl(
+            reviewRepository,
+            orderRepository,
+            orderItemRepository,
+            productStatisticsRepository
+        )
+    }
+
+    @Nested
+    @DisplayName("createReview")
+    inner class CreateReview {
+
+        @Test
+        fun 리뷰_생성_성공() {
+            // Data
+            val buyerId = 1L
+            val orderItem = OrderItem.fixture(orderId = 1L, productId = 100L).withId(1L)
+            val order = Order.deliveredFixture(buyerId = buyerId).withId(1L)
+            val request = ReviewCreateRequest(
+                orderItemId = 1L,
+                rating = 5,
+                content = "정말 좋은 상품입니다. 배송도 빠르고 품질도 만족합니다."
+            )
+
+            // Context
+            whenever(orderItemRepository.findById(1L)).thenReturn(Optional.of(orderItem))
+            whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+            whenever(reviewRepository.existsByOrderItemId(1L)).thenReturn(false)
+            whenever(reviewRepository.save(any<Review>())).thenAnswer { invocation ->
+                invocation.getArgument<Review>(0).withId(1L)
+            }
+            whenever(productStatisticsRepository.findByProductIdForUpdate(100L)).thenReturn(null)
+
+            // Interaction
+            val result = reviewCommandService.createReview(buyerId, request)
+
+            // Assertions
+            assertThat(result.rating).isEqualTo(5)
+            assertThat(result.productId).isEqualTo(100L)
+            assertThat(result.buyerId).isEqualTo(buyerId)
+            verify(reviewRepository).save(any())
+        }
+
+        @Test
+        fun 존재하지_않는_주문_상품으로_리뷰_생성_시_예외_발생() {
+            // Data
+            val buyerId = 1L
+            val request = ReviewCreateRequest(
+                orderItemId = 999L,
+                rating = 5,
+                content = "정말 좋은 상품입니다. 배송도 빠르고 품질도 만족합니다."
+            )
+
+            // Context
+            whenever(orderItemRepository.findById(999L)).thenReturn(Optional.empty())
+
+            // Interaction & Assertions
+            assertThatThrownBy { reviewCommandService.createReview(buyerId, request) }
+                .isInstanceOf(ReviewException::class.java)
+        }
+
+        @Test
+        fun 배송_완료되지_않은_주문에_리뷰_생성_시_예외_발생() {
+            // Data
+            val buyerId = 1L
+            val orderItem = OrderItem.fixture(orderId = 1L).withId(1L)
+            val order = Order.fixture(buyerId = buyerId).withId(1L)
+            val request = ReviewCreateRequest(
+                orderItemId = 1L,
+                rating = 5,
+                content = "정말 좋은 상품입니다. 배송도 빠르고 품질도 만족합니다."
+            )
+
+            // Context
+            whenever(orderItemRepository.findById(1L)).thenReturn(Optional.of(orderItem))
+            whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+
+            // Interaction & Assertions
+            assertThatThrownBy { reviewCommandService.createReview(buyerId, request) }
+                .isInstanceOf(ReviewException::class.java)
+        }
+
+        @Test
+        fun 다른_구매자의_주문에_리뷰_생성_시_예외_발생() {
+            // Data
+            val buyerId = 2L
+            val orderItem = OrderItem.fixture(orderId = 1L).withId(1L)
+            val order = Order.deliveredFixture(buyerId = 1L).withId(1L)
+            val request = ReviewCreateRequest(
+                orderItemId = 1L,
+                rating = 5,
+                content = "정말 좋은 상품입니다. 배송도 빠르고 품질도 만족합니다."
+            )
+
+            // Context
+            whenever(orderItemRepository.findById(1L)).thenReturn(Optional.of(orderItem))
+            whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+
+            // Interaction & Assertions
+            assertThatThrownBy { reviewCommandService.createReview(buyerId, request) }
+                .isInstanceOf(ReviewAccessDeniedException::class.java)
+        }
+
+        @Test
+        fun 이미_리뷰가_존재하는_주문_상품에_리뷰_생성_시_예외_발생() {
+            // Data
+            val buyerId = 1L
+            val orderItem = OrderItem.fixture(orderId = 1L).withId(1L)
+            val order = Order.deliveredFixture(buyerId = buyerId).withId(1L)
+            val request = ReviewCreateRequest(
+                orderItemId = 1L,
+                rating = 5,
+                content = "정말 좋은 상품입니다. 배송도 빠르고 품질도 만족합니다."
+            )
+
+            // Context
+            whenever(orderItemRepository.findById(1L)).thenReturn(Optional.of(orderItem))
+            whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+            whenever(reviewRepository.existsByOrderItemId(1L)).thenReturn(true)
+
+            // Interaction & Assertions
+            assertThatThrownBy { reviewCommandService.createReview(buyerId, request) }
+                .isInstanceOf(ReviewAlreadyExistsException::class.java)
+        }
+
+        @Test
+        fun 리뷰_생성_시_상품_통계_업데이트() {
+            // Data
+            val buyerId = 1L
+            val orderItem = OrderItem.fixture(orderId = 1L, productId = 100L).withId(1L)
+            val order = Order.deliveredFixture(buyerId = buyerId).withId(1L)
+            val stats = ProductStatistics.fixture(productId = 100L).withId(1L)
+            val request = ReviewCreateRequest(
+                orderItemId = 1L,
+                rating = 4,
+                content = "좋은 상품이에요. 만족스럽습니다. 추천합니다."
+            )
+
+            // Context
+            whenever(orderItemRepository.findById(1L)).thenReturn(Optional.of(orderItem))
+            whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+            whenever(reviewRepository.existsByOrderItemId(1L)).thenReturn(false)
+            whenever(reviewRepository.save(any<Review>())).thenAnswer { invocation ->
+                invocation.getArgument<Review>(0).withId(1L)
+            }
+            whenever(productStatisticsRepository.findByProductIdForUpdate(100L)).thenReturn(stats)
+            whenever(reviewRepository.averageRatingByProductId(100L)).thenReturn(4.0)
+            whenever(reviewRepository.countByProductId(100L)).thenReturn(1L)
+
+            // Interaction
+            reviewCommandService.createReview(buyerId, request)
+
+            // Assertions
+            verify(productStatisticsRepository).findByProductIdForUpdate(100L)
+            verify(reviewRepository).averageRatingByProductId(100L)
+            verify(reviewRepository).countByProductId(100L)
+        }
+    }
+
+    @Nested
+    @DisplayName("updateReview")
+    inner class UpdateReview {
+
+        @Test
+        fun 리뷰_수정_성공() {
+            // Data
+            val buyerId = 1L
+            val review = Review.fixture(buyerId = buyerId, productId = 100L).withId(1L)
+            val request = ReviewUpdateRequest(
+                rating = 3,
+                content = "다시 생각해보니 보통인 것 같습니다. 괜찮은 수준이에요."
+            )
+
+            // Context
+            whenever(reviewRepository.findNullableById(1L)).thenReturn(review)
+            whenever(productStatisticsRepository.findByProductIdForUpdate(100L)).thenReturn(null)
+
+            // Interaction
+            val result = reviewCommandService.updateReview(1L, buyerId, request)
+
+            // Assertions
+            assertThat(result.rating).isEqualTo(3)
+            assertThat(result.content).isEqualTo("다시 생각해보니 보통인 것 같습니다. 괜찮은 수준이에요.")
+        }
+
+        @Test
+        fun 존재하지_않는_리뷰_수정_시_예외_발생() {
+            // Data
+            val request = ReviewUpdateRequest(
+                rating = 3,
+                content = "다시 생각해보니 보통인 것 같습니다. 괜찮은 수준이에요."
+            )
+
+            // Context
+            whenever(reviewRepository.findNullableById(999L)).thenReturn(null)
+
+            // Interaction & Assertions
+            assertThatThrownBy { reviewCommandService.updateReview(999L, 1L, request) }
+                .isInstanceOf(ReviewNotFoundException::class.java)
+        }
+
+        @Test
+        fun 다른_사용자의_리뷰_수정_시_예외_발생() {
+            // Data
+            val review = Review.fixture(buyerId = 1L).withId(1L)
+            val request = ReviewUpdateRequest(
+                rating = 3,
+                content = "다시 생각해보니 보통인 것 같습니다. 괜찮은 수준이에요."
+            )
+
+            // Context
+            whenever(reviewRepository.findNullableById(1L)).thenReturn(review)
+
+            // Interaction & Assertions
+            assertThatThrownBy { reviewCommandService.updateReview(1L, 2L, request) }
+                .isInstanceOf(ReviewAccessDeniedException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteReview")
+    inner class DeleteReview {
+
+        @Test
+        fun 리뷰_삭제_성공() {
+            // Data
+            val buyerId = 1L
+            val review = Review.fixture(buyerId = buyerId, productId = 100L).withId(1L)
+
+            // Context
+            whenever(reviewRepository.findNullableById(1L)).thenReturn(review)
+            whenever(productStatisticsRepository.findByProductIdForUpdate(100L)).thenReturn(null)
+
+            // Interaction
+            reviewCommandService.deleteReview(1L, buyerId)
+
+            // Assertions
+            assertThat(review.deletedAt).isNotNull()
+        }
+
+        @Test
+        fun 존재하지_않는_리뷰_삭제_시_예외_발생() {
+            // Context
+            whenever(reviewRepository.findNullableById(999L)).thenReturn(null)
+
+            // Interaction & Assertions
+            assertThatThrownBy { reviewCommandService.deleteReview(999L, 1L) }
+                .isInstanceOf(ReviewNotFoundException::class.java)
+        }
+
+        @Test
+        fun 다른_사용자의_리뷰_삭제_시_예외_발생() {
+            // Data
+            val review = Review.fixture(buyerId = 1L).withId(1L)
+
+            // Context
+            whenever(reviewRepository.findNullableById(1L)).thenReturn(review)
+
+            // Interaction & Assertions
+            assertThatThrownBy { reviewCommandService.deleteReview(1L, 2L) }
+                .isInstanceOf(ReviewAccessDeniedException::class.java)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/review/service/ReviewQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/review/service/ReviewQueryServiceImplTest.kt
@@ -1,0 +1,146 @@
+package com.hoppingmall.mall.review.service
+
+import com.hoppingmall.mall.review.domain.Review
+import com.hoppingmall.mall.review.domain.repository.ReviewRepository
+import com.hoppingmall.mall.review.exception.ReviewNotFoundException
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.*
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+
+@DisplayName("ReviewQueryServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ReviewQueryServiceImplTest {
+
+    @Mock
+    private lateinit var reviewRepository: ReviewRepository
+
+    private lateinit var reviewQueryService: ReviewQueryServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        reviewQueryService = ReviewQueryServiceImpl(reviewRepository)
+    }
+
+    @Nested
+    @DisplayName("getReview")
+    inner class GetReview {
+
+        @Test
+        fun 리뷰_단건_조회_성공() {
+            // Data
+            val review = Review.fixture().withId(1L)
+
+            // Context
+            whenever(reviewRepository.findNullableById(1L)).thenReturn(review)
+
+            // Interaction
+            val result = reviewQueryService.getReview(1L)
+
+            // Assertions
+            assertThat(result.id).isEqualTo(1L)
+            assertThat(result.rating).isEqualTo(5)
+            verify(reviewRepository).findNullableById(1L)
+        }
+
+        @Test
+        fun 존재하지_않는_리뷰_조회_시_예외_발생() {
+            // Context
+            whenever(reviewRepository.findNullableById(999L)).thenReturn(null)
+
+            // Interaction & Assertions
+            assertThatThrownBy { reviewQueryService.getReview(999L) }
+                .isInstanceOf(ReviewNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("getReviewsByProductId")
+    inner class GetReviewsByProductId {
+
+        @Test
+        fun 상품별_리뷰_목록_조회_성공() {
+            // Data
+            val productId = 100L
+            val pageable = PageRequest.of(0, 10)
+            val reviews = listOf(
+                Review.fixture(productId = productId, rating = 5).withId(1L),
+                Review.fixture(productId = productId, rating = 4, orderItemId = 2L).withId(2L)
+            )
+
+            // Context
+            whenever(reviewRepository.findByProductId(productId, pageable))
+                .thenReturn(PageImpl(reviews, pageable, 2))
+
+            // Interaction
+            val result = reviewQueryService.getReviewsByProductId(productId, pageable)
+
+            // Assertions
+            assertThat(result.content).hasSize(2)
+            assertThat(result.content[0].rating).isEqualTo(5)
+            assertThat(result.content[1].rating).isEqualTo(4)
+            assertThat(result.totalElements).isEqualTo(2)
+            verify(reviewRepository).findByProductId(productId, pageable)
+        }
+
+        @Test
+        fun 빈_리뷰_목록_조회_성공() {
+            // Data
+            val productId = 100L
+            val pageable = PageRequest.of(0, 10)
+
+            // Context
+            whenever(reviewRepository.findByProductId(productId, pageable))
+                .thenReturn(PageImpl(emptyList(), pageable, 0))
+
+            // Interaction
+            val result = reviewQueryService.getReviewsByProductId(productId, pageable)
+
+            // Assertions
+            assertThat(result.content).isEmpty()
+            assertThat(result.totalElements).isEqualTo(0)
+            verify(reviewRepository).findByProductId(productId, pageable)
+        }
+    }
+
+    @Nested
+    @DisplayName("getMyReviews")
+    inner class GetMyReviews {
+
+        @Test
+        fun 내_리뷰_목록_조회_성공() {
+            // Data
+            val buyerId = 1L
+            val pageable = PageRequest.of(0, 10)
+            val reviews = listOf(
+                Review.fixture(buyerId = buyerId, productId = 100L).withId(1L),
+                Review.fixture(buyerId = buyerId, productId = 200L, orderItemId = 2L).withId(2L)
+            )
+
+            // Context
+            whenever(reviewRepository.findByBuyerId(buyerId, pageable))
+                .thenReturn(PageImpl(reviews, pageable, 2))
+
+            // Interaction
+            val result = reviewQueryService.getMyReviews(buyerId, pageable)
+
+            // Assertions
+            assertThat(result.content).hasSize(2)
+            assertThat(result.totalElements).isEqualTo(2)
+            verify(reviewRepository).findByBuyerId(buyerId, pageable)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/OrderFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/OrderFixture.kt
@@ -39,3 +39,14 @@ fun Order.Companion.cancelledFixture(
         status = OrderStatus.CANCELLED
     )
 }
+
+fun Order.Companion.deliveredFixture(
+    buyerId: Long = 1L,
+    totalAmount: BigDecimal = BigDecimal("50000")
+): Order {
+    return Order.fixture(
+        buyerId = buyerId,
+        totalAmount = totalAmount,
+        status = OrderStatus.DELIVERED
+    )
+}

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/ReviewFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/ReviewFixture.kt
@@ -1,0 +1,22 @@
+package com.hoppingmall.mall.support.fixture
+
+import com.hoppingmall.mall.review.domain.Review
+import com.hoppingmall.mall.support.withId
+
+fun Review.Companion.fixture(
+    buyerId: Long = 1L,
+    orderItemId: Long = 1L,
+    productId: Long = 100L,
+    rating: Int = 5,
+    content: String = "정말 좋은 상품입니다. 배송도 빠르고 품질도 만족합니다.",
+    imageUrl: String? = null
+): Review {
+    return Review.create(
+        buyerId = buyerId,
+        orderItemId = orderItemId,
+        productId = productId,
+        rating = rating,
+        content = content,
+        imageUrl = imageUrl
+    ).withId(1L)
+}


### PR DESCRIPTION
## 📌 개요
구매 확정(DELIVERED)된 상품에 대한 리뷰/평점 기능을 구현합니다.

Closes #76

## ✅ 변경 사항
- Review 엔티티 및 Repository 구현 (orderItemId unique 제약조건)
- ReviewErrorCode(REV001~REV005) 및 예외 클래스 추가
- 리뷰 CQRS 서비스 (Command/Query 분리)
  - 주문 상태(DELIVERED) 검증, 구매자 본인 확인, 중복 리뷰 방지
  - 비관적 락 기반 ProductStatistics 평균 평점/리뷰 수 업데이트
- 리뷰 CRUD REST API (POST/GET/PUT/DELETE)
- SecurityConfig: 리뷰 단건 조회, 상품별 리뷰 목록 permitAll 설정
- ProductStatistics에 averageRating, reviewCount 필드 추가

## 🧪 테스트
- ReviewTest: 엔티티 생성/수정 단위 테스트
- ReviewCommandServiceImplTest: 생성/수정/삭제 + 예외 케이스 (11개)
- ReviewQueryServiceImplTest: 단건/상품별/내 리뷰 조회 (5개)
- ReviewControllerTest: 전체 API 엔드포인트 (6개)
- jacocoTestVerification 80% 통과 확인

## 📎 API 엔드포인트
| Method | Path | Auth | 설명 |
|--------|------|------|------|
| POST | /api/v1/reviews | 인증 | 리뷰 작성 |
| GET | /api/v1/reviews/{reviewId} | 공개 | 단건 조회 |
| GET | /api/v1/products/{productId}/reviews | 공개 | 상품별 리뷰 |
| GET | /api/v1/reviews/my | 인증 | 내 리뷰 |
| PUT | /api/v1/reviews/{reviewId} | 본인 | 리뷰 수정 |
| DELETE | /api/v1/reviews/{reviewId} | 본인 | 리뷰 삭제 |