### PR TITLE
feat: DLQ 자동 재처리 스케줄러 구현

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/domain/DLQMessage.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/domain/DLQMessage.kt
@@ -9,7 +9,8 @@ import jakarta.persistence.*
     indexes = [
         Index(name = "idx_dlq_topic", columnList = "original_topic"),
         Index(name = "idx_dlq_status", columnList = "status"),
-        Index(name = "idx_dlq_created_at", columnList = "created_at")
+        Index(name = "idx_dlq_created_at", columnList = "created_at"),
+        Index(name = "idx_dlq_next_retry_at", columnList = "status, next_retry_at")
     ]
 )
 class DLQMessage(
@@ -48,14 +49,18 @@ class DLQMessage(
     var processedAt: Long? = null,
     
     @Column(name = "notes", columnDefinition = "TEXT")
-    var notes: String? = null
-    
+    var notes: String? = null,
+
+    @Column(name = "next_retry_at")
+    var nextRetryAt: Long? = null
+
 ) : BaseEntity() {
-    
+
     fun incrementRetry() {
         this.retryCount++
         this.lastRetryAt = System.currentTimeMillis()
         this.status = DLQStatus.RETRYING
+        this.nextRetryAt = calculateNextRetryAt(this.retryCount)
     }
     
     fun markAsProcessed(notes: String? = null) {
@@ -71,6 +76,40 @@ class DLQMessage(
     
     fun getMessageKey(): String {
         return "${originalTopic}:${originalPartition}:${originalOffset}"
+    }
+
+    fun scheduleNextRetry() {
+        this.status = DLQStatus.PENDING
+        this.nextRetryAt = calculateNextRetryAt(this.retryCount)
+    }
+
+    fun isNonRetryableException(): Boolean {
+        val message = exceptionMessage ?: return false
+        return NON_RETRYABLE_PATTERNS.any { message.contains(it, ignoreCase = true) }
+    }
+
+    companion object {
+        private val BACKOFF_INTERVALS = longArrayOf(
+            60_000L,
+            300_000L,
+            1_800_000L
+        )
+
+        private val NON_RETRYABLE_PATTERNS = listOf(
+            "DeserializationException",
+            "SerializationException",
+            "MessageConversionException",
+            "IllegalArgumentException",
+            "JsonParseException",
+            "JsonMappingException",
+            "InvalidFormatException",
+            "MethodArgumentNotValidException"
+        )
+
+        fun calculateNextRetryAt(retryCount: Int): Long {
+            val index = (retryCount).coerceAtMost(BACKOFF_INTERVALS.size - 1)
+            return System.currentTimeMillis() + BACKOFF_INTERVALS[index]
+        }
     }
 }
 

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/domain/repository/DLQMessageRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/domain/repository/DLQMessageRepository.kt
@@ -68,6 +68,21 @@ interface DLQMessageRepository : JpaRepository<DLQMessage, Long> {
     """)
     fun getDLQStatsByTopic(): List<DLQStatsProjection>
     
+    @Query("""
+        SELECT d FROM DLQMessage d
+        WHERE d.status = :status
+        AND d.retryCount < :maxRetryCount
+        AND d.nextRetryAt IS NOT NULL
+        AND d.nextRetryAt <= :now
+        ORDER BY d.nextRetryAt ASC
+    """)
+    fun findAutoRetryableMessages(
+        @Param("status") status: DLQStatus,
+        @Param("maxRetryCount") maxRetryCount: Int,
+        @Param("now") now: Long,
+        pageable: Pageable
+    ): Page<DLQMessage>
+
     fun existsByOriginalTopicAndOriginalPartitionAndOriginalOffset(
         originalTopic: String,
         originalPartition: Int,

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/service/DLQService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/service/DLQService.kt
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.concurrent.ConcurrentHashMap
@@ -23,6 +24,11 @@ class DLQService(
     private val logger = LoggerFactory.getLogger(DLQService::class.java)
     
     private val processingMessages = ConcurrentHashMap<String, Boolean>()
+
+    companion object {
+        private const val MAX_RETRY_COUNT = 3
+        private const val AUTO_RETRY_BATCH_SIZE = 20
+    }
     
     fun saveDLQMessage(deadLetterMessage: DeadLetterMessage) {
         try {
@@ -47,7 +53,16 @@ class DLQService(
                 exceptionMessage = deadLetterMessage.exception,
                 errorTimestamp = deadLetterMessage.timestamp
             )
-            
+
+            if (dlqMessage.isNonRetryableException()) {
+                dlqMessage.markAsFailed("비재시도 에러: ${deadLetterMessage.exception}")
+                dlqMessageRepository.save(dlqMessage)
+                logger.info("비재시도 에러로 즉시 FAILED 처리: topic={}, error={}",
+                    deadLetterMessage.originalTopic, deadLetterMessage.exception)
+                return
+            }
+
+            dlqMessage.nextRetryAt = DLQMessage.calculateNextRetryAt(0)
             dlqMessageRepository.save(dlqMessage)
             logger.info("DLQ 메시지 저장 완료: topic={}, partition={}, offset={}", 
                 deadLetterMessage.originalTopic, deadLetterMessage.originalPartition, deadLetterMessage.originalOffset)
@@ -117,7 +132,7 @@ class DLQService(
                 return false
             }
             
-            if (dlqMessage.retryCount >= 3) {
+            if (dlqMessage.retryCount >= MAX_RETRY_COUNT) {
                 dlqMessage.markAsFailed("최대 재시도 횟수 초과")
                 dlqMessageRepository.save(dlqMessage)
                 logger.warn("최대 재시도 횟수 초과: id={}, retryCount={}", dlqMessageId, dlqMessage.retryCount)
@@ -140,17 +155,21 @@ class DLQService(
             
         } catch (e: Exception) {
             logger.error("DLQ 메시지 재처리 실패: id={}, error={}", dlqMessageId, e.message, e)
-            
+
             try {
                 val dlqMessage = dlqMessageRepository.findById(dlqMessageId).orElse(null)
                 dlqMessage?.let {
-                    it.markAsFailed("재처리 실패: ${e.message}")
+                    if (it.retryCount >= MAX_RETRY_COUNT) {
+                        it.markAsFailed("최대 재시도 후 실패: ${e.message}")
+                    } else {
+                        it.scheduleNextRetry()
+                    }
                     dlqMessageRepository.save(it)
                 }
             } catch (updateException: Exception) {
                 logger.error("DLQ 메시지 상태 업데이트 실패: id={}", dlqMessageId, updateException)
             }
-            
+
             false
         } finally {
             processingMessages.remove(messageKey)
@@ -199,6 +218,32 @@ class DLQService(
         return deleteCount
     }
     
+    @Scheduled(fixedDelay = 30_000)
+    fun autoRetryPendingMessages() {
+        val now = System.currentTimeMillis()
+        val pageable = PageRequest.of(0, AUTO_RETRY_BATCH_SIZE)
+        val retryableMessages = dlqMessageRepository.findAutoRetryableMessages(
+            DLQStatus.PENDING, MAX_RETRY_COUNT, now, pageable
+        )
+
+        if (retryableMessages.isEmpty) return
+
+        logger.info("DLQ 자동 재처리 시작: {} 건", retryableMessages.content.size)
+
+        var successCount = 0
+        var failureCount = 0
+
+        retryableMessages.content.forEach { message ->
+            if (retryDLQMessage(message.id!!)) {
+                successCount++
+            } else {
+                failureCount++
+            }
+        }
+
+        logger.info("DLQ 자동 재처리 완료: 성공={}, 실패={}", successCount, failureCount)
+    }
+
     private fun reconstructOriginalMessage(dlqMessage: DLQMessage): Any? {
         return try {
             dlqMessage.originalValue?.let { value ->

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/domain/DLQMessageTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/domain/DLQMessageTest.kt
@@ -132,6 +132,114 @@ class DLQMessageTest {
         }
     }
     
+    @Nested
+    @DisplayName("scheduleNextRetry")
+    inner class ScheduleNextRetry {
+
+        @Test
+        fun 다음_재시도를_스케줄링하고_상태를_PENDING으로_변경한다() {
+            // given
+            val dlqMessage = createDLQMessage()
+            dlqMessage.incrementRetry()
+            assertEquals(DLQStatus.RETRYING, dlqMessage.status)
+
+            // when
+            dlqMessage.scheduleNextRetry()
+
+            // then
+            assertEquals(DLQStatus.PENDING, dlqMessage.status)
+            assertNotNull(dlqMessage.nextRetryAt)
+        }
+    }
+
+    @Nested
+    @DisplayName("isNonRetryableException")
+    inner class IsNonRetryableException {
+
+        @Test
+        fun DeserializationException이_포함된_에러는_비재시도로_판별한다() {
+            // given
+            val dlqMessage = createDLQMessage(exception = "org.apache.kafka.common.errors.DeserializationException: Error")
+
+            // when & then
+            assertTrue(dlqMessage.isNonRetryableException())
+        }
+
+        @Test
+        fun IllegalArgumentException이_포함된_에러는_비재시도로_판별한다() {
+            // given
+            val dlqMessage = createDLQMessage(exception = "java.lang.IllegalArgumentException: Invalid value")
+
+            // when & then
+            assertTrue(dlqMessage.isNonRetryableException())
+        }
+
+        @Test
+        fun 일반_런타임_에러는_재시도_가능으로_판별한다() {
+            // given
+            val dlqMessage = createDLQMessage(exception = "java.net.SocketTimeoutException: Connection timed out")
+
+            // when & then
+            assertFalse(dlqMessage.isNonRetryableException())
+        }
+
+        @Test
+        fun 예외_메시지가_null이면_재시도_가능으로_판별한다() {
+            // given
+            val dlqMessage = createDLQMessage(exception = null)
+
+            // when & then
+            assertFalse(dlqMessage.isNonRetryableException())
+        }
+    }
+
+    @Nested
+    @DisplayName("calculateNextRetryAt")
+    inner class CalculateNextRetryAt {
+
+        @Test
+        fun 재시도_횟수에_따라_백오프_간격이_증가한다() {
+            // given & when
+            val before = System.currentTimeMillis()
+            val firstRetry = DLQMessage.calculateNextRetryAt(0)
+            val secondRetry = DLQMessage.calculateNextRetryAt(1)
+            val thirdRetry = DLQMessage.calculateNextRetryAt(2)
+
+            // then
+            assertTrue(firstRetry >= before + 60_000L)
+            assertTrue(secondRetry >= before + 300_000L)
+            assertTrue(thirdRetry >= before + 1_800_000L)
+        }
+
+        @Test
+        fun 최대_인덱스를_초과해도_마지막_간격을_사용한다() {
+            // given & when
+            val before = System.currentTimeMillis()
+            val retryAt = DLQMessage.calculateNextRetryAt(10)
+
+            // then
+            assertTrue(retryAt >= before + 1_800_000L)
+        }
+    }
+
+    @Nested
+    @DisplayName("incrementRetry with nextRetryAt")
+    inner class IncrementRetryWithNextRetryAt {
+
+        @Test
+        fun 재시도_증가_시_nextRetryAt도_설정된다() {
+            // given
+            val dlqMessage = createDLQMessage()
+
+            // when
+            dlqMessage.incrementRetry()
+
+            // then
+            assertNotNull(dlqMessage.nextRetryAt)
+            assertTrue(dlqMessage.nextRetryAt!! > System.currentTimeMillis())
+        }
+    }
+
     private fun createDLQMessage(
         topic: String = "test-topic",
         partition: Int = 0,

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/service/DLQServiceTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/service/DLQServiceTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.kafka.core.KafkaTemplate
@@ -45,6 +46,48 @@ class DLQServiceTest {
             verify(dlqMessageRepository).save(any<DLQMessage>())
         }
         
+        @Test
+        fun 비재시도_에러는_즉시_FAILED로_저장한다() {
+            // given
+            val deadLetterMessage = createDeadLetterMessage(
+                exception = "org.apache.kafka.common.errors.DeserializationException: Error"
+            )
+            whenever(dlqMessageRepository.existsByOriginalTopicAndOriginalPartitionAndOriginalOffset(
+                deadLetterMessage.originalTopic,
+                deadLetterMessage.originalPartition,
+                deadLetterMessage.originalOffset
+            )).thenReturn(false)
+
+            // when
+            dlqService.saveDLQMessage(deadLetterMessage)
+
+            // then
+            verify(dlqMessageRepository).save(argThat<DLQMessage> {
+                this.status == DLQStatus.FAILED && this.nextRetryAt == null
+            })
+        }
+
+        @Test
+        fun 재시도_가능한_에러는_nextRetryAt을_설정하여_저장한다() {
+            // given
+            val deadLetterMessage = createDeadLetterMessage(
+                exception = "java.net.SocketTimeoutException: Connection timed out"
+            )
+            whenever(dlqMessageRepository.existsByOriginalTopicAndOriginalPartitionAndOriginalOffset(
+                deadLetterMessage.originalTopic,
+                deadLetterMessage.originalPartition,
+                deadLetterMessage.originalOffset
+            )).thenReturn(false)
+
+            // when
+            dlqService.saveDLQMessage(deadLetterMessage)
+
+            // then
+            verify(dlqMessageRepository).save(argThat<DLQMessage> {
+                this.status == DLQStatus.PENDING && this.nextRetryAt != null
+            })
+        }
+
         @Test
         fun 중복된_DLQ_메시지는_저장하지_않는다() {
             // given
@@ -209,7 +252,7 @@ class DLQServiceTest {
         }
         
         @Test
-        fun Kafka_전송_실패_시_FAILED로_처리한다() {
+        fun Kafka_전송_실패_시_재시도_가능하면_다음_재시도를_스케줄링한다() {
             // given
             val dlqMessageId = 1L
             val dlqMessage = createDLQMessage(
@@ -217,18 +260,44 @@ class DLQServiceTest {
                 status = DLQStatus.PENDING,
                 retryCount = 1
             )
-            
+
             whenever(dlqMessageRepository.findById(dlqMessageId))
                 .thenReturn(Optional.of(dlqMessage))
             whenever(kafkaTemplate.send(any<String>(), any(), any()))
                 .thenThrow(RuntimeException("Kafka 전송 실패"))
-            
+
             // when
             val result = dlqService.retryDLQMessage(dlqMessageId)
-            
+
             // then
             assertFalse(result)
-            verify(dlqMessageRepository, atLeast(2)).save(dlqMessage) // incrementRetry + markAsFailed
+            assertEquals(DLQStatus.PENDING, dlqMessage.status)
+            assertNotNull(dlqMessage.nextRetryAt)
+            verify(dlqMessageRepository, atLeast(2)).save(dlqMessage)
+        }
+
+        @Test
+        fun Kafka_전송_실패_시_최대_재시도_초과하면_FAILED로_처리한다() {
+            // given
+            val dlqMessageId = 1L
+            val dlqMessage = createDLQMessage(
+                id = dlqMessageId,
+                status = DLQStatus.PENDING,
+                retryCount = 2
+            )
+
+            whenever(dlqMessageRepository.findById(dlqMessageId))
+                .thenReturn(Optional.of(dlqMessage))
+            whenever(kafkaTemplate.send(any<String>(), any(), any()))
+                .thenThrow(RuntimeException("Kafka 전송 실패"))
+
+            // when
+            val result = dlqService.retryDLQMessage(dlqMessageId)
+
+            // then
+            assertFalse(result)
+            assertEquals(DLQStatus.FAILED, dlqMessage.status)
+            verify(dlqMessageRepository, atLeast(2)).save(dlqMessage)
         }
     }
     
@@ -314,6 +383,51 @@ class DLQServiceTest {
         }
     }
     
+    @Nested
+    @DisplayName("autoRetryPendingMessages")
+    inner class AutoRetryPendingMessages {
+
+        @Test
+        fun 재시도_대상_메시지를_자동으로_재처리한다() {
+            // given
+            val dlqMessage = createDLQMessage(
+                id = 1L,
+                status = DLQStatus.PENDING,
+                retryCount = 0
+            ).apply { nextRetryAt = System.currentTimeMillis() - 1000 }
+
+            val page = PageImpl(listOf(dlqMessage))
+            whenever(dlqMessageRepository.findAutoRetryableMessages(
+                eq(DLQStatus.PENDING), eq(3), any(), any()
+            )).thenReturn(page)
+            whenever(dlqMessageRepository.findById(1L)).thenReturn(Optional.of(dlqMessage))
+
+            // when
+            dlqService.autoRetryPendingMessages()
+
+            // then
+            verify(kafkaTemplate).send(
+                eq(dlqMessage.originalTopic),
+                eq(dlqMessage.originalKey ?: ""),
+                any()
+            )
+        }
+
+        @Test
+        fun 재시도_대상이_없으면_아무_작업도_하지_않는다() {
+            // given
+            whenever(dlqMessageRepository.findAutoRetryableMessages(
+                eq(DLQStatus.PENDING), eq(3), any(), any()
+            )).thenReturn(Page.empty())
+
+            // when
+            dlqService.autoRetryPendingMessages()
+
+            // then
+            verify(kafkaTemplate, never()).send(any<String>(), any(), any())
+        }
+    }
+
     private fun createDeadLetterMessage(
         topic: String = "test-topic",
         partition: Int = 0,


### PR DESCRIPTION
Closes #125

### 📌 작업 개요
DLQ 메시지의 자동 재처리 스케줄러를 구현하여 장애 복구를 자동화합니다.
지수 백오프(1분→5분→30분) 기반으로 재시도하며, 비재시도 에러는 즉시 FAILED 처리합니다.

---

### ✅ 주요 변경 사항

- `global.common.domain`
  - `DLQMessage`: `nextRetryAt` 필드, `scheduleNextRetry()`, `isNonRetryableException()`, `calculateNextRetryAt()` 추가
  - `status+next_retry_at` 복합 인덱스 추가

- `global.common.domain.repository`
  - `DLQMessageRepository`: `findAutoRetryableMessages()` 쿼리 추가 (PENDING + nextRetryAt ≤ now)

- `global.common.service`
  - `DLQService`: `@Scheduled(30초)` 자동 재처리 스케줄러 추가
  - `saveDLQMessage()`: 비재시도 에러(DeserializationException, IllegalArgumentException 등) 즉시 FAILED 처리
  - `retryDLQMessage()`: 전송 실패 시 retryCount < 3이면 다음 재시도 스케줄링, 3회 초과 시 FAILED

---

### 🧪 테스트

- `DLQMessageTest`: scheduleNextRetry, isNonRetryableException, calculateNextRetryAt 백오프 간격 테스트
- `DLQServiceTest`: 비재시도 에러 즉시 FAILED, nextRetryAt 설정, 자동 재처리 스케줄러, 전송 실패 분기 테스트

---

### 📎 관련 이슈
- #125