### PR TITLE
feat: API 멱등성 키 도입 (Phase 1)

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyAspect.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyAspect.kt
@@ -1,0 +1,84 @@
+package com.hoppingmall.mall.global.idempotency
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.redisson.api.RedissonClient
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import java.util.concurrent.TimeUnit
+
+@Aspect
+@Component
+class IdempotencyAspect(
+    private val idempotencyService: IdempotencyService,
+    private val redissonClient: RedissonClient,
+    private val objectMapper: ObjectMapper
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Around("@annotation(idempotent)")
+    fun handleIdempotency(joinPoint: ProceedingJoinPoint, idempotent: Idempotent): Any? {
+        val requestAttributes = RequestContextHolder.getRequestAttributes() as? ServletRequestAttributes
+            ?: return joinPoint.proceed()
+
+        val request = requestAttributes.request
+        val key = request.getHeader(IDEMPOTENCY_KEY_HEADER)
+            ?: throw IdempotencyKeyMissingException()
+
+        val existing = idempotencyService.findByKey(key)
+        if (existing != null) {
+            log.info("멱등성 캐시 히트: key={}, endpoint={}", key, existing.endpoint)
+            return buildCachedResponse(existing)
+        }
+
+        val lockKey = "idempotency:$key"
+        val lock = redissonClient.getLock(lockKey)
+
+        if (!lock.tryLock(0, idempotent.lockTimeoutSeconds, TimeUnit.SECONDS)) {
+            throw IdempotencyConflictException()
+        }
+
+        try {
+            val existingAfterLock = idempotencyService.findByKey(key)
+            if (existingAfterLock != null) {
+                log.info("멱등성 캐시 히트 (락 후): key={}", key)
+                return buildCachedResponse(existingAfterLock)
+            }
+
+            val result = joinPoint.proceed()
+
+            if (result is ResponseEntity<*> && result.statusCode.is2xxSuccessful) {
+                idempotencyService.save(
+                    key = key,
+                    httpMethod = request.method,
+                    endpoint = request.requestURI,
+                    responseStatus = result.statusCode.value(),
+                    responseBody = objectMapper.writeValueAsString(result.body),
+                    ttlHours = idempotent.ttlHours
+                )
+                log.info("멱등성 레코드 저장: key={}, endpoint={}", key, request.requestURI)
+            }
+
+            return result
+        } finally {
+            if (lock.isHeldByCurrentThread) {
+                lock.unlock()
+            }
+        }
+    }
+
+    private fun buildCachedResponse(record: IdempotencyRecord): ResponseEntity<Any> {
+        val body = objectMapper.readValue(record.responseBody, Any::class.java)
+        return ResponseEntity.status(record.responseStatus).body(body)
+    }
+
+    companion object {
+        const val IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyConflictException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyConflictException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.global.idempotency
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+
+class IdempotencyConflictException : BusinessException(IdempotencyErrorCode.IDEMPOTENCY_KEY_CONFLICT)

--- a/src/main/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyErrorCode.kt
@@ -1,0 +1,13 @@
+package com.hoppingmall.mall.global.idempotency
+
+import com.hoppingmall.mall.global.common.error.code.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class IdempotencyErrorCode(
+    override val code: String,
+    override val message: String,
+    override val status: HttpStatus
+) : ErrorCode {
+    IDEMPOTENCY_KEY_MISSING("IDEM001", "Idempotency-Key 헤더가 필요합니다.", HttpStatus.BAD_REQUEST),
+    IDEMPOTENCY_KEY_CONFLICT("IDEM002", "동일한 요청이 처리 중입니다. 잠시 후 다시 시도해 주세요.", HttpStatus.CONFLICT)
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyKeyMissingException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyKeyMissingException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.global.idempotency
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+
+class IdempotencyKeyMissingException : BusinessException(IdempotencyErrorCode.IDEMPOTENCY_KEY_MISSING)

--- a/src/main/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyRecord.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyRecord.kt
@@ -1,0 +1,33 @@
+package com.hoppingmall.mall.global.idempotency
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "idempotency_records")
+class IdempotencyRecord(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false, unique = true, length = 64)
+    val idempotencyKey: String,
+
+    @Column(nullable = false, length = 10)
+    val httpMethod: String,
+
+    @Column(nullable = false)
+    val endpoint: String,
+
+    @Column(nullable = false)
+    val responseStatus: Int,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val responseBody: String,
+
+    @Column(nullable = false, updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(nullable = false)
+    val expiresAt: LocalDateTime
+)

--- a/src/main/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyRecordRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyRecordRepository.kt
@@ -1,0 +1,15 @@
+package com.hoppingmall.mall.global.idempotency
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDateTime
+import java.util.Optional
+
+interface IdempotencyRecordRepository : JpaRepository<IdempotencyRecord, Long> {
+    fun findByIdempotencyKey(idempotencyKey: String): Optional<IdempotencyRecord>
+
+    @Modifying
+    @Query("DELETE FROM IdempotencyRecord r WHERE r.expiresAt < :now")
+    fun deleteExpiredRecords(now: LocalDateTime): Int
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyService.kt
@@ -1,0 +1,53 @@
+package com.hoppingmall.mall.global.idempotency
+
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class IdempotencyService(
+    private val idempotencyRecordRepository: IdempotencyRecordRepository
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional(readOnly = true)
+    fun findByKey(key: String): IdempotencyRecord? {
+        return idempotencyRecordRepository.findByIdempotencyKey(key)
+            .filter { it.expiresAt.isAfter(LocalDateTime.now()) }
+            .orElse(null)
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun save(
+        key: String,
+        httpMethod: String,
+        endpoint: String,
+        responseStatus: Int,
+        responseBody: String,
+        ttlHours: Long
+    ): IdempotencyRecord {
+        return idempotencyRecordRepository.save(
+            IdempotencyRecord(
+                idempotencyKey = key,
+                httpMethod = httpMethod,
+                endpoint = endpoint,
+                responseStatus = responseStatus,
+                responseBody = responseBody,
+                expiresAt = LocalDateTime.now().plusHours(ttlHours)
+            )
+        )
+    }
+
+    @Scheduled(cron = "0 0 3 * * ?")
+    @Transactional
+    fun cleanupExpiredRecords() {
+        val deleted = idempotencyRecordRepository.deleteExpiredRecords(LocalDateTime.now())
+        if (deleted > 0) {
+            log.info("멱등성 만료 레코드 정리: {}건 삭제", deleted)
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/idempotency/Idempotent.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/idempotency/Idempotent.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.mall.global.idempotency
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Idempotent(
+    val ttlHours: Long = 24,
+    val lockTimeoutSeconds: Long = 10
+)

--- a/src/main/kotlin/com/hoppingmall/mall/order/controller/OrderController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/controller/OrderController.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.order.controller
 
 import com.hoppingmall.mall.global.auth.UserPrincipal
 import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.global.idempotency.Idempotent
 import com.hoppingmall.mall.order.dto.request.OrderCreateRequest
 import com.hoppingmall.mall.order.dto.request.OrderStatusUpdateRequest
 import com.hoppingmall.mall.order.dto.response.OrderResponse
@@ -23,6 +24,7 @@ class OrderController(
     private val orderQueryService: OrderQueryService
 ) {
 
+    @Idempotent(ttlHours = 24)
     @PostMapping
     fun createOrder(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,

--- a/src/main/kotlin/com/hoppingmall/mall/payment/controller/PaymentController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/controller/PaymentController.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.mall.payment.controller
 
+import com.hoppingmall.mall.global.idempotency.Idempotent
 import com.hoppingmall.mall.payment.dto.request.PaymentRequest
 import com.hoppingmall.mall.payment.dto.response.PaymentResponse
 import com.hoppingmall.mall.payment.service.PaymentCommandService
@@ -19,6 +20,7 @@ class PaymentController(
     private val paymentQueryService: PaymentQueryService
 ) {
     
+    @Idempotent(ttlHours = 24)
     @PostMapping
     fun processPayment(
         @Valid @RequestBody paymentRequest: PaymentRequest,

--- a/src/main/kotlin/com/hoppingmall/mall/refund/controller/RefundController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/controller/RefundController.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.mall.refund.controller
 
+import com.hoppingmall.mall.global.idempotency.Idempotent
 import com.hoppingmall.mall.refund.dto.request.RefundApprovalRequest
 import com.hoppingmall.mall.refund.dto.request.RefundCreateRequest
 import com.hoppingmall.mall.refund.dto.response.RefundResponse
@@ -20,6 +21,7 @@ class RefundController(
     private val refundQueryService: RefundQueryService
 ) {
 
+    @Idempotent(ttlHours = 24)
     @PostMapping
     fun requestRefund(
         @Valid @RequestBody request: RefundCreateRequest,

--- a/src/test/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyAspectTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyAspectTest.kt
@@ -1,0 +1,200 @@
+package com.hoppingmall.mall.global.idempotency
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.aspectj.lang.ProceedingJoinPoint
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.*
+import org.redisson.api.RLock
+import org.redisson.api.RedissonClient
+import org.springframework.http.ResponseEntity
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
+
+@DisplayName("IdempotencyAspect")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class IdempotencyAspectTest {
+
+    private val idempotencyService: IdempotencyService = mock()
+    private val redissonClient: RedissonClient = mock()
+    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+    private val aspect = IdempotencyAspect(idempotencyService, redissonClient, objectMapper)
+
+    private val joinPoint: ProceedingJoinPoint = mock()
+    private val idempotent = mock<Idempotent>()
+    private val lock: RLock = mock()
+
+    @BeforeEach
+    fun setUp() {
+        whenever(idempotent.ttlHours).thenReturn(24)
+        whenever(idempotent.lockTimeoutSeconds).thenReturn(10)
+    }
+
+    private fun setUpRequest(idempotencyKey: String? = null): MockHttpServletRequest {
+        val request = MockHttpServletRequest("POST", "/api/v1/payments")
+        idempotencyKey?.let { request.addHeader("Idempotency-Key", it) }
+        RequestContextHolder.setRequestAttributes(ServletRequestAttributes(request))
+        return request
+    }
+
+    @Nested
+    @DisplayName("handleIdempotency")
+    inner class HandleIdempotency {
+
+        @Test
+        fun 헤더가_없으면_예외가_발생한다() {
+            // given
+            setUpRequest(idempotencyKey = null)
+
+            // when & then
+            assertThrows<IdempotencyKeyMissingException> {
+                aspect.handleIdempotency(joinPoint, idempotent)
+            }
+        }
+
+        @Test
+        fun 캐시_히트_시_저장된_응답을_반환한다() {
+            // given
+            val key = "cached-key"
+            setUpRequest(idempotencyKey = key)
+
+            val cachedRecord = IdempotencyRecord(
+                id = 1L,
+                idempotencyKey = key,
+                httpMethod = "POST",
+                endpoint = "/api/v1/payments",
+                responseStatus = 200,
+                responseBody = """{"id":1,"amount":50000}""",
+                expiresAt = LocalDateTime.now().plusHours(1)
+            )
+
+            whenever(idempotencyService.findByKey(key)).thenReturn(cachedRecord)
+
+            // when
+            val result = aspect.handleIdempotency(joinPoint, idempotent)
+
+            // then
+            assertTrue(result is ResponseEntity<*>)
+            val response = result as ResponseEntity<*>
+            assertEquals(200, response.statusCode.value())
+            verify(joinPoint, never()).proceed()
+        }
+
+        @Test
+        fun 새_요청은_실행_후_결과를_저장한다() {
+            // given
+            val key = "new-key"
+            setUpRequest(idempotencyKey = key)
+
+            whenever(idempotencyService.findByKey(key)).thenReturn(null)
+            whenever(redissonClient.getLock("idempotency:$key")).thenReturn(lock)
+            whenever(lock.tryLock(0, 10, TimeUnit.SECONDS)).thenReturn(true)
+            whenever(lock.isHeldByCurrentThread).thenReturn(true)
+
+            val responseBody = mapOf("id" to 1, "amount" to 50000)
+            whenever(joinPoint.proceed()).thenReturn(ResponseEntity.ok(responseBody))
+
+            val savedRecord = IdempotencyRecord(
+                id = 1L,
+                idempotencyKey = key,
+                httpMethod = "POST",
+                endpoint = "/api/v1/payments",
+                responseStatus = 200,
+                responseBody = objectMapper.writeValueAsString(responseBody),
+                expiresAt = LocalDateTime.now().plusHours(24)
+            )
+            whenever(idempotencyService.save(eq(key), any(), any(), any(), any(), any()))
+                .thenReturn(savedRecord)
+
+            // when
+            val result = aspect.handleIdempotency(joinPoint, idempotent)
+
+            // then
+            assertTrue(result is ResponseEntity<*>)
+            val response = result as ResponseEntity<*>
+            assertEquals(200, response.statusCode.value())
+            verify(joinPoint).proceed()
+            verify(idempotencyService).save(eq(key), eq("POST"), eq("/api/v1/payments"), eq(200), any(), eq(24))
+            verify(lock).unlock()
+        }
+
+        @Test
+        fun 락_획득_실패_시_예외가_발생한다() {
+            // given
+            val key = "conflict-key"
+            setUpRequest(idempotencyKey = key)
+
+            whenever(idempotencyService.findByKey(key)).thenReturn(null)
+            whenever(redissonClient.getLock("idempotency:$key")).thenReturn(lock)
+            whenever(lock.tryLock(0, 10, TimeUnit.SECONDS)).thenReturn(false)
+
+            // when & then
+            assertThrows<IdempotencyConflictException> {
+                aspect.handleIdempotency(joinPoint, idempotent)
+            }
+            verify(joinPoint, never()).proceed()
+        }
+
+        @Test
+        fun 락_후_이중_체크에서_캐시_히트_시_실행하지_않는다() {
+            // given
+            val key = "double-check-key"
+            setUpRequest(idempotencyKey = key)
+
+            val cachedRecord = IdempotencyRecord(
+                id = 1L,
+                idempotencyKey = key,
+                httpMethod = "POST",
+                endpoint = "/api/v1/payments",
+                responseStatus = 200,
+                responseBody = """{"id":1}""",
+                expiresAt = LocalDateTime.now().plusHours(1)
+            )
+
+            whenever(idempotencyService.findByKey(key))
+                .thenReturn(null)
+                .thenReturn(cachedRecord)
+            whenever(redissonClient.getLock("idempotency:$key")).thenReturn(lock)
+            whenever(lock.tryLock(0, 10, TimeUnit.SECONDS)).thenReturn(true)
+            whenever(lock.isHeldByCurrentThread).thenReturn(true)
+
+            // when
+            val result = aspect.handleIdempotency(joinPoint, idempotent)
+
+            // then
+            assertTrue(result is ResponseEntity<*>)
+            verify(joinPoint, never()).proceed()
+            verify(lock).unlock()
+        }
+
+        @Test
+        fun 실행_중_예외_발생_시_레코드를_저장하지_않는다() {
+            // given
+            val key = "error-key"
+            setUpRequest(idempotencyKey = key)
+
+            whenever(idempotencyService.findByKey(key)).thenReturn(null)
+            whenever(redissonClient.getLock("idempotency:$key")).thenReturn(lock)
+            whenever(lock.tryLock(0, 10, TimeUnit.SECONDS)).thenReturn(true)
+            whenever(lock.isHeldByCurrentThread).thenReturn(true)
+            whenever(joinPoint.proceed()).thenThrow(RuntimeException("결제 실패"))
+
+            // when & then
+            assertThrows<RuntimeException> {
+                aspect.handleIdempotency(joinPoint, idempotent)
+            }
+            verify(idempotencyService, never()).save(any(), any(), any(), any(), any(), any())
+            verify(lock).unlock()
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyServiceTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/idempotency/IdempotencyServiceTest.kt
@@ -1,0 +1,138 @@
+package com.hoppingmall.mall.global.idempotency
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import java.time.LocalDateTime
+import java.util.Optional
+
+@DisplayName("IdempotencyService")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class IdempotencyServiceTest {
+
+    private val idempotencyRecordRepository: IdempotencyRecordRepository = mock()
+    private val idempotencyService = IdempotencyService(idempotencyRecordRepository)
+
+    @Nested
+    @DisplayName("findByKey")
+    inner class FindByKey {
+
+        @Test
+        fun 유효한_레코드가_있으면_반환한다() {
+            // given
+            val key = "test-key-123"
+            val record = IdempotencyRecord(
+                id = 1L,
+                idempotencyKey = key,
+                httpMethod = "POST",
+                endpoint = "/api/v1/payments",
+                responseStatus = 200,
+                responseBody = """{"id":1}""",
+                expiresAt = LocalDateTime.now().plusHours(1)
+            )
+
+            whenever(idempotencyRecordRepository.findByIdempotencyKey(key))
+                .thenReturn(Optional.of(record))
+
+            // when
+            val result = idempotencyService.findByKey(key)
+
+            // then
+            assertNotNull(result)
+            assertEquals(key, result!!.idempotencyKey)
+            assertEquals(200, result.responseStatus)
+        }
+
+        @Test
+        fun 만료된_레코드는_null을_반환한다() {
+            // given
+            val key = "expired-key"
+            val record = IdempotencyRecord(
+                id = 1L,
+                idempotencyKey = key,
+                httpMethod = "POST",
+                endpoint = "/api/v1/payments",
+                responseStatus = 200,
+                responseBody = """{"id":1}""",
+                expiresAt = LocalDateTime.now().minusHours(1)
+            )
+
+            whenever(idempotencyRecordRepository.findByIdempotencyKey(key))
+                .thenReturn(Optional.of(record))
+
+            // when
+            val result = idempotencyService.findByKey(key)
+
+            // then
+            assertNull(result)
+        }
+
+        @Test
+        fun 레코드가_없으면_null을_반환한다() {
+            // given
+            val key = "nonexistent-key"
+
+            whenever(idempotencyRecordRepository.findByIdempotencyKey(key))
+                .thenReturn(Optional.empty())
+
+            // when
+            val result = idempotencyService.findByKey(key)
+
+            // then
+            assertNull(result)
+        }
+    }
+
+    @Nested
+    @DisplayName("save")
+    inner class Save {
+
+        @Test
+        fun 멱등성_레코드를_저장한다() {
+            // given
+            val key = "new-key"
+            val captor = argumentCaptor<IdempotencyRecord>()
+
+            whenever(idempotencyRecordRepository.save(captor.capture())).thenAnswer { captor.lastValue }
+
+            // when
+            val result = idempotencyService.save(
+                key = key,
+                httpMethod = "POST",
+                endpoint = "/api/v1/payments",
+                responseStatus = 200,
+                responseBody = """{"id":1}""",
+                ttlHours = 24
+            )
+
+            // then
+            assertEquals(key, result.idempotencyKey)
+            assertEquals("POST", result.httpMethod)
+            assertEquals("/api/v1/payments", result.endpoint)
+            assertEquals(200, result.responseStatus)
+            assertTrue(result.expiresAt.isAfter(LocalDateTime.now().plusHours(23)))
+        }
+    }
+
+    @Nested
+    @DisplayName("cleanupExpiredRecords")
+    inner class CleanupExpiredRecords {
+
+        @Test
+        fun 만료된_레코드를_정리한다() {
+            // given
+            whenever(idempotencyRecordRepository.deleteExpiredRecords(any()))
+                .thenReturn(5)
+
+            // when
+            idempotencyService.cleanupExpiredRecords()
+
+            // then
+            verify(idempotencyRecordRepository).deleteExpiredRecords(any())
+        }
+    }
+}


### PR DESCRIPTION
Closes #121

### 📌 작업 개요

CRITICAL 엔드포인트(결제, 주문, 환불 생성)에 `Idempotency-Key` 헤더 기반 멱등성 처리를 도입하여 이중 결제/주문/환불을 방지합니다.
AOP 기반 `@Idempotent` 어노테이션으로 투명하게 적용하며, Redisson 분산 락으로 동시 요청을 방어합니다.

---

### ✅ 주요 변경 사항

- `global.idempotency`
  - `@Idempotent`: 멱등성 적용 대상 표시 어노테이션 (ttlHours, lockTimeoutSeconds)
  - `IdempotencyRecord`: DB 엔티티 (키, HTTP 메서드, 엔드포인트, 응답 캐시, 만료시간)
  - `IdempotencyRecordRepository`: JPA 레포지토리 + 만료 레코드 삭제 쿼리
  - `IdempotencyService`: 레코드 조회/저장, 매일 3시 만료 레코드 자동 정리
  - `IdempotencyAspect`: AOP Around 어드바이스, Redisson 분산 락 + 이중 체크 패턴
  - `IdempotencyErrorCode`: IDEM001(키 누락), IDEM002(동시 요청 충돌)

- `payment.controller`
  - `PaymentController.processPayment`: `@Idempotent(ttlHours = 24)` 적용

- `order.controller`
  - `OrderController.createOrder`: `@Idempotent(ttlHours = 24)` 적용

- `refund.controller`
  - `RefundController.requestRefund`: `@Idempotent(ttlHours = 24)` 적용

---

### 🧪 테스트

- `IdempotencyServiceTest`: 유효/만료/미존재 레코드 조회, 저장, 만료 레코드 정리
- `IdempotencyAspectTest`: 헤더 누락 예외, 캐시 히트 응답, 새 요청 실행+저장, 락 실패 충돌, 이중 체크 패턴, 예외 시 미저장

---

### 📎 관련 이슈
- #121