### PR TITLE
feat: Bucket4j + Redis 기반 분산 Rate Limiting 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,23 +22,14 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: JDK 21 설정
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
+          cache: 'gradle'
 
-      - name: Gradle 캐시
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Gradle 빌드 및 테스트
-        run: ./gradlew build jacocoTestReport jacocoTestCoverageVerification --no-daemon --build-cache --quiet
+      - name: 테스트 및 커버리지 검증
+        run: ./gradlew test jacocoTestReport jacocoTestCoverageVerification --no-daemon --build-cache --quiet
 
       - name: 커버리지 업로드
         uses: codecov/codecov-action@v5

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,10 @@ dependencies {
 	implementation("org.redisson:redisson-spring-boot-starter:4.3.0")
 	implementation("org.springframework.boot:spring-boot-starter-cache")
 	implementation("com.github.ben-manes.caffeine:caffeine")
+
+	// Rate Limiting
+	implementation("com.bucket4j:bucket4j-core:8.10.1")
+	implementation("com.bucket4j:bucket4j-redis:8.10.1")
 }
 
 kotlin {

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/ratelimit/RateLimitConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/ratelimit/RateLimitConfig.kt
@@ -1,0 +1,36 @@
+package com.hoppingmall.mall.global.common.config.ratelimit
+
+import io.github.bucket4j.distributed.proxy.ProxyManager
+import io.github.bucket4j.redis.redisson.cas.RedissonBasedProxyManager
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+@Profile("!test")
+class RateLimitConfig(
+    private val redissonClient: RedissonClient
+) : WebMvcConfigurer {
+
+    @Bean
+    fun rateLimitProxyManager(): ProxyManager<String> {
+        val commandExecutor = (redissonClient as Redisson).commandExecutor
+        return RedissonBasedProxyManager.builderFor(commandExecutor)
+            .build()
+    }
+
+    @Bean
+    fun rateLimitInterceptor(): RateLimitInterceptor {
+        return RateLimitInterceptor(rateLimitProxyManager())
+    }
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        val paths = RateLimitPolicy.POLICIES.map { it.pathPattern }.distinct().toTypedArray()
+        registry.addInterceptor(rateLimitInterceptor())
+            .addPathPatterns(*paths)
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/ratelimit/RateLimitInterceptor.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/ratelimit/RateLimitInterceptor.kt
@@ -1,0 +1,75 @@
+package com.hoppingmall.mall.global.common.config.ratelimit
+
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.BucketConfiguration
+import io.github.bucket4j.distributed.proxy.ProxyManager
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.util.AntPathMatcher
+import org.springframework.web.servlet.HandlerInterceptor
+
+class RateLimitInterceptor(
+    private val proxyManager: ProxyManager<String>
+) : HandlerInterceptor {
+
+    private val pathMatcher = AntPathMatcher()
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        val policy = findMatchingPolicy(request) ?: return true
+
+        val key = resolveKey(policy, request) ?: return true
+        val bucketKey = "${policy.pathPattern}:${policy.httpMethod}:$key"
+
+        val bucket = proxyManager.builder()
+            .build(bucketKey) { buildConfiguration(policy) }
+
+        val probe = bucket.tryConsumeAndReturnRemaining(1)
+        if (!probe.isConsumed) {
+            response.status = HttpStatus.TOO_MANY_REQUESTS.value()
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            response.characterEncoding = "UTF-8"
+            val retryAfterSeconds = probe.nanosToWaitForRefill / 1_000_000_000 + 1
+            response.setHeader("Retry-After", retryAfterSeconds.toString())
+            response.writer.write("""{"code":"FAILURE","message":"요청이 너무 많습니다. ${retryAfterSeconds}초 후 다시 시도해주세요.","data":null}""")
+            return false
+        }
+
+        return true
+    }
+
+    private fun findMatchingPolicy(request: HttpServletRequest): RateLimitPolicy? {
+        val requestPath = request.requestURI
+        val requestMethod = request.method
+        return RateLimitPolicy.POLICIES.find { policy ->
+            policy.httpMethod.equals(requestMethod, ignoreCase = true)
+                    && pathMatcher.match(policy.pathPattern, requestPath)
+        }
+    }
+
+    private fun resolveKey(policy: RateLimitPolicy, request: HttpServletRequest): String? {
+        return when (policy.keyType) {
+            RateLimitKeyType.IP -> request.getHeader("X-Forwarded-For")?.split(",")?.first()?.trim()
+                ?: request.remoteAddr
+            RateLimitKeyType.USER_ID -> {
+                val auth = SecurityContextHolder.getContext().authentication ?: return null
+                val principal = auth.principal as? UserPrincipal ?: return null
+                principal.getUserId().toString()
+            }
+        }
+    }
+
+    private fun buildConfiguration(policy: RateLimitPolicy): BucketConfiguration {
+        return BucketConfiguration.builder()
+            .addLimit(
+                Bandwidth.builder()
+                    .capacity(policy.capacity)
+                    .refillGreedy(policy.refillTokens, policy.refillDuration)
+                    .build()
+            )
+            .build()
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/ratelimit/RateLimitPolicy.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/ratelimit/RateLimitPolicy.kt
@@ -1,0 +1,28 @@
+package com.hoppingmall.mall.global.common.config.ratelimit
+
+import java.time.Duration
+
+enum class RateLimitKeyType { IP, USER_ID }
+
+data class RateLimitPolicy(
+    val pathPattern: String,
+    val httpMethod: String,
+    val keyType: RateLimitKeyType,
+    val capacity: Long,
+    val refillTokens: Long,
+    val refillDuration: Duration
+) {
+    companion object {
+        val POLICIES = listOf(
+            RateLimitPolicy("/api/v1/users/login", "POST", RateLimitKeyType.IP, 5, 5, Duration.ofMinutes(1)),
+            RateLimitPolicy("/api/v1/users/signup", "POST", RateLimitKeyType.IP, 3, 3, Duration.ofMinutes(1)),
+            RateLimitPolicy("/api/v1/auth/refresh", "POST", RateLimitKeyType.IP, 5, 5, Duration.ofMinutes(1)),
+            RateLimitPolicy("/api/v1/coupons/*/issue", "POST", RateLimitKeyType.USER_ID, 5, 5, Duration.ofMinutes(1)),
+            RateLimitPolicy("/api/v1/products/search", "GET", RateLimitKeyType.IP, 20, 20, Duration.ofMinutes(1)),
+            RateLimitPolicy("/api/v1/products/images/upload", "POST", RateLimitKeyType.USER_ID, 20, 20, Duration.ofMinutes(1)),
+            RateLimitPolicy("/api/v1/orders", "POST", RateLimitKeyType.USER_ID, 5, 5, Duration.ofMinutes(1)),
+            RateLimitPolicy("/api/v1/refunds", "POST", RateLimitKeyType.USER_ID, 5, 5, Duration.ofMinutes(1)),
+            RateLimitPolicy("/api/v1/reviews", "POST", RateLimitKeyType.USER_ID, 5, 5, Duration.ofMinutes(1))
+        )
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/config/ratelimit/RateLimitInterceptorTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/config/ratelimit/RateLimitInterceptorTest.kt
@@ -1,0 +1,142 @@
+package com.hoppingmall.mall.global.common.config.ratelimit
+
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.BucketConfiguration
+import io.github.bucket4j.distributed.BucketProxy
+import io.github.bucket4j.distributed.proxy.ProxyManager
+import io.github.bucket4j.distributed.proxy.RemoteBucketBuilder
+import jakarta.servlet.http.HttpServletResponse
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.mockito.kotlin.*
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import java.time.Duration
+import java.util.function.Supplier
+
+@DisplayName("RateLimitInterceptor")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class RateLimitInterceptorTest {
+
+    private val proxyManager: ProxyManager<String> = mock()
+    private val interceptor = RateLimitInterceptor(proxyManager)
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    private fun mockBucketWithCapacity(capacity: Long, consumeFirst: Int = 0): Pair<RemoteBucketBuilder<String>, BucketProxy> {
+        val localBucket = io.github.bucket4j.Bucket.builder()
+            .addLimit(Bandwidth.builder().capacity(capacity).refillGreedy(capacity, Duration.ofMinutes(1)).build())
+            .build()
+        repeat(consumeFirst) { localBucket.tryConsume(1) }
+        val probe = localBucket.tryConsumeAndReturnRemaining(1)
+
+        val bucketProxy: BucketProxy = mock()
+        val builder: RemoteBucketBuilder<String> = mock()
+        whenever(proxyManager.builder()).thenReturn(builder)
+        whenever(builder.build(any<String>(), any<Supplier<BucketConfiguration>>())).thenReturn(bucketProxy)
+        whenever(bucketProxy.tryConsumeAndReturnRemaining(1)).thenReturn(probe)
+
+        return builder to bucketProxy
+    }
+
+    @Nested
+    @DisplayName("preHandle")
+    inner class PreHandle {
+
+        @Test
+        fun 정책에_해당하지_않는_경로는_통과한다() {
+            val request = MockHttpServletRequest("GET", "/api/v1/products")
+            val response = MockHttpServletResponse()
+
+            val result = interceptor.preHandle(request, response, Any())
+
+            assertTrue(result)
+            verifyNoInteractions(proxyManager)
+        }
+
+        @Test
+        fun IP_기반_정책에서_요청이_허용되면_통과한다() {
+            val request = MockHttpServletRequest("POST", "/api/v1/users/login")
+            request.remoteAddr = "192.168.1.1"
+            val response = MockHttpServletResponse()
+            mockBucketWithCapacity(5)
+
+            val result = interceptor.preHandle(request, response, Any())
+
+            assertTrue(result)
+        }
+
+        @Test
+        fun 요청_횟수_초과_시_429_응답을_반환한다() {
+            val request = MockHttpServletRequest("POST", "/api/v1/users/login")
+            request.remoteAddr = "192.168.1.1"
+            val response = MockHttpServletResponse()
+            mockBucketWithCapacity(1, consumeFirst = 1)
+
+            val result = interceptor.preHandle(request, response, Any())
+
+            assertFalse(result)
+            assertEquals(429, response.status)
+            assertTrue(response.contentAsString.contains("요청이 너무 많습니다"))
+        }
+
+        @Test
+        fun USER_ID_기반_정책에서_인증_정보가_없으면_통과한다() {
+            val request = MockHttpServletRequest("POST", "/api/v1/orders")
+            val response = MockHttpServletResponse()
+            SecurityContextHolder.clearContext()
+
+            val result = interceptor.preHandle(request, response, Any())
+
+            assertTrue(result)
+            verifyNoInteractions(proxyManager)
+        }
+
+        @Test
+        fun X_Forwarded_For_헤더가_있으면_첫번째_IP를_사용한다() {
+            val request = MockHttpServletRequest("POST", "/api/v1/users/login")
+            request.addHeader("X-Forwarded-For", "10.0.0.1, 192.168.1.1")
+            val response = MockHttpServletResponse()
+            val (builder, _) = mockBucketWithCapacity(5)
+
+            interceptor.preHandle(request, response, Any())
+
+            verify(builder).build(eq("/api/v1/users/login:POST:10.0.0.1"), any<Supplier<BucketConfiguration>>())
+        }
+
+        @Test
+        fun USER_ID_기반_정책에서_인증된_사용자는_userId로_제한한다() {
+            val request = MockHttpServletRequest("POST", "/api/v1/orders")
+            val response = MockHttpServletResponse()
+            val userPrincipal = UserPrincipal(42L, "test@test.com", "ROLE_BUYER")
+            SecurityContextHolder.getContext().authentication =
+                UsernamePasswordAuthenticationToken(userPrincipal, null, userPrincipal.authorities)
+            val (builder, _) = mockBucketWithCapacity(5)
+
+            interceptor.preHandle(request, response, Any())
+
+            verify(builder).build(eq("/api/v1/orders:POST:42"), any<Supplier<BucketConfiguration>>())
+        }
+
+        @Test
+        fun 와일드카드_경로_패턴이_매칭된다() {
+            val request = MockHttpServletRequest("POST", "/api/v1/coupons/123/issue")
+            val response = MockHttpServletResponse()
+            val userPrincipal = UserPrincipal(1L, "test@test.com", "ROLE_BUYER")
+            SecurityContextHolder.getContext().authentication =
+                UsernamePasswordAuthenticationToken(userPrincipal, null, userPrincipal.authorities)
+            val (builder, _) = mockBucketWithCapacity(5)
+
+            interceptor.preHandle(request, response, Any())
+
+            verify(builder).build(eq("/api/v1/coupons/*/issue:POST:1"), any<Supplier<BucketConfiguration>>())
+        }
+    }
+}


### PR DESCRIPTION
Closes #104

### 📌 작업 개요
Bucket4j Token Bucket 알고리즘 + Redisson ProxyManager로 Redis Cluster 환경에서
엔드포인트별 분산 요율 제한을 구현합니다. IP/userId 기준으로 버킷을 관리하며,
초과 시 429 Too Many Requests를 반환합니다.

---

### ✅ 주요 변경 사항

- `global.common.config.ratelimit`
  - `RateLimitPolicy`: 엔드포인트별 정책 정의 (경로, HTTP 메서드, 키 타입, 버킷 용량, 리필 속도)
  - `RateLimitInterceptor`: HandlerInterceptor, AntPathMatcher로 경로 매칭, X-Forwarded-For IP 추출
  - `RateLimitConfig`: Redisson CommandExecutor 기반 ProxyManager 빈 + WebMvc Interceptor 등록

- `build.gradle.kts`
  - `bucket4j-core:8.10.1`, `bucket4j-redis:8.10.1` 의존성 추가

- 정책 요약:

  | 엔드포인트 | 키 | 용량/리필 |
  |-----------|-----|----------|
  | login | IP | 5/min |
  | signup | IP | 3/min |
  | refresh | IP | 5/min |
  | coupon issue | userId | 5/min |
  | product search | IP | 20/min |
  | image upload | userId | 20/min |
  | order create | userId | 5/min |
  | refund create | userId | 5/min |
  | review create | userId | 5/min |

---

### 🧪 테스트

- `RateLimitInterceptorTest`: 정책 미매칭 통과, IP 기반 허용/거부, userId 기반 제한, X-Forwarded-For 파싱, 와일드카드 패턴 매칭, 미인증 시 통과
- `./gradlew jacocoTestCoverageVerification` 통과

---

### 📎 관련 이슈
- #104