### PR TITLE
feat: Kafka traceId 전파 및 Consumer Lag 모니터링

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,9 @@ dependencies {
 	implementation("com.bucket4j:bucket4j-core:8.10.1")
 	implementation("com.bucket4j:bucket4j-redis:8.10.1")
 
+	// Monitoring
+	implementation("io.micrometer:micrometer-registry-prometheus")
+
 	// JSON 로깅
 	implementation("net.logstash.logback:logstash-logback-encoder:8.0")
 }

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/KafkaConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/KafkaConfig.kt
@@ -4,6 +4,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.apache.kafka.common.serialization.StringSerializer
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -19,10 +20,14 @@ import org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFI
 import org.springframework.messaging.converter.MessageConversionException
 import org.apache.kafka.common.errors.SerializationException
 import org.springframework.kafka.support.serializer.DeserializationException
+import com.hoppingmall.mall.global.common.config.kafka.TracingProducerInterceptor
+import com.hoppingmall.mall.global.common.config.kafka.TracingConsumerInterceptor
 import java.util.UUID
 @Configuration
 @org.springframework.context.annotation.Profile("!test")
 class KafkaConfig {
+
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @Value("\${spring.kafka.bootstrap-servers}")
     private lateinit var bootstrapServers: String
@@ -60,7 +65,8 @@ class KafkaConfig {
         configProps[ProducerConfig.BATCH_SIZE_CONFIG] = 16384
         configProps[ProducerConfig.LINGER_MS_CONFIG] = 10
         configProps[ProducerConfig.COMPRESSION_TYPE_CONFIG] = "lz4"
-        
+        configProps[ProducerConfig.INTERCEPTOR_CLASSES_CONFIG] = listOf(TracingProducerInterceptor::class.java.name)
+
         val producerFactory = DefaultKafkaProducerFactory<String, Any>(configProps)
         producerFactory.setTransactionIdPrefix("hoppingmall-tx-$instanceId-")
         return producerFactory
@@ -121,7 +127,8 @@ class KafkaConfig {
             MessageConversionException::class.java
         )
         factory.setCommonErrorHandler(errorHandler)
-        
+        factory.setRecordInterceptor(TracingConsumerInterceptor())
+
         return factory
     }
 
@@ -145,7 +152,7 @@ class KafkaConfig {
             dlqService.saveDLQMessage(dlqMessage)
         } catch (e: Exception) {
             // DLQ 저장 실패 시에도 메시지 손실 방지를 위해 로깅만 수행
-            println("DLQ 저장 실패: ${e.message}")
+            log.error("DLQ 저장 실패: topic={}, offset={}, error={}", record.topic(), record.offset(), e.message)
         }
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/kafka/TracingConsumerInterceptor.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/kafka/TracingConsumerInterceptor.kt
@@ -1,0 +1,34 @@
+package com.hoppingmall.mall.global.common.config.kafka
+
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.MDC
+import org.springframework.kafka.listener.RecordInterceptor
+import java.util.UUID
+
+class TracingConsumerInterceptor : RecordInterceptor<String, Any> {
+
+    override fun intercept(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>): ConsumerRecord<String, Any> {
+        val traceId = extractTraceId(record)
+        MDC.put(TRACE_ID_KEY, traceId)
+        return record
+    }
+
+    override fun afterRecord(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>) {
+        MDC.remove(TRACE_ID_KEY)
+    }
+
+    private fun extractTraceId(record: ConsumerRecord<String, Any>): String {
+        val header = record.headers().lastHeader(TRACE_ID_HEADER)
+        return if (header != null) {
+            String(header.value(), Charsets.UTF_8)
+        } else {
+            UUID.randomUUID().toString().replace("-", "").take(16)
+        }
+    }
+
+    companion object {
+        const val TRACE_ID_KEY = "traceId"
+        const val TRACE_ID_HEADER = "X-Trace-Id"
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/kafka/TracingProducerInterceptor.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/kafka/TracingProducerInterceptor.kt
@@ -1,0 +1,28 @@
+package com.hoppingmall.mall.global.common.config.kafka
+
+import org.apache.kafka.clients.producer.ProducerInterceptor
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.slf4j.MDC
+
+class TracingProducerInterceptor : ProducerInterceptor<String, Any> {
+
+    override fun onSend(record: ProducerRecord<String, Any>): ProducerRecord<String, Any> {
+        val traceId = MDC.get(TRACE_ID_KEY)
+        if (traceId != null) {
+            record.headers().add(TRACE_ID_HEADER, traceId.toByteArray(Charsets.UTF_8))
+        }
+        return record
+    }
+
+    override fun onAcknowledgement(metadata: RecordMetadata?, exception: Exception?) {}
+
+    override fun close() {}
+
+    override fun configure(configs: MutableMap<String, *>?) {}
+
+    companion object {
+        const val TRACE_ID_KEY = "traceId"
+        const val TRACE_ID_HEADER = "X-Trace-Id"
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationEventConsumer.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationEventConsumer.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.notification.service
 import com.hoppingmall.mall.notification.domain.Notification
 import com.hoppingmall.mall.notification.domain.NotificationRepository
 import com.hoppingmall.mall.notification.dto.event.NotificationEvent
+import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.messaging.handler.annotation.Payload
@@ -14,18 +15,19 @@ import org.springframework.transaction.annotation.Transactional
 class NotificationEventConsumer(
     private val notificationRepository: NotificationRepository
 ) {
-    
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
     @KafkaListener(topics = ["notification"], groupId = "notification-service")
     fun handleNotificationEvent(
         @Payload event: NotificationEvent
     ) {
-        // Key 기반 파티셔닝으로 같은 userId의 알림은 같은 파티션에서 순차 처리
-        println("알림 처리: userId=${event.userId}, type=${event.type}")
+        log.info("알림 처리: userId={}, type={}", event.userId, event.type)
 
         if (notificationRepository.existsByEventId(event.eventId)) {
             return
         }
-        
+
         val notification = Notification(
             eventId = event.eventId,
             userId = event.userId,
@@ -34,13 +36,13 @@ class NotificationEventConsumer(
             content = event.content,
             metadata = event.metadata
         )
-        
+
         try {
             notificationRepository.save(notification)
         } catch (e: DataIntegrityViolationException) {
             return
         }
-        
-        println("알림 저장 완료: 사용자 ${event.userId}, 타입 ${event.type}, 제목 ${event.title}")
+
+        log.info("알림 저장 완료: userId={}, type={}, title={}", event.userId, event.type, event.title)
     }
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/point/service/PointEventConsumer.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/service/PointEventConsumer.kt
@@ -8,6 +8,7 @@ import com.hoppingmall.mall.point.domain.PointHistory
 import com.hoppingmall.mall.point.domain.PointRepository
 import com.hoppingmall.mall.point.domain.PointHistoryRepository
 import com.hoppingmall.mall.point.enum.PointType
+import org.slf4j.LoggerFactory
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -25,6 +26,8 @@ class PointEventConsumer(
     private val transactionalEventPublisher: TransactionalEventPublisher,
     private val objectMapper: ObjectMapper
 ) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @KafkaListener(topics = ["point-earn-request"], groupId = "point-service")
     @Retryable(
@@ -80,7 +83,7 @@ class PointEventConsumer(
                 partitionKey = event.userId.toString()
             )
         } catch (e: Exception) {
-            println("포인트 적립 처리 중 오류 발생: ${e.message}")
+            log.error("포인트 적립 처리 실패: userId={}, orderId={}, 오류={}", event.userId, event.orderId, e.message)
             throw e
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,6 +64,15 @@ kafka:
     restart:
       enabled: true
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,metrics,prometheus
+  metrics:
+    tags:
+      application: hoppingmall
+
 logging:
   level:
     org.hibernate.SQL: debug

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/config/kafka/TracingConsumerInterceptorTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/config/kafka/TracingConsumerInterceptorTest.kt
@@ -1,0 +1,66 @@
+package com.hoppingmall.mall.global.common.config.kafka
+
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.header.internals.RecordHeaders
+import org.apache.kafka.common.record.TimestampType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.mockito.Mockito.mock
+import org.slf4j.MDC
+
+@DisplayName("TracingConsumerInterceptor")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class TracingConsumerInterceptorTest {
+
+    private val interceptor = TracingConsumerInterceptor()
+    private val consumer = mock<Consumer<String, Any>>()
+
+    @AfterEach
+    fun tearDown() {
+        MDC.clear()
+    }
+
+    @Nested
+    @DisplayName("intercept")
+    inner class Intercept {
+
+        @Test
+        fun 헤더에_traceId가_있으면_MDC에_설정된다() {
+            val headers = RecordHeaders()
+            headers.add("X-Trace-Id", "incoming-trace".toByteArray(Charsets.UTF_8))
+            val record = ConsumerRecord("topic", 0, 0L, 0L, TimestampType.CREATE_TIME, 0, 0, "key", "value" as Any, headers, java.util.Optional.empty())
+
+            interceptor.intercept(record, consumer)
+
+            assertThat(MDC.get("traceId")).isEqualTo("incoming-trace")
+        }
+
+        @Test
+        fun 헤더에_traceId가_없으면_새로_생성하여_MDC에_설정된다() {
+            val record = ConsumerRecord("topic", 0, 0L, 0L, TimestampType.CREATE_TIME, 0, 0, "key", "value" as Any, RecordHeaders(), java.util.Optional.empty())
+
+            interceptor.intercept(record, consumer)
+
+            val traceId = MDC.get("traceId")
+            assertThat(traceId).isNotNull()
+            assertThat(traceId).hasSize(16)
+        }
+    }
+
+    @Nested
+    @DisplayName("afterRecord")
+    inner class AfterRecord {
+
+        @Test
+        fun 처리_완료_후_MDC에서_traceId가_제거된다() {
+            MDC.put("traceId", "some-trace")
+            val record = ConsumerRecord("topic", 0, 0L, 0L, TimestampType.CREATE_TIME, 0, 0, "key", "value" as Any, RecordHeaders(), java.util.Optional.empty())
+
+            interceptor.afterRecord(record, consumer)
+
+            assertThat(MDC.get("traceId")).isNull()
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/config/kafka/TracingProducerInterceptorTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/config/kafka/TracingProducerInterceptorTest.kt
@@ -1,0 +1,46 @@
+package com.hoppingmall.mall.global.common.config.kafka
+
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.slf4j.MDC
+
+@DisplayName("TracingProducerInterceptor")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class TracingProducerInterceptorTest {
+
+    private val interceptor = TracingProducerInterceptor()
+
+    @AfterEach
+    fun tearDown() {
+        MDC.clear()
+    }
+
+    @Nested
+    @DisplayName("onSend")
+    inner class OnSend {
+
+        @Test
+        fun MDC에_traceId가_있으면_Kafka_헤더에_추가된다() {
+            MDC.put("traceId", "abc123")
+            val record = ProducerRecord<String, Any>("test-topic", "key", "value")
+
+            val result = interceptor.onSend(record)
+
+            val header = result.headers().lastHeader("X-Trace-Id")
+            assertThat(header).isNotNull
+            assertThat(String(header.value(), Charsets.UTF_8)).isEqualTo("abc123")
+        }
+
+        @Test
+        fun MDC에_traceId가_없으면_헤더를_추가하지_않는다() {
+            val record = ProducerRecord<String, Any>("test-topic", "key", "value")
+
+            val result = interceptor.onSend(record)
+
+            val header = result.headers().lastHeader("X-Trace-Id")
+            assertThat(header).isNull()
+        }
+    }
+}


### PR DESCRIPTION
Closes #107

### 📌 작업 개요
Kafka Header를 통한 MDC traceId 전파로 서비스 간 분산 추적을 구현하고,
Micrometer Prometheus를 통해 Consumer Lag 등 Kafka 메트릭을 수집할 수 있도록 설정합니다.
남은 println 호출도 SLF4J로 전환했습니다.

---

### ✅ 주요 변경 사항

- `global.common.config.kafka`
  - `TracingProducerInterceptor`: MDC traceId → Kafka X-Trace-Id 헤더 전파
  - `TracingConsumerInterceptor`: Kafka 헤더에서 traceId 복원, 없으면 신규 생성

- `global.common.config`
  - `KafkaConfig`: Producer/Consumer 인터셉터 등록, println → SLF4J 전환

- `notification.service`
  - `NotificationEventConsumer`: println → SLF4J 전환

- `point.service`
  - `PointEventConsumer`: println → SLF4J 전환

- `build.gradle.kts`
  - `micrometer-registry-prometheus` 의존성 추가

- `application.yml`
  - actuator 엔드포인트 노출 (health, metrics, prometheus)

---

### 🧪 테스트

- `TracingProducerInterceptorTest`: MDC traceId 헤더 추가, MDC 없을 때 헤더 미추가
- `TracingConsumerInterceptorTest`: 헤더에서 traceId 복원, 헤더 없을 때 신규 생성, 처리 후 MDC 정리

---

### 📎 관련 이슈
- #107