### PR TITLE
perf: HotKey 동적 탐지 + Cache Smearing 구현

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/CacheConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/CacheConfig.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.global.common.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.hoppingmall.mall.global.common.config.cache.CachePolicy
+import com.hoppingmall.mall.global.common.config.cache.HotKeyDetectorRegistry
 import com.hoppingmall.mall.global.common.config.cache.LockProvider
 import com.hoppingmall.mall.global.common.config.cache.RedissonLockProvider
 import com.hoppingmall.mall.global.common.config.cache.TtlJitter
@@ -34,7 +35,7 @@ class CacheConfig(
             CachePolicy("category:notfound", l1MaxSize = 200, l1Ttl = Duration.ofSeconds(5), l2Ttl = Duration.ofSeconds(15), jitterPercent = 10),
             CachePolicy("categories:root", l1MaxSize = 10, l1Ttl = Duration.ofSeconds(60), l2Ttl = Duration.ofMinutes(5), jitterPercent = 10),
             CachePolicy("categories:sub", l1MaxSize = 200, l1Ttl = Duration.ofSeconds(60), l2Ttl = Duration.ofMinutes(5), jitterPercent = 10),
-            CachePolicy("product", l1MaxSize = 1000, l1Ttl = Duration.ofSeconds(10), l2Ttl = Duration.ofMinutes(10), jitterPercent = 10, hotKey = true),
+            CachePolicy("product", l1MaxSize = 1000, l1Ttl = Duration.ofSeconds(10), l2Ttl = Duration.ofMinutes(10), jitterPercent = 10, hotKeyThreshold = 50L, hotKeyShardCount = 4),
             CachePolicy("product:notfound", l1MaxSize = 500, l1Ttl = Duration.ofSeconds(5), l2Ttl = Duration.ofSeconds(20), jitterPercent = 10)
         )
     }
@@ -44,8 +45,13 @@ class CacheConfig(
         return RedissonLockProvider(redissonClient)
     }
 
+    @Bean(destroyMethod = "close")
+    fun hotKeyDetectorRegistry(): HotKeyDetectorRegistry {
+        return HotKeyDetectorRegistry(CACHE_POLICIES)
+    }
+
     @Bean
