### PR TITLE
fix: 카테고리 순환 참조 검증 추가

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/category/exception/CategoryCircularReferenceException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/exception/CategoryCircularReferenceException.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.category.exception
+
+import com.hoppingmall.mall.category.exception.code.CategoryErrorCode
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+
+class CategoryCircularReferenceException : BusinessException(CategoryErrorCode.CATEGORY_CIRCULAR_REFERENCE)

--- a/src/main/kotlin/com/hoppingmall/mall/category/exception/code/CategoryErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/exception/code/CategoryErrorCode.kt
@@ -11,4 +11,5 @@ enum class CategoryErrorCode(
     CATEGORY_NOT_FOUND("CAT001", "카테고리를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     CATEGORY_ALREADY_EXISTS("CAT002", "이미 존재하는 카테고리 이름입니다.", HttpStatus.CONFLICT),
     CATEGORY_HAS_CHILDREN("CAT003", "하위 카테고리가 존재하여 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    CATEGORY_CIRCULAR_REFERENCE("CAT004", "순환 참조가 발생하는 카테고리 구조입니다.", HttpStatus.BAD_REQUEST),
 }

--- a/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/service/CategoryCommandServiceImpl.kt
@@ -6,6 +6,7 @@ import com.hoppingmall.mall.category.dto.request.CategoryCreateRequest
 import com.hoppingmall.mall.category.dto.request.CategoryUpdateRequest
 import com.hoppingmall.mall.category.dto.response.CategoryResponse
 import com.hoppingmall.mall.category.exception.CategoryAlreadyExistsException
+import com.hoppingmall.mall.category.exception.CategoryCircularReferenceException
 import com.hoppingmall.mall.category.exception.CategoryHasChildrenException
 import com.hoppingmall.mall.category.exception.CategoryNotFoundException
 import org.springframework.cache.annotation.CacheEvict
@@ -19,6 +20,10 @@ class CategoryCommandServiceImpl(
     private val categoryRepository: CategoryRepository
 ) : CategoryCommandService {
 
+    companion object {
+        private const val MAX_DEPTH = 10
+    }
+
     @Caching(evict = [
         CacheEvict(cacheNames = ["categories:root"], allEntries = true),
         CacheEvict(cacheNames = ["categories:sub"], allEntries = true)
@@ -31,6 +36,7 @@ class CategoryCommandServiceImpl(
         val depth = if (request.parentCategoryId != null) {
             val parent = categoryRepository.findNullableById(request.parentCategoryId)
                 ?: throw CategoryNotFoundException()
+            validateNoCircularReference(request.parentCategoryId)
             parent.depth + 1
         } else {
             0
@@ -76,5 +82,21 @@ class CategoryCommandServiceImpl(
         }
 
         category.softDelete()
+    }
+
+    private fun validateNoCircularReference(parentCategoryId: Long) {
+        val visited = mutableSetOf<Long>()
+        var currentId: Long? = parentCategoryId
+
+        while (currentId != null) {
+            if (!visited.add(currentId)) {
+                throw CategoryCircularReferenceException()
+            }
+            if (visited.size > MAX_DEPTH) {
+                throw CategoryCircularReferenceException()
+            }
+            val current = categoryRepository.findNullableById(currentId)
+            currentId = current?.parentCategoryId
+        }
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/category/service/CategoryCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/category/service/CategoryCommandServiceImplTest.kt
@@ -5,6 +5,7 @@ import com.hoppingmall.mall.category.domain.repository.CategoryRepository
 import com.hoppingmall.mall.category.dto.request.CategoryCreateRequest
 import com.hoppingmall.mall.category.dto.request.CategoryUpdateRequest
 import com.hoppingmall.mall.category.exception.CategoryAlreadyExistsException
+import com.hoppingmall.mall.category.exception.CategoryCircularReferenceException
 import com.hoppingmall.mall.category.exception.CategoryHasChildrenException
 import com.hoppingmall.mall.category.exception.CategoryNotFoundException
 import com.hoppingmall.mall.support.fixture.fixture
@@ -81,6 +82,47 @@ class CategoryCommandServiceImplTest {
 
             // when & then
             assertThrows<CategoryAlreadyExistsException> {
+                categoryCommandService.createCategory(request)
+            }
+        }
+
+        @Test
+        fun 조상_체인에_순환_참조가_있으면_예외가_발생한다() {
+            // given
+            val request = CategoryCreateRequest(name = "새카테고리", parentCategoryId = 3L)
+
+            val catA = Category.fixture(name = "A", parentCategoryId = 3L).withId(1L)
+            val catB = Category.fixture(name = "B", parentCategoryId = 1L, depth = 1).withId(2L)
+            val catC = Category.fixture(name = "C", parentCategoryId = 2L, depth = 2).withId(3L)
+
+            whenever(categoryRepository.existsByName("새카테고리")).thenReturn(false)
+            whenever(categoryRepository.findNullableById(3L)).thenReturn(catC)
+            whenever(categoryRepository.findNullableById(2L)).thenReturn(catB)
+            whenever(categoryRepository.findNullableById(1L)).thenReturn(catA)
+
+            // when & then
+            assertThrows<CategoryCircularReferenceException> {
+                categoryCommandService.createCategory(request)
+            }
+        }
+
+        @Test
+        fun 조상_체인_깊이가_상한을_초과하면_예외가_발생한다() {
+            // given
+            val request = CategoryCreateRequest(name = "깊은카테고리", parentCategoryId = 1L)
+
+            val categories = (1L..12L).map { id ->
+                val parentId = if (id < 12L) id + 1 else null
+                Category.fixture(name = "Cat$id", parentCategoryId = parentId, depth = id.toInt()).withId(id)
+            }
+
+            whenever(categoryRepository.existsByName("깊은카테고리")).thenReturn(false)
+            categories.forEach { cat ->
+                whenever(categoryRepository.findNullableById(cat.id!!)).thenReturn(cat)
+            }
+
+            // when & then
+            assertThrows<CategoryCircularReferenceException> {
                 categoryCommandService.createCategory(request)
             }
         }


### PR DESCRIPTION
Closes #117

### 📌 작업 개요
카테고리 생성 시 parentCategoryId를 따라가며 조상 체인을 검증하여 순환 참조를 방지합니다.
MAX_DEPTH 상한을 설정하여 비정상적으로 깊은 트리 구조도 차단합니다.

---

### ✅ 주요 변경 사항

- `category.exception.code`
  - `CategoryErrorCode`: `CATEGORY_CIRCULAR_REFERENCE(CAT004)` 추가

- `category.exception`
  - `CategoryCircularReferenceException`: 순환 참조 감지 시 발생하는 예외

- `category.service`
  - `CategoryCommandServiceImpl`: `validateNoCircularReference()` 메서드 추가, `createCategory()`에서 호출

---

### 🧪 테스트

- `CategoryCommandServiceImplTest`: 순환 참조(A→B→C→A) 감지, 깊이 상한 초과 테스트 추가
- `./gradlew test` 전체 통과
- `./gradlew jacocoTestCoverageVerification` 80% 이상 검증 통과

---

### 📎 관련 이슈
- #117