### PR TITLE
perf: 쿠폰 발급 Redisson 분산 락 전환

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/coupon/domain/repository/CouponRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/coupon/domain/repository/CouponRepository.kt
@@ -2,9 +2,7 @@ package com.hoppingmall.mall.coupon.domain.repository
 
 import com.hoppingmall.mall.coupon.domain.Coupon
 import com.hoppingmall.mall.coupon.enum.CouponStatus
-import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
@@ -13,9 +11,8 @@ import java.time.LocalDateTime
 @Repository
 interface CouponRepository : JpaRepository<Coupon, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT c FROM Coupon c WHERE c.id = :id AND c.deletedAt IS NULL")
-    fun findByIdForUpdate(@Param("id") id: Long): Coupon?
+    fun findActiveById(@Param("id") id: Long): Coupon?
 
     @Query(
         "SELECT c FROM Coupon c WHERE c.status = :status AND c.validFrom <= :now AND c.validTo > :now " +

--- a/src/main/kotlin/com/hoppingmall/mall/coupon/service/CouponCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/coupon/service/CouponCommandServiceImpl.kt
@@ -10,6 +10,7 @@ import com.hoppingmall.mall.coupon.dto.response.UserCouponResponse
 import com.hoppingmall.mall.coupon.enum.CouponStatus
 import com.hoppingmall.mall.coupon.enum.UserCouponStatus
 import com.hoppingmall.mall.coupon.exception.*
+import com.hoppingmall.mall.global.common.lock.DistributedLockExecutor
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Caching
 import org.springframework.stereotype.Service
@@ -20,7 +21,8 @@ import java.math.BigDecimal
 @Transactional
 class CouponCommandServiceImpl(
     private val couponRepository: CouponRepository,
-    private val userCouponRepository: UserCouponRepository
+    private val userCouponRepository: UserCouponRepository,
+    private val distributedLockExecutor: DistributedLockExecutor
 ) : CouponCommandService {
 
     @Caching(evict = [
@@ -56,32 +58,34 @@ class CouponCommandServiceImpl(
 
     @CacheEvict(cacheNames = ["coupon:available"], allEntries = true)
     override fun issueCoupon(userId: Long, couponId: Long): UserCouponResponse {
-        val coupon = couponRepository.findByIdForUpdate(couponId)
-            ?: throw CouponNotFoundException()
+        return distributedLockExecutor.withLock("coupon:issue:$couponId") {
+            val coupon = couponRepository.findActiveById(couponId)
+                ?: throw CouponNotFoundException()
 
-        if (coupon.isExpired()) {
-            throw CouponExpiredException()
+            if (coupon.isExpired()) {
+                throw CouponExpiredException()
+            }
+
+            if (coupon.isExhausted()) {
+                throw CouponExhaustedException()
+            }
+
+            if (!coupon.isValid()) {
+                throw CouponNotAvailableException()
+            }
+
+            if (userCouponRepository.existsByUserIdAndCouponId(userId, couponId)) {
+                throw CouponAlreadyIssuedException()
+            }
+
+            coupon.issue()
+            couponRepository.save(coupon)
+
+            val userCoupon = UserCoupon.create(userId = userId, couponId = couponId)
+            val savedUserCoupon = userCouponRepository.save(userCoupon)
+
+            UserCouponResponse.from(savedUserCoupon, coupon)
         }
-
-        if (coupon.isExhausted()) {
-            throw CouponExhaustedException()
-        }
-
-        if (!coupon.isValid()) {
-            throw CouponNotAvailableException()
-        }
-
-        if (userCouponRepository.existsByUserIdAndCouponId(userId, couponId)) {
-            throw CouponAlreadyIssuedException()
-        }
-
-        coupon.issue()
-        couponRepository.save(coupon)
-
-        val userCoupon = UserCoupon.create(userId = userId, couponId = couponId)
-        val savedUserCoupon = userCouponRepository.save(userCoupon)
-
-        return UserCouponResponse.from(savedUserCoupon, coupon)
     }
 
     override fun useCoupon(userId: Long, couponId: Long, orderAmount: BigDecimal, orderId: Long): BigDecimal {

--- a/src/main/kotlin/com/hoppingmall/mall/coupon/service/CouponCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/coupon/service/CouponCommandServiceImpl.kt
@@ -14,6 +14,7 @@ import com.hoppingmall.mall.global.common.lock.DistributedLockExecutor
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Caching
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 
@@ -57,6 +58,7 @@ class CouponCommandServiceImpl(
     }
 
     @CacheEvict(cacheNames = ["coupon:available"], allEntries = true)
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     override fun issueCoupon(userId: Long, couponId: Long): UserCouponResponse {
         return distributedLockExecutor.withLock("coupon:issue:$couponId") {
             val coupon = couponRepository.findActiveById(couponId)

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/error/code/CommonErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/error/code/CommonErrorCode.kt
@@ -10,5 +10,6 @@ enum class CommonErrorCode(
     INVALID_INPUT("C001", "잘못된 입력입니다.", HttpStatus.BAD_REQUEST),
     UNAUTHORIZED("A001", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
     FORBIDDEN("A002", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
-    INTERNAL_ERROR("S001", "서버 내부 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR)
+    INTERNAL_ERROR("S001", "서버 내부 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    LOCK_ACQUISITION_FAILED("S002", "요청 처리 중입니다. 잠시 후 다시 시도해 주세요.", HttpStatus.CONFLICT)
 }

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/lock/DistributedLockException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/lock/DistributedLockException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.global.common.lock
+
+import com.hoppingmall.mall.global.common.error.code.CommonErrorCode
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+
+class DistributedLockException : BusinessException(CommonErrorCode.LOCK_ACQUISITION_FAILED)

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/lock/DistributedLockExecutor.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/lock/DistributedLockExecutor.kt
@@ -1,0 +1,32 @@
+package com.hoppingmall.mall.global.common.lock
+
+import org.redisson.api.RedissonClient
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+@Component
+class DistributedLockExecutor(
+    private val redissonClient: RedissonClient
+) {
+
+    fun <T> withLock(
+        key: String,
+        waitTime: Duration = Duration.ofSeconds(3),
+        leaseTime: Duration = Duration.ofSeconds(5),
+        action: () -> T
+    ): T {
+        val lock = redissonClient.getLock(key)
+        val acquired = lock.tryLock(waitTime.toMillis(), leaseTime.toMillis(), TimeUnit.MILLISECONDS)
+        if (!acquired) {
+            throw DistributedLockException()
+        }
+        try {
+            return action()
+        } finally {
+            if (lock.isHeldByCurrentThread) {
+                lock.unlock()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/lock/DistributedLockExecutor.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/lock/DistributedLockExecutor.kt
@@ -13,7 +13,7 @@ class DistributedLockExecutor(
     private val transactionManager: PlatformTransactionManager
 ) {
 
-    fun <T> withLock(
+    fun <T : Any> withLock(
         key: String,
         waitTime: Duration = Duration.ofSeconds(3),
         leaseTime: Duration = Duration.ofSeconds(5),
@@ -25,7 +25,28 @@ class DistributedLockExecutor(
             throw DistributedLockException()
         }
         try {
-            return TransactionTemplate(transactionManager).execute { action() }!!
+            return TransactionTemplate(transactionManager).execute { action() }
+                ?: throw IllegalStateException("Transaction returned null for lock key: $key")
+        } finally {
+            if (lock.isHeldByCurrentThread) {
+                lock.unlock()
+            }
+        }
+    }
+
+    fun withLockVoid(
+        key: String,
+        waitTime: Duration = Duration.ofSeconds(3),
+        leaseTime: Duration = Duration.ofSeconds(5),
+        action: () -> Unit
+    ) {
+        val lock = redissonClient.getLock(key)
+        val acquired = lock.tryLock(waitTime.toMillis(), leaseTime.toMillis(), TimeUnit.MILLISECONDS)
+        if (!acquired) {
+            throw DistributedLockException()
+        }
+        try {
+            TransactionTemplate(transactionManager).executeWithoutResult { action() }
         } finally {
             if (lock.isHeldByCurrentThread) {
                 lock.unlock()

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/lock/DistributedLockExecutor.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/lock/DistributedLockExecutor.kt
@@ -2,12 +2,15 @@ package com.hoppingmall.mall.global.common.lock
 
 import org.redisson.api.RedissonClient
 import org.springframework.stereotype.Component
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 @Component
 class DistributedLockExecutor(
-    private val redissonClient: RedissonClient
+    private val redissonClient: RedissonClient,
+    private val transactionManager: PlatformTransactionManager
 ) {
 
     fun <T> withLock(
@@ -22,7 +25,7 @@ class DistributedLockExecutor(
             throw DistributedLockException()
         }
         try {
-            return action()
+            return TransactionTemplate(transactionManager).execute { action() }!!
         } finally {
             if (lock.isHeldByCurrentThread) {
                 lock.unlock()

--- a/src/test/kotlin/com/hoppingmall/mall/coupon/service/CouponCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/coupon/service/CouponCommandServiceImplTest.kt
@@ -9,6 +9,7 @@ import com.hoppingmall.mall.coupon.enum.CouponStatus
 import com.hoppingmall.mall.coupon.enum.DiscountType
 import com.hoppingmall.mall.coupon.enum.UserCouponStatus
 import com.hoppingmall.mall.coupon.exception.*
+import com.hoppingmall.mall.global.common.lock.DistributedLockExecutor
 import com.hoppingmall.mall.support.fixture.*
 import com.hoppingmall.mall.support.withId
 import org.assertj.core.api.Assertions.assertThat
@@ -38,11 +39,21 @@ class CouponCommandServiceImplTest {
     @Mock
     private lateinit var userCouponRepository: UserCouponRepository
 
+    @Mock
+    private lateinit var distributedLockExecutor: DistributedLockExecutor
+
     private lateinit var couponCommandService: CouponCommandServiceImpl
 
     @BeforeEach
     fun setUp() {
-        couponCommandService = CouponCommandServiceImpl(couponRepository, userCouponRepository)
+        couponCommandService = CouponCommandServiceImpl(couponRepository, userCouponRepository, distributedLockExecutor)
+    }
+
+    private fun stubLockExecutor() {
+        whenever(distributedLockExecutor.withLock<Any>(any(), any(), any(), any())).thenAnswer { invocation ->
+            val action = invocation.getArgument<() -> Any>(3)
+            action()
+        }
     }
 
     @Nested
@@ -117,6 +128,11 @@ class CouponCommandServiceImplTest {
     @DisplayName("issueCoupon")
     inner class IssueCoupon {
 
+        @BeforeEach
+        fun setUpLock() {
+            stubLockExecutor()
+        }
+
         @Test
         fun 쿠폰_발급_성공() {
             // Data
@@ -125,7 +141,7 @@ class CouponCommandServiceImplTest {
             val coupon = Coupon.fixture()
 
             // Context
-            whenever(couponRepository.findByIdForUpdate(couponId)).thenReturn(coupon)
+            whenever(couponRepository.findActiveById(couponId)).thenReturn(coupon)
             whenever(userCouponRepository.existsByUserIdAndCouponId(userId, couponId)).thenReturn(false)
             whenever(couponRepository.save(any<Coupon>())).thenReturn(coupon)
             whenever(userCouponRepository.save(any<UserCoupon>())).thenAnswer { invocation ->
@@ -140,12 +156,13 @@ class CouponCommandServiceImplTest {
             assertThat(result.status).isEqualTo(UserCouponStatus.ISSUED)
             verify(couponRepository).save(any())
             verify(userCouponRepository).save(any())
+            verify(distributedLockExecutor).withLock<Any>(eq("coupon:issue:$couponId"), any(), any(), any())
         }
 
         @Test
         fun 존재하지_않는_쿠폰_발급_시_예외_발생() {
             // Context
-            whenever(couponRepository.findByIdForUpdate(999L)).thenReturn(null)
+            whenever(couponRepository.findActiveById(999L)).thenReturn(null)
 
             // Interaction & Assertions
             assertThatThrownBy { couponCommandService.issueCoupon(1L, 999L) }
@@ -158,7 +175,7 @@ class CouponCommandServiceImplTest {
             val coupon = Coupon.expiredFixture()
 
             // Context
-            whenever(couponRepository.findByIdForUpdate(1L)).thenReturn(coupon)
+            whenever(couponRepository.findActiveById(1L)).thenReturn(coupon)
 
             // Interaction & Assertions
             assertThatThrownBy { couponCommandService.issueCoupon(1L, 1L) }
@@ -171,7 +188,7 @@ class CouponCommandServiceImplTest {
             val coupon = Coupon.exhaustedFixture()
 
             // Context
-            whenever(couponRepository.findByIdForUpdate(1L)).thenReturn(coupon)
+            whenever(couponRepository.findActiveById(1L)).thenReturn(coupon)
 
             // Interaction & Assertions
             assertThatThrownBy { couponCommandService.issueCoupon(1L, 1L) }
@@ -184,7 +201,7 @@ class CouponCommandServiceImplTest {
             val coupon = Coupon.fixture()
 
             // Context
-            whenever(couponRepository.findByIdForUpdate(1L)).thenReturn(coupon)
+            whenever(couponRepository.findActiveById(1L)).thenReturn(coupon)
             whenever(userCouponRepository.existsByUserIdAndCouponId(1L, 1L)).thenReturn(true)
 
             // Interaction & Assertions

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/lock/DistributedLockExecutorTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/lock/DistributedLockExecutorTest.kt
@@ -2,20 +2,21 @@ package com.hoppingmall.mall.global.common.lock
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.SimpleTransactionStatus
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
@@ -28,14 +29,26 @@ class DistributedLockExecutorTest {
     private lateinit var redissonClient: RedissonClient
 
     @Mock
+    private lateinit var transactionManager: PlatformTransactionManager
+
+    @Mock
     private lateinit var rLock: RLock
 
-    @InjectMocks
     private lateinit var lockExecutor: DistributedLockExecutor
 
+    @BeforeEach
+    fun setUp() {
+        lockExecutor = DistributedLockExecutor(redissonClient, transactionManager)
+    }
+
+    private fun stubTransaction() {
+        whenever(transactionManager.getTransaction(any())).thenReturn(SimpleTransactionStatus())
+    }
+
     @Test
-    fun 락_획득_성공_시_액션을_실행한다() {
+    fun 락_획득_성공_시_트랜잭션_내에서_액션을_실행한다() {
         // Context
+        stubTransaction()
         whenever(redissonClient.getLock("test-key")).thenReturn(rLock)
         whenever(rLock.tryLock(3000L, 5000L, TimeUnit.MILLISECONDS)).thenReturn(true)
         whenever(rLock.isHeldByCurrentThread).thenReturn(true)
@@ -45,6 +58,7 @@ class DistributedLockExecutorTest {
 
         // Assertions
         assertThat(result).isEqualTo("success")
+        verify(transactionManager).commit(any())
         verify(rLock).unlock()
     }
 
@@ -60,8 +74,9 @@ class DistributedLockExecutorTest {
     }
 
     @Test
-    fun 액션_예외_발생_시에도_락을_해제한다() {
+    fun 액션_예외_발생_시_롤백_후_락을_해제한다() {
         // Context
+        stubTransaction()
         whenever(redissonClient.getLock("test-key")).thenReturn(rLock)
         whenever(rLock.tryLock(3000L, 5000L, TimeUnit.MILLISECONDS)).thenReturn(true)
         whenever(rLock.isHeldByCurrentThread).thenReturn(true)
@@ -71,12 +86,14 @@ class DistributedLockExecutorTest {
             lockExecutor.withLock("test-key") { throw RuntimeException("action failed") }
         }.isInstanceOf(RuntimeException::class.java)
 
+        verify(transactionManager).rollback(any())
         verify(rLock).unlock()
     }
 
     @Test
     fun 커스텀_대기_시간과_임대_시간을_사용한다() {
         // Context
+        stubTransaction()
         val waitTime = Duration.ofSeconds(5)
         val leaseTime = Duration.ofSeconds(10)
         whenever(redissonClient.getLock("custom-key")).thenReturn(rLock)

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/lock/DistributedLockExecutorTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/lock/DistributedLockExecutorTest.kt
@@ -91,6 +91,25 @@ class DistributedLockExecutorTest {
     }
 
     @Test
+    fun withLockVoid는_반환값_없이_실행한다() {
+        // Context
+        stubTransaction()
+        whenever(redissonClient.getLock("void-key")).thenReturn(rLock)
+        whenever(rLock.tryLock(3000L, 5000L, TimeUnit.MILLISECONDS)).thenReturn(true)
+        whenever(rLock.isHeldByCurrentThread).thenReturn(true)
+
+        var executed = false
+
+        // Interaction
+        lockExecutor.withLockVoid("void-key") { executed = true }
+
+        // Assertions
+        assertThat(executed).isTrue()
+        verify(transactionManager).commit(any())
+        verify(rLock).unlock()
+    }
+
+    @Test
     fun 커스텀_대기_시간과_임대_시간을_사용한다() {
         // Context
         stubTransaction()

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/lock/DistributedLockExecutorTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/lock/DistributedLockExecutorTest.kt
@@ -1,0 +1,93 @@
+package com.hoppingmall.mall.global.common.lock
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.redisson.api.RLock
+import org.redisson.api.RedissonClient
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+@DisplayName("DistributedLockExecutor")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class DistributedLockExecutorTest {
+
+    @Mock
+    private lateinit var redissonClient: RedissonClient
+
+    @Mock
+    private lateinit var rLock: RLock
+
+    @InjectMocks
+    private lateinit var lockExecutor: DistributedLockExecutor
+
+    @Test
+    fun 락_획득_성공_시_액션을_실행한다() {
+        // Context
+        whenever(redissonClient.getLock("test-key")).thenReturn(rLock)
+        whenever(rLock.tryLock(3000L, 5000L, TimeUnit.MILLISECONDS)).thenReturn(true)
+        whenever(rLock.isHeldByCurrentThread).thenReturn(true)
+
+        // Interaction
+        val result = lockExecutor.withLock("test-key") { "success" }
+
+        // Assertions
+        assertThat(result).isEqualTo("success")
+        verify(rLock).unlock()
+    }
+
+    @Test
+    fun 락_획득_실패_시_예외를_던진다() {
+        // Context
+        whenever(redissonClient.getLock("test-key")).thenReturn(rLock)
+        whenever(rLock.tryLock(3000L, 5000L, TimeUnit.MILLISECONDS)).thenReturn(false)
+
+        // Interaction & Assertions
+        assertThatThrownBy { lockExecutor.withLock("test-key") { "should-not-run" } }
+            .isInstanceOf(DistributedLockException::class.java)
+    }
+
+    @Test
+    fun 액션_예외_발생_시에도_락을_해제한다() {
+        // Context
+        whenever(redissonClient.getLock("test-key")).thenReturn(rLock)
+        whenever(rLock.tryLock(3000L, 5000L, TimeUnit.MILLISECONDS)).thenReturn(true)
+        whenever(rLock.isHeldByCurrentThread).thenReturn(true)
+
+        // Interaction & Assertions
+        assertThatThrownBy {
+            lockExecutor.withLock("test-key") { throw RuntimeException("action failed") }
+        }.isInstanceOf(RuntimeException::class.java)
+
+        verify(rLock).unlock()
+    }
+
+    @Test
+    fun 커스텀_대기_시간과_임대_시간을_사용한다() {
+        // Context
+        val waitTime = Duration.ofSeconds(5)
+        val leaseTime = Duration.ofSeconds(10)
+        whenever(redissonClient.getLock("custom-key")).thenReturn(rLock)
+        whenever(rLock.tryLock(5000L, 10000L, TimeUnit.MILLISECONDS)).thenReturn(true)
+        whenever(rLock.isHeldByCurrentThread).thenReturn(true)
+
+        // Interaction
+        val result = lockExecutor.withLock("custom-key", waitTime, leaseTime) { 42 }
+
+        // Assertions
+        assertThat(result).isEqualTo(42)
+        verify(rLock).tryLock(5000L, 10000L, TimeUnit.MILLISECONDS)
+    }
+}


### PR DESCRIPTION
Closes #93

### 📌 작업 개요
쿠폰 선착순 발급 시 DB 비관적 락(PESSIMISTIC_WRITE)을 Redisson RLock 기반 분산 락으로 전환하여
DB 커넥션 점유를 줄이고 Redis Cluster 환경에서의 동시성 제어를 강화합니다.
락 내부에서 TransactionTemplate으로 트랜잭션을 관리하여 커밋 후 락 해제 순서를 보장합니다.

---

### ✅ 주요 변경 사항

- `global.common.lock`
  - `DistributedLockExecutor`: Redisson RLock 기반 범용 withLock/withLockVoid 패턴 컴포넌트
  - 락 → TX 시작 → 비즈니스 로직 → TX 커밋 → 락 해제 순서 보장
  - `withLock<T : Any>`: non-null 반환 강제, null 시 IllegalStateException
  - `withLockVoid`: 반환값 없는 락 실행 메서드
  - `DistributedLockException`: 락 획득 실패 시 BusinessException

- `global.common.error.code`
  - `CommonErrorCode`: LOCK_ACQUISITION_FAILED (409 Conflict) 추가

- `coupon.domain.repository`
  - `CouponRepository`: findByIdForUpdate(@Lock PESSIMISTIC_WRITE) 제거 → findActiveById 추가

- `coupon.service`
  - `CouponCommandServiceImpl`: issueCoupon에서 분산 락 사용, Propagation.NOT_SUPPORTED로 외부 TX 분리

---

### 🧪 테스트

- `DistributedLockExecutorTest`: 락 획득 성공/실패, 예외 시 롤백+락 해제, withLockVoid, 커스텀 타임아웃
- `CouponCommandServiceImplTest`: DistributedLockExecutor 모킹 반영, 기존 테스트 전체 통과
- jacocoTestCoverageVerification 80% 이상 통과

---

### 📎 관련 이슈
- #93