### PR TITLE
feat: Redis 기반 Access Token 블랙리스트 구현

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/auth/domain/repository/AccessTokenBlacklistRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/auth/domain/repository/AccessTokenBlacklistRepository.kt
@@ -1,0 +1,24 @@
+package com.hoppingmall.mall.global.auth.domain.repository
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Repository
+import java.util.concurrent.TimeUnit
+
+@Repository
+class AccessTokenBlacklistRepository(
+    private val customStringRedisTemplate: RedisTemplate<String, String>
+) {
+    private val prefix = "blacklist:"
+
+    fun add(token: String, remainingTtlMs: Long) {
+        if (remainingTtlMs <= 0) return
+        customStringRedisTemplate.opsForValue()
+            .set(getKey(token), "blacklisted", remainingTtlMs, TimeUnit.MILLISECONDS)
+    }
+
+    fun exists(token: String): Boolean {
+        return customStringRedisTemplate.hasKey(getKey(token))
+    }
+
+    private fun getKey(token: String) = "$prefix$token"
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/auth/service/AuthServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/auth/service/AuthServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.mall.global.auth.service
 
+import com.hoppingmall.mall.global.auth.domain.repository.AccessTokenBlacklistRepository
 import com.hoppingmall.mall.global.auth.dto.response.TokenRefreshResponse
 import com.hoppingmall.mall.global.jwt.JwtProperties
 import com.hoppingmall.mall.global.jwt.TokenProvider
@@ -18,7 +19,8 @@ class AuthServiceImpl(
     private val tokenProvider: TokenProvider,
     private val refreshTokenService: RefreshTokenService,
     private val jwtProperties: JwtProperties,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val accessTokenBlacklistRepository: AccessTokenBlacklistRepository
 ) : AuthService {
 
     override fun login(request: SignInRequest): SignInResponse {
@@ -61,6 +63,8 @@ class AuthServiceImpl(
 
     override fun logout(accessToken: String) {
         val userId = tokenProvider.parseAccessToken(accessToken)
+        val remainingMs = tokenProvider.getRemainingExpirationMs(accessToken)
+        accessTokenBlacklistRepository.add(accessToken, remainingMs)
         refreshTokenService.delete(userId)
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/global/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/jwt/JwtAuthenticationFilter.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.mall.global.jwt
 
+import com.hoppingmall.mall.global.auth.domain.repository.AccessTokenBlacklistRepository
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -11,7 +12,8 @@ import org.springframework.web.filter.OncePerRequestFilter
 
 @Component
 class JwtAuthenticationFilter(
-    private val tokenProvider: TokenProvider
+    private val tokenProvider: TokenProvider,
+    private val accessTokenBlacklistRepository: AccessTokenBlacklistRepository
 ) : OncePerRequestFilter() {
 
     override fun doFilterInternal(
@@ -21,7 +23,7 @@ class JwtAuthenticationFilter(
     ) {
         val token = resolveToken(request)
 
-        if (token != null && tokenProvider.validateToken(token)) {
+        if (token != null && tokenProvider.validateToken(token) && !accessTokenBlacklistRepository.exists(token)) {
             val userPrincipal = tokenProvider.getUserPrincipal(token)
 
             val authentication = UsernamePasswordAuthenticationToken(

--- a/src/main/kotlin/com/hoppingmall/mall/global/jwt/TokenProvider.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/jwt/TokenProvider.kt
@@ -16,4 +16,6 @@ interface TokenProvider {
     fun getUserIdFromToken(token: String): Long
     fun getUserRoleFromToken(token: String): Role
     fun getUserPrincipal(token: String): UserPrincipal
+
+    fun getRemainingExpirationMs(token: String): Long
 }

--- a/src/main/kotlin/com/hoppingmall/mall/global/jwt/TokenProviderImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/jwt/TokenProviderImpl.kt
@@ -70,6 +70,11 @@ class TokenProviderImpl(
         return UserPrincipal.of(userId, role.name)
     }
 
+    override fun getRemainingExpirationMs(token: String): Long {
+        val expiration = parseClaims(token).expiration
+        return expiration.time - System.currentTimeMillis()
+    }
+
     fun parseClaims(token: String): Claims {
         return try {
             Jwts.parserBuilder()

--- a/src/test/kotlin/com/hoppingmall/mall/global/auth/domain/repository/AccessTokenBlacklistRepositoryTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/auth/domain/repository/AccessTokenBlacklistRepositoryTest.kt
@@ -1,0 +1,66 @@
+package com.hoppingmall.mall.global.auth.domain.repository
+
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.mockito.kotlin.*
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.util.concurrent.TimeUnit
+
+@DisplayName("AccessTokenBlacklistRepository")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class AccessTokenBlacklistRepositoryTest {
+
+    private val redisTemplate: RedisTemplate<String, String> = mock()
+    private val valueOps: ValueOperations<String, String> = mock()
+    private lateinit var repository: AccessTokenBlacklistRepository
+
+    @BeforeEach
+    fun setUp() {
+        whenever(redisTemplate.opsForValue()).thenReturn(valueOps)
+        repository = AccessTokenBlacklistRepository(redisTemplate)
+    }
+
+    @Nested
+    @DisplayName("add")
+    inner class Add {
+        @Test
+        fun 토큰을_블랙리스트에_등록하면_Redis에_TTL과_함께_저장된다() {
+            val token = "expired.jwt.token"
+
+            repository.add(token, 1800000L)
+
+            verify(valueOps).set("blacklist:$token", "blacklisted", 1800000L, TimeUnit.MILLISECONDS)
+        }
+
+        @Test
+        fun 남은_TTL이_0_이하이면_저장하지_않는다() {
+            repository.add("token", 0L)
+            repository.add("token", -100L)
+
+            verifyNoInteractions(valueOps)
+        }
+    }
+
+    @Nested
+    @DisplayName("exists")
+    inner class Exists {
+        @Test
+        fun 블랙리스트에_등록된_토큰이면_true를_반환한다() {
+            val token = "blacklisted.jwt.token"
+            whenever(redisTemplate.hasKey("blacklist:$token")).thenReturn(true)
+
+            assertTrue(repository.exists(token))
+        }
+
+        @Test
+        fun 블랙리스트에_없는_토큰이면_false를_반환한다() {
+            val token = "valid.jwt.token"
+            whenever(redisTemplate.hasKey("blacklist:$token")).thenReturn(false)
+
+            assertFalse(repository.exists(token))
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/global/auth/service/AuthServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/auth/service/AuthServiceImplTest.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.mall.global.auth.service
 
+import com.hoppingmall.mall.global.auth.domain.repository.AccessTokenBlacklistRepository
 import com.hoppingmall.mall.global.auth.dto.response.TokenRefreshResponse
 import com.hoppingmall.mall.global.enums.Role
 import com.hoppingmall.mall.global.jwt.JwtProperties
@@ -30,6 +31,7 @@ class AuthServiceImplTest {
         refreshExpirationMs = 86400000L
     }
     private val userRepository: UserRepository = mock()
+    private val accessTokenBlacklistRepository: AccessTokenBlacklistRepository = mock()
     private lateinit var authService: AuthServiceImpl
 
     @BeforeEach
@@ -39,7 +41,8 @@ class AuthServiceImplTest {
             tokenProvider,
             refreshTokenService,
             jwtProperties,
-            userRepository
+            userRepository,
+            accessTokenBlacklistRepository
         )
     }
 
@@ -98,12 +101,14 @@ class AuthServiceImplTest {
     @DisplayName("로그아웃")
     inner class Logout {
         @Test
-        fun accessToken으로_userId를_파싱하고_refreshToken을_삭제한다() {
+        fun accessToken으로_userId를_파싱하고_블랙리스트_등록_후_refreshToken을_삭제한다() {
             val accessToken = "valid-access-token"
             whenever(tokenProvider.parseAccessToken(accessToken)).thenReturn(7L)
+            whenever(tokenProvider.getRemainingExpirationMs(accessToken)).thenReturn(1800000L)
 
             authService.logout(accessToken)
 
+            verify(accessTokenBlacklistRepository).add(accessToken, 1800000L)
             verify(refreshTokenService).delete(7L)
         }
     }

--- a/src/test/kotlin/com/hoppingmall/mall/global/jwt/JwtAuthenticationFilterTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/jwt/JwtAuthenticationFilterTest.kt
@@ -1,7 +1,12 @@
 package com.hoppingmall.mall.global.jwt
 
 import com.hoppingmall.mall.global.auth.UserPrincipal
+import com.hoppingmall.mall.global.auth.domain.repository.AccessTokenBlacklistRepository
 import jakarta.servlet.FilterChain
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
@@ -9,33 +14,60 @@ import org.mockito.kotlin.whenever
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.core.context.SecurityContextHolder
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@DisplayName("JwtAuthenticationFilter")
+@DisplayNameGeneration(ReplaceUnderscores::class)
 class JwtAuthenticationFilterTest {
 
     private val tokenProvider: TokenProvider = mock()
-    private val filter = JwtAuthenticationFilter(tokenProvider)
+    private val accessTokenBlacklistRepository: AccessTokenBlacklistRepository = mock()
+    private val filter = JwtAuthenticationFilter(tokenProvider, accessTokenBlacklistRepository)
 
-    @Test
-    fun `유효한 토큰이 있을 경우 SecurityContext에 인증 정보가 저장된다`() {
-        // given
-        val token = "valid.jwt.token"
-        val request = MockHttpServletRequest().apply {
-            addHeader("Authorization", "Bearer $token")
+    @Nested
+    @DisplayName("doFilterInternal")
+    inner class DoFilterInternal {
+
+        @Test
+        fun 유효한_토큰이_있을_경우_SecurityContext에_인증_정보가_저장된다() {
+            val token = "valid.jwt.token"
+            val request = MockHttpServletRequest().apply {
+                addHeader("Authorization", "Bearer $token")
+            }
+            val response = MockHttpServletResponse()
+            val filterChain: FilterChain = mock()
+            val userPrincipal: UserPrincipal = mock()
+
+            whenever(tokenProvider.validateToken(token)).thenReturn(true)
+            whenever(accessTokenBlacklistRepository.exists(token)).thenReturn(false)
+            whenever(tokenProvider.getUserPrincipal(token)).thenReturn(userPrincipal)
+
+            filter.doFilter(request, response, filterChain)
+
+            val authentication = SecurityContextHolder.getContext().authentication
+            assertTrue(authentication?.principal === userPrincipal)
+            verify(filterChain).doFilter(request, response)
         }
-        val response = MockHttpServletResponse()
-        val filterChain: FilterChain = mock()
-        val userPrincipal: UserPrincipal = mock()
 
-        whenever(tokenProvider.validateToken(token)).thenReturn(true)
-        whenever(tokenProvider.getUserPrincipal(token)).thenReturn(userPrincipal)
+        @Test
+        fun 블랙리스트에_등록된_토큰이면_인증_정보가_저장되지_않는다() {
+            val token = "blacklisted.jwt.token"
+            val request = MockHttpServletRequest().apply {
+                addHeader("Authorization", "Bearer $token")
+            }
+            val response = MockHttpServletResponse()
+            val filterChain: FilterChain = mock()
 
-        // when
-        filter.doFilter(request, response, filterChain)
+            SecurityContextHolder.clearContext()
+            whenever(tokenProvider.validateToken(token)).thenReturn(true)
+            whenever(accessTokenBlacklistRepository.exists(token)).thenReturn(true)
 
-        // then
-        val authentication = SecurityContextHolder.getContext().authentication
-        assertTrue(authentication?.principal === userPrincipal)
-        verify(filterChain).doFilter(request, response)
+            filter.doFilter(request, response, filterChain)
+
+            val authentication = SecurityContextHolder.getContext().authentication
+            assertNull(authentication)
+            verify(filterChain).doFilter(request, response)
+        }
     }
 }


### PR DESCRIPTION
Closes #102

### 📌 작업 개요
로그아웃 시 access token이 만료까지 유효한 보안 취약점을 해결합니다.
Redis에 블랙리스트를 저장하고, JwtAuthenticationFilter에서 매 요청마다 체크하여 즉시 무효화합니다.

---

### ✅ 주요 변경 사항

- `global.auth.domain.repository`
  - `AccessTokenBlacklistRepository`: Redis에 `blacklist:{token}` 키로 저장, TTL = access token 남은 만료 시간

- `global.jwt`
  - `TokenProvider`: `getRemainingExpirationMs()` 메서드 추가
  - `TokenProviderImpl`: JWT claims에서 남은 만료 시간 계산 구현
  - `JwtAuthenticationFilter`: 토큰 유효성 검증 후 블랙리스트 체크 추가

- `global.auth.service`
  - `AuthServiceImpl.logout()`: access token 블랙리스트 등록 → refresh token 삭제

---

### 🧪 테스트

- `AccessTokenBlacklistRepositoryTest`: Redis 저장/조회, TTL 0 이하 미저장 테스트
- `AuthServiceImplTest`: 로그아웃 시 블랙리스트 등록 검증
- `JwtAuthenticationFilterTest`: 블랙리스트 토큰 인증 거부 테스트
- `./gradlew jacocoTestCoverageVerification` 통과

---

### 📎 관련 이슈
- #102