### PR TITLE
feat: CORS 설정 추가

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/CorsProperties.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/CorsProperties.kt
@@ -1,0 +1,12 @@
+package com.hoppingmall.mall.global.common.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "cors")
+data class CorsProperties(
+    val allowedOrigins: List<String> = listOf("http://localhost:3000"),
+    val allowedMethods: List<String> = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"),
+    val allowedHeaders: List<String> = listOf("*"),
+    val allowCredentials: Boolean = true,
+    val maxAge: Long = 3600
+)

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.mall.global.common.config
 
 import jakarta.servlet.Filter
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
@@ -13,16 +14,22 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
+@EnableConfigurationProperties(CorsProperties::class)
 class SecurityConfig(
     private val jwtAuthenticationFilter: Filter,
-    private val jwtAuthenticationEntryPoint: AuthenticationEntryPoint
+    private val jwtAuthenticationEntryPoint: AuthenticationEntryPoint,
+    private val corsProperties: CorsProperties
 ) {
 
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         http
+            .cors { it.configurationSource(corsConfigurationSource()) }
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .exceptionHandling { it.authenticationEntryPoint(jwtAuthenticationEntryPoint) }
@@ -82,6 +89,20 @@ class SecurityConfig(
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
 
         return http.build()
+    }
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration()
+        configuration.allowedOrigins = corsProperties.allowedOrigins
+        configuration.allowedMethods = corsProperties.allowedMethods
+        configuration.allowedHeaders = corsProperties.allowedHeaders
+        configuration.allowCredentials = corsProperties.allowCredentials
+        configuration.maxAge = corsProperties.maxAge
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+        return source
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,6 +73,21 @@ management:
     tags:
       application: hoppingmall
 
+cors:
+  allowed-origins:
+    - http://localhost:3000
+  allowed-methods:
+    - GET
+    - POST
+    - PUT
+    - PATCH
+    - DELETE
+    - OPTIONS
+  allowed-headers:
+    - "*"
+  allow-credentials: true
+  max-age: 3600
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
Closes #113

### 📌 작업 개요
SecurityConfig에 명시적 CORS 설정이 없어 프론트엔드 연동 시 Cross-Origin 요청이 차단되는 문제를 해결합니다.
`CorsProperties`로 허용 정책을 외부화하고, `CorsConfigurationSource` 빈을 등록하여 프로필별 CORS 관리를 가능하게 합니다.

---

### ✅ 주요 변경 사항

- `global.common.config`
  - `CorsProperties`: `@ConfigurationProperties(prefix = "cors")`로 허용 Origin, Method, Header, Credentials, maxAge 외부화
  - `SecurityConfig`: `.cors()` 설정 추가, `corsConfigurationSource()` 빈 등록

- `resources`
  - `application.yml`: `cors` 프로퍼티 추가 (기본값: `localhost:3000`)

---

### 🧪 테스트

- `./gradlew test` 전체 통과
- `./gradlew jacocoTestCoverageVerification` 80% 이상 검증 통과

---

### 📎 관련 이슈
- #113