### PR TITLE
perf: N+1 쿼리 IN 배치 로딩 최적화

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/coupon/service/CouponQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/coupon/service/CouponQueryServiceImpl.kt
@@ -30,9 +30,12 @@ class CouponQueryServiceImpl(
 
     override fun getMyCoupons(userId: Long): List<UserCouponResponse> {
         val userCoupons = userCouponRepository.findByUserId(userId)
+        val couponIds = userCoupons.map { it.couponId }
+        val couponMap = couponRepository.findAllById(couponIds).associateBy { it.id }
+
         return userCoupons.map { userCoupon ->
-            val coupon = couponRepository.findById(userCoupon.couponId)
-                .orElseThrow { CouponNotFoundException() }
+            val coupon = couponMap[userCoupon.couponId]
+                ?: throw CouponNotFoundException()
             UserCouponResponse.from(userCoupon, coupon)
         }
     }

--- a/src/main/kotlin/com/hoppingmall/mall/order/domain/repository/OrderItemRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/domain/repository/OrderItemRepository.kt
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Repository
 interface OrderItemRepository : JpaRepository<OrderItem, Long> {
     fun findByOrderId(orderId: Long): List<OrderItem>
 
+    fun findByOrderIdIn(orderIds: List<Long>): List<OrderItem>
+
     @Query(
         value = """
             SELECT oi.product_id AS productId,

--- a/src/main/kotlin/com/hoppingmall/mall/order/service/OrderQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/service/OrderQueryServiceImpl.kt
@@ -30,9 +30,13 @@ class OrderQueryServiceImpl(
     }
 
     override fun getMyOrders(buyerId: Long, pageable: Pageable): Page<OrderResponse> {
-        return orderRepository.findByBuyerId(buyerId, pageable).map { order ->
-            val orderItems = orderItemRepository.findByOrderId(order.id!!)
-            OrderResponse.from(order, orderItems)
+        val orderPage = orderRepository.findByBuyerId(buyerId, pageable)
+        val orderIds = orderPage.content.mapNotNull { it.id }
+        val orderItemMap = orderItemRepository.findByOrderIdIn(orderIds)
+            .groupBy { it.orderId }
+
+        return orderPage.map { order ->
+            OrderResponse.from(order, orderItemMap[order.id] ?: emptyList())
         }
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductImageRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductImageRepository.kt
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository
 interface ProductImageRepository: JpaRepository<ProductImage, Long> {
 
     fun findByProductId(productId: Long): ProductImage?
+
+    fun findByProductIdIn(productIds: List<Long>): List<ProductImage>
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.mall.product.service
 
 import com.hoppingmall.mall.global.common.config.cache.NotFoundMarker
+import com.hoppingmall.mall.product.domain.Product
 import com.hoppingmall.mall.product.domain.repository.ProductImageRepository
 import com.hoppingmall.mall.product.domain.repository.ProductRepository
 import com.hoppingmall.mall.product.dto.request.ProductSearchCondition
@@ -23,17 +24,7 @@ class ProductQueryServiceImpl(
 
     override fun getProducts(pageable: Pageable): Page<ProductResponse> {
         val productPage = productRepository.findAll(pageable)
-
-        val productResponses = productPage.content.map { product ->
-            val image = productImageRepository.findByProductId(product.id!!)
-            ProductResponse.from(product, image)
-        }
-
-        return PageImpl(
-            productResponses,
-            pageable,
-            productPage.totalElements
-        )
+        return toProductResponsePage(productPage, pageable)
     }
 
     @Cacheable(cacheNames = ["product"], key = "#productId", sync = true)
@@ -60,17 +51,7 @@ class ProductQueryServiceImpl(
         pageable: Pageable
     ): Page<ProductResponse> {
         val productPage = productRepository.findBySellerId(sellerId, pageable)
-
-        val productResponses = productPage.content.map { product ->
-            val image = productImageRepository.findByProductId(product.id!!)
-            ProductResponse.from(product, image)
-        }
-
-        return PageImpl(
-            productResponses,
-            pageable,
-            productPage.totalElements
-        )
+        return toProductResponsePage(productPage, pageable)
     }
 
     override fun getProductsByCategoryId(
@@ -78,17 +59,7 @@ class ProductQueryServiceImpl(
         pageable: Pageable
     ): Page<ProductResponse> {
         val productPage = productRepository.findByCategoryId(categoryId, pageable)
-
-        val productResponses = productPage.content.map { product ->
-            val image = productImageRepository.findByProductId(product.id!!)
-            ProductResponse.from(product, image)
-        }
-
-        return PageImpl(
-            productResponses,
-            pageable,
-            productPage.totalElements
-        )
+        return toProductResponsePage(productPage, pageable)
     }
 
     override fun searchProducts(
@@ -103,16 +74,21 @@ class ProductQueryServiceImpl(
             maxPrice = condition.maxPrice,
             pageable = pageable
         )
+        return toProductResponsePage(productPage, pageable)
+    }
+
+    private fun toProductResponsePage(
+        productPage: Page<Product>,
+        pageable: Pageable
+    ): Page<ProductResponse> {
+        val productIds = productPage.content.mapNotNull { it.id }
+        val imageMap = productImageRepository.findByProductIdIn(productIds)
+            .associateBy { it.productId }
 
         val productResponses = productPage.content.map { product ->
-            val image = productImageRepository.findByProductId(product.id!!)
-            ProductResponse.from(product, image)
+            ProductResponse.from(product, imageMap[product.id])
         }
 
-        return PageImpl(
-            productResponses,
-            pageable,
-            productPage.totalElements
-        )
+        return PageImpl(productResponses, pageable, productPage.totalElements)
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/coupon/service/CouponQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/coupon/service/CouponQueryServiceImplTest.kt
@@ -115,7 +115,7 @@ class CouponQueryServiceImplTest {
 
             // Context
             whenever(userCouponRepository.findByUserId(userId)).thenReturn(userCoupons)
-            whenever(couponRepository.findById(1L)).thenReturn(Optional.of(coupon))
+            whenever(couponRepository.findAllById(listOf(1L))).thenReturn(listOf(coupon))
 
             // Interaction
             val result = couponQueryService.getMyCoupons(userId)
@@ -124,6 +124,7 @@ class CouponQueryServiceImplTest {
             assertThat(result).hasSize(1)
             assertThat(result[0].couponName).isEqualTo(coupon.name)
             verify(userCouponRepository).findByUserId(userId)
+            verify(couponRepository).findAllById(listOf(1L))
         }
 
         @Test
@@ -145,7 +146,7 @@ class CouponQueryServiceImplTest {
 
             // Context
             whenever(userCouponRepository.findByUserId(1L)).thenReturn(userCoupons)
-            whenever(couponRepository.findById(999L)).thenReturn(Optional.empty())
+            whenever(couponRepository.findAllById(listOf(999L))).thenReturn(emptyList())
 
             // Interaction & Assertions
             assertThatThrownBy { couponQueryService.getMyCoupons(1L) }

--- a/src/test/kotlin/com/hoppingmall/mall/order/service/OrderQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/order/service/OrderQueryServiceImplTest.kt
@@ -97,8 +97,10 @@ class OrderQueryServiceImplTest {
             val page = PageImpl(listOf(order1, order2), pageable, 2)
 
             whenever(orderRepository.findByBuyerId(buyerId, pageable)).thenReturn(page)
-            whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(OrderItem.fixture(orderId = 1L)))
-            whenever(orderItemRepository.findByOrderId(2L)).thenReturn(listOf(OrderItem.fixture(orderId = 2L)))
+            whenever(orderItemRepository.findByOrderIdIn(listOf(1L, 2L))).thenReturn(listOf(
+                OrderItem.fixture(orderId = 1L),
+                OrderItem.fixture(orderId = 2L)
+            ))
 
             // when
             val response = orderQueryService.getMyOrders(buyerId, pageable)

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImplTest.kt
@@ -52,8 +52,10 @@ class ProductQueryServiceImplTest {
             val productPage = PageImpl(products, pageable, products.size.toLong())
 
             whenever(productRepository.findAll(pageable)).thenReturn(productPage)
-            whenever(productImageRepository.findByProductId(1L)).thenReturn(ProductImage.create(1L, "https://example.com/image1.jpg"))
-            whenever(productImageRepository.findByProductId(2L)).thenReturn(ProductImage.create(2L, "https://example.com/image2.jpg"))
+            whenever(productImageRepository.findByProductIdIn(listOf(1L, 2L))).thenReturn(listOf(
+                ProductImage.create(1L, "https://example.com/image1.jpg"),
+                ProductImage.create(2L, "https://example.com/image2.jpg")
+            ))
 
             val result = productQueryService.getProducts(pageable)
 
@@ -63,6 +65,7 @@ class ProductQueryServiceImplTest {
             assertEquals("상품2", result.content[1].name)
             assertEquals("https://example.com/image2.jpg", result.content[1].imageUrl)
             verify(productRepository).findAll(pageable)
+            verify(productImageRepository).findByProductIdIn(listOf(1L, 2L))
         }
     }
 
@@ -153,8 +156,10 @@ class ProductQueryServiceImplTest {
             val productPage = PageImpl(products, pageable, products.size.toLong())
 
             whenever(productRepository.findBySellerId(sellerId, pageable)).thenReturn(productPage)
-            whenever(productImageRepository.findByProductId(1L)).thenReturn(ProductImage.create(1L, "https://example.com/image1.jpg"))
-            whenever(productImageRepository.findByProductId(2L)).thenReturn(ProductImage.create(2L, "https://example.com/image2.jpg"))
+            whenever(productImageRepository.findByProductIdIn(listOf(1L, 2L))).thenReturn(listOf(
+                ProductImage.create(1L, "https://example.com/image1.jpg"),
+                ProductImage.create(2L, "https://example.com/image2.jpg")
+            ))
 
             val result = productQueryService.getProductsBySellerId(sellerId, pageable)
 
@@ -166,6 +171,7 @@ class ProductQueryServiceImplTest {
             assertEquals("상품2", result.content[1].name)
             assertEquals("https://example.com/image2.jpg", result.content[1].imageUrl)
             verify(productRepository).findBySellerId(sellerId, pageable)
+            verify(productImageRepository).findByProductIdIn(listOf(1L, 2L))
         }
     }
 
@@ -183,8 +189,10 @@ class ProductQueryServiceImplTest {
             val productPage = PageImpl(products, pageable, products.size.toLong())
 
             whenever(productRepository.findByCategoryId(categoryId, pageable)).thenReturn(productPage)
-            whenever(productImageRepository.findByProductId(1L)).thenReturn(ProductImage.create(1L, "https://example.com/image1.jpg"))
-            whenever(productImageRepository.findByProductId(2L)).thenReturn(ProductImage.create(2L, "https://example.com/image2.jpg"))
+            whenever(productImageRepository.findByProductIdIn(listOf(1L, 2L))).thenReturn(listOf(
+                ProductImage.create(1L, "https://example.com/image1.jpg"),
+                ProductImage.create(2L, "https://example.com/image2.jpg")
+            ))
 
             val result = productQueryService.getProductsByCategoryId(categoryId, pageable)
 
@@ -196,6 +204,7 @@ class ProductQueryServiceImplTest {
             assertEquals("상품2", result.content[1].name)
             assertEquals("https://example.com/image2.jpg", result.content[1].imageUrl)
             verify(productRepository).findByCategoryId(categoryId, pageable)
+            verify(productImageRepository).findByProductIdIn(listOf(1L, 2L))
         }
     }
 
@@ -214,7 +223,7 @@ class ProductQueryServiceImplTest {
             whenever(productRepository.searchProducts(
                 eq("노트북"), isNull(), isNull(), isNull(), isNull(), eq(pageable)
             )).thenReturn(productPage)
-            whenever(productImageRepository.findByProductId(1L)).thenReturn(null)
+            whenever(productImageRepository.findByProductIdIn(listOf(1L))).thenReturn(emptyList())
 
             val result = productQueryService.searchProducts(condition, pageable)
 
@@ -238,8 +247,7 @@ class ProductQueryServiceImplTest {
             whenever(productRepository.searchProducts(
                 isNull(), isNull(), isNull(), eq(BigDecimal("10000")), eq(BigDecimal("30000")), eq(pageable)
             )).thenReturn(productPage)
-            whenever(productImageRepository.findByProductId(1L)).thenReturn(null)
-            whenever(productImageRepository.findByProductId(2L)).thenReturn(null)
+            whenever(productImageRepository.findByProductIdIn(listOf(1L, 2L))).thenReturn(emptyList())
 
             val result = productQueryService.searchProducts(condition, pageable)
 
@@ -265,8 +273,9 @@ class ProductQueryServiceImplTest {
                 eq("상품"), eq(1L), eq(ProductStatus.AVAILABLE),
                 eq(BigDecimal("5000")), eq(BigDecimal("50000")), eq(pageable)
             )).thenReturn(productPage)
-            whenever(productImageRepository.findByProductId(1L))
-                .thenReturn(ProductImage.create(1L, "https://example.com/image1.jpg"))
+            whenever(productImageRepository.findByProductIdIn(listOf(1L))).thenReturn(listOf(
+                ProductImage.create(1L, "https://example.com/image1.jpg")
+            ))
 
             val result = productQueryService.searchProducts(condition, pageable)
 


### PR DESCRIPTION
Closes #96

### 📌 작업 개요
목록 조회 시 발생하는 N+1 쿼리를 IN 배치 로딩 방식으로 최적화했습니다.
엔티티에 JPA 연관관계 없이 FK만 사용하는 현재 구조를 유지하면서, Repository에 `findByXxxIdIn` 메서드를 추가하고 서비스에서 ID를 모아 한 번에 조회하도록 변경했습니다.

**IN 배치 로딩을 선택한 이유:**
- 현재 엔티티가 JPA 연관관계 없이 FK 컬럼만 보유하는 DDD 스타일로 설계되어 있어, JOIN FETCH/@EntityGraph를 쓰려면 엔티티 구조 변경이 필요함
- 양방향 연관관계 추가 시 관리 부담 증가 + 페이징과 JOIN FETCH 조합 시 메모리 페이징 경고 발생 가능
- QueryDSL 프로젝션은 의존성 추가 비용 대비 현재 규모에 과한 선택
- IN 배치 로딩은 기존 엔티티/아키텍처를 건드리지 않고 Repository 메서드 추가만으로 해결 가능
- Spring Data JPA가 빈 리스트 IN 쿼리를 자동 처리하므로 엣지 케이스도 안전

---

### ✅ 주요 변경 사항

- `product.domain.repository`
  - `ProductImageRepository`: `findByProductIdIn` IN 배치 조회 메서드 추가

- `order.domain.repository`
  - `OrderItemRepository`: `findByOrderIdIn` IN 배치 조회 메서드 추가

- `product.service`
  - `ProductQueryServiceImpl`: 4개 목록 조회 메서드에서 개별 이미지 조회 → `findByProductIdIn` + Map 매핑으로 전환, 공통 `toProductResponsePage` 메서드 추출

- `order.service`
  - `OrderQueryServiceImpl`: `getMyOrders`에서 개별 주문아이템 조회 → `findByOrderIdIn` + groupBy 매핑으로 전환

- `coupon.service`
  - `CouponQueryServiceImpl`: `getMyCoupons`에서 개별 쿠폰 조회 → `findAllById` + Map 매핑으로 전환

---

### 🧪 테스트

- `ProductQueryServiceImplTest`: 개별 `findByProductId` mock → `findByProductIdIn` 배치 mock 전환 (6개 테스트)
- `OrderQueryServiceImplTest`: 개별 `findByOrderId` mock → `findByOrderIdIn` 배치 mock 전환 (1개 테스트)
- `CouponQueryServiceImplTest`: 개별 `findById` mock → `findAllById` 배치 mock 전환 (2개 테스트)
- `./gradlew jacocoTestCoverageVerification` 통과

---

### 📎 관련 이슈
- #96