-    fun cacheManager(connectionFactory: RedisConnectionFactory, cacheLockProvider: LockProvider): CacheManager {
+    fun cacheManager(connectionFactory: RedisConnectionFactory, cacheLockProvider: LockProvider, hotKeyDetectorRegistry: HotKeyDetectorRegistry): CacheManager {
         val jsonSerializer = GenericJackson2JsonRedisSerializer(objectMapper)
 
         val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
@@ -65,7 +71,7 @@ class CacheConfig(
 
         val policyMap = CACHE_POLICIES.associateBy { it.cacheName }
 
-        return TwoLevelCacheManager(redisCacheManager, policyMap, cacheLockProvider)
+        return TwoLevelCacheManager(redisCacheManager, policyMap, cacheLockProvider, hotKeyDetectorRegistry)
     }
 
     override fun errorHandler(): CacheErrorHandler {

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/TwoLevelCache.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/TwoLevelCache.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.global.common.config
 
 import com.github.benmanes.caffeine.cache.Cache
 import com.hoppingmall.mall.global.common.config.cache.CachePolicy
+import com.hoppingmall.mall.global.common.config.cache.HotKeyDetector
 import com.hoppingmall.mall.global.common.config.cache.LockProvider
 import org.slf4j.LoggerFactory
 import org.springframework.cache.support.AbstractValueAdaptingCache
@@ -13,7 +14,9 @@ class TwoLevelCache(
     private val caffeineCache: Cache<Any, Any>,
     private val redisCache: org.springframework.cache.Cache,
     private val policy: CachePolicy,
-    private val lockProvider: LockProvider
+    private val lockProvider: LockProvider,
+    private val shardedRedisCache: org.springframework.cache.Cache? = null,
+    private val hotKeyDetector: HotKeyDetector? = null
 ) : AbstractValueAdaptingCache(true) {
 
     private val log = LoggerFactory.getLogger(TwoLevelCache::class.java)
@@ -33,7 +36,11 @@ class TwoLevelCache(
         val l1Value = caffeineCache.getIfPresent(key)
         if (l1Value != null) return l1Value
 
-        val l2Value = redisCache.get(key)?.get()
+        hotKeyDetector?.recordAccess(key.toString())
+        val isHot = hotKeyDetector?.isHot(key.toString()) ?: false
+
+        val l2Cache = if (isHot && shardedRedisCache != null) shardedRedisCache else redisCache
+        val l2Value = l2Cache.get(key)?.get()
         if (l2Value != null) {
             caffeineCache.put(key, l2Value)
         }
@@ -45,17 +52,25 @@ class TwoLevelCache(
         val l1Value = caffeineCache.getIfPresent(key)
         if (l1Value != null) return fromStoreValue(l1Value) as T?
 
+        hotKeyDetector?.recordAccess(key.toString())
+        val isHot = hotKeyDetector?.isHot(key.toString()) ?: false
+
+        if (isHot && shardedRedisCache != null) {
+            val shardValue = shardedRedisCache.get(key)?.get()
+            if (shardValue != null) {
+                caffeineCache.put(key, shardValue)
+                return fromStoreValue(shardValue) as T?
+            }
+            return loadWithLock(key, valueLoader)
+        }
+
         val l2Value = redisCache.get(key)?.get()
         if (l2Value != null) {
             caffeineCache.put(key, l2Value)
             return fromStoreValue(l2Value) as T?
         }
 
-        if (!policy.hotKey) {
-            return loadAndCache(key, valueLoader)
-        }
-
-        return loadWithLock(key, valueLoader)
+        return loadAndCache(key, valueLoader)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -104,17 +119,33 @@ class TwoLevelCache(
     }
 
     override fun put(key: Any, value: Any?) {
+        val isHot = hotKeyDetector?.isHot(key.toString()) ?: false
+
         if (value != null) {
-            redisCache.put(key, value)
+            if (isHot && shardedRedisCache != null) {
+                shardedRedisCache.put(key, value)
+            } else {
+                redisCache.put(key, value)
+            }
             caffeineCache.put(key, toStoreValue(value))
         } else {
-            redisCache.put(key, value)
+            if (isHot && shardedRedisCache != null) {
+                shardedRedisCache.put(key, value)
+            } else {
+                redisCache.put(key, value)
+            }
             caffeineCache.invalidate(key)
         }
     }
 
     override fun evict(key: Any) {
-        redisCache.evict(key)
+        val isHot = hotKeyDetector?.isHot(key.toString()) ?: false
+
+        if (isHot && shardedRedisCache != null) {
+            shardedRedisCache.evict(key)
+        } else {
+            redisCache.evict(key)
+        }
         caffeineCache.invalidate(key)
     }
 

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/TwoLevelCacheManager.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/TwoLevelCacheManager.kt
@@ -2,7 +2,9 @@ package com.hoppingmall.mall.global.common.config
 
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.hoppingmall.mall.global.common.config.cache.CachePolicy
+import com.hoppingmall.mall.global.common.config.cache.HotKeyDetectorRegistry
 import com.hoppingmall.mall.global.common.config.cache.LockProvider
+import com.hoppingmall.mall.global.common.config.cache.ShardedRedisCache
 import org.springframework.cache.Cache
 import org.springframework.cache.CacheManager
 import java.util.concurrent.ConcurrentHashMap
@@ -10,7 +12,8 @@ import java.util.concurrent.ConcurrentHashMap
 class TwoLevelCacheManager(
     private val redisCacheManager: CacheManager,
     private val policies: Map<String, CachePolicy>,
-    private val lockProvider: LockProvider
+    private val lockProvider: LockProvider,
+    private val hotKeyDetectorRegistry: HotKeyDetectorRegistry
 ) : CacheManager {
 
     private val cacheMap = ConcurrentHashMap<String, Cache>()
@@ -27,7 +30,15 @@ class TwoLevelCacheManager(
             .expireAfterWrite(policy.l1Ttl)
             .build<Any, Any>()
 
-        val twoLevelCache = TwoLevelCache(name, caffeineCache, redisCache, policy, lockProvider)
+        val detector = hotKeyDetectorRegistry.getDetector(name)
+        val shardedRedisCache = if (policy.dynamicHotKeyEnabled) {
+            ShardedRedisCache(redisCache, policy.hotKeyShardCount)
+        } else null
+
+        val twoLevelCache = TwoLevelCache(
+            name, caffeineCache, redisCache, policy, lockProvider,
+            shardedRedisCache, detector
+        )
         cacheMap[name] = twoLevelCache
         return twoLevelCache
     }

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/CachePolicy.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/CachePolicy.kt
@@ -8,5 +8,9 @@ data class CachePolicy(
     val l1Ttl: Duration,
     val l2Ttl: Duration,
     val jitterPercent: Int = 10,
-    val hotKey: Boolean = false
-)
+    val hotKeyThreshold: Long = 0L,
+    val hotKeyWindow: Duration = Duration.ofSeconds(60),
+    val hotKeyShardCount: Int = 4
+) {
+    val dynamicHotKeyEnabled: Boolean get() = hotKeyThreshold > 0L
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/HotKeyDetector.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/HotKeyDetector.kt
@@ -1,0 +1,45 @@
+package com.hoppingmall.mall.global.common.config.cache
+
+import java.io.Closeable
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.LongAdder
+
+open class HotKeyDetector(
+    private val threshold: Long,
+    windowDuration: Duration
+) : Closeable {
+
+    private val counts = ConcurrentHashMap<String, LongAdder>()
+    private val hotKeys: MutableSet<String> = ConcurrentHashMap.newKeySet()
+    private val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { r ->
+        Thread(r, "hotkey-detector").apply { isDaemon = true }
+    }
+
+    init {
+        val windowMs = windowDuration.toMillis()
+        scheduler.scheduleAtFixedRate(::reset, windowMs, windowMs, TimeUnit.MILLISECONDS)
+    }
+
+    open fun recordAccess(key: String) {
+        val adder = counts.computeIfAbsent(key) { LongAdder() }
+        adder.increment()
+        if (adder.sum() >= threshold) {
+            hotKeys.add(key)
+        }
+    }
+
+    open fun isHot(key: String): Boolean = hotKeys.contains(key)
+
+    private fun reset() {
+        counts.clear()
+        hotKeys.clear()
+    }
+
+    override fun close() {
+        scheduler.shutdown()
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/HotKeyDetectorRegistry.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/HotKeyDetectorRegistry.kt
@@ -1,0 +1,20 @@
+package com.hoppingmall.mall.global.common.config.cache
+
+import java.io.Closeable
+
+class HotKeyDetectorRegistry(
+    policies: Collection<CachePolicy>
+) : Closeable {
+
+    private val detectors: Map<String, HotKeyDetector> =
+        policies.filter { it.dynamicHotKeyEnabled }
+            .associate { policy ->
+                policy.cacheName to HotKeyDetector(policy.hotKeyThreshold, policy.hotKeyWindow)
+            }
+
+    fun getDetector(cacheName: String): HotKeyDetector? = detectors[cacheName]
+
+    override fun close() {
+        detectors.values.forEach { it.close() }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/ShardedRedisCache.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/cache/ShardedRedisCache.kt
@@ -1,0 +1,55 @@
+package com.hoppingmall.mall.global.common.config.cache
+
+import org.springframework.cache.Cache
+import java.util.concurrent.Callable
+import java.util.concurrent.ThreadLocalRandom
+
+class ShardedRedisCache(
+    private val delegate: Cache,
+    private val shardCount: Int
+) : Cache {
+
+    override fun getName(): String = delegate.name
+
+    override fun getNativeCache(): Any = delegate.nativeCache
+
+    override fun get(key: Any): Cache.ValueWrapper? {
+        val shardIndex = ThreadLocalRandom.current().nextInt(shardCount)
+        val shardValue = delegate.get(shardKey(key, shardIndex))
+        if (shardValue != null) return shardValue
+
+        return delegate.get(key)
+    }
+
+    override fun <T : Any?> get(key: Any, type: Class<T>?): T? {
+        val shardIndex = ThreadLocalRandom.current().nextInt(shardCount)
+        val shardValue = delegate.get(shardKey(key, shardIndex), type)
+        if (shardValue != null) return shardValue
+
+        return delegate.get(key, type)
+    }
+
+    override fun <T : Any?> get(key: Any, valueLoader: Callable<T>): T? {
+        return delegate.get(key, valueLoader)
+    }
+
+    override fun put(key: Any, value: Any?) {
+        delegate.put(key, value)
+        repeat(shardCount) { i ->
+            delegate.put(shardKey(key, i), value)
+        }
+    }
+
+    override fun evict(key: Any) {
+        delegate.evict(key)
+        repeat(shardCount) { i ->
+            delegate.evict(shardKey(key, i))
+        }
+    }
+
+    override fun clear() {
+        delegate.clear()
+    }
+
+    private fun shardKey(key: Any, index: Int): String = "$key::shard:$index"
+}

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/config/TwoLevelCacheTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/config/TwoLevelCacheTest.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.global.common.config
 
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.hoppingmall.mall.global.common.config.cache.CachePolicy
+import com.hoppingmall.mall.global.common.config.cache.FakeHotKeyDetector
 import com.hoppingmall.mall.global.common.config.cache.FakeLockProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -35,7 +36,8 @@ class TwoLevelCacheTest {
         l1Ttl = Duration.ofSeconds(10),
         l2Ttl = Duration.ofMinutes(10),
         jitterPercent = 10,
-        hotKey = true
+        hotKeyThreshold = 5L,
+        hotKeyShardCount = 4
     )
 
     private val normalPolicy = CachePolicy(
@@ -43,8 +45,7 @@ class TwoLevelCacheTest {
         l1MaxSize = 100,
         l1Ttl = Duration.ofSeconds(30),
         l2Ttl = Duration.ofMinutes(5),
-        jitterPercent = 10,
-        hotKey = false
+        jitterPercent = 10
     )
 
     @BeforeEach
@@ -64,13 +65,25 @@ class TwoLevelCacheTest {
     @DisplayName("핫키 분산락")
     inner class HotKeyLock {
         @Test
-        fun 핫키_캐시는_락을_사용한다() {
-            val cache = createCache(hotKeyPolicy)
-            val valueLoader = Callable { "loaded-value" }
+        fun 핫키_감지_시_락을_사용한다() {
+            val fakeDetector = FakeHotKeyDetector()
+            fakeDetector.overrideIsHot = true
+            val shardedCache: Cache = mock()
 
+            val caffeineCache = Caffeine.newBuilder()
+                .maximumSize(hotKeyPolicy.l1MaxSize)
+                .expireAfterWrite(hotKeyPolicy.l1Ttl)
+                .build<Any, Any>()
+
+            val cache = TwoLevelCache(
+                hotKeyPolicy.cacheName, caffeineCache, redisCache, hotKeyPolicy,
+                lockProvider, shardedCache, fakeDetector
+            )
+
+            whenever(shardedCache.get(1L)).thenReturn(null)
             whenever(redisCache.get(1L)).thenReturn(null)
 
-            cache.get(1L, valueLoader)
+            cache.get(1L, Callable { "loaded-value" })
 
             assertEquals(1, lockProvider.lockCallCount)
             assertEquals(1, lockProvider.unlockCallCount)
@@ -90,7 +103,20 @@ class TwoLevelCacheTest {
 
         @Test
         fun 핫키_동시_요청_시_DB_로더는_최소_호출된다() {
-            val cache = createCache(hotKeyPolicy)
+            val fakeDetector = FakeHotKeyDetector()
+            fakeDetector.overrideIsHot = true
+            val shardedCache: Cache = mock()
+
+            val caffeineCache = Caffeine.newBuilder()
+                .maximumSize(hotKeyPolicy.l1MaxSize)
+                .expireAfterWrite(hotKeyPolicy.l1Ttl)
+                .build<Any, Any>()
+
+            val cache = TwoLevelCache(
+                hotKeyPolicy.cacheName, caffeineCache, redisCache, hotKeyPolicy,
+                lockProvider, shardedCache, fakeDetector
+            )
+
             val dbCallCount = AtomicInteger(0)
             val threadCount = 10
             val latch = CountDownLatch(threadCount)
@@ -98,6 +124,7 @@ class TwoLevelCacheTest {
 
             val valueWrapper: Cache.ValueWrapper = mock()
             whenever(valueWrapper.get()).thenReturn("cached-value")
+            whenever(shardedCache.get(1L)).thenReturn(null)
 
             var firstCall = true
             whenever(redisCache.get(1L)).thenAnswer {
@@ -145,6 +172,104 @@ class TwoLevelCacheTest {
 
             assertEquals("cached-value", result)
             verify(redisCache, never()).get(1L)
+        }
+    }
+
+    @Nested
+    @DisplayName("핫키 동적 감지")
+    inner class HotKeyDynamicDetection {
+
+        private val fakeDetector = FakeHotKeyDetector()
+        private val shardedCache: Cache = mock()
+
+        private fun createHotKeyCache(): TwoLevelCache {
+            val caffeineCache = Caffeine.newBuilder()
+                .maximumSize(hotKeyPolicy.l1MaxSize)
+                .expireAfterWrite(hotKeyPolicy.l1Ttl)
+                .build<Any, Any>()
+            return TwoLevelCache(
+                hotKeyPolicy.cacheName, caffeineCache, redisCache, hotKeyPolicy,
+                lockProvider, shardedCache, fakeDetector
+            )
+        }
+
+        @BeforeEach
+        fun setUp() {
+            fakeDetector.reset()
+        }
+
+        @Test
+        fun 핫키로_판별되면_샤딩된_캐시에서_조회한다() {
+            fakeDetector.overrideIsHot = true
+            val cache = createHotKeyCache()
+
+            val valueWrapper: Cache.ValueWrapper = mock()
+            whenever(valueWrapper.get()).thenReturn("shard-value")
+            whenever(shardedCache.get(any())).thenReturn(valueWrapper)
+
+            val result = cache.get(1L, Callable { "should-not-call" })
+
+            assertEquals("shard-value", result)
+        }
+
+        @Test
+        fun 콜드키는_일반_Redis_캐시에서_조회한다() {
+            fakeDetector.overrideIsHot = false
+            val cache = createHotKeyCache()
+
+            val valueWrapper: Cache.ValueWrapper = mock()
+            whenever(valueWrapper.get()).thenReturn("redis-value")
+            whenever(redisCache.get(1L)).thenReturn(valueWrapper)
+
+            val result = cache.get(1L, Callable { "should-not-call" })
+
+            assertEquals("redis-value", result)
+            verify(shardedCache, never()).get(any())
+        }
+
+        @Test
+        fun L1_미스_시_접근을_기록한다() {
+            fakeDetector.overrideIsHot = false
+            val cache = createHotKeyCache()
+
+            whenever(redisCache.get(1L)).thenReturn(null)
+
+            cache.get(1L, Callable { "loaded" })
+
+            assertEquals(1, fakeDetector.recordCount)
+        }
+
+        @Test
+        fun 핫키_evict은_샤딩된_캐시에서_삭제한다() {
+            fakeDetector.overrideIsHot = true
+            val cache = createHotKeyCache()
+
+            cache.evict(1L)
+
+            verify(shardedCache).evict(1L)
+            verify(redisCache, never()).evict(any())
+        }
+
+        @Test
+        fun 콜드키_evict은_일반_캐시에서_삭제한다() {
+            fakeDetector.overrideIsHot = false
+            val cache = createHotKeyCache()
+
+            cache.evict(1L)
+
+            verify(redisCache).evict(1L)
+            verify(shardedCache, never()).evict(any())
+        }
+
+        @Test
+        fun 핫키_put은_샤딩된_캐시에_저장한다() {
+            fakeDetector.overrideIsHot = true
+            val cache = createHotKeyCache()
+
+            cache.put(1L, "value")
+
+            verify(shardedCache).put(1L, "value")
+            verify(redisCache, never()).put(any(), any())
         }
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/config/cache/FakeHotKeyDetector.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/config/cache/FakeHotKeyDetector.kt
@@ -1,0 +1,23 @@
+package com.hoppingmall.mall.global.common.config.cache
+
+import java.time.Duration
+
+class FakeHotKeyDetector : HotKeyDetector(
+    threshold = Long.MAX_VALUE,
+    windowDuration = Duration.ofHours(1)
+) {
+    var overrideIsHot: Boolean = false
+    var recordCount: Int = 0
+        private set
+
+    override fun recordAccess(key: String) {
+        recordCount++
+    }
+
+    override fun isHot(key: String): Boolean = overrideIsHot
+
+    fun reset() {
+        overrideIsHot = false
+        recordCount = 0
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/config/cache/HotKeyDetectorTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/config/cache/HotKeyDetectorTest.kt
@@ -1,0 +1,95 @@
+package com.hoppingmall.mall.global.common.config.cache
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+@DisplayName("HotKeyDetector")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class HotKeyDetectorTest {
+
+    @Test
+    fun 임계값_미만_접근은_핫키로_판별하지_않는다() {
+        val detector = HotKeyDetector(threshold = 5, windowDuration = Duration.ofMinutes(10))
+
+        repeat(4) { detector.recordAccess("key1") }
+
+        assertFalse(detector.isHot("key1"))
+        detector.close()
+    }
+
+    @Test
+    fun 임계값_이상_접근은_핫키로_승격한다() {
+        val detector = HotKeyDetector(threshold = 5, windowDuration = Duration.ofMinutes(10))
+
+        repeat(5) { detector.recordAccess("key1") }
+
+        assertTrue(detector.isHot("key1"))
+        detector.close()
+    }
+
+    @Test
+    fun 키별로_독립적으로_추적한다() {
+        val detector = HotKeyDetector(threshold = 3, windowDuration = Duration.ofMinutes(10))
+
+        repeat(3) { detector.recordAccess("hot-key") }
+        repeat(2) { detector.recordAccess("cold-key") }
+
+        assertTrue(detector.isHot("hot-key"))
+        assertFalse(detector.isHot("cold-key"))
+        detector.close()
+    }
+
+    @Test
+    fun 동시_접근_시_정확하게_카운팅한다() {
+        val detector = HotKeyDetector(threshold = 100, windowDuration = Duration.ofMinutes(10))
+        val threadCount = 10
+        val accessPerThread = 10
+        val latch = CountDownLatch(threadCount)
+        val executor = Executors.newFixedThreadPool(threadCount)
+
+        repeat(threadCount) {
+            executor.submit {
+                try {
+                    repeat(accessPerThread) { detector.recordAccess("concurrent-key") }
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        latch.await()
+        executor.shutdown()
+
+        assertTrue(detector.isHot("concurrent-key"))
+        detector.close()
+    }
+
+    @Test
+    fun 윈도우_리셋_후_핫키가_강등된다() {
+        val detector = HotKeyDetector(threshold = 3, windowDuration = Duration.ofMillis(100))
+
+        repeat(3) { detector.recordAccess("key1") }
+        assertTrue(detector.isHot("key1"))
+
+        Thread.sleep(300)
+
+        assertFalse(detector.isHot("key1"))
+        detector.close()
+    }
+
+    @Test
+    fun 존재하지_않는_키는_핫키가_아니다() {
+        val detector = HotKeyDetector(threshold = 5, windowDuration = Duration.ofMinutes(10))
+
+        assertFalse(detector.isHot("nonexistent"))
+        detector.close()
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/config/cache/ShardedRedisCacheTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/config/cache/ShardedRedisCacheTest.kt
@@ -1,0 +1,77 @@
+package com.hoppingmall.mall.global.common.config.cache
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.cache.Cache
+
+@DisplayName("ShardedRedisCache")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class ShardedRedisCacheTest {
+
+    private val delegate: Cache = mock()
+    private val shardCount = 4
+    private val shardedCache = ShardedRedisCache(delegate, shardCount)
+
+    @Test
+    fun 샤드_또는_원본_키에서_값을_조회한다() {
+        val valueWrapper: Cache.ValueWrapper = mock()
+        whenever(valueWrapper.get()).thenReturn("cached-value")
+        whenever(delegate.get(eq("key1"))).thenReturn(valueWrapper)
+
+        val result = shardedCache.get("key1")
+
+        assertEquals("cached-value", result?.get())
+    }
+
+    @Test
+    fun 모든_샤드와_원본에_미스이면_null을_반환한다() {
+        whenever(delegate.get(any())).thenReturn(null)
+
+        val result = shardedCache.get("missing-key")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun put은_원본과_전체_샤드에_저장한다() {
+        shardedCache.put("key1", "value1")
+
+        verify(delegate).put("key1", "value1")
+        repeat(shardCount) { i ->
+            verify(delegate).put("key1::shard:$i", "value1")
+        }
+    }
+
+    @Test
+    fun evict은_원본과_전체_샤드를_삭제한다() {
+        shardedCache.evict("key1")
+
+        verify(delegate).evict("key1")
+        repeat(shardCount) { i ->
+            verify(delegate).evict("key1::shard:$i")
+        }
+    }
+
+    @Test
+    fun clear는_delegate에_위임한다() {
+        shardedCache.clear()
+
+        verify(delegate).clear()
+    }
+
+    @Test
+    fun name은_delegate의_name을_반환한다() {
+        whenever(delegate.name).thenReturn("product")
+
+        assertEquals("product", shardedCache.name)
+    }
+}


### PR DESCRIPTION
Closes #90

### 📌 작업 개요
기존 `CachePolicy.hotKey` 정적 Boolean을 런타임 빈도 기반 동적 탐지로 교체하고,
핫키로 감지된 캐시 키의 L2(Redis) 읽기를 N개 샤드 키로 분산하여 Redis Cluster 핫스팟을 해소합니다.

---

### ✅ 주요 변경 사항

- `config.cache.CachePolicy`
  - `hotKey: Boolean` → `hotKeyThreshold`, `hotKeyWindow`, `hotKeyShardCount` 동적 설정 필드로 교체

- `config.cache.HotKeyDetector`
  - `ConcurrentHashMap<String, LongAdder>` 기반 빈도 카운터, tumbling window 주기 리셋

- `config.cache.HotKeyDetectorRegistry`
  - cacheName → HotKeyDetector 매핑, `Closeable` 구현으로 Spring 종료 시 정리

- `config.cache.ShardedRedisCache`
  - Spring Cache 래퍼, L2 읽기를 `{key}::shard:{i}` 형태 N개 키로 분산

- `config.TwoLevelCache`
  - HotKeyDetector 기반 hot/cold 경로 분기, 핫키는 ShardedRedisCache + 분산 락, 콜드키는 기존 경로

- `config.TwoLevelCacheManager`
  - HotKeyDetectorRegistry 주입, `dynamicHotKeyEnabled` 시 ShardedRedisCache 인스턴스 생성

- `config.CacheConfig`
  - product 캐시 `hotKeyThreshold=50L, hotKeyShardCount=4` 설정, `hotKeyDetectorRegistry` 빈 등록

---

### 🧪 테스트

- `HotKeyDetectorTest`: 임계값 미만/이상 판별, 키별 독립 추적, 동시 접근 정확성, 윈도우 리셋 후 강등
- `ShardedRedisCacheTest`: 랜덤 샤드 조회, 미스 시 원본 폴백, put/evict 전체 샤드 브로드캐스트
- `TwoLevelCacheTest`: `@Nested 핫키_동적_감지` 추가 — 샤딩 활성화, hot/cold 경로 분기, evict/put 샤딩 검증
- `FakeHotKeyDetector`: `overrideIsHot` 플래그 + `recordCount` 카운터

---

### 📎 관련 이슈
- #90