### PR TITLE
fix: 중복 환불 수량 검증 추가

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/refund/domain/repository/RefundItemRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/domain/repository/RefundItemRepository.kt
@@ -13,6 +13,22 @@ interface RefundItemRepository : JpaRepository<RefundItem, Long> {
 
     @Query(
         value = """
+            SELECT ri.order_item_id AS orderItemId,
+                   COALESCE(SUM(ri.quantity), 0) AS totalRefundedQuantity
+            FROM refund_items ri
+            JOIN refunds r ON ri.refund_id = r.id
+            WHERE r.order_id = :orderId
+              AND r.status NOT IN ('REJECTED')
+              AND ri.deleted_at IS NULL
+              AND r.deleted_at IS NULL
+            GROUP BY ri.order_item_id
+        """,
+        nativeQuery = true
+    )
+    fun findRefundedQuantitiesByOrderId(@Param("orderId") orderId: Long): List<RefundedQuantityProjection>
+
+    @Query(
+        value = """
             SELECT ri.product_id AS productId,
                    SUM(ri.quantity) AS totalQuantity,
                    SUM(ri.refund_price) AS totalAmount
@@ -26,4 +42,9 @@ interface RefundItemRepository : JpaRepository<RefundItem, Long> {
         nativeQuery = true
     )
     fun aggregateRefundsByProduct(@Param("status") status: String): List<RefundAggregation>
+}
+
+interface RefundedQuantityProjection {
+    val orderItemId: Long
+    val totalRefundedQuantity: Long
 }

--- a/src/main/kotlin/com/hoppingmall/mall/refund/exception/code/RefundErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/exception/code/RefundErrorCode.kt
@@ -15,4 +15,5 @@ enum class RefundErrorCode(
     REFUND_INVALID_ORDER_STATUS("RFD005", "현재 주문 상태에서는 환불을 요청할 수 없습니다.", HttpStatus.BAD_REQUEST),
     REFUND_INVALID_PAYMENT_STATUS("RFD006", "결제 상태가 유효하지 않아 환불을 요청할 수 없습니다.", HttpStatus.BAD_REQUEST),
     REFUND_INVALID_ITEM("RFD007", "환불 요청 아이템이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    REFUND_QUANTITY_EXCEEDED("RFD008", "환불 가능한 수량을 초과했습니다.", HttpStatus.BAD_REQUEST),
 }

--- a/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImpl.kt
@@ -19,7 +19,6 @@ import com.hoppingmall.mall.refund.dto.request.RefundCreateRequest
 import com.hoppingmall.mall.refund.dto.response.RefundResponse
 import com.hoppingmall.mall.refund.enum.RefundStatus
 import com.hoppingmall.mall.refund.exception.RefundAccessDeniedException
-import com.hoppingmall.mall.refund.exception.RefundAlreadyExistsException
 import com.hoppingmall.mall.refund.exception.RefundNotFoundException
 import com.hoppingmall.mall.shipping.domain.repository.ShippingRepository
 import com.hoppingmall.mall.shipping.enum.ShippingStatus
@@ -66,22 +65,22 @@ class RefundCommandServiceImpl(
             )
         }
 
-        val existingRefunds = refundRepository.findByOrderIdAndStatusNot(request.orderId, RefundStatus.REJECTED)
-        if (existingRefunds.isNotEmpty()) {
-            throw RefundAlreadyExistsException()
-        }
-
         val orderItems = orderItemRepository.findByOrderId(request.orderId)
         val orderItemMap = orderItems.associateBy { it.id!! }
+
+        val refundedQuantities = refundItemRepository.findRefundedQuantitiesByOrderId(request.orderId)
+        val refundedMap = refundedQuantities.associate { it.orderItemId to it.totalRefundedQuantity.toInt() }
 
         request.items.forEach { item ->
             val orderItem = orderItemMap[item.orderItemId]
                 ?: throw com.hoppingmall.mall.refund.exception.RefundException(
                     com.hoppingmall.mall.refund.exception.code.RefundErrorCode.REFUND_INVALID_ITEM
                 )
-            if (item.quantity > orderItem.quantity) {
+            val alreadyRefunded = refundedMap[item.orderItemId] ?: 0
+            val availableQuantity = orderItem.quantity - alreadyRefunded
+            if (item.quantity > availableQuantity) {
                 throw com.hoppingmall.mall.refund.exception.RefundException(
-                    com.hoppingmall.mall.refund.exception.code.RefundErrorCode.REFUND_INVALID_ITEM
+                    com.hoppingmall.mall.refund.exception.code.RefundErrorCode.REFUND_QUANTITY_EXCEEDED
                 )
             }
         }
@@ -91,11 +90,12 @@ class RefundCommandServiceImpl(
             orderItem.productPrice.multiply(BigDecimal(item.quantity))
         }
 
-        val isFullRefund = request.items.size == orderItems.size &&
-            request.items.all { item ->
-                val orderItem = orderItemMap[item.orderItemId]!!
-                item.quantity == orderItem.quantity
-            }
+        val requestItemMap = request.items.associate { it.orderItemId to it.quantity }
+        val isFullRefund = orderItems.all { orderItem ->
+            val alreadyRefunded = refundedMap[orderItem.id!!] ?: 0
+            val currentRefund = requestItemMap[orderItem.id!!] ?: 0
+            alreadyRefunded + currentRefund == orderItem.quantity
+        }
 
         val firstOrderItem = orderItemMap[request.items.first().orderItemId]!!
         val product = productRepository.findById(firstOrderItem.productId).orElse(null)

--- a/src/test/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImplTest.kt
@@ -21,8 +21,8 @@ import com.hoppingmall.mall.refund.dto.request.RefundCreateRequest
 import com.hoppingmall.mall.refund.dto.request.RefundItemRequest
 import com.hoppingmall.mall.refund.enum.RefundReason
 import com.hoppingmall.mall.refund.enum.RefundStatus
+import com.hoppingmall.mall.refund.domain.repository.RefundedQuantityProjection
 import com.hoppingmall.mall.refund.exception.RefundAccessDeniedException
-import com.hoppingmall.mall.refund.exception.RefundAlreadyExistsException
 import com.hoppingmall.mall.refund.exception.RefundException
 import com.hoppingmall.mall.refund.exception.RefundNotFoundException
 import com.hoppingmall.mall.shipping.domain.Shipping
@@ -86,7 +86,7 @@ class RefundCommandServiceImplTest {
 
             whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
             whenever(paymentRepository.findByOrderId(orderId)).thenReturn(payment)
-            whenever(refundRepository.findByOrderIdAndStatusNot(orderId, RefundStatus.REJECTED)).thenReturn(emptyList())
+            whenever(refundItemRepository.findRefundedQuantitiesByOrderId(orderId)).thenReturn(emptyList())
             whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(listOf(orderItem))
             whenever(productRepository.findById(100L)).thenReturn(Optional.of(product))
             whenever(shippingRepository.findByOrderId(orderId)).thenReturn(null)
@@ -127,7 +127,7 @@ class RefundCommandServiceImplTest {
 
             whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
             whenever(paymentRepository.findByOrderId(orderId)).thenReturn(payment)
-            whenever(refundRepository.findByOrderIdAndStatusNot(orderId, RefundStatus.REJECTED)).thenReturn(emptyList())
+            whenever(refundItemRepository.findRefundedQuantitiesByOrderId(orderId)).thenReturn(emptyList())
             whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(listOf(orderItem))
             whenever(productRepository.findById(100L)).thenReturn(Optional.of(product))
             whenever(shippingRepository.findByOrderId(orderId)).thenReturn(shipping)
@@ -166,7 +166,7 @@ class RefundCommandServiceImplTest {
 
             whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
             whenever(paymentRepository.findByOrderId(orderId)).thenReturn(payment)
-            whenever(refundRepository.findByOrderIdAndStatusNot(orderId, RefundStatus.REJECTED)).thenReturn(emptyList())
+            whenever(refundItemRepository.findRefundedQuantitiesByOrderId(orderId)).thenReturn(emptyList())
             whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(listOf(orderItem1, orderItem2))
             whenever(productRepository.findById(100L)).thenReturn(Optional.of(product))
             whenever(shippingRepository.findByOrderId(orderId)).thenReturn(null)
@@ -267,30 +267,6 @@ class RefundCommandServiceImplTest {
         }
 
         @Test
-        fun `이미_진행_중인_환불이_있으면_예외_발생`() {
-            // given
-            val buyerId = 1L
-            val order = Order.paidFixture(buyerId = buyerId)
-            val payment = Payment.successFixture(orderId = 1L)
-            val existingRefund = Refund.fixture(status = RefundStatus.REQUESTED)
-
-            val request = RefundCreateRequest(
-                orderId = 1L,
-                reason = RefundReason.CHANGE_OF_MIND,
-                items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 1))
-            )
-
-            whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
-            whenever(paymentRepository.findByOrderId(1L)).thenReturn(payment)
-            whenever(refundRepository.findByOrderIdAndStatusNot(1L, RefundStatus.REJECTED)).thenReturn(listOf(existingRefund))
-
-            // when & then
-            assertThrows(RefundAlreadyExistsException::class.java) {
-                refundCommandService.requestRefund(buyerId, request)
-            }
-        }
-
-        @Test
         fun `환불_수량이_주문_수량을_초과하면_예외_발생`() {
             // given
             val buyerId = 1L
@@ -306,13 +282,120 @@ class RefundCommandServiceImplTest {
 
             whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
             whenever(paymentRepository.findByOrderId(1L)).thenReturn(payment)
-            whenever(refundRepository.findByOrderIdAndStatusNot(1L, RefundStatus.REJECTED)).thenReturn(emptyList())
             whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(orderItem))
+            whenever(refundItemRepository.findRefundedQuantitiesByOrderId(1L)).thenReturn(emptyList())
 
             // when & then
             assertThrows(RefundException::class.java) {
                 refundCommandService.requestRefund(buyerId, request)
             }
+        }
+
+        @Test
+        fun `이전_환불과_합산하여_수량_초과_시_예외_발생`() {
+            // given
+            val buyerId = 1L
+            val order = Order.paidFixture(buyerId = buyerId)
+            val payment = Payment.successFixture(orderId = 1L)
+            val orderItem = OrderItem.fixture(orderId = 1L, quantity = 3)
+
+            val request = RefundCreateRequest(
+                orderId = 1L,
+                reason = RefundReason.CHANGE_OF_MIND,
+                items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 2))
+            )
+
+            val alreadyRefunded = mockRefundedQuantity(orderItemId = 1L, totalRefundedQuantity = 2L)
+
+            whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+            whenever(paymentRepository.findByOrderId(1L)).thenReturn(payment)
+            whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(orderItem))
+            whenever(refundItemRepository.findRefundedQuantitiesByOrderId(1L)).thenReturn(listOf(alreadyRefunded))
+
+            // when & then
+            assertThrows(RefundException::class.java) {
+                refundCommandService.requestRefund(buyerId, request)
+            }
+        }
+
+        @Test
+        fun `이전_부분_환불_후_남은_수량_내에서_추가_환불_성공`() {
+            // given
+            val buyerId = 1L
+            val orderId = 1L
+            val order = Order.paidFixture(buyerId = buyerId)
+            val payment = Payment.successFixture(orderId = orderId, amount = BigDecimal("30000"), pointAmount = BigDecimal("1000"))
+            val orderItem = OrderItem.fixture(orderId = orderId, productId = 100L, productPrice = BigDecimal("10000"), quantity = 3)
+            val product = Product.fixture(sellerId = 2L).withId(100L)
+
+            val request = RefundCreateRequest(
+                orderId = orderId,
+                reason = RefundReason.CHANGE_OF_MIND,
+                items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 1))
+            )
+
+            val alreadyRefunded = mockRefundedQuantity(orderItemId = 1L, totalRefundedQuantity = 1L)
+
+            whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
+            whenever(paymentRepository.findByOrderId(orderId)).thenReturn(payment)
+            whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(listOf(orderItem))
+            whenever(refundItemRepository.findRefundedQuantitiesByOrderId(orderId)).thenReturn(listOf(alreadyRefunded))
+            whenever(productRepository.findById(100L)).thenReturn(Optional.of(product))
+            whenever(shippingRepository.findByOrderId(orderId)).thenReturn(null)
+            whenever(refundRepository.save(any<Refund>())).thenAnswer { invocation ->
+                (invocation.arguments[0] as Refund).withId(2L)
+            }
+            whenever(refundItemRepository.saveAll(any<List<RefundItem>>())).thenAnswer { invocation ->
+                @Suppress("UNCHECKED_CAST")
+                (invocation.arguments[0] as List<RefundItem>).mapIndexed { index, item -> item.withId(index.toLong() + 1) }
+            }
+
+            // when
+            val response = refundCommandService.requestRefund(buyerId, request)
+
+            // then
+            assertFalse(response.isFullRefund)
+            assertEquals(BigDecimal("10000"), response.refundAmount)
+        }
+
+        @Test
+        fun `이전_부분_환불과_합산하여_전체_환불이_되면_isFullRefund_true`() {
+            // given
+            val buyerId = 1L
+            val orderId = 1L
+            val order = Order.paidFixture(buyerId = buyerId)
+            val payment = Payment.successFixture(orderId = orderId, amount = BigDecimal("30000"), pointAmount = BigDecimal("1000"))
+            val orderItem = OrderItem.fixture(orderId = orderId, productId = 100L, productPrice = BigDecimal("10000"), quantity = 3)
+            val product = Product.fixture(sellerId = 2L).withId(100L)
+
+            val request = RefundCreateRequest(
+                orderId = orderId,
+                reason = RefundReason.CHANGE_OF_MIND,
+                items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 2))
+            )
+
+            val alreadyRefunded = mockRefundedQuantity(orderItemId = 1L, totalRefundedQuantity = 1L)
+
+            whenever(orderRepository.findById(orderId)).thenReturn(Optional.of(order))
+            whenever(paymentRepository.findByOrderId(orderId)).thenReturn(payment)
+            whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(listOf(orderItem))
+            whenever(refundItemRepository.findRefundedQuantitiesByOrderId(orderId)).thenReturn(listOf(alreadyRefunded))
+            whenever(productRepository.findById(100L)).thenReturn(Optional.of(product))
+            whenever(shippingRepository.findByOrderId(orderId)).thenReturn(null)
+            whenever(refundRepository.save(any<Refund>())).thenAnswer { invocation ->
+                (invocation.arguments[0] as Refund).withId(2L)
+            }
+            whenever(refundItemRepository.saveAll(any<List<RefundItem>>())).thenAnswer { invocation ->
+                @Suppress("UNCHECKED_CAST")
+                (invocation.arguments[0] as List<RefundItem>).mapIndexed { index, item -> item.withId(index.toLong() + 1) }
+            }
+
+            // when
+            val response = refundCommandService.requestRefund(buyerId, request)
+
+            // then
+            assertTrue(response.isFullRefund)
+            verify(refundEventPublisher).publishRefundCompletedEvent(any())
         }
 
         @Test
@@ -428,6 +511,13 @@ class RefundCommandServiceImplTest {
             assertThrows(RefundAccessDeniedException::class.java) {
                 refundCommandService.rejectRefund(refundId, 999L, rejectionRequest)
             }
+        }
+    }
+
+    private fun mockRefundedQuantity(orderItemId: Long, totalRefundedQuantity: Long): RefundedQuantityProjection {
+        return object : RefundedQuantityProjection {
+            override val orderItemId: Long = orderItemId
+            override val totalRefundedQuantity: Long = totalRefundedQuantity
         }
     }
 }


### PR DESCRIPTION
Closes #127

### 📌 작업 개요
같은 주문 아이템에 대해 여러 번 부분 환불을 요청할 때 누적 수량 검증이 없어
주문 수량을 초과하는 환불이 가능한 취약점을 해소합니다.
기존 all-or-nothing 방식을 누적 기반으로 변경하여 순차 부분 환불도 지원합니다.

---

### ✅ 주요 변경 사항

- `refund.domain.repository`
  - `RefundItemRepository`: `findRefundedQuantitiesByOrderId()` 네이티브 쿼리 추가 (orderItemId별 누적 환불 수량)
  - `RefundedQuantityProjection`: 집계 결과 프로젝션 인터페이스

- `refund.exception.code`
  - `RefundErrorCode`: `REFUND_QUANTITY_EXCEEDED(RFD008)` 추가

- `refund.service`
  - `RefundCommandServiceImpl`: all-or-nothing 환불 차단 → 누적 수량 기반 검증으로 변경
  - `isFullRefund` 판정도 누적 기반으로 변경 (이전 환불 + 현재 요청 = 전체 수량)

---

### 🧪 테스트

- `RefundCommandServiceImplTest`: 이전 환불 합산 초과 예외, 남은 수량 내 추가 환불 성공, 순차 부분 환불 합산 전체 환불 판정 테스트 추가

---

### 📎 관련 이슈
- #127