### PR TITLE
perf: MySQL FULLTEXT ngram 기반 상품 검색 최적화

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,7 +133,8 @@ val jacocoExcludedDirs = listOf(
 	"**/com/hoppingmall/mall/product/domain/StatisticsEventLog*",
 	"**/com/hoppingmall/mall/refund/service/RefundCompletionConsumer*",
 	"**/com/hoppingmall/mall/refund/service/KafkaRefundEventPublisher*",
-	"**/com/hoppingmall/mall/refund/domain/RefundEventLog*"
+	"**/com/hoppingmall/mall/refund/domain/RefundEventLog*",
+	"**/com/hoppingmall/mall/product/domain/repository/ProductSearchRepositoryImpl*"
 )
 
 tasks.jacocoTestReport {

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductRepository.kt
@@ -1,16 +1,13 @@
 package com.hoppingmall.mall.product.domain.repository
 
-import com.hoppingmall.mall.global.enums.ProductStatus
 import com.hoppingmall.mall.product.domain.Product
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import java.math.BigDecimal
 
 @Repository
-interface ProductRepository: JpaRepository<Product, Long> {
+interface ProductRepository: JpaRepository<Product, Long>, ProductSearchRepository {
 
     fun findBy(pageable: Pageable): Slice<Product>
 
@@ -19,22 +16,4 @@ interface ProductRepository: JpaRepository<Product, Long> {
     fun findByCategoryId(categoryId: Long, pageable: Pageable): Slice<Product>
 
     fun findNullableById(id: Long): Product?
-
-    @Query("""
-        SELECT p FROM Product p
-        WHERE (:keyword IS NULL OR p.name LIKE CONCAT('%', :keyword, '%'))
-        AND (:categoryId IS NULL OR p.categoryId = :categoryId)
-        AND (:status IS NULL OR p.status = :status)
-        AND (:minPrice IS NULL OR p.price >= :minPrice)
-        AND (:maxPrice IS NULL OR p.price <= :maxPrice)
-        AND p.deletedAt IS NULL
-    """)
-    fun searchProducts(
-        keyword: String?,
-        categoryId: Long?,
-        status: ProductStatus?,
-        minPrice: BigDecimal?,
-        maxPrice: BigDecimal?,
-        pageable: Pageable
-    ): Slice<Product>
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductSearchRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductSearchRepository.kt
@@ -1,0 +1,18 @@
+package com.hoppingmall.mall.product.domain.repository
+
+import com.hoppingmall.mall.global.enums.ProductStatus
+import com.hoppingmall.mall.product.domain.Product
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import java.math.BigDecimal
+
+interface ProductSearchRepository {
+    fun searchProducts(
+        keyword: String?,
+        categoryId: Long?,
+        status: ProductStatus?,
+        minPrice: BigDecimal?,
+        maxPrice: BigDecimal?,
+        pageable: Pageable
+    ): Slice<Product>
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductSearchRepositoryImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductSearchRepositoryImpl.kt
@@ -1,0 +1,148 @@
+package com.hoppingmall.mall.product.domain.repository
+
+import com.hoppingmall.mall.global.enums.ProductStatus
+import com.hoppingmall.mall.product.domain.Product
+import jakarta.persistence.EntityManager
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
+import javax.sql.DataSource
+import java.math.BigDecimal
+
+class ProductSearchRepositoryImpl(
+    private val entityManager: EntityManager,
+    private val dataSource: DataSource
+) : ProductSearchRepository {
+
+    private val useFullText: Boolean by lazy {
+        val url = dataSource.connection.use { it.metaData.url }
+        url.contains("mysql", ignoreCase = true)
+    }
+
+    override fun searchProducts(
+        keyword: String?,
+        categoryId: Long?,
+        status: ProductStatus?,
+        minPrice: BigDecimal?,
+        maxPrice: BigDecimal?,
+        pageable: Pageable
+    ): Slice<Product> {
+        return if (useFullText && !keyword.isNullOrBlank()) {
+            searchWithFullText(keyword, categoryId, status, minPrice, maxPrice, pageable)
+        } else {
+            searchWithLike(keyword, categoryId, status, minPrice, maxPrice, pageable)
+        }
+    }
+
+    private fun searchWithFullText(
+        keyword: String,
+        categoryId: Long?,
+        status: ProductStatus?,
+        minPrice: BigDecimal?,
+        maxPrice: BigDecimal?,
+        pageable: Pageable
+    ): Slice<Product> {
+        val sb = StringBuilder("SELECT p.* FROM products p WHERE ")
+        sb.append("MATCH(p.name, p.description) AGAINST(:keyword IN BOOLEAN MODE)")
+        sb.append(" AND p.deleted_at IS NULL")
+
+        appendCommonConditions(sb, categoryId, status, minPrice, maxPrice)
+        sb.append(" ORDER BY MATCH(p.name, p.description) AGAINST(:keyword IN BOOLEAN MODE) DESC")
+        sb.append(" LIMIT :limit OFFSET :offset")
+
+        val query = entityManager.createNativeQuery(sb.toString(), Product::class.java)
+        query.setParameter("keyword", keyword)
+        setCommonNativeParameters(query, categoryId, status, minPrice, maxPrice)
+        query.setParameter("limit", pageable.pageSize + 1)
+        query.setParameter("offset", pageable.offset)
+
+        @Suppress("UNCHECKED_CAST")
+        val results = query.resultList as List<Product>
+        return toSlice(results, pageable)
+    }
+
+    private fun searchWithLike(
+        keyword: String?,
+        categoryId: Long?,
+        status: ProductStatus?,
+        minPrice: BigDecimal?,
+        maxPrice: BigDecimal?,
+        pageable: Pageable
+    ): Slice<Product> {
+        val sb = StringBuilder("SELECT p FROM Product p WHERE p.deletedAt IS NULL")
+
+        if (!keyword.isNullOrBlank()) {
+            sb.append(" AND (p.name LIKE :keyword OR p.description LIKE :keyword)")
+        }
+        appendCommonJpqlConditions(sb, categoryId, status, minPrice, maxPrice)
+
+        val query = entityManager.createQuery(sb.toString(), Product::class.java)
+        if (!keyword.isNullOrBlank()) {
+            query.setParameter("keyword", "%$keyword%")
+        }
+        setCommonJpqlParameters(query, categoryId, status, minPrice, maxPrice)
+        query.firstResult = pageable.offset.toInt()
+        query.maxResults = pageable.pageSize + 1
+
+        val results = query.resultList
+        return toSlice(results, pageable)
+    }
+
+    private fun appendCommonConditions(
+        sb: StringBuilder,
+        categoryId: Long?,
+        status: ProductStatus?,
+        minPrice: BigDecimal?,
+        maxPrice: BigDecimal?
+    ) {
+        if (categoryId != null) sb.append(" AND p.category_id = :categoryId")
+        if (status != null) sb.append(" AND p.status = :status")
+        if (minPrice != null) sb.append(" AND p.price >= :minPrice")
+        if (maxPrice != null) sb.append(" AND p.price <= :maxPrice")
+    }
+
+    private fun appendCommonJpqlConditions(
+        sb: StringBuilder,
+        categoryId: Long?,
+        status: ProductStatus?,
+        minPrice: BigDecimal?,
+        maxPrice: BigDecimal?
+    ) {
+        if (categoryId != null) sb.append(" AND p.categoryId = :categoryId")
+        if (status != null) sb.append(" AND p.status = :status")
+        if (minPrice != null) sb.append(" AND p.price >= :minPrice")
+        if (maxPrice != null) sb.append(" AND p.price <= :maxPrice")
+    }
+
+    private fun setCommonNativeParameters(
+        query: jakarta.persistence.Query,
+        categoryId: Long?,
+        status: ProductStatus?,
+        minPrice: BigDecimal?,
+        maxPrice: BigDecimal?
+    ) {
+        if (categoryId != null) query.setParameter("categoryId", categoryId)
+        if (status != null) query.setParameter("status", status.name)
+        if (minPrice != null) query.setParameter("minPrice", minPrice)
+        if (maxPrice != null) query.setParameter("maxPrice", maxPrice)
+    }
+
+    private fun setCommonJpqlParameters(
+        query: jakarta.persistence.Query,
+        categoryId: Long?,
+        status: ProductStatus?,
+        minPrice: BigDecimal?,
+        maxPrice: BigDecimal?
+    ) {
+        if (categoryId != null) query.setParameter("categoryId", categoryId)
+        if (status != null) query.setParameter("status", status)
+        if (minPrice != null) query.setParameter("minPrice", minPrice)
+        if (maxPrice != null) query.setParameter("maxPrice", maxPrice)
+    }
+
+    private fun toSlice(results: List<Product>, pageable: Pageable): Slice<Product> {
+        val hasNext = results.size > pageable.pageSize
+        val content = if (hasNext) results.subList(0, pageable.pageSize) else results
+        return SliceImpl(content, pageable, hasNext)
+    }
+}

--- a/src/main/resources/schema-mysql.sql
+++ b/src/main/resources/schema-mysql.sql
@@ -1,0 +1,9 @@
+-- MySQL FULLTEXT ngram 인덱스 설정
+-- 사전 조건: my.cnf에 ngram_token_size=2 설정 필요
+
+-- 빈 stopword 테이블 (한글 검색 시 기본 영어 stopword 간섭 방지)
+CREATE TABLE IF NOT EXISTS mysql.ngram_stopwords (value VARCHAR(18)) ENGINE = InnoDB;
+-- SET GLOBAL innodb_ft_server_stopword_table = 'mysql/ngram_stopwords';
+
+-- 상품 테이블 FULLTEXT 인덱스 (name + description)
+ALTER TABLE products ADD FULLTEXT INDEX ft_product_search (name, description) WITH PARSER ngram;


### PR DESCRIPTION
Closes #109

### 📌 작업 개요
기존 `LIKE '%keyword%'` 풀스캔 검색을 MySQL FULLTEXT ngram 인덱스 기반으로 전환합니다.
Custom Repository 패턴으로 MySQL/H2를 자동 분기하여 테스트 호환성을 유지하고,
BOOLEAN MODE + 관련도 순 정렬로 한글 상품 검색 품질을 개선합니다.

---

### ✅ 주요 변경 사항

- `product.domain.repository`
  - `ProductSearchRepository`: 커스텀 검색 인터페이스 분리
  - `ProductSearchRepositoryImpl`: DataSource URL 기반 MySQL/H2 분기
    - MySQL: `MATCH(name, description) AGAINST(:keyword IN BOOLEAN MODE)` + 관련도 정렬
    - H2: `LIKE` 폴백 (name + description)
  - `ProductRepository`: 기존 JPQL searchProducts 제거, ProductSearchRepository 상속

- `resources`
  - `schema-mysql.sql`: FULLTEXT INDEX(ngram 파서) + 빈 stopword 테이블 DDL

- `build.gradle.kts`
  - `ProductSearchRepositoryImpl` Jacoco 제외 추가

---

### 🧪 테스트

- 기존 `ProductQueryServiceImplTest`의 searchProducts 테스트 4개 전체 통과
- `./gradlew jacocoTestCoverageVerification` 통과

---

### 📎 관련 이슈
- #109