### PR TITLE
perf: 페이지네이션 Page → Slice 전환으로 COUNT 쿼리 제거

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/order/controller/OrderController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/controller/OrderController.kt
@@ -8,8 +8,8 @@ import com.hoppingmall.mall.order.dto.response.OrderResponse
 import com.hoppingmall.mall.order.service.OrderCommandService
 import com.hoppingmall.mall.order.service.OrderQueryService
 import jakarta.validation.Valid
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -46,7 +46,7 @@ class OrderController(
     fun getMyOrders(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
         @PageableDefault(size = 20) pageable: Pageable
-    ): ResponseEntity<ApiResponse<Page<OrderResponse>>> {
+    ): ResponseEntity<ApiResponse<Slice<OrderResponse>>> {
         val orders = orderQueryService.getMyOrders(userPrincipal.getUserId(), pageable)
         return ResponseEntity.ok(ApiResponse.success(orders))
     }

--- a/src/main/kotlin/com/hoppingmall/mall/order/domain/repository/OrderRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/domain/repository/OrderRepository.kt
@@ -1,12 +1,12 @@
 package com.hoppingmall.mall.order.domain.repository
 
 import com.hoppingmall.mall.order.domain.Order
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface OrderRepository : JpaRepository<Order, Long> {
-    fun findByBuyerId(buyerId: Long, pageable: Pageable): Page<Order>
+    fun findByBuyerId(buyerId: Long, pageable: Pageable): Slice<Order>
 }

--- a/src/main/kotlin/com/hoppingmall/mall/order/service/OrderQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/service/OrderQueryService.kt
@@ -1,10 +1,10 @@
 package com.hoppingmall.mall.order.service
 
 import com.hoppingmall.mall.order.dto.response.OrderResponse
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 
 interface OrderQueryService {
     fun getOrder(orderId: Long, buyerId: Long): OrderResponse
-    fun getMyOrders(buyerId: Long, pageable: Pageable): Page<OrderResponse>
+    fun getMyOrders(buyerId: Long, pageable: Pageable): Slice<OrderResponse>
 }

--- a/src/main/kotlin/com/hoppingmall/mall/order/service/OrderQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/service/OrderQueryServiceImpl.kt
@@ -5,8 +5,8 @@ import com.hoppingmall.mall.order.domain.repository.OrderRepository
 import com.hoppingmall.mall.order.dto.response.OrderResponse
 import com.hoppingmall.mall.order.exception.OrderAccessDeniedException
 import com.hoppingmall.mall.order.exception.OrderNotFoundException
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -29,13 +29,13 @@ class OrderQueryServiceImpl(
         return OrderResponse.from(order, orderItems)
     }
 
-    override fun getMyOrders(buyerId: Long, pageable: Pageable): Page<OrderResponse> {
-        val orderPage = orderRepository.findByBuyerId(buyerId, pageable)
-        val orderIds = orderPage.content.mapNotNull { it.id }
+    override fun getMyOrders(buyerId: Long, pageable: Pageable): Slice<OrderResponse> {
+        val orderSlice = orderRepository.findByBuyerId(buyerId, pageable)
+        val orderIds = orderSlice.content.mapNotNull { it.id }
         val orderItemMap = orderItemRepository.findByOrderIdIn(orderIds)
             .groupBy { it.orderId }
 
-        return orderPage.map { order ->
+        return orderSlice.map { order ->
             OrderResponse.from(order, orderItemMap[order.id] ?: emptyList())
         }
     }

--- a/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductController.kt
@@ -11,8 +11,8 @@ import com.hoppingmall.mall.product.service.ProductCommandService
 import com.hoppingmall.mall.product.service.ProductImageService
 import com.hoppingmall.mall.product.service.ProductQueryService
 import jakarta.validation.Valid
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
@@ -25,7 +25,7 @@ class ProductController(
 ) {
 
     @GetMapping
-    fun getProducts(pageable: Pageable): ApiResponse<Page<ProductResponse>> {
+    fun getProducts(pageable: Pageable): ApiResponse<Slice<ProductResponse>> {
         val products = productQueryService.getProducts(pageable)
         return ApiResponse.success(products)
     }
@@ -41,7 +41,7 @@ class ProductController(
     fun getProductsBySeller(
         @PathVariable sellerId: Long,
         pageable: Pageable
-    ): ApiResponse<Page<ProductResponse>> {
+    ): ApiResponse<Slice<ProductResponse>> {
         val products = productQueryService.getProductsBySellerId(sellerId, pageable)
         return ApiResponse.success(products)
     }
@@ -50,7 +50,7 @@ class ProductController(
     fun getProductsByCategory(
         @PathVariable categoryId: Long,
         pageable: Pageable
-    ): ApiResponse<Page<ProductResponse>> {
+    ): ApiResponse<Slice<ProductResponse>> {
         val products = productQueryService.getProductsByCategoryId(categoryId, pageable)
         return ApiResponse.success(products)
     }
@@ -59,7 +59,7 @@ class ProductController(
     fun searchProducts(
         @ModelAttribute condition: ProductSearchCondition,
         pageable: Pageable
-    ): ApiResponse<Page<ProductResponse>> {
+    ): ApiResponse<Slice<ProductResponse>> {
         val products = productQueryService.searchProducts(condition, pageable)
         return ApiResponse.success(products)
     }

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductRepository.kt
@@ -2,8 +2,8 @@ package com.hoppingmall.mall.product.domain.repository
 
 import com.hoppingmall.mall.global.enums.ProductStatus
 import com.hoppingmall.mall.product.domain.Product
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
@@ -12,9 +12,11 @@ import java.math.BigDecimal
 @Repository
 interface ProductRepository: JpaRepository<Product, Long> {
 
-    fun findBySellerId(sellerId: Long, pageable: Pageable): Page<Product>
+    fun findBy(pageable: Pageable): Slice<Product>
 
-    fun findByCategoryId(categoryId: Long, pageable: Pageable): Page<Product>
+    fun findBySellerId(sellerId: Long, pageable: Pageable): Slice<Product>
+
+    fun findByCategoryId(categoryId: Long, pageable: Pageable): Slice<Product>
 
     fun findNullableById(id: Long): Product?
 
@@ -34,5 +36,5 @@ interface ProductRepository: JpaRepository<Product, Long> {
         minPrice: BigDecimal?,
         maxPrice: BigDecimal?,
         pageable: Pageable
-    ): Page<Product>
+    ): Slice<Product>
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryService.kt
@@ -2,17 +2,17 @@ package com.hoppingmall.mall.product.service
 
 import com.hoppingmall.mall.product.dto.request.ProductSearchCondition
 import com.hoppingmall.mall.product.dto.response.ProductResponse
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 
 interface ProductQueryService {
-    fun getProducts(pageable: Pageable): Page<ProductResponse>
+    fun getProducts(pageable: Pageable): Slice<ProductResponse>
 
     fun getProductById(productId: Long): ProductResponse?
 
-    fun getProductsBySellerId(sellerId: Long, pageable: Pageable): Page<ProductResponse>
+    fun getProductsBySellerId(sellerId: Long, pageable: Pageable): Slice<ProductResponse>
 
-    fun getProductsByCategoryId(categoryId: Long, pageable: Pageable): Page<ProductResponse>
+    fun getProductsByCategoryId(categoryId: Long, pageable: Pageable): Slice<ProductResponse>
 
-    fun searchProducts(condition: ProductSearchCondition, pageable: Pageable): Page<ProductResponse>
+    fun searchProducts(condition: ProductSearchCondition, pageable: Pageable): Slice<ProductResponse>
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImpl.kt
@@ -7,9 +7,9 @@ import com.hoppingmall.mall.product.domain.repository.ProductRepository
 import com.hoppingmall.mall.product.dto.request.ProductSearchCondition
 import com.hoppingmall.mall.product.dto.response.ProductResponse
 import org.springframework.cache.CacheManager
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -22,9 +22,9 @@ class ProductQueryServiceImpl(
     private val cacheManager: CacheManager
 ) : ProductQueryService {
 
-    override fun getProducts(pageable: Pageable): Page<ProductResponse> {
-        val productPage = productRepository.findAll(pageable)
-        return toProductResponsePage(productPage, pageable)
+    override fun getProducts(pageable: Pageable): Slice<ProductResponse> {
+        val productSlice = productRepository.findBy(pageable)
+        return toProductResponseSlice(productSlice, pageable)
     }
 
     @Cacheable(cacheNames = ["product"], key = "#productId", sync = true)
@@ -49,24 +49,24 @@ class ProductQueryServiceImpl(
     override fun getProductsBySellerId(
         sellerId: Long,
         pageable: Pageable
-    ): Page<ProductResponse> {
-        val productPage = productRepository.findBySellerId(sellerId, pageable)
-        return toProductResponsePage(productPage, pageable)
+    ): Slice<ProductResponse> {
+        val productSlice = productRepository.findBySellerId(sellerId, pageable)
+        return toProductResponseSlice(productSlice, pageable)
     }
 
     override fun getProductsByCategoryId(
         categoryId: Long,
         pageable: Pageable
-    ): Page<ProductResponse> {
-        val productPage = productRepository.findByCategoryId(categoryId, pageable)
-        return toProductResponsePage(productPage, pageable)
+    ): Slice<ProductResponse> {
+        val productSlice = productRepository.findByCategoryId(categoryId, pageable)
+        return toProductResponseSlice(productSlice, pageable)
     }
 
     override fun searchProducts(
         condition: ProductSearchCondition,
         pageable: Pageable
-    ): Page<ProductResponse> {
-        val productPage = productRepository.searchProducts(
+    ): Slice<ProductResponse> {
+        val productSlice = productRepository.searchProducts(
             keyword = condition.keyword,
             categoryId = condition.categoryId,
             status = condition.status,
@@ -74,21 +74,21 @@ class ProductQueryServiceImpl(
             maxPrice = condition.maxPrice,
             pageable = pageable
         )
-        return toProductResponsePage(productPage, pageable)
+        return toProductResponseSlice(productSlice, pageable)
     }
 
-    private fun toProductResponsePage(
-        productPage: Page<Product>,
+    private fun toProductResponseSlice(
+        productSlice: Slice<Product>,
         pageable: Pageable
-    ): Page<ProductResponse> {
-        val productIds = productPage.content.mapNotNull { it.id }
+    ): Slice<ProductResponse> {
+        val productIds = productSlice.content.mapNotNull { it.id }
         val imageMap = productImageRepository.findByProductIdIn(productIds)
             .associateBy { it.productId }
 
-        val productResponses = productPage.content.map { product ->
+        val productResponses = productSlice.content.map { product ->
             ProductResponse.from(product, imageMap[product.id])
         }
 
-        return PageImpl(productResponses, pageable, productPage.totalElements)
+        return SliceImpl(productResponses, pageable, productSlice.hasNext())
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/order/controller/OrderControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/order/controller/OrderControllerTest.kt
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.mockito.kotlin.*
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import java.math.BigDecimal
@@ -104,16 +104,16 @@ class OrderControllerTest {
         fun 내_주문_목록_조회_성공() {
             // given
             val pageable = PageRequest.of(0, 20)
-            val expectedPage = PageImpl(listOf(createOrderResponse()), pageable, 1)
+            val expectedSlice = SliceImpl(listOf(createOrderResponse()), pageable, false)
 
-            whenever(orderQueryService.getMyOrders(userPrincipal.getUserId(), pageable)).thenReturn(expectedPage)
+            whenever(orderQueryService.getMyOrders(userPrincipal.getUserId(), pageable)).thenReturn(expectedSlice)
 
             // when
             val response = controller.getMyOrders(userPrincipal, pageable)
 
             // then
             assertEquals("SUCCESS", response.body?.code)
-            assertEquals(1, response.body?.data?.totalElements)
+            assertEquals(1, response.body?.data?.content?.size)
             verify(orderQueryService).getMyOrders(userPrincipal.getUserId(), pageable)
         }
     }

--- a/src/test/kotlin/com/hoppingmall/mall/order/service/OrderQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/order/service/OrderQueryServiceImplTest.kt
@@ -18,8 +18,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
 import java.util.*
 
 @DisplayName("OrderQueryServiceImpl")
@@ -94,9 +94,9 @@ class OrderQueryServiceImplTest {
             val pageable = PageRequest.of(0, 20)
             val order1 = Order.fixture(buyerId = buyerId).withId(1L)
             val order2 = Order.fixture(buyerId = buyerId).withId(2L)
-            val page = PageImpl(listOf(order1, order2), pageable, 2)
+            val slice = SliceImpl(listOf(order1, order2), pageable, false)
 
-            whenever(orderRepository.findByBuyerId(buyerId, pageable)).thenReturn(page)
+            whenever(orderRepository.findByBuyerId(buyerId, pageable)).thenReturn(slice)
             whenever(orderItemRepository.findByOrderIdIn(listOf(1L, 2L))).thenReturn(listOf(
                 OrderItem.fixture(orderId = 1L),
                 OrderItem.fixture(orderId = 2L)
@@ -106,8 +106,8 @@ class OrderQueryServiceImplTest {
             val response = orderQueryService.getMyOrders(buyerId, pageable)
 
             // then
-            assertEquals(2, response.totalElements)
             assertEquals(2, response.content.size)
+            assertEquals(false, response.hasNext())
         }
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductControllerTest.kt
@@ -15,9 +15,9 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import java.math.BigDecimal
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.mockito.kotlin.*
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
 import org.springframework.mock.web.MockMultipartFile
 import java.time.LocalDateTime
 
@@ -62,15 +62,15 @@ class ProductControllerTest {
                     updatedAt = null
                 )
             )
-            val productResponsePage = PageImpl(productResponses, pageable, productResponses.size.toLong())
+            val productResponseSlice = SliceImpl(productResponses, pageable, false)
 
-            whenever(productQueryService.getProducts(any())).thenReturn(productResponsePage)
+            whenever(productQueryService.getProducts(any())).thenReturn(productResponseSlice)
 
-            val response: ApiResponse<Page<ProductResponse>> = controller.getProducts(pageable)
+            val response: ApiResponse<Slice<ProductResponse>> = controller.getProducts(pageable)
 
             assertEquals("SUCCESS", response.code)
             assertEquals("성공", response.message)
-            assertEquals(productResponsePage, response.data)
+            assertEquals(productResponseSlice, response.data)
             verify(productQueryService).getProducts(pageable)
         }
     }
@@ -151,15 +151,15 @@ class ProductControllerTest {
                     updatedAt = null
                 )
             )
-            val productResponsePage = PageImpl(productResponses, pageable, productResponses.size.toLong())
+            val productResponseSlice = SliceImpl(productResponses, pageable, false)
 
-            whenever(productQueryService.getProductsBySellerId(eq(sellerId), any())).thenReturn(productResponsePage)
+            whenever(productQueryService.getProductsBySellerId(eq(sellerId), any())).thenReturn(productResponseSlice)
 
-            val response: ApiResponse<Page<ProductResponse>> = controller.getProductsBySeller(sellerId, pageable)
+            val response: ApiResponse<Slice<ProductResponse>> = controller.getProductsBySeller(sellerId, pageable)
 
             assertEquals("SUCCESS", response.code)
             assertEquals("성공", response.message)
-            assertEquals(productResponsePage, response.data)
+            assertEquals(productResponseSlice, response.data)
             verify(productQueryService).getProductsBySellerId(sellerId, pageable)
         }
     }
@@ -197,15 +197,15 @@ class ProductControllerTest {
                     updatedAt = null
                 )
             )
-            val productResponsePage = PageImpl(productResponses, pageable, productResponses.size.toLong())
+            val productResponseSlice = SliceImpl(productResponses, pageable, false)
 
-            whenever(productQueryService.getProductsByCategoryId(eq(categoryId), any())).thenReturn(productResponsePage)
+            whenever(productQueryService.getProductsByCategoryId(eq(categoryId), any())).thenReturn(productResponseSlice)
 
-            val response: ApiResponse<Page<ProductResponse>> = controller.getProductsByCategory(categoryId, pageable)
+            val response: ApiResponse<Slice<ProductResponse>> = controller.getProductsByCategory(categoryId, pageable)
 
             assertEquals("SUCCESS", response.code)
             assertEquals("성공", response.message)
-            assertEquals(productResponsePage, response.data)
+            assertEquals(productResponseSlice, response.data)
             verify(productQueryService).getProductsByCategoryId(categoryId, pageable)
         }
     }
@@ -231,15 +231,15 @@ class ProductControllerTest {
                     updatedAt = null
                 )
             )
-            val productResponsePage = PageImpl(productResponses, pageable, productResponses.size.toLong())
+            val productResponseSlice = SliceImpl(productResponses, pageable, false)
 
-            whenever(productQueryService.searchProducts(eq(condition), any())).thenReturn(productResponsePage)
+            whenever(productQueryService.searchProducts(eq(condition), any())).thenReturn(productResponseSlice)
 
-            val response: ApiResponse<Page<ProductResponse>> = controller.searchProducts(condition, pageable)
+            val response: ApiResponse<Slice<ProductResponse>> = controller.searchProducts(condition, pageable)
 
             assertEquals("SUCCESS", response.code)
             assertEquals("성공", response.message)
-            assertEquals(productResponsePage, response.data)
+            assertEquals(productResponseSlice, response.data)
             verify(productQueryService).searchProducts(condition, pageable)
         }
 
@@ -261,14 +261,14 @@ class ProductControllerTest {
                     updatedAt = null
                 )
             )
-            val productResponsePage = PageImpl(productResponses, pageable, productResponses.size.toLong())
+            val productResponseSlice = SliceImpl(productResponses, pageable, false)
 
-            whenever(productQueryService.searchProducts(eq(condition), any())).thenReturn(productResponsePage)
+            whenever(productQueryService.searchProducts(eq(condition), any())).thenReturn(productResponseSlice)
 
-            val response: ApiResponse<Page<ProductResponse>> = controller.searchProducts(condition, pageable)
+            val response: ApiResponse<Slice<ProductResponse>> = controller.searchProducts(condition, pageable)
 
             assertEquals("SUCCESS", response.code)
-            assertEquals(productResponsePage, response.data)
+            assertEquals(productResponseSlice, response.data)
             verify(productQueryService).searchProducts(condition, pageable)
         }
     }

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImplTest.kt
@@ -26,8 +26,8 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.cache.Cache
 import org.springframework.cache.CacheManager
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
 
 @DisplayName("ProductQueryServiceImpl")
 @DisplayNameGeneration(ReplaceUnderscores::class)
@@ -49,9 +49,9 @@ class ProductQueryServiceImplTest {
                 Product.create(1L, 1L, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(1L),
                 Product.create(2L, 1L, "상품2", "설명2", BigDecimal("20000"), ProductStatus.AVAILABLE).withId(2L)
             )
-            val productPage = PageImpl(products, pageable, products.size.toLong())
+            val productSlice = SliceImpl(products, pageable, false)
 
-            whenever(productRepository.findAll(pageable)).thenReturn(productPage)
+            whenever(productRepository.findBy(pageable)).thenReturn(productSlice)
             whenever(productImageRepository.findByProductIdIn(listOf(1L, 2L))).thenReturn(listOf(
                 ProductImage.create(1L, "https://example.com/image1.jpg"),
                 ProductImage.create(2L, "https://example.com/image2.jpg")
@@ -64,7 +64,7 @@ class ProductQueryServiceImplTest {
             assertEquals("https://example.com/image1.jpg", result.content[0].imageUrl)
             assertEquals("상품2", result.content[1].name)
             assertEquals("https://example.com/image2.jpg", result.content[1].imageUrl)
-            verify(productRepository).findAll(pageable)
+            verify(productRepository).findBy(pageable)
             verify(productImageRepository).findByProductIdIn(listOf(1L, 2L))
         }
     }
@@ -153,9 +153,9 @@ class ProductQueryServiceImplTest {
                 Product.create(sellerId, 1L, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(1L),
                 Product.create(sellerId, 1L, "상품2", "설명2", BigDecimal("20000"), ProductStatus.AVAILABLE).withId(2L)
             )
-            val productPage = PageImpl(products, pageable, products.size.toLong())
+            val productSlice = SliceImpl(products, pageable, false)
 
-            whenever(productRepository.findBySellerId(sellerId, pageable)).thenReturn(productPage)
+            whenever(productRepository.findBySellerId(sellerId, pageable)).thenReturn(productSlice)
             whenever(productImageRepository.findByProductIdIn(listOf(1L, 2L))).thenReturn(listOf(
                 ProductImage.create(1L, "https://example.com/image1.jpg"),
                 ProductImage.create(2L, "https://example.com/image2.jpg")
@@ -186,9 +186,9 @@ class ProductQueryServiceImplTest {
                 Product.create(1L, categoryId, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(1L),
                 Product.create(2L, categoryId, "상품2", "설명2", BigDecimal("20000"), ProductStatus.AVAILABLE).withId(2L)
             )
-            val productPage = PageImpl(products, pageable, products.size.toLong())
+            val productSlice = SliceImpl(products, pageable, false)
 
-            whenever(productRepository.findByCategoryId(categoryId, pageable)).thenReturn(productPage)
+            whenever(productRepository.findByCategoryId(categoryId, pageable)).thenReturn(productSlice)
             whenever(productImageRepository.findByProductIdIn(listOf(1L, 2L))).thenReturn(listOf(
                 ProductImage.create(1L, "https://example.com/image1.jpg"),
                 ProductImage.create(2L, "https://example.com/image2.jpg")
@@ -218,11 +218,11 @@ class ProductQueryServiceImplTest {
             val products = listOf(
                 Product.create(1L, 1L, "게이밍 노트북", "설명1", BigDecimal("1500000"), ProductStatus.AVAILABLE).withId(1L)
             )
-            val productPage = PageImpl(products, pageable, products.size.toLong())
+            val productSlice = SliceImpl(products, pageable, false)
 
             whenever(productRepository.searchProducts(
                 eq("노트북"), isNull(), isNull(), isNull(), isNull(), eq(pageable)
-            )).thenReturn(productPage)
+            )).thenReturn(productSlice)
             whenever(productImageRepository.findByProductIdIn(listOf(1L))).thenReturn(emptyList())
 
             val result = productQueryService.searchProducts(condition, pageable)
@@ -242,11 +242,11 @@ class ProductQueryServiceImplTest {
                 Product.create(1L, 1L, "상품1", "설명1", BigDecimal("15000"), ProductStatus.AVAILABLE).withId(1L),
                 Product.create(2L, 1L, "상품2", "설명2", BigDecimal("25000"), ProductStatus.AVAILABLE).withId(2L)
             )
-            val productPage = PageImpl(products, pageable, products.size.toLong())
+            val productSlice = SliceImpl(products, pageable, false)
 
             whenever(productRepository.searchProducts(
                 isNull(), isNull(), isNull(), eq(BigDecimal("10000")), eq(BigDecimal("30000")), eq(pageable)
-            )).thenReturn(productPage)
+            )).thenReturn(productSlice)
             whenever(productImageRepository.findByProductIdIn(listOf(1L, 2L))).thenReturn(emptyList())
 
             val result = productQueryService.searchProducts(condition, pageable)
@@ -267,12 +267,12 @@ class ProductQueryServiceImplTest {
             val products = listOf(
                 Product.create(1L, 1L, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(1L)
             )
-            val productPage = PageImpl(products, pageable, products.size.toLong())
+            val productSlice = SliceImpl(products, pageable, false)
 
             whenever(productRepository.searchProducts(
                 eq("상품"), eq(1L), eq(ProductStatus.AVAILABLE),
                 eq(BigDecimal("5000")), eq(BigDecimal("50000")), eq(pageable)
-            )).thenReturn(productPage)
+            )).thenReturn(productSlice)
             whenever(productImageRepository.findByProductIdIn(listOf(1L))).thenReturn(listOf(
                 ProductImage.create(1L, "https://example.com/image1.jpg")
             ))
@@ -285,19 +285,19 @@ class ProductQueryServiceImplTest {
         }
 
         @Test
-        fun 검색_결과가_없으면_빈_페이지_반환() {
+        fun 검색_결과가_없으면_빈_슬라이스_반환() {
             val pageable = PageRequest.of(0, 10)
             val condition = ProductSearchCondition(keyword = "존재하지않는상품")
-            val productPage = PageImpl<Product>(emptyList(), pageable, 0)
+            val productSlice = SliceImpl<Product>(emptyList(), pageable, false)
 
             whenever(productRepository.searchProducts(
                 eq("존재하지않는상품"), isNull(), isNull(), isNull(), isNull(), eq(pageable)
-            )).thenReturn(productPage)
+            )).thenReturn(productSlice)
 
             val result = productQueryService.searchProducts(condition, pageable)
 
             assertEquals(0, result.content.size)
-            assertEquals(0, result.totalElements)
+            assertEquals(false, result.hasNext())
         }
     }
 }


### PR DESCRIPTION
Closes #98

### 📌 작업 개요
목록 조회 API의 페이지네이션 반환 타입을 `Page<T>`에서 `Slice<T>`로 전환했습니다.
`Page<T>`는 매 요청마다 `SELECT COUNT(*)` 쿼리를 추가 실행하는데, 데이터가 커지면 이 COUNT 쿼리가 실질적인 병목이 됩니다. `Slice<T>`는 `LIMIT N+1`만 실행하여 다음 페이지 존재 여부만 판단하므로 COUNT 쿼리가 완전히 제거됩니다.

**Slice를 선택한 이유:**
- `Page<T>`의 COUNT 쿼리는 모든 페이지에서 실행되므로 deep page만의 문제가 아닌 전체 페이징 성능 문제
- 대용량 테이블(60만건+)에서 COUNT 쿼리 단독으로 20초 이상 소요되는 사례 보고됨
- Deferred Join은 현재 규모(상품 수천~수만건)에서 OFFSET 스캔이 PK 인덱스로 충분히 빠르므로 과한 최적화
- `findAll(Pageable)` 오버라이드 시 Slice로 바꿔도 COUNT가 여전히 실행되는 Spring Data JPA 이슈([#1782](https://github.com/spring-projects/spring-data-jpa/issues/1782))가 있어 `findBy(Pageable)` 파생 메서드로 대체

---

### ✅ 주요 변경 사항

- `product.domain.repository`
  - `ProductRepository`: `findAll` 대신 `findBy(Pageable): Slice<Product>` 추가, `findBySellerId`/`findByCategoryId`/`searchProducts` 반환 타입 Slice로 변경

- `order.domain.repository`
  - `OrderRepository`: `findByBuyerId` 반환 타입 Slice로 변경

- `product.service`
  - `ProductQueryService`/`ProductQueryServiceImpl`: 4개 목록 조회 메서드 Slice 반환, `toProductResponsePage` → `toProductResponseSlice` 변경, `PageImpl` → `SliceImpl`

- `order.service`
  - `OrderQueryService`/`OrderQueryServiceImpl`: `getMyOrders` Slice 반환으로 변경

- `product.controller`
  - `ProductController`: 4개 목록 API 응답 타입 `Slice<ProductResponse>`로 변경

- `order.controller`
  - `OrderController`: `getMyOrders` API 응답 타입 `Slice<OrderResponse>`로 변경

---

### 🧪 테스트

- `ProductQueryServiceImplTest`: PageImpl → SliceImpl 전환, findAll → findBy mock 변경 (8개 테스트)
- `OrderQueryServiceImplTest`: PageImpl → SliceImpl 전환, totalElements → hasNext 검증 변경 (1개 테스트)
- `ProductControllerTest`: PageImpl → SliceImpl, 응답 타입 Slice 검증 (5개 테스트)
- `OrderControllerTest`: PageImpl → SliceImpl, totalElements → content.size 검증 변경 (1개 테스트)
- `./gradlew jacocoTestCoverageVerification` 통과

---

### 📎 관련 이슈
- #98