### PR TITLE
fix: Payment/Refund/Order API 인가 강화

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/order/controller/OrderController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/controller/OrderController.kt
@@ -62,10 +62,12 @@ class OrderController(
 
     @PatchMapping("/{orderId}/status")
     fun updateOrderStatus(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
         @PathVariable orderId: Long,
         @Valid @RequestBody request: OrderStatusUpdateRequest
     ): ResponseEntity<ApiResponse<OrderResponse>> {
-        val order = orderCommandService.updateOrderStatus(orderId, request)
+        val isAdmin = userPrincipal.getRole() == "ADMIN"
+        val order = orderCommandService.updateOrderStatus(orderId, request, userPrincipal.getUserId(), isAdmin)
         return ResponseEntity.ok(ApiResponse.success(order))
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/order/service/OrderCommandService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/service/OrderCommandService.kt
@@ -7,5 +7,5 @@ import com.hoppingmall.mall.order.dto.response.OrderResponse
 interface OrderCommandService {
     fun createOrder(buyerId: Long, request: OrderCreateRequest): OrderResponse
     fun cancelOrder(buyerId: Long, orderId: Long): OrderResponse
-    fun updateOrderStatus(orderId: Long, request: OrderStatusUpdateRequest): OrderResponse
+    fun updateOrderStatus(orderId: Long, request: OrderStatusUpdateRequest, userId: Long, isAdmin: Boolean): OrderResponse
 }

--- a/src/main/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImpl.kt
@@ -85,9 +85,13 @@ class OrderCommandServiceImpl(
         return OrderResponse.from(order, orderItems)
     }
 
-    override fun updateOrderStatus(orderId: Long, request: OrderStatusUpdateRequest): OrderResponse {
+    override fun updateOrderStatus(orderId: Long, request: OrderStatusUpdateRequest, userId: Long, isAdmin: Boolean): OrderResponse {
         val order = orderRepository.findById(orderId)
             .orElseThrow { OrderNotFoundException() }
+
+        if (order.buyerId != userId && !isAdmin) {
+            throw OrderAccessDeniedException()
+        }
 
         order.updateStatus(request.status)
 

--- a/src/main/kotlin/com/hoppingmall/mall/payment/controller/PaymentController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/controller/PaymentController.kt
@@ -30,8 +30,12 @@ class PaymentController(
     }
     
     @GetMapping("/{paymentId}")
-    fun getPaymentById(@PathVariable paymentId: Long): ResponseEntity<PaymentResponse> {
-        val paymentResponse = paymentQueryService.getPaymentById(paymentId)
+    fun getPaymentById(
+        @PathVariable paymentId: Long,
+        @AuthenticationPrincipal userDetails: UserDetails
+    ): ResponseEntity<PaymentResponse> {
+        val userId = userDetails.username.toLong()
+        val paymentResponse = paymentQueryService.getPaymentById(paymentId, userId)
         return ResponseEntity.ok(paymentResponse)
     }
     
@@ -48,8 +52,12 @@ class PaymentController(
     }
     
     @GetMapping("/order/{orderId}")
-    fun getPaymentsByOrderId(@PathVariable orderId: Long): ResponseEntity<List<PaymentResponse>> {
-        val payments = paymentQueryService.getPaymentsByOrderId(orderId)
+    fun getPaymentsByOrderId(
+        @PathVariable orderId: Long,
+        @AuthenticationPrincipal userDetails: UserDetails
+    ): ResponseEntity<List<PaymentResponse>> {
+        val userId = userDetails.username.toLong()
+        val payments = paymentQueryService.getPaymentsByOrderId(orderId, userId)
         return ResponseEntity.ok(payments)
     }
 

--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentQueryService.kt
@@ -5,11 +5,11 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 
 interface PaymentQueryService {
-    fun getPaymentById(paymentId: Long): PaymentResponse
-    
+    fun getPaymentById(paymentId: Long, userId: Long): PaymentResponse
+
     fun getPaymentsByUserId(userId: Long, pageable: Pageable): Page<PaymentResponse>
-    
-    fun getPaymentsByOrderId(orderId: Long): List<PaymentResponse>
+
+    fun getPaymentsByOrderId(orderId: Long, userId: Long): List<PaymentResponse>
     
     fun getPaymentByTransactionId(transactionId: String): PaymentResponse?
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/service/PaymentQueryServiceImpl.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.payment.service
 
 import com.hoppingmall.mall.payment.domain.repository.PaymentRepository
 import com.hoppingmall.mall.payment.dto.response.PaymentResponse
+import com.hoppingmall.mall.payment.exception.PaymentAccessDeniedException
 import com.hoppingmall.mall.payment.exception.PaymentNotFoundException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -14,9 +15,12 @@ class PaymentQueryServiceImpl(
     private val paymentRepository: PaymentRepository
 ) : PaymentQueryService {
     
-    override fun getPaymentById(paymentId: Long): PaymentResponse {
+    override fun getPaymentById(paymentId: Long, userId: Long): PaymentResponse {
         val payment = paymentRepository.findById(paymentId)
             .orElseThrow { PaymentNotFoundException() }
+        if (payment.userId != userId) {
+            throw PaymentAccessDeniedException()
+        }
         return PaymentResponse.from(payment)
     }
     
@@ -25,9 +29,12 @@ class PaymentQueryServiceImpl(
             .map { PaymentResponse.from(it) }
     }
     
-    override fun getPaymentsByOrderId(orderId: Long): List<PaymentResponse> {
+    override fun getPaymentsByOrderId(orderId: Long, userId: Long): List<PaymentResponse> {
         val payment = paymentRepository.findByOrderId(orderId)
         return if (payment != null) {
+            if (payment.userId != userId) {
+                throw PaymentAccessDeniedException()
+            }
             listOf(PaymentResponse.from(payment))
         } else {
             emptyList()

--- a/src/main/kotlin/com/hoppingmall/mall/refund/controller/RefundController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/controller/RefundController.kt
@@ -31,8 +31,12 @@ class RefundController(
     }
 
     @GetMapping("/{refundId}")
-    fun getRefund(@PathVariable refundId: Long): ResponseEntity<RefundResponse> {
-        val response = refundQueryService.getRefund(refundId)
+    fun getRefund(
+        @PathVariable refundId: Long,
+        @AuthenticationPrincipal userDetails: UserDetails
+    ): ResponseEntity<RefundResponse> {
+        val userId = userDetails.username.toLong()
+        val response = refundQueryService.getRefund(refundId, userId)
         return ResponseEntity.ok(response)
     }
 

--- a/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundQueryService.kt
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 
 interface RefundQueryService {
-    fun getRefund(refundId: Long): RefundResponse
+    fun getRefund(refundId: Long, userId: Long): RefundResponse
     fun getMyRefunds(buyerId: Long, pageable: Pageable): Page<RefundResponse>
     fun getSellerRefunds(sellerId: Long, pageable: Pageable): Page<RefundResponse>
 }

--- a/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundQueryServiceImpl.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.refund.service
 import com.hoppingmall.mall.refund.domain.repository.RefundItemRepository
 import com.hoppingmall.mall.refund.domain.repository.RefundRepository
 import com.hoppingmall.mall.refund.dto.response.RefundResponse
+import com.hoppingmall.mall.refund.exception.RefundAccessDeniedException
 import com.hoppingmall.mall.refund.exception.RefundNotFoundException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -16,9 +17,12 @@ class RefundQueryServiceImpl(
     private val refundItemRepository: RefundItemRepository
 ) : RefundQueryService {
 
-    override fun getRefund(refundId: Long): RefundResponse {
+    override fun getRefund(refundId: Long, userId: Long): RefundResponse {
         val refund = refundRepository.findById(refundId)
             .orElseThrow { RefundNotFoundException() }
+        if (refund.buyerId != userId && refund.sellerId != userId) {
+            throw RefundAccessDeniedException()
+        }
         val items = refundItemRepository.findByRefundId(refundId)
         return RefundResponse.from(refund, items)
     }

--- a/src/test/kotlin/com/hoppingmall/mall/order/controller/OrderControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/order/controller/OrderControllerTest.kt
@@ -149,15 +149,15 @@ class OrderControllerTest {
             val request = OrderStatusUpdateRequest(status = OrderStatus.PAID)
             val expectedResponse = createOrderResponse(status = OrderStatus.PAID)
 
-            whenever(orderCommandService.updateOrderStatus(orderId, request)).thenReturn(expectedResponse)
+            whenever(orderCommandService.updateOrderStatus(orderId, request, userPrincipal.getUserId(), false)).thenReturn(expectedResponse)
 
             // when
-            val response: ResponseEntity<ApiResponse<OrderResponse>> = controller.updateOrderStatus(orderId, request)
+            val response: ResponseEntity<ApiResponse<OrderResponse>> = controller.updateOrderStatus(userPrincipal, orderId, request)
 
             // then
             assertEquals("SUCCESS", response.body?.code)
             assertEquals(OrderStatus.PAID, response.body?.data?.status)
-            verify(orderCommandService).updateOrderStatus(orderId, request)
+            verify(orderCommandService).updateOrderStatus(orderId, request, userPrincipal.getUserId(), false)
         }
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImplTest.kt
@@ -180,16 +180,17 @@ class OrderCommandServiceImplTest {
         @Test
         fun 주문_상태를_변경한다() {
             // given
+            val buyerId = 1L
             val orderId = 1L
             val request = OrderStatusUpdateRequest(status = OrderStatus.PAID)
-            val order = Order.fixture()
+            val order = Order.fixture(buyerId = buyerId)
             val orderItems = listOf(OrderItem.fixture(orderId = orderId))
 
             whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
             whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(orderItems)
 
             // when
-            val response = orderCommandService.updateOrderStatus(orderId, request)
+            val response = orderCommandService.updateOrderStatus(orderId, request, buyerId, false)
 
             // then
             assertEquals(OrderStatus.PAID, response.status)
@@ -205,8 +206,42 @@ class OrderCommandServiceImplTest {
 
             // when & then
             assertThrows<OrderNotFoundException> {
-                orderCommandService.updateOrderStatus(orderId, request)
+                orderCommandService.updateOrderStatus(orderId, request, 1L, false)
             }
+        }
+
+        @Test
+        fun 다른_사용자의_주문이면_예외가_발생한다() {
+            // given
+            val orderId = 1L
+            val request = OrderStatusUpdateRequest(status = OrderStatus.PAID)
+            val order = Order.fixture(buyerId = 999L)
+
+            whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
+
+            // when & then
+            assertThrows<OrderAccessDeniedException> {
+                orderCommandService.updateOrderStatus(orderId, request, 1L, false)
+            }
+        }
+
+        @Test
+        fun 관리자는_다른_사용자의_주문_상태를_변경할_수_있다() {
+            // given
+            val adminId = 99L
+            val orderId = 1L
+            val request = OrderStatusUpdateRequest(status = OrderStatus.PAID)
+            val order = Order.fixture(buyerId = 1L)
+            val orderItems = listOf(OrderItem.fixture(orderId = orderId))
+
+            whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
+            whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(orderItems)
+
+            // when
+            val response = orderCommandService.updateOrderStatus(orderId, request, adminId, true)
+
+            // then
+            assertEquals(OrderStatus.PAID, response.status)
         }
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/payment/controller/PaymentControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/controller/PaymentControllerTest.kt
@@ -79,10 +79,11 @@ class PaymentControllerTest {
         fun `결제 조회 성공`() {
             // given
             val paymentId = 1L
+            val userId = 1L
             val response = PaymentResponse(
                 id = paymentId,
                 orderId = 1L,
-                userId = 1L,
+                userId = userId,
                 amount = BigDecimal("50000"),
                 pointAmount = BigDecimal.ZERO,
                 couponId = null,
@@ -95,16 +96,18 @@ class PaymentControllerTest {
                 createdAt = LocalDateTime.now(),
                 updatedAt = LocalDateTime.now()
             )
+            val userDetails: UserDetails = mock()
 
-            whenever(paymentQueryService.getPaymentById(paymentId)).thenReturn(response)
+            whenever(userDetails.username).thenReturn(userId.toString())
+            whenever(paymentQueryService.getPaymentById(paymentId, userId)).thenReturn(response)
 
             // when
-            val result = paymentController.getPaymentById(paymentId)
+            val result = paymentController.getPaymentById(paymentId, userDetails)
 
             // then
             assertEquals(HttpStatus.OK, result.statusCode)
             assertEquals(response, result.body)
-            verify(paymentQueryService).getPaymentById(paymentId)
+            verify(paymentQueryService).getPaymentById(paymentId, userId)
         }
     }
 
@@ -160,11 +163,12 @@ class PaymentControllerTest {
         fun `주문별 결제 목록 조회 성공`() {
             // given
             val orderId = 1L
+            val userId = 1L
 
             val paymentResponse = PaymentResponse(
                 id = 1L,
                 orderId = orderId,
-                userId = 1L,
+                userId = userId,
                 amount = BigDecimal("50000"),
                 pointAmount = BigDecimal.ZERO,
                 couponId = null,
@@ -179,16 +183,18 @@ class PaymentControllerTest {
             )
 
             val payments = listOf(paymentResponse)
+            val userDetails: UserDetails = mock()
 
-            whenever(paymentQueryService.getPaymentsByOrderId(orderId)).thenReturn(payments)
+            whenever(userDetails.username).thenReturn(userId.toString())
+            whenever(paymentQueryService.getPaymentsByOrderId(orderId, userId)).thenReturn(payments)
 
             // when
-            val result = paymentController.getPaymentsByOrderId(orderId)
+            val result = paymentController.getPaymentsByOrderId(orderId, userDetails)
 
             // then
             assertEquals(HttpStatus.OK, result.statusCode)
             assertEquals(payments, result.body)
-            verify(paymentQueryService).getPaymentsByOrderId(orderId)
+            verify(paymentQueryService).getPaymentsByOrderId(orderId, userId)
         }
     }
 

--- a/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentQueryServiceImplTest.kt
@@ -5,6 +5,7 @@ import com.hoppingmall.mall.payment.domain.repository.PaymentRepository
 import com.hoppingmall.mall.payment.dto.response.PaymentResponse
 import com.hoppingmall.mall.payment.enum.PaymentMethod
 import com.hoppingmall.mall.payment.enum.PaymentStatus
+import com.hoppingmall.mall.payment.exception.PaymentAccessDeniedException
 import com.hoppingmall.mall.payment.exception.PaymentNotFoundException
 import com.hoppingmall.mall.support.fixture.fixture
 import com.hoppingmall.mall.support.fixture.successFixture
@@ -36,16 +37,17 @@ class PaymentQueryServiceImplTest {
         fun `결제 조회 성공`() {
             // given
             val paymentId = 1L
+            val userId = 1L
             val payment = Payment.successFixture()
 
             whenever(paymentRepository.findById(paymentId)).thenReturn(java.util.Optional.of(payment))
 
             // when
-            val result = paymentQueryService.getPaymentById(paymentId)
+            val result = paymentQueryService.getPaymentById(paymentId, userId)
 
             // then
             assertEquals(paymentId, result.id)
-            assertEquals(1L, result.userId)
+            assertEquals(userId, result.userId)
             assertEquals(BigDecimal("50000"), result.amount)
             assertEquals(PaymentStatus.SUCCESS, result.status)
         }
@@ -59,7 +61,21 @@ class PaymentQueryServiceImplTest {
 
             // when & then
             assertThrows(PaymentNotFoundException::class.java) {
-                paymentQueryService.getPaymentById(paymentId)
+                paymentQueryService.getPaymentById(paymentId, 1L)
+            }
+        }
+
+        @Test
+        fun `다른 사용자의 결제 조회 시 접근 거부`() {
+            // given
+            val paymentId = 1L
+            val payment = Payment.successFixture(userId = 1L)
+
+            whenever(paymentRepository.findById(paymentId)).thenReturn(java.util.Optional.of(payment))
+
+            // when & then
+            assertThrows(PaymentAccessDeniedException::class.java) {
+                paymentQueryService.getPaymentById(paymentId, 999L)
             }
         }
     }
@@ -116,12 +132,13 @@ class PaymentQueryServiceImplTest {
         fun `주문별 결제 조회 성공`() {
             // given
             val orderId = 1L
-            val payment = Payment.successFixture(orderId = orderId)
+            val userId = 1L
+            val payment = Payment.successFixture(orderId = orderId, userId = userId)
 
             whenever(paymentRepository.findByOrderId(orderId)).thenReturn(payment)
 
             // when
-            val result = paymentQueryService.getPaymentsByOrderId(orderId)
+            val result = paymentQueryService.getPaymentsByOrderId(orderId, userId)
 
             // then
             assertEquals(1, result.size)
@@ -137,10 +154,24 @@ class PaymentQueryServiceImplTest {
             whenever(paymentRepository.findByOrderId(orderId)).thenReturn(null)
 
             // when
-            val result = paymentQueryService.getPaymentsByOrderId(orderId)
+            val result = paymentQueryService.getPaymentsByOrderId(orderId, 1L)
 
             // then
             assertEquals(0, result.size)
+        }
+
+        @Test
+        fun `다른 사용자의 주문 결제 조회 시 접근 거부`() {
+            // given
+            val orderId = 1L
+            val payment = Payment.successFixture(orderId = orderId, userId = 1L)
+
+            whenever(paymentRepository.findByOrderId(orderId)).thenReturn(payment)
+
+            // when & then
+            assertThrows(PaymentAccessDeniedException::class.java) {
+                paymentQueryService.getPaymentsByOrderId(orderId, 999L)
+            }
         }
     }
 

--- a/src/test/kotlin/com/hoppingmall/mall/refund/controller/RefundControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/refund/controller/RefundControllerTest.kt
@@ -100,17 +100,20 @@ class RefundControllerTest {
         fun `환불_상세_조회_성공`() {
             // given
             val refundId = 1L
+            val userId = 1L
             val response = createRefundResponse()
+            val userDetails: UserDetails = mock()
 
-            whenever(refundQueryService.getRefund(refundId)).thenReturn(response)
+            whenever(userDetails.username).thenReturn(userId.toString())
+            whenever(refundQueryService.getRefund(refundId, userId)).thenReturn(response)
 
             // when
-            val result = refundController.getRefund(refundId)
+            val result = refundController.getRefund(refundId, userDetails)
 
             // then
             assertEquals(HttpStatus.OK, result.statusCode)
             assertEquals(response, result.body)
-            verify(refundQueryService).getRefund(refundId)
+            verify(refundQueryService).getRefund(refundId, userId)
         }
     }
 

--- a/src/test/kotlin/com/hoppingmall/mall/refund/service/RefundQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/refund/service/RefundQueryServiceImplTest.kt
@@ -4,6 +4,7 @@ import com.hoppingmall.mall.refund.domain.Refund
 import com.hoppingmall.mall.refund.domain.RefundItem
 import com.hoppingmall.mall.refund.domain.repository.RefundItemRepository
 import com.hoppingmall.mall.refund.domain.repository.RefundRepository
+import com.hoppingmall.mall.refund.exception.RefundAccessDeniedException
 import com.hoppingmall.mall.refund.exception.RefundNotFoundException
 import com.hoppingmall.mall.support.fixture.fixture
 import org.junit.jupiter.api.Assertions.*
@@ -30,17 +31,37 @@ class RefundQueryServiceImplTest {
     inner class GetRefund {
 
         @Test
-        fun `환불_상세_조회_성공`() {
+        fun `구매자가_환불_상세_조회_성공`() {
             // given
             val refundId = 1L
-            val refund = Refund.fixture()
+            val buyerId = 1L
+            val refund = Refund.fixture(buyerId = buyerId, sellerId = 2L)
             val refundItem = RefundItem.fixture(refundId = refundId)
 
             whenever(refundRepository.findById(refundId)).thenReturn(Optional.of(refund))
             whenever(refundItemRepository.findByRefundId(refundId)).thenReturn(listOf(refundItem))
 
             // when
-            val response = refundQueryService.getRefund(refundId)
+            val response = refundQueryService.getRefund(refundId, buyerId)
+
+            // then
+            assertEquals(refundId, response.id)
+            assertEquals(1, response.items.size)
+        }
+
+        @Test
+        fun `판매자가_환불_상세_조회_성공`() {
+            // given
+            val refundId = 1L
+            val sellerId = 2L
+            val refund = Refund.fixture(buyerId = 1L, sellerId = sellerId)
+            val refundItem = RefundItem.fixture(refundId = refundId)
+
+            whenever(refundRepository.findById(refundId)).thenReturn(Optional.of(refund))
+            whenever(refundItemRepository.findByRefundId(refundId)).thenReturn(listOf(refundItem))
+
+            // when
+            val response = refundQueryService.getRefund(refundId, sellerId)
 
             // then
             assertEquals(refundId, response.id)
@@ -54,7 +75,21 @@ class RefundQueryServiceImplTest {
 
             // when & then
             assertThrows(RefundNotFoundException::class.java) {
-                refundQueryService.getRefund(999L)
+                refundQueryService.getRefund(999L, 1L)
+            }
+        }
+
+        @Test
+        fun `다른_사용자의_환불_조회_시_접근_거부`() {
+            // given
+            val refundId = 1L
+            val refund = Refund.fixture(buyerId = 1L, sellerId = 2L)
+
+            whenever(refundRepository.findById(refundId)).thenReturn(Optional.of(refund))
+
+            // when & then
+            assertThrows(RefundAccessDeniedException::class.java) {
+                refundQueryService.getRefund(refundId, 999L)
             }
         }
     }


### PR DESCRIPTION
Closes #119

### 📌 작업 개요

Payment, Refund, Order API의 GET/상태변경 엔드포인트에 소유권 검증이 누락되어 타 사용자의 결제/환불/주문 정보가 노출될 수 있는 보안 취약점을 수정했습니다.

---

### ✅ 주요 변경 사항

- `payment.service`
  - `PaymentQueryService`, `PaymentQueryServiceImpl`: `getPaymentById`, `getPaymentsByOrderId`에 userId 파라미터 추가 및 소유권 검증

- `payment.controller`
  - `PaymentController`: 두 GET 엔드포인트에 `@AuthenticationPrincipal` 주입

- `refund.service`
  - `RefundQueryService`, `RefundQueryServiceImpl`: `getRefund`에 userId 파라미터 추가, 구매자 또는 판매자만 조회 가능

- `refund.controller`
  - `RefundController`: `getRefund`에 `@AuthenticationPrincipal` 주입

- `order.service`
  - `OrderCommandService`, `OrderCommandServiceImpl`: `updateOrderStatus`에 userId, isAdmin 파라미터 추가, 소유자 또는 ADMIN만 상태 변경 가능

- `order.controller`
  - `OrderController`: `updateOrderStatus`에 `@AuthenticationPrincipal` 주입

---

### 🧪 테스트

- `PaymentQueryServiceImplTest`: 타 사용자 결제 조회 접근 거부 테스트 추가
- `PaymentControllerTest`: 소유권 검증 반영
- `RefundQueryServiceImplTest`: 구매자/판매자 조회 성공 + 타 사용자 접근 거부 테스트 추가
- `RefundControllerTest`: 소유권 검증 반영
- `OrderCommandServiceImplTest`: 상태 변경 소유권/ADMIN 검증 테스트 추가
- `OrderControllerTest`: UserPrincipal 주입 반영

---

### 📎 관련 이슈
- #119