### PR TITLE
perf: Redis 캐싱 고도화

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,8 +68,9 @@ dependencies {
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
-	// Redis
+	// Redis & Cache
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+	implementation("org.springframework.boot:spring-boot-starter-cache")
 }
 
 kotlin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
 	// Redis & Cache
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 	implementation("org.springframework.boot:spring-boot-starter-cache")
+	implementation("com.github.ben-manes.caffeine:caffeine")
 }
 
 kotlin {

--- a/src/main/kotlin/com/hoppingmall/mall/category/controller/CategoryController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/controller/CategoryController.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.category.controller
 import com.hoppingmall.mall.category.dto.request.CategoryCreateRequest
 import com.hoppingmall.mall.category.dto.request.CategoryUpdateRequest
 import com.hoppingmall.mall.category.dto.response.CategoryResponse
+import com.hoppingmall.mall.category.exception.CategoryNotFoundException
 import com.hoppingmall.mall.category.service.CategoryCommandService
 import com.hoppingmall.mall.category.service.CategoryQueryService
 import com.hoppingmall.mall.global.common.response.ApiResponse
@@ -32,6 +33,7 @@ class CategoryController(
         @PathVariable categoryId: Long
     ): ResponseEntity<ApiResponse<CategoryResponse>> {
         val response = categoryQueryService.getCategory(categoryId)
+            ?: throw CategoryNotFoundException()
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 

--- a/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryCommandServiceImpl.kt
@@ -8,6 +8,8 @@ import com.hoppingmall.mall.category.dto.response.CategoryResponse
 import com.hoppingmall.mall.category.exception.CategoryAlreadyExistsException
 import com.hoppingmall.mall.category.exception.CategoryHasChildrenException
 import com.hoppingmall.mall.category.exception.CategoryNotFoundException
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Caching
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -17,6 +19,10 @@ class CategoryCommandServiceImpl(
     private val categoryRepository: CategoryRepository
 ) : CategoryCommandService {
 
+    @Caching(evict = [
+        CacheEvict(cacheNames = ["categories:root"], allEntries = true),
+        CacheEvict(cacheNames = ["categories:sub"], allEntries = true)
+    ])
     override fun createCategory(request: CategoryCreateRequest): CategoryResponse {
         if (categoryRepository.existsByName(request.name)) {
             throw CategoryAlreadyExistsException()
@@ -39,6 +45,11 @@ class CategoryCommandServiceImpl(
         return CategoryResponse.from(savedCategory)
     }
 
+    @Caching(evict = [
+        CacheEvict(cacheNames = ["category"], key = "#categoryId"),
+        CacheEvict(cacheNames = ["categories:root"], allEntries = true),
+        CacheEvict(cacheNames = ["categories:sub"], allEntries = true)
+    ])
     override fun updateCategory(categoryId: Long, request: CategoryUpdateRequest): CategoryResponse {
         val category = categoryRepository.findNullableById(categoryId)
             ?: throw CategoryNotFoundException()
@@ -51,6 +62,11 @@ class CategoryCommandServiceImpl(
         return CategoryResponse.from(category)
     }
 
+    @Caching(evict = [
+        CacheEvict(cacheNames = ["category"], key = "#categoryId"),
+        CacheEvict(cacheNames = ["categories:root"], allEntries = true),
+        CacheEvict(cacheNames = ["categories:sub"], allEntries = true)
+    ])
     override fun deleteCategory(categoryId: Long) {
         val category = categoryRepository.findNullableById(categoryId)
             ?: throw CategoryNotFoundException()

--- a/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryQueryService.kt
@@ -3,7 +3,7 @@ package com.hoppingmall.mall.category.service
 import com.hoppingmall.mall.category.dto.response.CategoryResponse
 
 interface CategoryQueryService {
-    fun getCategory(categoryId: Long): CategoryResponse
+    fun getCategory(categoryId: Long): CategoryResponse?
     fun getRootCategories(): List<CategoryResponse>
     fun getSubCategories(parentCategoryId: Long): List<CategoryResponse>
 }

--- a/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryQueryServiceImpl.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.category.service
 import com.hoppingmall.mall.category.domain.repository.CategoryRepository
 import com.hoppingmall.mall.category.dto.response.CategoryResponse
 import com.hoppingmall.mall.category.exception.CategoryNotFoundException
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -12,6 +13,7 @@ class CategoryQueryServiceImpl(
     private val categoryRepository: CategoryRepository
 ) : CategoryQueryService {
 
+    @Cacheable(cacheNames = ["category"], key = "#categoryId")
     override fun getCategory(categoryId: Long): CategoryResponse {
         val category = categoryRepository.findNullableById(categoryId)
             ?: throw CategoryNotFoundException()
@@ -19,11 +21,13 @@ class CategoryQueryServiceImpl(
         return CategoryResponse.from(category)
     }
 
+    @Cacheable(cacheNames = ["categories:root"])
     override fun getRootCategories(): List<CategoryResponse> {
         return categoryRepository.findByParentCategoryIdIsNull()
             .map { CategoryResponse.from(it) }
     }
 
+    @Cacheable(cacheNames = ["categories:sub"], key = "#parentCategoryId")
     override fun getSubCategories(parentCategoryId: Long): List<CategoryResponse> {
         return categoryRepository.findByParentCategoryId(parentCategoryId)
             .map { CategoryResponse.from(it) }

--- a/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryQueryServiceImpl.kt
@@ -2,7 +2,6 @@ package com.hoppingmall.mall.category.service
 
 import com.hoppingmall.mall.category.domain.repository.CategoryRepository
 import com.hoppingmall.mall.category.dto.response.CategoryResponse
-import com.hoppingmall.mall.category.exception.CategoryNotFoundException
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -13,21 +12,21 @@ class CategoryQueryServiceImpl(
     private val categoryRepository: CategoryRepository
 ) : CategoryQueryService {
 
-    @Cacheable(cacheNames = ["category"], key = "#categoryId")
-    override fun getCategory(categoryId: Long): CategoryResponse {
+    @Cacheable(cacheNames = ["category"], key = "#categoryId", sync = true)
+    override fun getCategory(categoryId: Long): CategoryResponse? {
         val category = categoryRepository.findNullableById(categoryId)
-            ?: throw CategoryNotFoundException()
+            ?: return null
 
         return CategoryResponse.from(category)
     }
 
-    @Cacheable(cacheNames = ["categories:root"])
+    @Cacheable(cacheNames = ["categories:root"], sync = true)
     override fun getRootCategories(): List<CategoryResponse> {
         return categoryRepository.findByParentCategoryIdIsNull()
             .map { CategoryResponse.from(it) }
     }
 
-    @Cacheable(cacheNames = ["categories:sub"], key = "#parentCategoryId")
+    @Cacheable(cacheNames = ["categories:sub"], key = "#parentCategoryId", sync = true)
     override fun getSubCategories(parentCategoryId: Long): List<CategoryResponse> {
         return categoryRepository.findByParentCategoryId(parentCategoryId)
             .map { CategoryResponse.from(it) }

--- a/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryQueryServiceImpl.kt
@@ -2,6 +2,8 @@ package com.hoppingmall.mall.category.service
 
 import com.hoppingmall.mall.category.domain.repository.CategoryRepository
 import com.hoppingmall.mall.category.dto.response.CategoryResponse
+import com.hoppingmall.mall.global.common.config.cache.NotFoundMarker
+import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -9,13 +11,23 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(readOnly = true)
 class CategoryQueryServiceImpl(
-    private val categoryRepository: CategoryRepository
+    private val categoryRepository: CategoryRepository,
+    private val cacheManager: CacheManager
 ) : CategoryQueryService {
 
     @Cacheable(cacheNames = ["category"], key = "#categoryId", sync = true)
     override fun getCategory(categoryId: Long): CategoryResponse? {
+        val notFoundCache = cacheManager.getCache("category:notfound")
+        val cached = notFoundCache?.get(categoryId)
+        if (cached != null && NotFoundMarker.isNotFound(cached.get())) {
+            return null
+        }
+
         val category = categoryRepository.findNullableById(categoryId)
-            ?: return null
+        if (category == null) {
+            notFoundCache?.put(categoryId, NotFoundMarker.INSTANCE)
+            return null
+        }
 
         return CategoryResponse.from(category)
     }

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/CacheConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/CacheConfig.kt
@@ -30,21 +30,29 @@ class CacheConfig(
         val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
             .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
             .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer))
-            .disableCachingNullValues()
             .entryTtl(Duration.ofHours(1))
 
         val cacheConfigurations = mapOf(
-            "category" to defaultConfig.entryTtl(Duration.ofHours(2)),
-            "categories:root" to defaultConfig.entryTtl(Duration.ofHours(2)),
-            "categories:sub" to defaultConfig.entryTtl(Duration.ofHours(2)),
-            "product" to defaultConfig.entryTtl(Duration.ofHours(1))
+            "category" to defaultConfig.entryTtl(Duration.ofMinutes(5)),
+            "categories:root" to defaultConfig.entryTtl(Duration.ofMinutes(5)),
+            "categories:sub" to defaultConfig.entryTtl(Duration.ofMinutes(5)),
+            "product" to defaultConfig.entryTtl(Duration.ofMinutes(10))
         )
 
-        return RedisCacheManager.builder(connectionFactory)
+        val redisCacheManager = RedisCacheManager.builder(connectionFactory)
             .cacheDefaults(defaultConfig)
             .withInitialCacheConfigurations(cacheConfigurations)
             .transactionAware()
             .build()
+
+        val l1Specs = mapOf(
+            "category" to L1CacheSpec(maxSize = 500, ttl = Duration.ofSeconds(30)),
+            "categories:root" to L1CacheSpec(maxSize = 10, ttl = Duration.ofSeconds(60)),
+            "categories:sub" to L1CacheSpec(maxSize = 200, ttl = Duration.ofSeconds(60)),
+            "product" to L1CacheSpec(maxSize = 1000, ttl = Duration.ofSeconds(10))
+        )
+
+        return TwoLevelCacheManager(redisCacheManager, l1Specs)
     }
 
     override fun errorHandler(): CacheErrorHandler {

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/CacheConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/CacheConfig.kt
@@ -1,0 +1,74 @@
+package com.hoppingmall.mall.global.common.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.CachingConfigurer
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.interceptor.CacheErrorHandler
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class CacheConfig(
+    private val objectMapper: ObjectMapper
+) : CachingConfigurer {
+
+    @Bean
+    fun cacheManager(connectionFactory: RedisConnectionFactory): CacheManager {
+        val jsonSerializer = GenericJackson2JsonRedisSerializer(objectMapper)
+
+        val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer))
+            .disableCachingNullValues()
+            .entryTtl(Duration.ofHours(1))
+
+        val cacheConfigurations = mapOf(
+            "category" to defaultConfig.entryTtl(Duration.ofHours(2)),
+            "categories:root" to defaultConfig.entryTtl(Duration.ofHours(2)),
+            "categories:sub" to defaultConfig.entryTtl(Duration.ofHours(2)),
+            "product" to defaultConfig.entryTtl(Duration.ofHours(1))
+        )
+
+        return RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(defaultConfig)
+            .withInitialCacheConfigurations(cacheConfigurations)
+            .transactionAware()
+            .build()
+    }
+
+    override fun errorHandler(): CacheErrorHandler {
+        return RedisCacheErrorHandler()
+    }
+
+    class RedisCacheErrorHandler : CacheErrorHandler {
+
+        private val log = LoggerFactory.getLogger(RedisCacheErrorHandler::class.java)
+
+        override fun handleCacheGetError(exception: RuntimeException, cache: Cache, key: Any) {
+            log.warn("Cache GET 실패 [cache={}, key={}]: {}", cache.name, key, exception.message)
+        }
+
+        override fun handleCachePutError(exception: RuntimeException, cache: Cache, key: Any, value: Any?) {
+            log.warn("Cache PUT 실패 [cache={}, key={}]: {}", cache.name, key, exception.message)
+        }
+
+        override fun handleCacheEvictError(exception: RuntimeException, cache: Cache, key: Any) {
+            log.warn("Cache EVICT 실패 [cache={}, key={}]: {}", cache.name, key, exception.message)
+        }
+
+        override fun handleCacheClearError(exception: RuntimeException, cache: Cache) {
+            log.warn("Cache CLEAR 실패 [cache={}]: {}", cache.name, exception.message)
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/CacheConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/CacheConfig.kt
@@ -1,6 +1,10 @@
 package com.hoppingmall.mall.global.common.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.mall.global.common.config.cache.CachePolicy
+import com.hoppingmall.mall.global.common.config.cache.LockProvider
+import com.hoppingmall.mall.global.common.config.cache.RedisLockProvider
+import com.hoppingmall.mall.global.common.config.cache.TtlJitter
 import org.slf4j.LoggerFactory
 import org.springframework.cache.Cache
 import org.springframework.cache.CacheManager
@@ -12,6 +16,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.cache.RedisCacheConfiguration
 import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.RedisSerializationContext
 import org.springframework.data.redis.serializer.StringRedisSerializer
@@ -23,8 +28,24 @@ class CacheConfig(
     private val objectMapper: ObjectMapper
 ) : CachingConfigurer {
 
+    companion object {
+        val CACHE_POLICIES = listOf(
+            CachePolicy("category", l1MaxSize = 500, l1Ttl = Duration.ofSeconds(30), l2Ttl = Duration.ofMinutes(5), jitterPercent = 10),
+            CachePolicy("category:notfound", l1MaxSize = 200, l1Ttl = Duration.ofSeconds(5), l2Ttl = Duration.ofSeconds(15), jitterPercent = 10),
+            CachePolicy("categories:root", l1MaxSize = 10, l1Ttl = Duration.ofSeconds(60), l2Ttl = Duration.ofMinutes(5), jitterPercent = 10),
+            CachePolicy("categories:sub", l1MaxSize = 200, l1Ttl = Duration.ofSeconds(60), l2Ttl = Duration.ofMinutes(5), jitterPercent = 10),
+            CachePolicy("product", l1MaxSize = 1000, l1Ttl = Duration.ofSeconds(10), l2Ttl = Duration.ofMinutes(10), jitterPercent = 10, hotKey = true),
+            CachePolicy("product:notfound", l1MaxSize = 500, l1Ttl = Duration.ofSeconds(5), l2Ttl = Duration.ofSeconds(20), jitterPercent = 10)
+        )
+    }
+
     @Bean
-    fun cacheManager(connectionFactory: RedisConnectionFactory): CacheManager {
+    fun cacheLockProvider(connectionFactory: RedisConnectionFactory): LockProvider {
+        return RedisLockProvider(StringRedisTemplate(connectionFactory))
+    }
+
+    @Bean
+    fun cacheManager(connectionFactory: RedisConnectionFactory, cacheLockProvider: LockProvider): CacheManager {
         val jsonSerializer = GenericJackson2JsonRedisSerializer(objectMapper)
 
         val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
@@ -32,12 +53,9 @@ class CacheConfig(
             .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer))
             .entryTtl(Duration.ofHours(1))
 
-        val cacheConfigurations = mapOf(
-            "category" to defaultConfig.entryTtl(Duration.ofMinutes(5)),
-            "categories:root" to defaultConfig.entryTtl(Duration.ofMinutes(5)),
-            "categories:sub" to defaultConfig.entryTtl(Duration.ofMinutes(5)),
-            "product" to defaultConfig.entryTtl(Duration.ofMinutes(10))
-        )
+        val cacheConfigurations = CACHE_POLICIES.associate { policy ->
+            policy.cacheName to defaultConfig.entryTtl(TtlJitter.apply(policy.l2Ttl, policy.jitterPercent))
+        }
 
         val redisCacheManager = RedisCacheManager.builder(connectionFactory)
             .cacheDefaults(defaultConfig)
@@ -45,14 +63,9 @@ class CacheConfig(
             .transactionAware()
             .build()
 
-        val l1Specs = mapOf(
-            "category" to L1CacheSpec(maxSize = 500, ttl = Duration.ofSeconds(30)),
-            "categories:root" to L1CacheSpec(maxSize = 10, ttl = Duration.ofSeconds(60)),
-            "categories:sub" to L1CacheSpec(maxSize = 200, ttl = Duration.ofSeconds(60)),
-            "product" to L1CacheSpec(maxSize = 1000, ttl = Duration.ofSeconds(10))
-        )
+        val policyMap = CACHE_POLICIES.associateBy { it.cacheName }
 
-        return TwoLevelCacheManager(redisCacheManager, l1Specs)
+        return TwoLevelCacheManager(redisCacheManager, policyMap, cacheLockProvider)
     }
 
     override fun errorHandler(): CacheErrorHandler {

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/TwoLevelCache.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/TwoLevelCache.kt
@@ -1,14 +1,29 @@
 package com.hoppingmall.mall.global.common.config
 
 import com.github.benmanes.caffeine.cache.Cache
+import com.hoppingmall.mall.global.common.config.cache.CachePolicy
+import com.hoppingmall.mall.global.common.config.cache.LockProvider
+import org.slf4j.LoggerFactory
 import org.springframework.cache.support.AbstractValueAdaptingCache
+import java.time.Duration
 import java.util.concurrent.Callable
 
 class TwoLevelCache(
     private val name: String,
     private val caffeineCache: Cache<Any, Any>,
-    private val redisCache: org.springframework.cache.Cache
+    private val redisCache: org.springframework.cache.Cache,
+    private val policy: CachePolicy,
+    private val lockProvider: LockProvider
 ) : AbstractValueAdaptingCache(true) {
+
+    private val log = LoggerFactory.getLogger(TwoLevelCache::class.java)
+
+    companion object {
+        private const val LOCK_KEY_PREFIX = "lock:"
+        private val LOCK_LEASE_TIME = Duration.ofSeconds(3)
+        private const val LOCK_RETRY_INTERVAL_MS = 80L
+        private const val LOCK_MAX_WAIT_MS = 1500L
+    }
 
     override fun getName(): String = name
 
@@ -30,18 +45,70 @@ class TwoLevelCache(
         val l1Value = caffeineCache.getIfPresent(key)
         if (l1Value != null) return fromStoreValue(l1Value) as T?
 
-        val l2Value = redisCache.get(key, valueLoader)
+        val l2Value = redisCache.get(key)?.get()
         if (l2Value != null) {
-            caffeineCache.put(key, toStoreValue(l2Value))
+            caffeineCache.put(key, l2Value)
+            return fromStoreValue(l2Value) as T?
         }
-        return l2Value
+
+        if (!policy.hotKey) {
+            return loadAndCache(key, valueLoader)
+        }
+
+        return loadWithLock(key, valueLoader)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : Any?> loadWithLock(key: Any, valueLoader: Callable<T>): T? {
+        val lockKey = "$LOCK_KEY_PREFIX$name:$key"
+        val locked = lockProvider.tryLock(lockKey, LOCK_LEASE_TIME)
+
+        if (locked) {
+            try {
+                val l2Recheck = redisCache.get(key)?.get()
+                if (l2Recheck != null) {
+                    caffeineCache.put(key, l2Recheck)
+                    return fromStoreValue(l2Recheck) as T?
+                }
+                return loadAndCache(key, valueLoader)
+            } finally {
+                lockProvider.unlock(lockKey)
+            }
+        }
+
+        return waitForCacheOrFallback(key, valueLoader)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : Any?> waitForCacheOrFallback(key: Any, valueLoader: Callable<T>): T? {
+        var waited = 0L
+        while (waited < LOCK_MAX_WAIT_MS) {
+            Thread.sleep(LOCK_RETRY_INTERVAL_MS)
+            waited += LOCK_RETRY_INTERVAL_MS
+
+            val l2Value = redisCache.get(key)?.get()
+            if (l2Value != null) {
+                caffeineCache.put(key, l2Value)
+                return fromStoreValue(l2Value) as T?
+            }
+        }
+
+        log.warn("Lock 대기 초과 [cache={}, key={}], DB 로더 직접 호출", name, key)
+        return loadAndCache(key, valueLoader)
+    }
+
+    private fun <T : Any?> loadAndCache(key: Any, valueLoader: Callable<T>): T? {
+        val loaded = valueLoader.call()
+        put(key, loaded)
+        return loaded
     }
 
     override fun put(key: Any, value: Any?) {
-        redisCache.put(key, value)
         if (value != null) {
+            redisCache.put(key, value)
             caffeineCache.put(key, toStoreValue(value))
         } else {
+            redisCache.put(key, value)
             caffeineCache.invalidate(key)
         }
     }

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/TwoLevelCache.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/TwoLevelCache.kt
@@ -1,0 +1,58 @@
+package com.hoppingmall.mall.global.common.config
+
+import com.github.benmanes.caffeine.cache.Cache
+import org.springframework.cache.support.AbstractValueAdaptingCache
+import java.util.concurrent.Callable
+
+class TwoLevelCache(
+    private val name: String,
+    private val caffeineCache: Cache<Any, Any>,
+    private val redisCache: org.springframework.cache.Cache
+) : AbstractValueAdaptingCache(true) {
+
+    override fun getName(): String = name
+
+    override fun getNativeCache(): Any = caffeineCache
+
+    override fun lookup(key: Any): Any? {
+        val l1Value = caffeineCache.getIfPresent(key)
+        if (l1Value != null) return l1Value
+
+        val l2Value = redisCache.get(key)?.get()
+        if (l2Value != null) {
+            caffeineCache.put(key, l2Value)
+        }
+        return l2Value
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any?> get(key: Any, valueLoader: Callable<T>): T? {
+        val l1Value = caffeineCache.getIfPresent(key)
+        if (l1Value != null) return fromStoreValue(l1Value) as T?
+
+        val l2Value = redisCache.get(key, valueLoader)
+        if (l2Value != null) {
+            caffeineCache.put(key, toStoreValue(l2Value))
+        }
+        return l2Value
+    }
+
+    override fun put(key: Any, value: Any?) {
+        redisCache.put(key, value)
+        if (value != null) {
+            caffeineCache.put(key, toStoreValue(value))
+        } else {
+            caffeineCache.invalidate(key)
+        }
+    }
+
+    override fun evict(key: Any) {
+        redisCache.evict(key)
+        caffeineCache.invalidate(key)
+    }
+
+    override fun clear() {
+        redisCache.clear()
+        caffeineCache.invalidateAll()
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/TwoLevelCacheManager.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/TwoLevelCacheManager.kt
@@ -1,0 +1,38 @@
+package com.hoppingmall.mall.global.common.config
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
+import java.time.Duration
+
+data class L1CacheSpec(
+    val maxSize: Long,
+    val ttl: Duration
+)
+
+class TwoLevelCacheManager(
+    private val redisCacheManager: CacheManager,
+    private val l1Specs: Map<String, L1CacheSpec>
+) : CacheManager {
+
+    private val cacheMap = mutableMapOf<String, Cache>()
+
+    override fun getCache(name: String): Cache? {
+        return cacheMap.getOrPut(name) {
+            val redisCache = redisCacheManager.getCache(name) ?: return null
+
+            val spec = l1Specs[name] ?: return redisCache
+
+            val caffeineCache = Caffeine.newBuilder()
+                .maximumSize(spec.maxSize)
+                .expireAfterWrite(spec.ttl)
+                .build<Any, Any>()
+
+            TwoLevelCache(name, caffeineCache, redisCache)
+        }
+    }
+
+    override fun getCacheNames(): Collection<String> {
+        return redisCacheManager.cacheNames
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/TwoLevelCacheManager.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/TwoLevelCacheManager.kt
@@ -1,35 +1,35 @@
 package com.hoppingmall.mall.global.common.config
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import com.hoppingmall.mall.global.common.config.cache.CachePolicy
+import com.hoppingmall.mall.global.common.config.cache.LockProvider
 import org.springframework.cache.Cache
 import org.springframework.cache.CacheManager
-import java.time.Duration
-
-data class L1CacheSpec(
-    val maxSize: Long,
-    val ttl: Duration
-)
+import java.util.concurrent.ConcurrentHashMap
 
 class TwoLevelCacheManager(
     private val redisCacheManager: CacheManager,
-    private val l1Specs: Map<String, L1CacheSpec>
+    private val policies: Map<String, CachePolicy>,
+    private val lockProvider: LockProvider
 ) : CacheManager {
 
-    private val cacheMap = mutableMapOf<String, Cache>()
+    private val cacheMap = ConcurrentHashMap<String, Cache>()
 
     override fun getCache(name: String): Cache? {
-        return cacheMap.getOrPut(name) {
-            val redisCache = redisCacheManager.getCache(name) ?: return null
+        val existing = cacheMap[name]
+        if (existing != null) return existing
 
-            val spec = l1Specs[name] ?: return redisCache
+        val redisCache = redisCacheManager.getCache(name) ?: return null
+        val policy = policies[name] ?: return redisCache
 
-            val caffeineCache = Caffeine.newBuilder()
-                .maximumSize(spec.maxSize)
-                .expireAfterWrite(spec.ttl)
-                .build<Any, Any>()
+        val caffeineCache = Caffeine.newBuilder()
+            .maximumSize(policy.l1MaxSize)
+            .expireAfterWrite(policy.l1Ttl)
+            .build<Any, Any>()
 
-            TwoLevelCache(name, caffeineCache, redisCache)
-        }
+        val twoLevelCache = TwoLevelCache(name, caffeineCache, redisCache, policy, lockProvider)
+        cacheMap[name] = twoLevelCache
+        return twoLevelCache
     }
 
     override fun getCacheNames(): Collection<String> {

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/CachePolicy.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/CachePolicy.kt
@@ -1,0 +1,12 @@
+package com.hoppingmall.mall.global.common.config.cache
+
+import java.time.Duration
+
+data class CachePolicy(
+    val cacheName: String,
+    val l1MaxSize: Long,
+    val l1Ttl: Duration,
+    val l2Ttl: Duration,
+    val jitterPercent: Int = 10,
+    val hotKey: Boolean = false
+)

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/LockProvider.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/LockProvider.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.mall.global.common.config.cache
+
+import java.time.Duration
+
+interface LockProvider {
+    fun tryLock(key: String, leaseTime: Duration): Boolean
+    fun unlock(key: String)
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/NotFoundMarker.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/NotFoundMarker.kt
@@ -1,0 +1,13 @@
+package com.hoppingmall.mall.global.common.config.cache
+
+import java.io.Serializable
+
+data class NotFoundMarker(
+    val reason: String = "NOT_FOUND"
+) : Serializable {
+    companion object {
+        val INSTANCE = NotFoundMarker()
+
+        fun isNotFound(value: Any?): Boolean = value is NotFoundMarker
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/RedisLockProvider.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/RedisLockProvider.kt
@@ -1,0 +1,18 @@
+package com.hoppingmall.mall.global.common.config.cache
+
+import org.springframework.data.redis.core.StringRedisTemplate
+import java.time.Duration
+
+class RedisLockProvider(
+    private val redisTemplate: StringRedisTemplate
+) : LockProvider {
+
+    override fun tryLock(key: String, leaseTime: Duration): Boolean {
+        return redisTemplate.opsForValue()
+            .setIfAbsent(key, "locked", leaseTime) ?: false
+    }
+
+    override fun unlock(key: String) {
+        redisTemplate.delete(key)
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/TtlJitter.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/TtlJitter.kt
@@ -1,0 +1,15 @@
+package com.hoppingmall.mall.global.common.config.cache
+
+import java.time.Duration
+import java.util.concurrent.ThreadLocalRandom
+
+object TtlJitter {
+
+    fun apply(baseTtl: Duration, jitterPercent: Int): Duration {
+        if (jitterPercent <= 0) return baseTtl
+        val baseSeconds = baseTtl.seconds
+        val maxJitter = baseSeconds * jitterPercent / 100
+        val jitter = ThreadLocalRandom.current().nextLong(0, maxJitter + 1)
+        return Duration.ofSeconds(baseSeconds + jitter)
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductController.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.product.controller
 
 import com.hoppingmall.mall.global.common.response.ApiResponse
 import com.hoppingmall.mall.product.dto.request.ProductCreateRequest
+import com.hoppingmall.mall.product.exception.ProductNotFoundException
 import com.hoppingmall.mall.product.dto.request.ProductSearchCondition
 import com.hoppingmall.mall.product.dto.request.ProductUpdateRequest
 import com.hoppingmall.mall.product.dto.response.ProductImageResponse
@@ -32,6 +33,7 @@ class ProductController(
     @GetMapping("/{productId}")
     fun getProduct(@PathVariable productId: Long): ApiResponse<ProductResponse> {
         val productResponse = productQueryService.getProductById(productId)
+            ?: throw ProductNotFoundException()
         return ApiResponse.success(productResponse)
     }
 

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImpl.kt
@@ -10,6 +10,7 @@ import com.hoppingmall.mall.product.dto.request.ProductCreateRequest
 import com.hoppingmall.mall.product.dto.request.ProductUpdateRequest
 import com.hoppingmall.mall.product.dto.response.ProductResponse
 import com.hoppingmall.mall.product.exception.ProductNotFoundException
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -50,6 +51,7 @@ class ProductCommandServiceImpl(
         return ProductResponse.from(savedProduct, savedProductImage)
     }
 
+    @CacheEvict(cacheNames = ["product"], key = "#productId")
     override fun updateProduct(productId: Long, request: ProductUpdateRequest): ProductResponse {
         if (!categoryRepository.existsById(request.categoryId)) {
             throw CategoryNotFoundException()
@@ -83,6 +85,7 @@ class ProductCommandServiceImpl(
         return ProductResponse.from(updatedProduct, updatedProductImage)
     }
 
+    @CacheEvict(cacheNames = ["product"], key = "#productId")
     override fun deleteProduct(productId: Long) {
         if (!productRepository.existsById(productId)) {
             throw ProductNotFoundException()

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryService.kt
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Pageable
 interface ProductQueryService {
     fun getProducts(pageable: Pageable): Page<ProductResponse>
 
-    fun getProductById(productId: Long): ProductResponse
+    fun getProductById(productId: Long): ProductResponse?
 
     fun getProductsBySellerId(sellerId: Long, pageable: Pageable): Page<ProductResponse>
 

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImpl.kt
@@ -4,7 +4,6 @@ import com.hoppingmall.mall.product.domain.repository.ProductImageRepository
 import com.hoppingmall.mall.product.domain.repository.ProductRepository
 import com.hoppingmall.mall.product.dto.request.ProductSearchCondition
 import com.hoppingmall.mall.product.dto.response.ProductResponse
-import com.hoppingmall.mall.product.exception.ProductNotFoundException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
@@ -21,12 +20,12 @@ class ProductQueryServiceImpl(
 
     override fun getProducts(pageable: Pageable): Page<ProductResponse> {
         val productPage = productRepository.findAll(pageable)
-        
+
         val productResponses = productPage.content.map { product ->
             val image = productImageRepository.findByProductId(product.id!!)
             ProductResponse.from(product, image)
         }
-        
+
         return PageImpl(
             productResponses,
             pageable,
@@ -34,13 +33,13 @@ class ProductQueryServiceImpl(
         )
     }
 
-    @Cacheable(cacheNames = ["product"], key = "#productId")
-    override fun getProductById(productId: Long): ProductResponse {
+    @Cacheable(cacheNames = ["product"], key = "#productId", sync = true)
+    override fun getProductById(productId: Long): ProductResponse? {
         val product = productRepository.findNullableById(productId)
-            ?: throw ProductNotFoundException()
-        
+            ?: return null
+
         val image = productImageRepository.findByProductId(productId)
-        
+
         return ProductResponse.from(product, image)
     }
 

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImpl.kt
@@ -1,9 +1,11 @@
 package com.hoppingmall.mall.product.service
 
+import com.hoppingmall.mall.global.common.config.cache.NotFoundMarker
 import com.hoppingmall.mall.product.domain.repository.ProductImageRepository
 import com.hoppingmall.mall.product.domain.repository.ProductRepository
 import com.hoppingmall.mall.product.dto.request.ProductSearchCondition
 import com.hoppingmall.mall.product.dto.response.ProductResponse
+import org.springframework.cache.CacheManager
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
@@ -15,8 +17,9 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class ProductQueryServiceImpl(
     private val productRepository: ProductRepository,
-    private val productImageRepository: ProductImageRepository
-): ProductQueryService {
+    private val productImageRepository: ProductImageRepository,
+    private val cacheManager: CacheManager
+) : ProductQueryService {
 
     override fun getProducts(pageable: Pageable): Page<ProductResponse> {
         val productPage = productRepository.findAll(pageable)
@@ -35,8 +38,17 @@ class ProductQueryServiceImpl(
 
     @Cacheable(cacheNames = ["product"], key = "#productId", sync = true)
     override fun getProductById(productId: Long): ProductResponse? {
+        val notFoundCache = cacheManager.getCache("product:notfound")
+        val cached = notFoundCache?.get(productId)
+        if (cached != null && NotFoundMarker.isNotFound(cached.get())) {
+            return null
+        }
+
         val product = productRepository.findNullableById(productId)
-            ?: return null
+        if (product == null) {
+            notFoundCache?.put(productId, NotFoundMarker.INSTANCE)
+            return null
+        }
 
         val image = productImageRepository.findByProductId(productId)
 

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImpl.kt
@@ -8,6 +8,7 @@ import com.hoppingmall.mall.product.exception.ProductNotFoundException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -33,6 +34,7 @@ class ProductQueryServiceImpl(
         )
     }
 
+    @Cacheable(cacheNames = ["product"], key = "#productId")
     override fun getProductById(productId: Long): ProductResponse {
         val product = productRepository.findNullableById(productId)
             ?: throw ProductNotFoundException()

--- a/src/test/kotlin/com/hoppingmall/mall/category/controller/CategoryControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/category/controller/CategoryControllerTest.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.category.controller
 import com.hoppingmall.mall.category.dto.request.CategoryCreateRequest
 import com.hoppingmall.mall.category.dto.request.CategoryUpdateRequest
 import com.hoppingmall.mall.category.dto.response.CategoryResponse
+import com.hoppingmall.mall.category.exception.CategoryNotFoundException
 import com.hoppingmall.mall.category.service.CategoryCommandService
 import com.hoppingmall.mall.category.service.CategoryQueryService
 import com.hoppingmall.mall.global.common.response.ApiResponse
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -75,6 +77,18 @@ class CategoryControllerTest {
             assertEquals("SUCCESS", response.body?.code)
             assertEquals(expectedResponse, response.body?.data)
             verify(categoryQueryService).getCategory(1L)
+        }
+
+        @Test
+        fun 존재하지_않는_카테고리_조회_시_예외_발생() {
+            // given
+            whenever(categoryQueryService.getCategory(999L)).thenReturn(null)
+
+            // when & then
+            assertThrows<CategoryNotFoundException> {
+                controller.getCategory(999L)
+            }
+            verify(categoryQueryService).getCategory(999L)
         }
     }
 

--- a/src/test/kotlin/com/hoppingmall/mall/category/service/CategoryQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/category/service/CategoryQueryServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.category.service
 
 import com.hoppingmall.mall.category.domain.Category
 import com.hoppingmall.mall.category.domain.repository.CategoryRepository
+import com.hoppingmall.mall.global.common.config.cache.NotFoundMarker
 import com.hoppingmall.mall.support.fixture.fixture
 import com.hoppingmall.mall.support.withId
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -11,15 +12,22 @@ import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
 
 @DisplayName("CategoryQueryServiceImpl")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class CategoryQueryServiceImplTest {
 
     private val categoryRepository: CategoryRepository = mock()
-    private val categoryQueryService = CategoryQueryServiceImpl(categoryRepository)
+    private val cacheManager: CacheManager = mock()
+    private val notFoundCache: Cache = mock()
+    private val categoryQueryService = CategoryQueryServiceImpl(categoryRepository, cacheManager)
 
     @Nested
     @DisplayName("getCategory")
@@ -29,6 +37,8 @@ class CategoryQueryServiceImplTest {
             // given
             val category = Category.fixture(name = "전자제품").withId(1L)
 
+            whenever(cacheManager.getCache("category:notfound")).thenReturn(notFoundCache)
+            whenever(notFoundCache.get(1L)).thenReturn(null)
             whenever(categoryRepository.findNullableById(1L)).thenReturn(category)
 
             // when
@@ -40,8 +50,10 @@ class CategoryQueryServiceImplTest {
         }
 
         @Test
-        fun 카테고리가_존재하지_않으면_null을_반환한다() {
+        fun 카테고리가_존재하지_않으면_null을_반환하고_notfound_캐시에_마커를_저장한다() {
             // given
+            whenever(cacheManager.getCache("category:notfound")).thenReturn(notFoundCache)
+            whenever(notFoundCache.get(999L)).thenReturn(null)
             whenever(categoryRepository.findNullableById(999L)).thenReturn(null)
 
             // when
@@ -49,6 +61,23 @@ class CategoryQueryServiceImplTest {
 
             // then
             assertNull(response)
+            verify(notFoundCache).put(999L, NotFoundMarker.INSTANCE)
+        }
+
+        @Test
+        fun notfound_캐시에_마커가_있으면_DB를_조회하지_않고_null을_반환한다() {
+            // given
+            val markerWrapper: Cache.ValueWrapper = mock()
+            whenever(cacheManager.getCache("category:notfound")).thenReturn(notFoundCache)
+            whenever(notFoundCache.get(999L)).thenReturn(markerWrapper)
+            whenever(markerWrapper.get()).thenReturn(NotFoundMarker.INSTANCE)
+
+            // when
+            val response = categoryQueryService.getCategory(999L)
+
+            // then
+            assertNull(response)
+            verify(categoryRepository, never()).findNullableById(any())
         }
     }
 

--- a/src/test/kotlin/com/hoppingmall/mall/category/service/CategoryQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/category/service/CategoryQueryServiceImplTest.kt
@@ -2,16 +2,15 @@ package com.hoppingmall.mall.category.service
 
 import com.hoppingmall.mall.category.domain.Category
 import com.hoppingmall.mall.category.domain.repository.CategoryRepository
-import com.hoppingmall.mall.category.exception.CategoryNotFoundException
 import com.hoppingmall.mall.support.fixture.fixture
 import com.hoppingmall.mall.support.withId
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -36,19 +35,20 @@ class CategoryQueryServiceImplTest {
             val response = categoryQueryService.getCategory(1L)
 
             // then
-            assertEquals(1L, response.id)
+            assertEquals(1L, response!!.id)
             assertEquals("전자제품", response.name)
         }
 
         @Test
-        fun 카테고리가_존재하지_않으면_예외가_발생한다() {
+        fun 카테고리가_존재하지_않으면_null을_반환한다() {
             // given
             whenever(categoryRepository.findNullableById(999L)).thenReturn(null)
 
-            // when & then
-            assertThrows<CategoryNotFoundException> {
-                categoryQueryService.getCategory(999L)
-            }
+            // when
+            val response = categoryQueryService.getCategory(999L)
+
+            // then
+            assertNull(response)
         }
     }
 

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/config/TwoLevelCacheTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/config/TwoLevelCacheTest.kt
@@ -1,0 +1,150 @@
+package com.hoppingmall.mall.global.common.config
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.hoppingmall.mall.global.common.config.cache.CachePolicy
+import com.hoppingmall.mall.global.common.config.cache.FakeLockProvider
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.cache.Cache
+import java.time.Duration
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+@DisplayName("TwoLevelCache")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class TwoLevelCacheTest {
+
+    private val redisCache: Cache = mock()
+    private val lockProvider = FakeLockProvider()
+
+    private val hotKeyPolicy = CachePolicy(
+        cacheName = "product",
+        l1MaxSize = 100,
+        l1Ttl = Duration.ofSeconds(10),
+        l2Ttl = Duration.ofMinutes(10),
+        jitterPercent = 10,
+        hotKey = true
+    )
+
+    private val normalPolicy = CachePolicy(
+        cacheName = "category",
+        l1MaxSize = 100,
+        l1Ttl = Duration.ofSeconds(30),
+        l2Ttl = Duration.ofMinutes(5),
+        jitterPercent = 10,
+        hotKey = false
+    )
+
+    @BeforeEach
+    fun setUp() {
+        lockProvider.reset()
+    }
+
+    private fun createCache(policy: CachePolicy): TwoLevelCache {
+        val caffeineCache = Caffeine.newBuilder()
+            .maximumSize(policy.l1MaxSize)
+            .expireAfterWrite(policy.l1Ttl)
+            .build<Any, Any>()
+        return TwoLevelCache(policy.cacheName, caffeineCache, redisCache, policy, lockProvider)
+    }
+
+    @Nested
+    @DisplayName("핫키 분산락")
+    inner class HotKeyLock {
+        @Test
+        fun 핫키_캐시는_락을_사용한다() {
+            val cache = createCache(hotKeyPolicy)
+            val valueLoader = Callable { "loaded-value" }
+
+            whenever(redisCache.get(1L)).thenReturn(null)
+
+            cache.get(1L, valueLoader)
+
+            assertEquals(1, lockProvider.lockCallCount)
+            assertEquals(1, lockProvider.unlockCallCount)
+        }
+
+        @Test
+        fun 일반_캐시는_락을_사용하지_않는다() {
+            val cache = createCache(normalPolicy)
+            val valueLoader = Callable { "loaded-value" }
+
+            whenever(redisCache.get(1L)).thenReturn(null)
+
+            cache.get(1L, valueLoader)
+
+            assertEquals(0, lockProvider.lockCallCount)
+        }
+
+        @Test
+        fun 핫키_동시_요청_시_DB_로더는_최소_호출된다() {
+            val cache = createCache(hotKeyPolicy)
+            val dbCallCount = AtomicInteger(0)
+            val threadCount = 10
+            val latch = CountDownLatch(threadCount)
+            val executor = Executors.newFixedThreadPool(threadCount)
+
+            val valueWrapper: Cache.ValueWrapper = mock()
+            whenever(valueWrapper.get()).thenReturn("cached-value")
+
+            var firstCall = true
+            whenever(redisCache.get(1L)).thenAnswer {
+                if (firstCall) {
+                    firstCall = false
+                    null
+                } else {
+                    valueWrapper
+                }
+            }
+
+            repeat(threadCount) {
+                executor.submit {
+                    try {
+                        cache.get(1L, Callable {
+                            dbCallCount.incrementAndGet()
+                            Thread.sleep(50)
+                            "loaded-value"
+                        })
+                    } finally {
+                        latch.countDown()
+                    }
+                }
+            }
+
+            latch.await()
+            executor.shutdown()
+
+            assert(dbCallCount.get() <= 3) {
+                "DB 로더가 ${dbCallCount.get()}회 호출됨 (3회 이하 기대)"
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("L1 캐시 히트")
+    inner class L1CacheHit {
+        @Test
+        fun L1에_값이_있으면_L2를_조회하지_않는다() {
+            val cache = createCache(normalPolicy)
+
+            cache.put(1L, "cached-value")
+
+            val result = cache.get(1L, Callable { "should-not-call" })
+
+            assertEquals("cached-value", result)
+            verify(redisCache, never()).get(1L)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/config/cache/FakeLockProvider.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/config/cache/FakeLockProvider.kt
@@ -1,0 +1,29 @@
+package com.hoppingmall.mall.global.common.config.cache
+
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+
+class FakeLockProvider : LockProvider {
+
+    private val locks = ConcurrentHashMap<String, Boolean>()
+    var lockCallCount = 0
+        private set
+    var unlockCallCount = 0
+        private set
+
+    override fun tryLock(key: String, leaseTime: Duration): Boolean {
+        lockCallCount++
+        return locks.putIfAbsent(key, true) == null
+    }
+
+    override fun unlock(key: String) {
+        unlockCallCount++
+        locks.remove(key)
+    }
+
+    fun reset() {
+        locks.clear()
+        lockCallCount = 0
+        unlockCallCount = 0
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/config/cache/TtlJitterTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/config/cache/TtlJitterTest.kt
@@ -1,0 +1,47 @@
+package com.hoppingmall.mall.global.common.config.cache
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+@DisplayName("TtlJitter")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class TtlJitterTest {
+
+    @Test
+    fun jitter_적용_시_base_이상_base_플러스_jitter_이하_범위의_TTL을_반환한다() {
+        val baseTtl = Duration.ofSeconds(600)
+        val jitterPercent = 10
+
+        repeat(100) {
+            val result = TtlJitter.apply(baseTtl, jitterPercent)
+            assertTrue(result.seconds in 600..660,
+                "TTL ${result.seconds}s 가 범위 [600, 660] 밖입니다")
+        }
+    }
+
+    @Test
+    fun jitter가_0이면_base_TTL을_그대로_반환한다() {
+        val baseTtl = Duration.ofSeconds(300)
+
+        val result = TtlJitter.apply(baseTtl, 0)
+
+        assertEquals(300, result.seconds)
+    }
+
+    @Test
+    fun 짧은_TTL에도_jitter가_적용된다() {
+        val baseTtl = Duration.ofSeconds(20)
+        val jitterPercent = 10
+
+        repeat(100) {
+            val result = TtlJitter.apply(baseTtl, jitterPercent)
+            assertTrue(result.seconds in 20..22,
+                "TTL ${result.seconds}s 가 범위 [20, 22] 밖입니다")
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductControllerTest.kt
@@ -108,14 +108,12 @@ class ProductControllerTest {
         fun 존재하지_않는_상품_조회_시_예외_발생() {
             val productId = 999L
 
-            whenever(productQueryService.getProductById(productId))
-                .thenThrow(com.hoppingmall.mall.product.exception.ProductNotFoundException())
+            whenever(productQueryService.getProductById(productId)).thenReturn(null)
 
-            val exception = assertThrows<com.hoppingmall.mall.product.exception.ProductNotFoundException> {
+            assertThrows<com.hoppingmall.mall.product.exception.ProductNotFoundException> {
                 controller.getProduct(productId)
             }
 
-            assertEquals("상품을 찾을 수 없습니다.", exception.message)
             verify(productQueryService).getProductById(productId)
         }
     }

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImplTest.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.mall.product.service
 
+import com.hoppingmall.mall.global.common.config.cache.NotFoundMarker
 import com.hoppingmall.mall.global.enums.ProductStatus
 import com.hoppingmall.mall.product.domain.Product
 import java.math.BigDecimal
@@ -10,6 +11,7 @@ import com.hoppingmall.mall.product.dto.request.ProductSearchCondition
 import com.hoppingmall.mall.support.withId
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
@@ -19,8 +21,11 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 
@@ -30,7 +35,9 @@ class ProductQueryServiceImplTest {
 
     private val productRepository: ProductRepository = mock()
     private val productImageRepository: ProductImageRepository = mock()
-    private val productQueryService = ProductQueryServiceImpl(productRepository, productImageRepository)
+    private val cacheManager: CacheManager = mock()
+    private val notFoundCache: Cache = mock()
+    private val productQueryService = ProductQueryServiceImpl(productRepository, productImageRepository, cacheManager)
 
     @Nested
     @DisplayName("getProducts")
@@ -68,6 +75,8 @@ class ProductQueryServiceImplTest {
             val product = Product.create(1L, 1L, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(productId)
             val image = ProductImage.create(productId, "https://example.com/image.jpg")
 
+            whenever(cacheManager.getCache("product:notfound")).thenReturn(notFoundCache)
+            whenever(notFoundCache.get(productId)).thenReturn(null)
             whenever(productRepository.findNullableById(productId)).thenReturn(product)
             whenever(productImageRepository.findByProductId(productId)).thenReturn(image)
 
@@ -81,15 +90,33 @@ class ProductQueryServiceImplTest {
         }
 
         @Test
-        fun 존재하지_않는_상품_ID로_조회_시_null을_반환한다() {
+        fun 존재하지_않는_상품_ID로_조회_시_null을_반환하고_notfound_캐시에_마커를_저장한다() {
             val productId = 999L
 
+            whenever(cacheManager.getCache("product:notfound")).thenReturn(notFoundCache)
+            whenever(notFoundCache.get(productId)).thenReturn(null)
             whenever(productRepository.findNullableById(productId)).thenReturn(null)
 
             val result = productQueryService.getProductById(productId)
 
             assertNull(result)
             verify(productRepository).findNullableById(productId)
+            verify(notFoundCache).put(productId, NotFoundMarker.INSTANCE)
+        }
+
+        @Test
+        fun notfound_캐시에_마커가_있으면_DB를_조회하지_않고_null을_반환한다() {
+            val productId = 999L
+            val markerWrapper: Cache.ValueWrapper = mock()
+
+            whenever(cacheManager.getCache("product:notfound")).thenReturn(notFoundCache)
+            whenever(notFoundCache.get(productId)).thenReturn(markerWrapper)
+            whenever(markerWrapper.get()).thenReturn(NotFoundMarker.INSTANCE)
+
+            val result = productQueryService.getProductById(productId)
+
+            assertNull(result)
+            verify(productRepository, never()).findNullableById(any())
         }
 
         @Test
@@ -97,6 +124,8 @@ class ProductQueryServiceImplTest {
             val productId = 1L
             val product = Product.create(1L, 1L, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(productId)
 
+            whenever(cacheManager.getCache("product:notfound")).thenReturn(notFoundCache)
+            whenever(notFoundCache.get(productId)).thenReturn(null)
             whenever(productRepository.findNullableById(productId)).thenReturn(product)
             whenever(productImageRepository.findByProductId(productId)).thenReturn(null)
 
@@ -262,4 +291,4 @@ class ProductQueryServiceImplTest {
             assertEquals(0, result.totalElements)
         }
     }
-} 
+}

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImplTest.kt
@@ -7,10 +7,9 @@ import com.hoppingmall.mall.product.domain.ProductImage
 import com.hoppingmall.mall.product.domain.repository.ProductImageRepository
 import com.hoppingmall.mall.product.domain.repository.ProductRepository
 import com.hoppingmall.mall.product.dto.request.ProductSearchCondition
-import com.hoppingmall.mall.product.exception.ProductNotFoundException
 import com.hoppingmall.mall.support.withId
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
@@ -74,7 +73,7 @@ class ProductQueryServiceImplTest {
 
             val result = productQueryService.getProductById(productId)
 
-            assertEquals(productId, result.id)
+            assertEquals(productId, result!!.id)
             assertEquals(product.name, result.name)
             assertEquals(image.imageUrl, result.imageUrl)
             verify(productRepository).findNullableById(productId)
@@ -82,15 +81,14 @@ class ProductQueryServiceImplTest {
         }
 
         @Test
-        fun 존재하지_않는_상품_ID로_조회_시_예외_발생() {
+        fun 존재하지_않는_상품_ID로_조회_시_null을_반환한다() {
             val productId = 999L
 
             whenever(productRepository.findNullableById(productId)).thenReturn(null)
 
-            assertThrows(ProductNotFoundException::class.java) {
-                productQueryService.getProductById(productId)
-            }
+            val result = productQueryService.getProductById(productId)
 
+            assertNull(result)
             verify(productRepository).findNullableById(productId)
         }
 
@@ -104,7 +102,7 @@ class ProductQueryServiceImplTest {
 
             val result = productQueryService.getProductById(productId)
 
-            assertEquals(productId, result.id)
+            assertEquals(productId, result!!.id)
             assertEquals(product.name, result.name)
             assertEquals(null, result.imageUrl)
             verify(productRepository).findNullableById(productId)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,8 @@
 spring:
   main:
     allow-bean-definition-overriding: true
+  cache:
+    type: none
   jackson:
     property-naming-strategy: SNAKE_CASE
 


### PR DESCRIPTION
Closes #80

### 📌 작업 개요
Redis 캐싱을 적용하고, 캐시 쇄도(Stampede)/관통(Penetration)/핫키(Hot Key) 방어를 구현하여
캐시 레이어의 운영 안정성을 확보했습니다.
Caffeine L1 + Redis L2 2계층 캐시 구조에 분산락, TTL Jitter, NotFoundMarker 기반 negative cache 분리를 적용했습니다.

---

### ✅ 주요 변경 사항

- `global.common.config`
  - `CacheConfig`: Caffeine 의존성 추가, disableCachingNullValues 제거, CachePolicy 기반 TTL Jitter 적용, LockProvider 빈 등록
  - `TwoLevelCache`: L1(Caffeine) → L2(Redis) → 핫키면 분산락 → DB 로더 흐름 구현
  - `TwoLevelCacheManager`: CachePolicy/LockProvider 주입, 캐시 이름별 정책 적용

- `global.common.config.cache`
  - `CachePolicy`: 캐시별 L1/L2 TTL, maxSize, jitterPercent, hotKey 여부 캡슐화
  - `NotFoundMarker`: not-found 전용 마커 객체 (null 대신 명시적 값 저장)
  - `LockProvider`, `RedisLockProvider`: 분산락 인터페이스 및 Redis SETNX 구현체
  - `TtlJitter`: L2 Redis TTL에 0~N% 랜덤 편차 적용

- `category.service`
  - `CategoryQueryServiceImpl`: not-found 시 `category:notfound` 캐시에 NotFoundMarker 저장, sync=true 적용

- `category.controller`
  - `CategoryController`: 서비스 null 반환 시 CategoryNotFoundException throw

- `product.service`
  - `ProductQueryServiceImpl`: not-found 시 `product:notfound` 캐시에 NotFoundMarker 저장, sync=true 적용

- `product.controller`
  - `ProductController`: 서비스 null 반환 시 ProductNotFoundException throw

---

### 🧪 테스트

- `TtlJitterTest`: jitter 범위 검증, 0% 시 원본 유지, 짧은 TTL 동작 검증
- `TwoLevelCacheTest`: 핫키 락 사용/미사용, 동시성 시 DB 로더 최소 호출, L1 히트 시 L2 미조회
- `FakeLockProvider`: 테스트용 락 구현체 (호출 횟수 추적)
- `CategoryQueryServiceImplTest`: NotFoundMarker 저장, 캐시 히트 시 DB 미조회 검증
- `ProductQueryServiceImplTest`: NotFoundMarker 저장, 캐시 히트 시 DB 미조회 검증
- `CategoryControllerTest`: not-found 시 예외 throw 검증
- `ProductControllerTest`: not-found 시 예외 throw 검증
- `./gradlew jacocoTestCoverageVerification` 통과 (80% 이상)

---

### 📎 관련 이슈
- #80