### PR TITLE
refactor: Consumer 에러 처리 패턴 통일

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,6 +127,7 @@ val jacocoExcludedDirs = listOf(
 	"**/com/hoppingmall/mall/payment/service/PaymentCompensationConsumer*",
 	"**/com/hoppingmall/mall/payment/service/PaymentEventConsumer*",
 	"**/com/hoppingmall/mall/membership/service/MembershipEventConsumer*",
+	"**/com/hoppingmall/mall/notification/service/NotificationEventConsumer*",
 	"**/com/hoppingmall/mall/membership/domain/MembershipEventLog*",
 	"**/com/hoppingmall/mall/product/service/ProductStatisticsScheduler*",
 	"**/com/hoppingmall/mall/product/service/StatisticsEventConsumer*",

--- a/src/main/kotlin/com/hoppingmall/mall/membership/service/MembershipEventConsumer.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/service/MembershipEventConsumer.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.membership.service
 import com.hoppingmall.mall.membership.domain.MembershipEventLog
 import com.hoppingmall.mall.membership.domain.repository.MembershipEventLogRepository
 import com.hoppingmall.mall.payment.dto.event.MembershipUpdateRequestEvent
+import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Service
@@ -15,24 +16,35 @@ class MembershipEventConsumer(
     private val membershipEventLogRepository: MembershipEventLogRepository
 ) {
 
+    private val log = LoggerFactory.getLogger(javaClass)
+
     @KafkaListener(topics = ["membership-update-request"], groupId = "membership-service")
     fun handleMembershipUpdateRequest(event: MembershipUpdateRequestEvent) {
         try {
             if (membershipEventLogRepository.existsByEventId(event.eventId)) {
+                log.info("이미 처리된 멤버십 이벤트: eventId={}", event.eventId)
                 return
             }
 
             membershipCommandService.addPurchaseAmount(event.userId, event.amount)
 
-            membershipEventLogRepository.save(
-                MembershipEventLog(
-                    eventId = event.eventId,
-                    paymentId = event.paymentId,
-                    orderId = event.orderId
+            try {
+                membershipEventLogRepository.save(
+                    MembershipEventLog(
+                        eventId = event.eventId,
+                        paymentId = event.paymentId,
+                        orderId = event.orderId
+                    )
                 )
-            )
-        } catch (e: DataIntegrityViolationException) {
-            return
+            } catch (e: DataIntegrityViolationException) {
+                log.info("이미 처리된 멤버십 이벤트: eventId={}", event.eventId)
+                return
+            }
+
+            log.info("멤버십 업데이트 완료: userId={}, amount={}", event.userId, event.amount)
+        } catch (e: Exception) {
+            log.error("멤버십 업데이트 실패: eventId={}, userId={}, 오류={}", event.eventId, event.userId, e.message)
+            throw e
         }
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationEventConsumer.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationEventConsumer.kt
@@ -22,27 +22,32 @@ class NotificationEventConsumer(
     fun handleNotificationEvent(
         @Payload event: NotificationEvent
     ) {
-        log.info("알림 처리: userId={}, type={}", event.userId, event.type)
-
-        if (notificationRepository.existsByEventId(event.eventId)) {
-            return
-        }
-
-        val notification = Notification(
-            eventId = event.eventId,
-            userId = event.userId,
-            type = event.type,
-            title = event.title,
-            content = event.content,
-            metadata = event.metadata
-        )
-
         try {
-            notificationRepository.save(notification)
-        } catch (e: DataIntegrityViolationException) {
-            return
-        }
+            if (notificationRepository.existsByEventId(event.eventId)) {
+                log.info("이미 처리된 알림 이벤트: eventId={}", event.eventId)
+                return
+            }
 
-        log.info("알림 저장 완료: userId={}, type={}, title={}", event.userId, event.type, event.title)
+            val notification = Notification(
+                eventId = event.eventId,
+                userId = event.userId,
+                type = event.type,
+                title = event.title,
+                content = event.content,
+                metadata = event.metadata
+            )
+
+            try {
+                notificationRepository.save(notification)
+            } catch (e: DataIntegrityViolationException) {
+                log.info("이미 처리된 알림 이벤트: eventId={}", event.eventId)
+                return
+            }
+
+            log.info("알림 처리 완료: userId={}, type={}, title={}", event.userId, event.type, event.title)
+        } catch (e: Exception) {
+            log.error("알림 처리 실패: eventId={}, userId={}, 오류={}", event.eventId, event.userId, e.message)
+            throw e
+        }
     }
-} 
+}

--- a/src/main/kotlin/com/hoppingmall/mall/point/service/PointEventConsumer.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/service/PointEventConsumer.kt
@@ -13,8 +13,6 @@ import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.dao.DataIntegrityViolationException
-import org.springframework.retry.annotation.Retryable
-import org.springframework.retry.annotation.Backoff
 import com.hoppingmall.mall.global.common.service.TransactionalEventPublisher
 import java.math.BigDecimal
 
@@ -30,14 +28,10 @@ class PointEventConsumer(
     private val log = LoggerFactory.getLogger(javaClass)
 
     @KafkaListener(topics = ["point-earn-request"], groupId = "point-service")
-    @Retryable(
-        value = [DataIntegrityViolationException::class],
-        maxAttempts = 5,
-        backoff = Backoff(delay = 50, multiplier = 2.0)
-    )
     fun handlePointEarnRequest(event: PointEarnRequestEvent) {
         try {
             if (pointHistoryRepository.existsByEventId(event.eventId)) {
+                log.info("이미 처리된 포인트 이벤트: eventId={}", event.eventId)
                 return
             }
 


### PR DESCRIPTION
Closes #111

### 📌 작업 개요
Kafka Consumer 간 에러 처리 방식이 불일관했던 문제를 통일합니다.
모든 Consumer가 동일한 패턴(try-catch + log.error + throw, 멱등성 체크 로깅)을 따르도록 정리했습니다.

---

### ✅ 주요 변경 사항

- `notification.service`
  - `NotificationEventConsumer`: try-catch + log.error + throw 패턴 적용, 멱등성 체크 시 log.info 추가

- `membership.service`
  - `MembershipEventConsumer`: SLF4J 로거 추가, try-catch + log.error + throw 패턴 적용, 멱등성 체크 로깅 추가

- `point.service`
  - `PointEventConsumer`: 불필요한 @Retryable 제거 (DefaultErrorHandler가 재시도 담당), 멱등성 체크 시 log.info 추가

- `build.gradle.kts`
  - Jacoco 제외 대상에 NotificationEventConsumer 추가 (다른 Consumer와 동일하게 제외)

---

### 🧪 테스트

- `./gradlew test` 전체 통과
- `./gradlew jacocoTestCoverageVerification` 80% 이상 검증 통과

---

### 📎 관련 이슈
- #111