### PR TITLE
fix: Soft Delete 계단식 처리 및 하드 삭제 전환

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/cartItem/service/CartItemCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/cartItem/service/CartItemCommandServiceImpl.kt
@@ -98,6 +98,6 @@ class CartItemCommandServiceImpl(
             throw CartItemAccessDeniedException()
         }
 
-        cartItemRepository.deleteById(cartItemId)
+        cartItem.softDelete()
     }
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryCommandServiceImpl.kt
@@ -75,6 +75,6 @@ class CategoryCommandServiceImpl(
             throw CategoryHasChildrenException()
         }
 
-        categoryRepository.deleteById(category.id!!)
+        category.softDelete()
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImpl.kt
@@ -87,13 +87,12 @@ class ProductCommandServiceImpl(
 
     @CacheEvict(cacheNames = ["product"], key = "#productId")
     override fun deleteProduct(productId: Long) {
-        if (!productRepository.existsById(productId)) {
-            throw ProductNotFoundException()
-        }
+        val product = productRepository.findById(productId)
+            .orElseThrow { ProductNotFoundException() }
 
         val productImage = productImageRepository.findByProductId(productId)
-        productImage?.let { productImageRepository.delete(it) }
+        productImage?.softDelete()
 
-        productRepository.deleteById(productId)
+        product.softDelete()
     }
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/wishlist/service/WishlistCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/wishlist/service/WishlistCommandServiceImpl.kt
@@ -40,6 +40,6 @@ class WishlistCommandServiceImpl(
             throw WishlistNotFoundException()
         }
 
-        wishlistRepository.deleteById(wishlistId)
+        wishlist.softDelete()
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/cartItem/service/CartItemCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/cartItem/service/CartItemCommandServiceImplTest.kt
@@ -228,13 +228,12 @@ class CartItemCommandServiceImplTest {
 
             // Context
             whenever(cartItemRepository.findById(cartItemId)).thenReturn(java.util.Optional.of(existingCartItem))
-            doNothing().`when`(cartItemRepository).deleteById(cartItemId)
 
             // Interaction
             cartItemCommandService.removeCartItem(buyerId, cartItemId)
 
             // Assertions
-            verify(cartItemRepository).deleteById(cartItemId)
+            assertThat(existingCartItem.deletedAt).isNotNull()
         }
 
         @Test

--- a/src/test/kotlin/com/hoppingmall/mall/category/service/CategoryCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/category/service/CategoryCommandServiceImplTest.kt
@@ -9,6 +9,7 @@ import com.hoppingmall.mall.category.exception.CategoryHasChildrenException
 import com.hoppingmall.mall.category.exception.CategoryNotFoundException
 import com.hoppingmall.mall.support.fixture.fixture
 import com.hoppingmall.mall.support.withId
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.DisplayName
@@ -158,7 +159,7 @@ class CategoryCommandServiceImplTest {
             categoryCommandService.deleteCategory(1L)
 
             // then
-            verify(categoryRepository).deleteById(1L)
+            assertThat(category.deletedAt).isNotNull()
         }
 
         @Test

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImplTest.kt
@@ -352,20 +352,19 @@ class ProductCommandServiceImplTest {
         fun 상품_삭제_성공() {
             // Data
             val productId = 1L
-            val productImage = ProductImage.fixture(productId = productId)
+            val product = Product.fixture().withId(productId)
+            val productImage = ProductImage.fixture(productId = productId).withId(1L)
 
             // Context
-            whenever(productRepository.existsById(productId)).thenReturn(true)
+            whenever(productRepository.findById(productId)).thenReturn(java.util.Optional.of(product))
             whenever(productImageRepository.findByProductId(productId)).thenReturn(productImage)
 
             // Interaction
             productCommandService.deleteProduct(productId)
 
             // Assertions
-            verify(productRepository).existsById(productId)
-            verify(productImageRepository).findByProductId(productId)
-            verify(productImageRepository).delete(productImage)
-            verify(productRepository).deleteById(productId)
+            assertThat(product.deletedAt).isNotNull()
+            assertThat(productImage.deletedAt).isNotNull()
         }
 
         @Test
@@ -374,35 +373,30 @@ class ProductCommandServiceImplTest {
             val productId = 999L
 
             // Context
-            whenever(productRepository.existsById(productId)).thenReturn(false)
+            whenever(productRepository.findById(productId)).thenReturn(java.util.Optional.empty())
 
             // Interaction & Assertions
             assertThatThrownBy { productCommandService.deleteProduct(productId) }
                 .isInstanceOf(ProductNotFoundException::class.java)
-            
-            verify(productRepository).existsById(productId)
+
             verify(productImageRepository, never()).findByProductId(any())
-            verify(productImageRepository, never()).delete(any())
-            verify(productRepository, never()).deleteById(any())
         }
 
         @Test
         fun 이미지가_없는_상품_삭제_성공() {
             // Data
             val productId = 1L
+            val product = Product.fixture().withId(productId)
 
             // Context
-            whenever(productRepository.existsById(productId)).thenReturn(true)
+            whenever(productRepository.findById(productId)).thenReturn(java.util.Optional.of(product))
             whenever(productImageRepository.findByProductId(productId)).thenReturn(null)
 
             // Interaction
             productCommandService.deleteProduct(productId)
 
             // Assertions
-            verify(productRepository).existsById(productId)
-            verify(productImageRepository).findByProductId(productId)
-            verify(productImageRepository, never()).delete(any())
-            verify(productRepository).deleteById(productId)
+            assertThat(product.deletedAt).isNotNull()
         }
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/wishlist/service/WishlistCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/wishlist/service/WishlistCommandServiceImplTest.kt
@@ -114,13 +114,12 @@ class WishlistCommandServiceImplTest {
 
             // Context
             whenever(wishlistRepository.findById(wishlistId)).thenReturn(java.util.Optional.of(wishlist))
-            doNothing().`when`(wishlistRepository).deleteById(wishlistId)
 
             // Interaction
             wishlistCommandService.removeWishlist(buyerId, wishlistId)
 
             // Assertions
-            verify(wishlistRepository).deleteById(wishlistId)
+            assertThat(wishlist.deletedAt).isNotNull()
         }
 
         @Test


### PR DESCRIPTION
Closes #115

### 📌 작업 개요
모든 엔티티에 `@Filter(softDeleteFilter)` + `BaseEntity.softDelete()` 인프라가 갖춰져 있지만,
실제 삭제 로직은 `deleteById`(하드 삭제)를 사용하고 있던 문제를 수정합니다.
특히 상품 삭제 시 ProductImage가 함께 soft delete 되지 않아 고아 데이터가 발생하던 문제를 해결합니다.

---

### ✅ 주요 변경 사항

- `product.service`
  - `ProductCommandServiceImpl`: `deleteById` → `softDelete()` 전환, ProductImage 계단식 soft delete 추가

- `cartItem.service`
  - `CartItemCommandServiceImpl`: `deleteById` → `softDelete()` 전환

- `category.service`
  - `CategoryCommandServiceImpl`: `deleteById` → `softDelete()` 전환

- `wishlist.service`
  - `WishlistCommandServiceImpl`: `deleteById` → `softDelete()` 전환

---

### 🧪 테스트

- `ProductCommandServiceImplTest`: `deleteById` verify → `deletedAt` not null 검증으로 변경
- `CartItemCommandServiceImplTest`: 동일 패턴 적용
- `CategoryCommandServiceImplTest`: 동일 패턴 적용
- `WishlistCommandServiceImplTest`: 동일 패턴 적용
- `./gradlew test` 전체 통과
- `./gradlew jacocoTestCoverageVerification` 80% 이상 검증 통과

---

### 📎 관련 이슈
- #115