### PR TITLE
perf: Redis 캐싱 적용 범위 확대

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/coupon/service/CouponCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/coupon/service/CouponCommandServiceImpl.kt
@@ -10,6 +10,8 @@ import com.hoppingmall.mall.coupon.dto.response.UserCouponResponse
 import com.hoppingmall.mall.coupon.enum.CouponStatus
 import com.hoppingmall.mall.coupon.enum.UserCouponStatus
 import com.hoppingmall.mall.coupon.exception.*
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Caching
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -21,6 +23,10 @@ class CouponCommandServiceImpl(
     private val userCouponRepository: UserCouponRepository
 ) : CouponCommandService {
 
+    @Caching(evict = [
+        CacheEvict(cacheNames = ["coupon:available"], allEntries = true),
+        CacheEvict(cacheNames = ["coupon:all"], allEntries = true)
+    ])
     override fun createCoupon(request: CouponCreateRequest): CouponResponse {
         val coupon = Coupon.create(
             name = request.name,
@@ -37,6 +43,10 @@ class CouponCommandServiceImpl(
         return CouponResponse.from(savedCoupon)
     }
 
+    @Caching(evict = [
+        CacheEvict(cacheNames = ["coupon:available"], allEntries = true),
+        CacheEvict(cacheNames = ["coupon:all"], allEntries = true)
+    ])
     override fun changeCouponStatus(couponId: Long, status: CouponStatus): CouponResponse {
         val coupon = couponRepository.findById(couponId)
             .orElseThrow { CouponNotFoundException() }
@@ -44,6 +54,7 @@ class CouponCommandServiceImpl(
         return CouponResponse.from(couponRepository.save(coupon))
     }
 
+    @CacheEvict(cacheNames = ["coupon:available"], allEntries = true)
     override fun issueCoupon(userId: Long, couponId: Long): UserCouponResponse {
         val coupon = couponRepository.findByIdForUpdate(couponId)
             ?: throw CouponNotFoundException()

--- a/src/main/kotlin/com/hoppingmall/mall/coupon/service/CouponQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/coupon/service/CouponQueryServiceImpl.kt
@@ -5,6 +5,7 @@ import com.hoppingmall.mall.coupon.domain.repository.UserCouponRepository
 import com.hoppingmall.mall.coupon.dto.response.CouponResponse
 import com.hoppingmall.mall.coupon.dto.response.UserCouponResponse
 import com.hoppingmall.mall.coupon.exception.CouponNotFoundException
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -15,11 +16,13 @@ class CouponQueryServiceImpl(
     private val userCouponRepository: UserCouponRepository
 ) : CouponQueryService {
 
+    @Cacheable(cacheNames = ["coupon:available"], key = "'all'", sync = true)
     override fun getAvailableCoupons(): List<CouponResponse> {
         return couponRepository.findAvailableCoupons()
             .map { CouponResponse.from(it) }
     }
 
+    @Cacheable(cacheNames = ["coupon:all"], key = "'all'", sync = true)
     override fun getAllCoupons(): List<CouponResponse> {
         return couponRepository.findAllActive()
             .map { CouponResponse.from(it) }

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/CacheConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/CacheConfig.kt
@@ -36,7 +36,12 @@ class CacheConfig(
             CachePolicy("categories:root", l1MaxSize = 10, l1Ttl = Duration.ofSeconds(60), l2Ttl = Duration.ofMinutes(5), jitterPercent = 10),
             CachePolicy("categories:sub", l1MaxSize = 200, l1Ttl = Duration.ofSeconds(60), l2Ttl = Duration.ofMinutes(5), jitterPercent = 10),
             CachePolicy("product", l1MaxSize = 1000, l1Ttl = Duration.ofSeconds(10), l2Ttl = Duration.ofMinutes(10), jitterPercent = 10, hotKeyThreshold = 50L, hotKeyShardCount = 4),
-            CachePolicy("product:notfound", l1MaxSize = 500, l1Ttl = Duration.ofSeconds(5), l2Ttl = Duration.ofSeconds(20), jitterPercent = 10)
+            CachePolicy("product:notfound", l1MaxSize = 500, l1Ttl = Duration.ofSeconds(5), l2Ttl = Duration.ofSeconds(20), jitterPercent = 10),
+            CachePolicy("point-policy", l1MaxSize = 10, l1Ttl = Duration.ofSeconds(60), l2Ttl = Duration.ofMinutes(30), jitterPercent = 10),
+            CachePolicy("membership", l1MaxSize = 500, l1Ttl = Duration.ofSeconds(30), l2Ttl = Duration.ofMinutes(15), jitterPercent = 10),
+            CachePolicy("coupon:available", l1MaxSize = 10, l1Ttl = Duration.ofSeconds(30), l2Ttl = Duration.ofMinutes(5), jitterPercent = 10),
+            CachePolicy("coupon:all", l1MaxSize = 10, l1Ttl = Duration.ofSeconds(60), l2Ttl = Duration.ofMinutes(10), jitterPercent = 10),
+            CachePolicy("inventory", l1MaxSize = 2000, l1Ttl = Duration.ofSeconds(5), l2Ttl = Duration.ofMinutes(3), jitterPercent = 10)
         )
     }
 

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/service/InventoryCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/service/InventoryCommandServiceImpl.kt
@@ -9,6 +9,7 @@ import com.hoppingmall.mall.inventory.exception.InventoryAlreadyExistsException
 import com.hoppingmall.mall.inventory.exception.InventoryNotFoundException
 import com.hoppingmall.mall.product.domain.repository.ProductRepository
 import com.hoppingmall.mall.product.exception.ProductNotFoundException
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -36,6 +37,7 @@ class InventoryCommandServiceImpl(
         return InventoryResponse.from(savedInventory)
     }
 
+    @CacheEvict(cacheNames = ["inventory"], key = "#productId")
     override fun updateStock(productId: Long, request: InventoryUpdateRequest): InventoryResponse {
         val inventory = inventoryRepository.findByProductIdForUpdate(productId)
             ?: throw InventoryNotFoundException()
@@ -44,6 +46,7 @@ class InventoryCommandServiceImpl(
         return InventoryResponse.from(inventory)
     }
 
+    @CacheEvict(cacheNames = ["inventory"], key = "#productId")
     override fun decreaseStock(productId: Long, quantity: Int) {
         val inventory = inventoryRepository.findByProductIdForUpdate(productId)
             ?: throw InventoryNotFoundException()
@@ -51,6 +54,7 @@ class InventoryCommandServiceImpl(
         inventory.decreaseStock(quantity)
     }
 
+    @CacheEvict(cacheNames = ["inventory"], key = "#productId")
     override fun increaseStock(productId: Long, quantity: Int) {
         val inventory = inventoryRepository.findByProductIdForUpdate(productId)
             ?: throw InventoryNotFoundException()

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/service/InventoryQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/service/InventoryQueryServiceImpl.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.inventory.service
 import com.hoppingmall.mall.inventory.domain.repository.InventoryRepository
 import com.hoppingmall.mall.inventory.dto.response.InventoryResponse
 import com.hoppingmall.mall.inventory.exception.InventoryNotFoundException
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -12,6 +13,7 @@ class InventoryQueryServiceImpl(
     private val inventoryRepository: InventoryRepository
 ) : InventoryQueryService {
 
+    @Cacheable(cacheNames = ["inventory"], key = "#productId", sync = true)
     override fun getStock(productId: Long): InventoryResponse {
         val inventory = inventoryRepository.findByProductId(productId)
             ?: throw InventoryNotFoundException()

--- a/src/main/kotlin/com/hoppingmall/mall/membership/service/MembershipCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/service/MembershipCommandServiceImpl.kt
@@ -4,6 +4,7 @@ import com.hoppingmall.mall.membership.domain.Membership
 import com.hoppingmall.mall.membership.domain.repository.MembershipRepository
 import com.hoppingmall.mall.membership.dto.response.MembershipResponse
 import com.hoppingmall.mall.membership.exception.MembershipAlreadyExistsException
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -23,6 +24,7 @@ class MembershipCommandServiceImpl(
         return MembershipResponse.from(saved)
     }
 
+    @CacheEvict(cacheNames = ["membership"], key = "#userId")
     override fun addPurchaseAmount(userId: Long, amount: BigDecimal): MembershipResponse {
         val membership = membershipRepository.findByUserId(userId)
             ?: membershipRepository.save(Membership.create(userId))

--- a/src/main/kotlin/com/hoppingmall/mall/membership/service/MembershipQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/service/MembershipQueryServiceImpl.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.membership.service
 import com.hoppingmall.mall.membership.domain.repository.MembershipRepository
 import com.hoppingmall.mall.membership.dto.response.MembershipResponse
 import com.hoppingmall.mall.membership.exception.MembershipNotFoundException
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -12,6 +13,7 @@ class MembershipQueryServiceImpl(
     private val membershipRepository: MembershipRepository
 ) : MembershipQueryService {
 
+    @Cacheable(cacheNames = ["membership"], key = "#userId", sync = true)
     override fun getMembershipByUserId(userId: Long): MembershipResponse {
         val membership = membershipRepository.findByUserId(userId)
             ?: throw MembershipNotFoundException()

--- a/src/main/kotlin/com/hoppingmall/mall/point/service/PointPolicyServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/service/PointPolicyServiceImpl.kt
@@ -5,6 +5,8 @@ import com.hoppingmall.mall.point.domain.PointPolicyRepository
 import com.hoppingmall.mall.point.dto.request.PointPolicyRequest
 import com.hoppingmall.mall.point.dto.response.PointPolicyResponse
 import com.hoppingmall.mall.point.exception.PointPolicyNotFoundException
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -14,6 +16,7 @@ class PointPolicyServiceImpl(
     private val pointPolicyRepository: PointPolicyRepository
 ) : PointPolicyService {
     
+    @CacheEvict(cacheNames = ["point-policy"], allEntries = true)
     override fun createPolicy(request: PointPolicyRequest): PointPolicyResponse {
         validatePolicyRequest(request)
         validatePolicyNameNotExists(request.policyName)
@@ -34,6 +37,7 @@ class PointPolicyServiceImpl(
         return PointPolicyResponse.from(savedPolicy)
     }
     
+    @CacheEvict(cacheNames = ["point-policy"], allEntries = true)
     override fun updatePolicy(policyId: Long, request: PointPolicyRequest): PointPolicyResponse {
         validatePolicyRequest(request)
         
@@ -53,6 +57,7 @@ class PointPolicyServiceImpl(
         return PointPolicyResponse.from(savedPolicy)
     }
     
+    @CacheEvict(cacheNames = ["point-policy"], allEntries = true)
     override fun activatePolicy(policyId: Long): PointPolicyResponse {
         val policy = pointPolicyRepository.findById(policyId)
             .orElseThrow { PointPolicyNotFoundException() }
@@ -66,6 +71,7 @@ class PointPolicyServiceImpl(
         return PointPolicyResponse.from(savedPolicy)
     }
     
+    @CacheEvict(cacheNames = ["point-policy"], allEntries = true)
     override fun deactivatePolicy(policyId: Long): PointPolicyResponse {
         val policy = pointPolicyRepository.findById(policyId)
             .orElseThrow { PointPolicyNotFoundException() }
@@ -75,6 +81,7 @@ class PointPolicyServiceImpl(
         return PointPolicyResponse.from(savedPolicy)
     }
     
+    @Cacheable(cacheNames = ["point-policy"], key = "'current'", sync = true)
     override fun getCurrentPolicy(): PointPolicyResponse? {
         val policy = pointPolicyRepository.findByIsActiveTrue()
         return policy?.let { PointPolicyResponse.from(it) }


### PR DESCRIPTION
Closes #92

### 📌 작업 개요
현재 product, category에만 적용된 TwoLevelCache(L1 Caffeine + L2 Redis) 캐싱을
포인트 정책, 멤버십, 쿠폰 목록, 재고 조회로 확대 적용하여 DB 부하를 절감합니다.

---

### ✅ 주요 변경 사항

- `global.common.config`
  - `CacheConfig`: point-policy, membership, coupon:available, coupon:all, inventory 캐시 정책 추가

- `point.service`
  - `PointPolicyServiceImpl`: getCurrentPolicy @Cacheable, CUD 메서드 @CacheEvict

- `membership.service`
  - `MembershipQueryServiceImpl`: getMembershipByUserId @Cacheable
  - `MembershipCommandServiceImpl`: addPurchaseAmount @CacheEvict

- `coupon.service`
  - `CouponQueryServiceImpl`: getAvailableCoupons, getAllCoupons @Cacheable
  - `CouponCommandServiceImpl`: createCoupon, changeCouponStatus @Caching evict, issueCoupon @CacheEvict

- `inventory.service`
  - `InventoryQueryServiceImpl`: getStock @Cacheable
  - `InventoryCommandServiceImpl`: updateStock, decreaseStock, increaseStock @CacheEvict

---

### 🧪 테스트

- 기존 전체 테스트 통과
- jacocoTestCoverageVerification 80% 이상 통과

---

### 📎 관련 이슈
- #92