### PR TITLE
perf: 장바구니/내 쿠폰 조회 Slice 페이지네이션 적용

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/cartItem/controller/CartItemController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/cartItem/controller/CartItemController.kt
@@ -8,6 +8,9 @@ import com.hoppingmall.mall.cartItem.service.CartItemQueryService
 import com.hoppingmall.mall.global.auth.UserPrincipal
 import com.hoppingmall.mall.global.common.response.ApiResponse
 import jakarta.validation.Valid
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -32,9 +35,10 @@ class CartItemController(
 
     @GetMapping
     fun getCartItems(
-        @AuthenticationPrincipal userPrincipal: UserPrincipal
-    ): ResponseEntity<ApiResponse<List<CartItemResponse>>> {
-        val cartItems = cartItemQueryService.getCartItems(userPrincipal.getUserId())
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PageableDefault(size = 20) pageable: Pageable
+    ): ResponseEntity<ApiResponse<Slice<CartItemResponse>>> {
+        val cartItems = cartItemQueryService.getCartItems(userPrincipal.getUserId(), pageable)
         return ResponseEntity.ok(ApiResponse.success(cartItems))
     }
 

--- a/src/main/kotlin/com/hoppingmall/mall/cartItem/domain/repository/CartItemRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/cartItem/domain/repository/CartItemRepository.kt
@@ -2,13 +2,15 @@ package com.hoppingmall.mall.cartItem.domain.repository
 
 import com.hoppingmall.mall.cartItem.domain.CartItem
 import com.hoppingmall.mall.product.dto.CartAggregation
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
 interface CartItemRepository: JpaRepository<CartItem, Long> {
-    fun findByBuyerId(buyerId: Long): List<CartItem>
+    fun findByBuyerId(buyerId: Long, pageable: Pageable): Slice<CartItem>
     fun findByBuyerIdAndProductId(buyerId: Long, productId: Long): CartItem?
 
     @Query(

--- a/src/main/kotlin/com/hoppingmall/mall/cartItem/service/CartItemQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/cartItem/service/CartItemQueryService.kt
@@ -1,7 +1,9 @@
 package com.hoppingmall.mall.cartItem.service
 
 import com.hoppingmall.mall.cartItem.dto.response.CartItemResponse
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 
 interface CartItemQueryService {
-    fun getCartItems(buyerId: Long): List<CartItemResponse>
+    fun getCartItems(buyerId: Long, pageable: Pageable): Slice<CartItemResponse>
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/cartItem/service/CartItemQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/cartItem/service/CartItemQueryServiceImpl.kt
@@ -2,6 +2,8 @@ package com.hoppingmall.mall.cartItem.service
 
 import com.hoppingmall.mall.cartItem.domain.repository.CartItemRepository
 import com.hoppingmall.mall.cartItem.dto.response.CartItemResponse
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -11,9 +13,8 @@ class CartItemQueryServiceImpl(
     private val cartItemRepository: CartItemRepository
 ) : CartItemQueryService {
 
-    override fun getCartItems(buyerId: Long): List<CartItemResponse> {
-        val cartItems = cartItemRepository.findByBuyerId(buyerId)
-
-        return cartItems.map { CartItemResponse.from(it) }
+    override fun getCartItems(buyerId: Long, pageable: Pageable): Slice<CartItemResponse> {
+        return cartItemRepository.findByBuyerId(buyerId, pageable)
+            .map { CartItemResponse.from(it) }
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/coupon/controller/CouponController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/coupon/controller/CouponController.kt
@@ -9,6 +9,9 @@ import com.hoppingmall.mall.coupon.service.CouponQueryService
 import com.hoppingmall.mall.global.auth.UserPrincipal
 import com.hoppingmall.mall.global.common.response.ApiResponse
 import jakarta.validation.Valid
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -63,9 +66,10 @@ class CouponController(
 
     @GetMapping("/coupons/my")
     fun getMyCoupons(
-        @AuthenticationPrincipal userPrincipal: UserPrincipal
-    ): ResponseEntity<ApiResponse<List<UserCouponResponse>>> {
-        val response = couponQueryService.getMyCoupons(userPrincipal.getUserId())
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PageableDefault(size = 20) pageable: Pageable
+    ): ResponseEntity<ApiResponse<Slice<UserCouponResponse>>> {
+        val response = couponQueryService.getMyCoupons(userPrincipal.getUserId(), pageable)
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/coupon/domain/repository/UserCouponRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/coupon/domain/repository/UserCouponRepository.kt
@@ -2,6 +2,8 @@ package com.hoppingmall.mall.coupon.domain.repository
 
 import com.hoppingmall.mall.coupon.domain.UserCoupon
 import com.hoppingmall.mall.coupon.enum.UserCouponStatus
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
@@ -14,7 +16,7 @@ interface UserCouponRepository : JpaRepository<UserCoupon, Long> {
 
     fun findByUserIdAndStatus(userId: Long, status: UserCouponStatus): List<UserCoupon>
 
-    fun findByUserId(userId: Long): List<UserCoupon>
+    fun findByUserId(userId: Long, pageable: Pageable): Slice<UserCoupon>
 
     fun findByOrderId(orderId: Long): UserCoupon?
 }

--- a/src/main/kotlin/com/hoppingmall/mall/coupon/service/CouponQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/coupon/service/CouponQueryService.kt
@@ -2,9 +2,11 @@ package com.hoppingmall.mall.coupon.service
 
 import com.hoppingmall.mall.coupon.dto.response.CouponResponse
 import com.hoppingmall.mall.coupon.dto.response.UserCouponResponse
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 
 interface CouponQueryService {
     fun getAvailableCoupons(): List<CouponResponse>
     fun getAllCoupons(): List<CouponResponse>
-    fun getMyCoupons(userId: Long): List<UserCouponResponse>
+    fun getMyCoupons(userId: Long, pageable: Pageable): Slice<UserCouponResponse>
 }

--- a/src/main/kotlin/com/hoppingmall/mall/coupon/service/CouponQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/coupon/service/CouponQueryServiceImpl.kt
@@ -6,6 +6,9 @@ import com.hoppingmall.mall.coupon.dto.response.CouponResponse
 import com.hoppingmall.mall.coupon.dto.response.UserCouponResponse
 import com.hoppingmall.mall.coupon.exception.CouponNotFoundException
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -28,15 +31,17 @@ class CouponQueryServiceImpl(
             .map { CouponResponse.from(it) }
     }
 
-    override fun getMyCoupons(userId: Long): List<UserCouponResponse> {
-        val userCoupons = userCouponRepository.findByUserId(userId)
-        val couponIds = userCoupons.map { it.couponId }
+    override fun getMyCoupons(userId: Long, pageable: Pageable): Slice<UserCouponResponse> {
+        val userCouponSlice = userCouponRepository.findByUserId(userId, pageable)
+        val couponIds = userCouponSlice.content.map { it.couponId }
         val couponMap = couponRepository.findAllById(couponIds).associateBy { it.id }
 
-        return userCoupons.map { userCoupon ->
+        val responses = userCouponSlice.content.map { userCoupon ->
             val coupon = couponMap[userCoupon.couponId]
                 ?: throw CouponNotFoundException()
             UserCouponResponse.from(userCoupon, coupon)
         }
+
+        return SliceImpl(responses, pageable, userCouponSlice.hasNext())
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/cartItem/controller/CartItemControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/cartItem/controller/CartItemControllerTest.kt
@@ -12,6 +12,9 @@ import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.mockito.kotlin.*
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
 import org.springframework.http.ResponseEntity
 
 @DisplayName("CartItemController")
@@ -61,6 +64,7 @@ class CartItemControllerTest {
         fun 장바구니_아이템_목록_조회_성공() {
             // Data
             val userPrincipal = UserPrincipal(1L, "test@example.com", "ROLE_USER")
+            val pageable = PageRequest.of(0, 20)
             val expectedResponses = listOf(
                 CartItemResponse(
                     id = 1L,
@@ -81,18 +85,20 @@ class CartItemControllerTest {
                     totalPrice = BigDecimal("20000")
                 )
             )
+            val slice = SliceImpl(expectedResponses, pageable, false)
 
             // Context
-            whenever(cartItemQueryService.getCartItems(userPrincipal.getUserId())).thenReturn(expectedResponses)
+            whenever(cartItemQueryService.getCartItems(userPrincipal.getUserId(), pageable)).thenReturn(slice)
 
             // Interaction
-            val response: ResponseEntity<ApiResponse<List<CartItemResponse>>> = controller.getCartItems(userPrincipal)
+            val response: ResponseEntity<ApiResponse<Slice<CartItemResponse>>> = controller.getCartItems(userPrincipal, pageable)
 
             // Assertions
             assertEquals("SUCCESS", response.body?.code)
             assertEquals("성공", response.body?.message)
-            assertEquals(expectedResponses, response.body?.data)
-            verify(cartItemQueryService).getCartItems(userPrincipal.getUserId())
+            assertEquals(2, response.body?.data?.content?.size)
+            assertEquals(false, response.body?.data?.hasNext())
+            verify(cartItemQueryService).getCartItems(userPrincipal.getUserId(), pageable)
         }
     }
 
@@ -151,4 +157,4 @@ class CartItemControllerTest {
             verify(cartItemCommandService).removeCartItem(userPrincipal.getUserId(), cartItemId)
         }
     }
-} 
+}

--- a/src/test/kotlin/com/hoppingmall/mall/cartItem/service/CartItemQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/cartItem/service/CartItemQueryServiceImplTest.kt
@@ -3,6 +3,8 @@ package com.hoppingmall.mall.cartItem.service
 import com.hoppingmall.mall.cartItem.domain.CartItem
 import com.hoppingmall.mall.cartItem.domain.repository.CartItemRepository
 import com.hoppingmall.mall.cartItem.dto.response.CartItemResponse
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -14,6 +16,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.*
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
 
 @DisplayName("CartItemQueryServiceImpl")
 @DisplayNameGeneration(ReplaceUnderscores::class)
@@ -35,20 +39,45 @@ class CartItemQueryServiceImplTest {
     inner class GetCartItems {
 
         @Test
+        fun 장바구니_아이템_조회_성공() {
+            // Data
+            val buyerId = 1L
+            val pageable = PageRequest.of(0, 20)
+            val cartItem = CartItem.fixture(buyerId = buyerId).withId(1L)
+            val slice = SliceImpl(listOf(cartItem), pageable, false)
+
+            // Context
+            whenever(cartItemRepository.findByBuyerId(buyerId, pageable)).thenReturn(slice)
+
+            // Interaction
+            val result = cartItemQueryService.getCartItems(buyerId, pageable)
+
+            // Assertions
+            assertThat(result.content).hasSize(1)
+            assertThat(result.content[0].productId).isEqualTo(cartItem.productId)
+            assertThat(result.hasNext()).isFalse()
+
+            verify(cartItemRepository).findByBuyerId(buyerId, pageable)
+        }
+
+        @Test
         fun 빈_장바구니_조회_성공() {
             // Data
             val buyerId = 1L
+            val pageable = PageRequest.of(0, 20)
 
             // Context
-            whenever(cartItemRepository.findByBuyerId(buyerId)).thenReturn(emptyList())
+            whenever(cartItemRepository.findByBuyerId(buyerId, pageable))
+                .thenReturn(SliceImpl(emptyList(), pageable, false))
 
             // Interaction
-            val result = cartItemQueryService.getCartItems(buyerId)
+            val result = cartItemQueryService.getCartItems(buyerId, pageable)
 
             // Assertions
-            assertThat(result).isEmpty()
+            assertThat(result.content).isEmpty()
+            assertThat(result.hasNext()).isFalse()
 
-            verify(cartItemRepository).findByBuyerId(buyerId)
+            verify(cartItemRepository).findByBuyerId(buyerId, pageable)
         }
     }
-} 
+}

--- a/src/test/kotlin/com/hoppingmall/mall/coupon/controller/CouponControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/coupon/controller/CouponControllerTest.kt
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.mockito.kotlin.*
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
 import org.springframework.http.HttpStatus
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -197,20 +199,23 @@ class CouponControllerTest {
         fun 내_쿠폰_목록_조회_성공() {
             // Data
             val userPrincipal = UserPrincipal(1L, "test@example.com", "BUYER")
-            val expectedResponse = listOf(createUserCouponResponse())
+            val pageable = PageRequest.of(0, 20)
+            val expectedResponses = listOf(createUserCouponResponse())
+            val slice = SliceImpl(expectedResponses, pageable, false)
 
             // Context
-            whenever(couponQueryService.getMyCoupons(userPrincipal.getUserId()))
-                .thenReturn(expectedResponse)
+            whenever(couponQueryService.getMyCoupons(userPrincipal.getUserId(), pageable))
+                .thenReturn(slice)
 
             // Interaction
-            val response = controller.getMyCoupons(userPrincipal)
+            val response = controller.getMyCoupons(userPrincipal, pageable)
 
             // Assertions
             assertEquals(HttpStatus.OK, response.statusCode)
             assertEquals("SUCCESS", response.body?.code)
-            assertEquals(expectedResponse, response.body?.data)
-            verify(couponQueryService).getMyCoupons(userPrincipal.getUserId())
+            assertEquals(1, response.body?.data?.content?.size)
+            assertEquals(false, response.body?.data?.hasNext())
+            verify(couponQueryService).getMyCoupons(userPrincipal.getUserId(), pageable)
         }
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/coupon/service/CouponQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/coupon/service/CouponQueryServiceImplTest.kt
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.*
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
 import java.util.*
 
 @DisplayName("CouponQueryServiceImpl")
@@ -108,48 +110,58 @@ class CouponQueryServiceImplTest {
         fun 내_쿠폰_목록_조회_성공() {
             // Data
             val userId = 1L
+            val pageable = PageRequest.of(0, 20)
             val coupon = Coupon.fixture().withId(1L)
             val userCoupons = listOf(
                 UserCoupon.fixture(userId = userId, couponId = 1L).withId(1L)
             )
+            val slice = SliceImpl(userCoupons, pageable, false)
 
             // Context
-            whenever(userCouponRepository.findByUserId(userId)).thenReturn(userCoupons)
+            whenever(userCouponRepository.findByUserId(userId, pageable)).thenReturn(slice)
             whenever(couponRepository.findAllById(listOf(1L))).thenReturn(listOf(coupon))
 
             // Interaction
-            val result = couponQueryService.getMyCoupons(userId)
+            val result = couponQueryService.getMyCoupons(userId, pageable)
 
             // Assertions
-            assertThat(result).hasSize(1)
-            assertThat(result[0].couponName).isEqualTo(coupon.name)
-            verify(userCouponRepository).findByUserId(userId)
+            assertThat(result.content).hasSize(1)
+            assertThat(result.content[0].couponName).isEqualTo(coupon.name)
+            assertThat(result.hasNext()).isFalse()
+            verify(userCouponRepository).findByUserId(userId, pageable)
             verify(couponRepository).findAllById(listOf(1L))
         }
 
         @Test
-        fun 쿠폰이_없으면_빈_목록_반환() {
+        fun 쿠폰이_없으면_빈_슬라이스_반환() {
+            // Data
+            val pageable = PageRequest.of(0, 20)
+
             // Context
-            whenever(userCouponRepository.findByUserId(1L)).thenReturn(emptyList())
+            whenever(userCouponRepository.findByUserId(1L, pageable))
+                .thenReturn(SliceImpl(emptyList(), pageable, false))
 
             // Interaction
-            val result = couponQueryService.getMyCoupons(1L)
+            val result = couponQueryService.getMyCoupons(1L, pageable)
 
             // Assertions
-            assertThat(result).isEmpty()
+            assertThat(result.content).isEmpty()
+            assertThat(result.hasNext()).isFalse()
         }
 
         @Test
         fun 쿠폰_원본이_삭제된_경우_예외_발생() {
             // Data
+            val pageable = PageRequest.of(0, 20)
             val userCoupons = listOf(UserCoupon.fixture(couponId = 999L).withId(1L))
+            val slice = SliceImpl(userCoupons, pageable, false)
 
             // Context
-            whenever(userCouponRepository.findByUserId(1L)).thenReturn(userCoupons)
+            whenever(userCouponRepository.findByUserId(1L, pageable)).thenReturn(slice)
             whenever(couponRepository.findAllById(listOf(999L))).thenReturn(emptyList())
 
             // Interaction & Assertions
-            assertThatThrownBy { couponQueryService.getMyCoupons(1L) }
+            assertThatThrownBy { couponQueryService.getMyCoupons(1L, pageable) }
                 .isInstanceOf(CouponNotFoundException::class.java)
         }
     }


### PR DESCRIPTION
Closes #100

### 📌 작업 개요
장바구니 조회(`GET /api/v1/cart-items`)와 내 쿠폰 조회(`GET /api/v1/coupons/my`) 엔드포인트에
Slice 기반 페이지네이션을 적용하여, 데이터가 많아졌을 때 전체 목록을 한 번에 로딩하는 문제를 해결합니다.

---

### ✅ 주요 변경 사항

- `cartItem.domain.repository`
  - `CartItemRepository`: `findByBuyerId` 반환 타입 `List` → `Slice`, `Pageable` 파라미터 추가

- `cartItem.service`
  - `CartItemQueryService`, `CartItemQueryServiceImpl`: `getCartItems` 시그니처 `Pageable` 추가, 반환 `Slice<CartItemResponse>`

- `cartItem.controller`
  - `CartItemController`: `getCartItems`에 `@PageableDefault(size = 20)` 적용

- `coupon.domain.repository`
  - `UserCouponRepository`: `findByUserId` 반환 타입 `List` → `Slice`, `Pageable` 파라미터 추가

- `coupon.service`
  - `CouponQueryService`, `CouponQueryServiceImpl`: `getMyCoupons` 시그니처 `Pageable` 추가, 반환 `Slice<UserCouponResponse>`

- `coupon.controller`
  - `CouponController`: `getMyCoupons`에 `@PageableDefault(size = 20)` 적용

---

### 🧪 테스트

- `CartItemQueryServiceImplTest`: Slice 기반 아이템 조회 + 빈 장바구니 테스트
- `CartItemControllerTest`: Slice 반환 검증
- `CouponQueryServiceImplTest`: Slice 기반 내 쿠폰 조회, 빈 슬라이스, 삭제된 쿠폰 예외 테스트
- `CouponControllerTest`: Slice 반환 검증
- `./gradlew jacocoTestCoverageVerification` 통과

---

### 📎 관련 이슈
- #100