### PR TITLE
perf: FK 컬럼 DB 인덱스 추가

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/cartItem/domain/CartItem.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/cartItem/domain/CartItem.kt
@@ -3,13 +3,20 @@ package com.hoppingmall.mall.cartItem.domain
 import com.hoppingmall.mall.global.common.entity.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.Index
 import jakarta.persistence.Table
 import org.hibernate.annotations.Filter
 import java.math.BigDecimal
 
 @Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 @Entity
-@Table(name = "cart_items")
+@Table(
+    name = "cart_items",
+    indexes = [
+        Index(name = "idx_cart_items_buyer_id", columnList = "buyerId"),
+        Index(name = "idx_cart_items_product_id", columnList = "productId")
+    ]
+)
 class CartItem private constructor(
     @Column
     val buyerId: Long,

--- a/src/main/kotlin/com/hoppingmall/mall/category/domain/Category.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/domain/Category.kt
@@ -3,12 +3,16 @@ package com.hoppingmall.mall.category.domain
 import com.hoppingmall.mall.global.common.entity.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.Index
 import jakarta.persistence.Table
 import org.hibernate.annotations.Filter
 
 @Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 @Entity
-@Table(name = "categories")
+@Table(
+    name = "categories",
+    indexes = [Index(name = "idx_categories_parent_id", columnList = "parentCategoryId")]
+)
 class Category private constructor(
     @Column(nullable = false, unique = true)
     var name: String,

--- a/src/main/kotlin/com/hoppingmall/mall/coupon/domain/UserCoupon.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/coupon/domain/UserCoupon.kt
@@ -9,7 +9,8 @@ import java.time.LocalDateTime
 @Entity
 @Table(
     name = "user_coupons",
-    uniqueConstraints = [UniqueConstraint(columnNames = ["user_id", "coupon_id"])]
+    uniqueConstraints = [UniqueConstraint(columnNames = ["user_id", "coupon_id"])],
+    indexes = [Index(name = "idx_user_coupons_user_id", columnList = "userId")]
 )
 @Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class UserCoupon private constructor(

--- a/src/main/kotlin/com/hoppingmall/mall/notification/domain/Notification.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/domain/Notification.kt
@@ -5,7 +5,10 @@ import com.hoppingmall.mall.notification.enum.NotificationType
 import jakarta.persistence.*
 
 @Entity
-@Table(name = "notifications")
+@Table(
+    name = "notifications",
+    indexes = [Index(name = "idx_notifications_user_id", columnList = "userId")]
+)
 class Notification(
     @Column(nullable = false, unique = true)
     val eventId: String,

--- a/src/main/kotlin/com/hoppingmall/mall/order/domain/Order.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/domain/Order.kt
@@ -8,7 +8,10 @@ import org.hibernate.annotations.Filter
 import java.math.BigDecimal
 
 @Entity
-@Table(name = "orders")
+@Table(
+    name = "orders",
+    indexes = [Index(name = "idx_orders_buyer_id", columnList = "buyerId")]
+)
 @Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class Order private constructor(
     @Column(nullable = false)

--- a/src/main/kotlin/com/hoppingmall/mall/order/domain/OrderItem.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/domain/OrderItem.kt
@@ -3,12 +3,19 @@ package com.hoppingmall.mall.order.domain
 import com.hoppingmall.mall.global.common.entity.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.Index
 import jakarta.persistence.Table
 import org.hibernate.annotations.Filter
 import java.math.BigDecimal
 
 @Entity
-@Table(name = "order_items")
+@Table(
+    name = "order_items",
+    indexes = [
+        Index(name = "idx_order_items_order_id", columnList = "orderId"),
+        Index(name = "idx_order_items_product_id", columnList = "productId")
+    ]
+)
 @Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class OrderItem private constructor(
     @Column(nullable = false)

--- a/src/main/kotlin/com/hoppingmall/mall/payment/domain/Payment.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/domain/Payment.kt
@@ -9,7 +9,13 @@ import java.math.BigDecimal
 import java.time.LocalDateTime
 
 @Entity
-@Table(name = "payments")
+@Table(
+    name = "payments",
+    indexes = [
+        Index(name = "idx_payments_order_id", columnList = "orderId"),
+        Index(name = "idx_payments_user_id", columnList = "userId")
+    ]
+)
 @Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class Payment private constructor(
     @Column(nullable = false)

--- a/src/main/kotlin/com/hoppingmall/mall/point/domain/PointHistory.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/domain/PointHistory.kt
@@ -6,7 +6,10 @@ import jakarta.persistence.*
 import java.math.BigDecimal
 
 @Entity
-@Table(name = "point_histories")
+@Table(
+    name = "point_histories",
+    indexes = [Index(name = "idx_point_histories_user_id", columnList = "userId")]
+)
 class PointHistory(
     @Column(nullable = false)
     val userId: Long,

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/Product.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/Product.kt
@@ -7,7 +7,13 @@ import org.hibernate.annotations.Filter
 import java.math.BigDecimal
 
 @Entity
-@Table(name = "products")
+@Table(
+    name = "products",
+    indexes = [
+        Index(name = "idx_products_seller_id", columnList = "sellerId"),
+        Index(name = "idx_products_category_id", columnList = "categoryId")
+    ]
+)
 @Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class Product private constructor(
 

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/ProductImage.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/ProductImage.kt
@@ -3,11 +3,15 @@ package com.hoppingmall.mall.product.domain
 import com.hoppingmall.mall.global.common.entity.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.Index
 import jakarta.persistence.Table
 import org.hibernate.annotations.Filter
 
 @Entity
-@Table(name = "product_images")
+@Table(
+    name = "product_images",
+    indexes = [Index(name = "idx_product_images_product_id", columnList = "productId")]
+)
 @Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class ProductImage private constructor(
 

--- a/src/main/kotlin/com/hoppingmall/mall/refund/domain/Refund.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/domain/Refund.kt
@@ -10,7 +10,15 @@ import java.math.BigDecimal
 import java.time.LocalDateTime
 
 @Entity
-@Table(name = "refunds")
+@Table(
+    name = "refunds",
+    indexes = [
+        Index(name = "idx_refunds_order_id", columnList = "orderId"),
+        Index(name = "idx_refunds_payment_id", columnList = "paymentId"),
+        Index(name = "idx_refunds_buyer_id", columnList = "buyerId"),
+        Index(name = "idx_refunds_seller_id", columnList = "sellerId")
+    ]
+)
 @Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class Refund private constructor(
     @Column(nullable = false)

--- a/src/main/kotlin/com/hoppingmall/mall/refund/domain/RefundItem.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/domain/RefundItem.kt
@@ -3,12 +3,16 @@ package com.hoppingmall.mall.refund.domain
 import com.hoppingmall.mall.global.common.entity.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.Index
 import jakarta.persistence.Table
 import org.hibernate.annotations.Filter
 import java.math.BigDecimal
 
 @Entity
-@Table(name = "refund_items")
+@Table(
+    name = "refund_items",
+    indexes = [Index(name = "idx_refund_items_refund_id", columnList = "refundId")]
+)
 @Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class RefundItem private constructor(
     @Column(nullable = false)

--- a/src/main/kotlin/com/hoppingmall/mall/review/domain/Review.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/domain/Review.kt
@@ -7,7 +7,11 @@ import org.hibernate.annotations.Filter
 @Entity
 @Table(
     name = "reviews",
-    uniqueConstraints = [UniqueConstraint(columnNames = ["order_item_id"])]
+    uniqueConstraints = [UniqueConstraint(columnNames = ["order_item_id"])],
+    indexes = [
+        Index(name = "idx_reviews_product_id", columnList = "productId"),
+        Index(name = "idx_reviews_buyer_id", columnList = "buyerId")
+    ]
 )
 @Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class Review private constructor(

--- a/src/main/kotlin/com/hoppingmall/mall/shipping/domain/Shipping.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/shipping/domain/Shipping.kt
@@ -7,7 +7,13 @@ import jakarta.persistence.*
 import org.hibernate.annotations.Filter
 
 @Entity
-@Table(name = "shippings")
+@Table(
+    name = "shippings",
+    indexes = [
+        Index(name = "idx_shippings_order_id", columnList = "orderId"),
+        Index(name = "idx_shippings_buyer_id", columnList = "buyerId")
+    ]
+)
 @Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class Shipping private constructor(
     @Column(nullable = false)


### PR DESCRIPTION
Closes #123

### 📌 작업 개요
FK 컬럼에 @Index 어노테이션을 추가하여 조회 성능을 개선합니다.
UNIQUE 제약조건이 이미 있는 컬럼(자동 인덱스 생성)과 복합 UNIQUE로 커버되는 컬럼은 제외했습니다.

---

### ✅ 주요 변경 사항

- `order.domain`
  - `Order`: `buyerId` 인덱스 추가
  - `OrderItem`: `orderId`, `productId` 인덱스 추가

- `payment.domain`
  - `Payment`: `orderId`, `userId` 인덱스 추가

- `refund.domain`
  - `Refund`: `orderId`, `paymentId`, `buyerId`, `sellerId` 인덱스 추가
  - `RefundItem`: `refundId` 인덱스 추가

- `product.domain`
  - `Product`: `sellerId`, `categoryId` 인덱스 추가
  - `ProductImage`: `productId` 인덱스 추가

- `cartItem.domain`
  - `CartItem`: `buyerId`, `productId` 인덱스 추가

- `review.domain`
  - `Review`: `productId`, `buyerId` 인덱스 추가

- `notification.domain`
  - `Notification`: `userId` 인덱스 추가

- `shipping.domain`
  - `Shipping`: `orderId`, `buyerId` 인덱스 추가

- `coupon.domain`
  - `UserCoupon`: `userId` 인덱스 추가

- `point.domain`
  - `PointHistory`: `userId` 인덱스 추가

- `category.domain`
  - `Category`: `parentCategoryId` 인덱스 추가

---

### 🧪 테스트

- `./gradlew test` 전체 통과
- `./gradlew jacocoTestCoverageVerification` 통과

---

### 📎 관련 이슈
- #123