### PR TITLE
perf: N+1 쿼리 최적화 - default_batch_fetch_size 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,7 @@ spring:
         format_sql: true
         show_sql: true
         legacy_id_generator_strategy: true
+        default_batch_fetch_size: 100
 
   data:
     redis:


### PR DESCRIPTION
## 📌 관련 이슈
Closes #85

## ✅ 변경 사항
- `hibernate.default_batch_fetch_size=100` 글로벌 설정 추가
- 모든 Lazy 연관관계에서 N+1 발생 시 IN 절 배치 로딩 적용

## 🧪 테스트
- 기존 테스트 통과 확인
- 설정값만 추가하므로 별도 테스트 불필요

## 📎 참고
- JOIN FETCH는 컬렉션 페이징과 충돌하므로 글로벌 batch_fetch_size가 더 범용적
- 상품/주문/쿠폰 목록 조회 등 N+1 발생 지점 전체에 효과