### PR TITLE
feat: 상품 다중 이미지 지원

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/cartItem/service/CartItemCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/cartItem/service/CartItemCommandServiceImpl.kt
@@ -27,7 +27,7 @@ class CartItemCommandServiceImpl(
         val product = productRepository.findById(request.productId)
             .orElseThrow { ProductNotFoundException() }
         
-        val productImage = productImageRepository.findByProductId(request.productId)
+        val productImage = productImageRepository.findByProductIdOrderBySortOrder(request.productId).firstOrNull()
         val existingCartItem = cartItemRepository.findByBuyerIdAndProductId(buyerId, request.productId)
 
         val cartItem = if (existingCartItem != null) {

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/ProductImage.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/ProductImage.kt
@@ -21,14 +21,18 @@ class ProductImage private constructor(
     @Column(nullable = false)
     var imageUrl: String,
 
-): BaseEntity() {
+    @Column(nullable = false)
+    val sortOrder: Int = 0
+
+) : BaseEntity() {
 
     companion object {
         fun create(
             productId: Long,
             imageUrl: String,
+            sortOrder: Int = 0
         ): ProductImage {
-            return ProductImage(productId, imageUrl)
+            return ProductImage(productId, imageUrl, sortOrder)
         }
     }
-}  
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductImageRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductImageRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository
 @Repository
 interface ProductImageRepository: JpaRepository<ProductImage, Long> {
 
-    fun findByProductId(productId: Long): ProductImage?
+    fun findByProductIdOrderBySortOrder(productId: Long): List<ProductImage>
 
     fun findByProductIdIn(productIds: List<Long>): List<ProductImage>
-} 
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/request/ProductCreateRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/request/ProductCreateRequest.kt
@@ -22,7 +22,7 @@ data class ProductCreateRequest(
     @field:Positive(message = "가격은 0보다 커야 합니다.")
     val price: BigDecimal,
     
-    val imageUrl: String? = null,
+    val imageUrls: List<String>? = null,
     
     @field:NotNull(message = "상품 상태는 필수입니다.")
     val status: ProductStatus = ProductStatus.AVAILABLE

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/request/ProductUpdateRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/request/ProductUpdateRequest.kt
@@ -19,7 +19,7 @@ data class ProductUpdateRequest(
     @field:Positive(message = "가격은 0보다 커야 합니다.")
     val price: BigDecimal,
     
-    val imageUrl: String? = null,
+    val imageUrls: List<String>? = null,
     
     val status: ProductStatus = ProductStatus.AVAILABLE
 ) 

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/response/ProductWithImageResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/response/ProductWithImageResponse.kt
@@ -14,12 +14,12 @@ data class ProductResponse(
     val description: String,
     val price: BigDecimal,
     val status: ProductStatus,
-    val imageUrl: String?,
+    val imageUrls: List<String>,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime?
 ) {
     companion object {
-        fun from(product: Product, image: ProductImage?): ProductResponse {
+        fun from(product: Product, images: List<ProductImage>): ProductResponse {
             return ProductResponse(
                 id = product.id!!,
                 sellerId = product.sellerId,
@@ -28,10 +28,10 @@ data class ProductResponse(
                 description = product.description,
                 price = product.price,
                 status = product.status,
-                imageUrl = image?.imageUrl,
+                imageUrls = images.sortedBy { it.sortOrder }.map { it.imageUrl },
                 createdAt = product.createdAt,
                 updatedAt = product.updatedAt
             )
         }
     }
-}  
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImpl.kt
@@ -41,14 +41,17 @@ class ProductCommandServiceImpl(
         )
         val savedProduct = productRepository.save(product)
 
-        val imageUrl = request.imageUrl ?: DEFAULT_IMAGE_PATH
-        val productImage = ProductImage.create(
-            productId = savedProduct.id!!,
-            imageUrl = imageUrl
-        )
-        val savedProductImage = productImageRepository.save(productImage)
+        val imageUrls = request.imageUrls?.ifEmpty { null } ?: listOf(DEFAULT_IMAGE_PATH)
+        val productImages = imageUrls.mapIndexed { index, url ->
+            ProductImage.create(
+                productId = savedProduct.id!!,
+                imageUrl = url,
+                sortOrder = index
+            )
+        }
+        val savedImages = productImageRepository.saveAll(productImages)
 
-        return ProductResponse.from(savedProduct, savedProductImage)
+        return ProductResponse.from(savedProduct, savedImages)
     }
 
     @CacheEvict(cacheNames = ["product"], key = "#productId")
@@ -68,21 +71,20 @@ class ProductCommandServiceImpl(
 
         val updatedProduct = productRepository.save(product)
 
-        val imageUrl = request.imageUrl ?: DEFAULT_IMAGE_PATH
-        val existingImage = productImageRepository.findByProductId(productId)
-        
-        val updatedProductImage = if (existingImage != null) {
-            existingImage.imageUrl = imageUrl
-            productImageRepository.save(existingImage)
-        } else {
-            val newProductImage = ProductImage.create(
-                productId = productId,
-                imageUrl = imageUrl
-            )
-            productImageRepository.save(newProductImage)
-        }
+        val existingImages = productImageRepository.findByProductIdOrderBySortOrder(productId)
+        existingImages.forEach { it.softDelete() }
 
-        return ProductResponse.from(updatedProduct, updatedProductImage)
+        val imageUrls = request.imageUrls?.ifEmpty { null } ?: listOf(DEFAULT_IMAGE_PATH)
+        val newImages = imageUrls.mapIndexed { index, url ->
+            ProductImage.create(
+                productId = productId,
+                imageUrl = url,
+                sortOrder = index
+            )
+        }
+        val savedImages = productImageRepository.saveAll(newImages)
+
+        return ProductResponse.from(updatedProduct, savedImages)
     }
 
     @CacheEvict(cacheNames = ["product"], key = "#productId")
@@ -90,9 +92,9 @@ class ProductCommandServiceImpl(
         val product = productRepository.findById(productId)
             .orElseThrow { ProductNotFoundException() }
 
-        val productImage = productImageRepository.findByProductId(productId)
-        productImage?.softDelete()
+        val productImages = productImageRepository.findByProductIdOrderBySortOrder(productId)
+        productImages.forEach { it.softDelete() }
 
         product.softDelete()
     }
-} 
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImpl.kt
@@ -41,9 +41,9 @@ class ProductQueryServiceImpl(
             return null
         }
 
-        val image = productImageRepository.findByProductId(productId)
+        val images = productImageRepository.findByProductIdOrderBySortOrder(productId)
 
-        return ProductResponse.from(product, image)
+        return ProductResponse.from(product, images)
     }
 
     override fun getProductsBySellerId(
@@ -83,10 +83,10 @@ class ProductQueryServiceImpl(
     ): Slice<ProductResponse> {
         val productIds = productSlice.content.mapNotNull { it.id }
         val imageMap = productImageRepository.findByProductIdIn(productIds)
-            .associateBy { it.productId }
+            .groupBy { it.productId }
 
         val productResponses = productSlice.content.map { product ->
-            ProductResponse.from(product, imageMap[product.id])
+            ProductResponse.from(product, imageMap[product.id!!] ?: emptyList())
         }
 
         return SliceImpl(productResponses, pageable, productSlice.hasNext())

--- a/src/test/kotlin/com/hoppingmall/mall/cartItem/service/CartItemCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/cartItem/service/CartItemCommandServiceImplTest.kt
@@ -63,7 +63,7 @@ class CartItemCommandServiceImplTest {
 
             // Context
             whenever(productRepository.findById(request.productId)).thenReturn(java.util.Optional.of(product))
-            whenever(productImageRepository.findByProductId(request.productId)).thenReturn(productImage)
+            whenever(productImageRepository.findByProductIdOrderBySortOrder(request.productId)).thenReturn(listOf(productImage))
             whenever(cartItemRepository.findByBuyerIdAndProductId(buyerId, request.productId)).thenReturn(null)
             whenever(cartItemRepository.save(any<CartItem>())).thenAnswer { invocation ->
                 val cartItem = invocation.getArgument<CartItem>(0)
@@ -96,7 +96,7 @@ class CartItemCommandServiceImplTest {
 
             // Context
             whenever(productRepository.findById(request.productId)).thenReturn(java.util.Optional.of(product))
-            whenever(productImageRepository.findByProductId(request.productId)).thenReturn(productImage)
+            whenever(productImageRepository.findByProductIdOrderBySortOrder(request.productId)).thenReturn(listOf(productImage))
             whenever(cartItemRepository.findByBuyerIdAndProductId(buyerId, request.productId)).thenReturn(existingCartItem)
             whenever(cartItemRepository.save(any<CartItem>())).thenAnswer { invocation ->
                 val cartItem = invocation.getArgument<CartItem>(0)
@@ -122,7 +122,7 @@ class CartItemCommandServiceImplTest {
 
             // Context
             whenever(productRepository.findById(request.productId)).thenReturn(java.util.Optional.of(product))
-            whenever(productImageRepository.findByProductId(request.productId)).thenReturn(null)
+            whenever(productImageRepository.findByProductIdOrderBySortOrder(request.productId)).thenReturn(emptyList())
             whenever(cartItemRepository.findByBuyerIdAndProductId(buyerId, request.productId)).thenReturn(null)
             whenever(cartItemRepository.save(any<CartItem>())).thenAnswer { invocation ->
                 val cartItem = invocation.getArgument<CartItem>(0)

--- a/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductControllerTest.kt
@@ -45,7 +45,7 @@ class ProductControllerTest {
                     description = "설명1",
                     price = BigDecimal("10000"),
                     status = ProductStatus.AVAILABLE,
-                    imageUrl = "https://example.com/image1.jpg",
+                    imageUrls = listOf("https://example.com/image1.jpg"),
                     createdAt = LocalDateTime.now(),
                     updatedAt = null
                 ),
@@ -57,7 +57,7 @@ class ProductControllerTest {
                     description = "설명2",
                     price = BigDecimal("20000"),
                     status = ProductStatus.AVAILABLE,
-                    imageUrl = "https://example.com/image2.jpg",
+                    imageUrls = listOf("https://example.com/image2.jpg"),
                     createdAt = LocalDateTime.now(),
                     updatedAt = null
                 )
@@ -89,7 +89,7 @@ class ProductControllerTest {
                 description = "설명1",
                 price = BigDecimal("10000"),
                 status = ProductStatus.AVAILABLE,
-                imageUrl = "https://example.com/image.jpg",
+                imageUrls = listOf("https://example.com/image.jpg"),
                 createdAt = LocalDateTime.now(),
                 updatedAt = null
             )
@@ -134,7 +134,7 @@ class ProductControllerTest {
                     description = "설명1",
                     price = BigDecimal("10000"),
                     status = ProductStatus.AVAILABLE,
-                    imageUrl = "https://example.com/image1.jpg",
+                    imageUrls = listOf("https://example.com/image1.jpg"),
                     createdAt = LocalDateTime.now(),
                     updatedAt = null
                 ),
@@ -146,7 +146,7 @@ class ProductControllerTest {
                     description = "설명2",
                     price = BigDecimal("20000"),
                     status = ProductStatus.AVAILABLE,
-                    imageUrl = "https://example.com/image2.jpg",
+                    imageUrls = listOf("https://example.com/image2.jpg"),
                     createdAt = LocalDateTime.now(),
                     updatedAt = null
                 )
@@ -180,7 +180,7 @@ class ProductControllerTest {
                     description = "설명1",
                     price = BigDecimal("10000"),
                     status = ProductStatus.AVAILABLE,
-                    imageUrl = "https://example.com/image1.jpg",
+                    imageUrls = listOf("https://example.com/image1.jpg"),
                     createdAt = LocalDateTime.now(),
                     updatedAt = null
                 ),
@@ -192,7 +192,7 @@ class ProductControllerTest {
                     description = "설명2",
                     price = BigDecimal("20000"),
                     status = ProductStatus.AVAILABLE,
-                    imageUrl = "https://example.com/image2.jpg",
+                    imageUrls = listOf("https://example.com/image2.jpg"),
                     createdAt = LocalDateTime.now(),
                     updatedAt = null
                 )
@@ -226,7 +226,7 @@ class ProductControllerTest {
                     description = "고성능 노트북",
                     price = BigDecimal("1500000"),
                     status = ProductStatus.AVAILABLE,
-                    imageUrl = null,
+                    imageUrls = emptyList(),
                     createdAt = LocalDateTime.now(),
                     updatedAt = null
                 )
@@ -256,7 +256,7 @@ class ProductControllerTest {
                     description = "설명1",
                     price = BigDecimal("10000"),
                     status = ProductStatus.AVAILABLE,
-                    imageUrl = null,
+                    imageUrls = emptyList(),
                     createdAt = LocalDateTime.now(),
                     updatedAt = null
                 )
@@ -284,7 +284,7 @@ class ProductControllerTest {
                 name = "새 상품",
                 description = "새 상품 설명",
                 price = BigDecimal("15000"),
-                imageUrl = "https://example.com/new-image.jpg",
+                imageUrls = listOf("https://example.com/new-image.jpg"),
                 status = ProductStatus.AVAILABLE
             )
 
@@ -296,7 +296,7 @@ class ProductControllerTest {
                 description = "새 상품 설명",
                 price = BigDecimal("15000"),
                 status = ProductStatus.AVAILABLE,
-                imageUrl = "https://example.com/new-image.jpg",
+                imageUrls = listOf("https://example.com/new-image.jpg"),
                 createdAt = LocalDateTime.now(),
                 updatedAt = null
             )
@@ -323,7 +323,7 @@ class ProductControllerTest {
                 name = "수정된 상품",
                 description = "수정된 상품 설명",
                 price = BigDecimal("20000"),
-                imageUrl = "https://example.com/updated-image.jpg",
+                imageUrls = listOf("https://example.com/updated-image.jpg"),
                 status = ProductStatus.AVAILABLE
             )
 
@@ -335,7 +335,7 @@ class ProductControllerTest {
                 description = "수정된 상품 설명",
                 price = BigDecimal("20000"),
                 status = ProductStatus.AVAILABLE,
-                imageUrl = "https://example.com/updated-image.jpg",
+                imageUrls = listOf("https://example.com/updated-image.jpg"),
                 createdAt = LocalDateTime.now(),
                 updatedAt = LocalDateTime.now()
             )

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImplTest.kt
@@ -43,20 +43,20 @@ class ProductCommandServiceImplTest {
                 name = "테스트 상품",
                 description = "테스트 상품 설명",
                 price = BigDecimal("10000"),
-                imageUrl = "https://example.com/image.jpg",
+                imageUrls = listOf("https://example.com/image.jpg"),
                 status = ProductStatus.AVAILABLE
             )
 
             val productCaptor = argumentCaptor<Product>()
-            val imageCaptor = argumentCaptor<ProductImage>()
+            val imagesCaptor = argumentCaptor<List<ProductImage>>()
 
             // Context
             whenever(categoryRepository.existsById(request.categoryId)).thenReturn(true)
             whenever(productRepository.save(productCaptor.capture())).thenAnswer {
                 productCaptor.firstValue.withId(1L)
             }
-            whenever(productImageRepository.save(imageCaptor.capture())).thenAnswer {
-                imageCaptor.firstValue.withId(1L)
+            whenever(productImageRepository.saveAll(imagesCaptor.capture())).thenAnswer {
+                imagesCaptor.firstValue.mapIndexed { index, image -> image.withId(index.toLong() + 1) }
             }
 
             // Interaction
@@ -70,20 +70,60 @@ class ProductCommandServiceImplTest {
             assertThat(result.description).isEqualTo(request.description)
             assertThat(result.price).isEqualTo(request.price)
             assertThat(result.status).isEqualTo(request.status)
-            assertThat(result.imageUrl).isEqualTo(request.imageUrl)
+            assertThat(result.imageUrls).containsExactly("https://example.com/image.jpg")
 
-            // 저장된 객체 검증
             val savedProduct = productCaptor.firstValue
             assertThat(savedProduct.name).isEqualTo(request.name)
             assertThat(savedProduct.sellerId).isEqualTo(request.sellerId)
             assertThat(savedProduct.categoryId).isEqualTo(request.categoryId)
 
-            val savedImage = imageCaptor.firstValue
-            assertThat(savedImage.imageUrl).isEqualTo(request.imageUrl)
+            val savedImages = imagesCaptor.firstValue
+            assertThat(savedImages[0].imageUrl).isEqualTo("https://example.com/image.jpg")
 
             verify(categoryRepository).existsById(request.categoryId)
             verify(productRepository).save(any())
-            verify(productImageRepository).save(any())
+            verify(productImageRepository).saveAll(any<List<ProductImage>>())
+        }
+
+        @Test
+        fun 다중_이미지_상품_생성_성공() {
+            // Data
+            val request = ProductCreateRequest(
+                sellerId = 1L,
+                categoryId = 1L,
+                name = "다중 이미지 상품",
+                description = "이미지 3장",
+                price = BigDecimal("30000"),
+                imageUrls = listOf("https://example.com/1.jpg", "https://example.com/2.jpg", "https://example.com/3.jpg"),
+                status = ProductStatus.AVAILABLE
+            )
+
+            val productCaptor = argumentCaptor<Product>()
+            val imagesCaptor = argumentCaptor<List<ProductImage>>()
+
+            // Context
+            whenever(categoryRepository.existsById(request.categoryId)).thenReturn(true)
+            whenever(productRepository.save(productCaptor.capture())).thenAnswer {
+                productCaptor.firstValue.withId(1L)
+            }
+            whenever(productImageRepository.saveAll(imagesCaptor.capture())).thenAnswer {
+                imagesCaptor.firstValue.mapIndexed { index, image -> image.withId(index.toLong() + 1) }
+            }
+
+            // Interaction
+            val result = productCommandService.createProduct(request)
+
+            // Assertions
+            assertThat(result.imageUrls).containsExactly(
+                "https://example.com/1.jpg",
+                "https://example.com/2.jpg",
+                "https://example.com/3.jpg"
+            )
+            val savedImages = imagesCaptor.firstValue
+            assertThat(savedImages).hasSize(3)
+            assertThat(savedImages[0].sortOrder).isEqualTo(0)
+            assertThat(savedImages[1].sortOrder).isEqualTo(1)
+            assertThat(savedImages[2].sortOrder).isEqualTo(2)
         }
 
         @Test
@@ -95,20 +135,20 @@ class ProductCommandServiceImplTest {
                 name = "테스트 상품",
                 description = "테스트 상품 설명",
                 price = BigDecimal("10000"),
-                imageUrl = null,
+                imageUrls = null,
                 status = ProductStatus.AVAILABLE
             )
 
             val productCaptor = argumentCaptor<Product>()
-            val imageCaptor = argumentCaptor<ProductImage>()
+            val imagesCaptor = argumentCaptor<List<ProductImage>>()
 
             // Context
             whenever(categoryRepository.existsById(request.categoryId)).thenReturn(true)
             whenever(productRepository.save(productCaptor.capture())).thenAnswer {
                 productCaptor.firstValue.withId(1L)
             }
-            whenever(productImageRepository.save(imageCaptor.capture())).thenAnswer {
-                imageCaptor.firstValue.withId(1L)
+            whenever(productImageRepository.saveAll(imagesCaptor.capture())).thenAnswer {
+                imagesCaptor.firstValue.mapIndexed { index, image -> image.withId(index.toLong() + 1) }
             }
 
             // Interaction
@@ -118,19 +158,18 @@ class ProductCommandServiceImplTest {
             assertThat(result).isNotNull()
             assertThat(result.id).isEqualTo(1L)
             assertThat(result.name).isEqualTo(request.name)
-            assertThat(result.imageUrl).isEqualTo("D:/hoppingmall/product/images/default-product.jpg")
+            assertThat(result.imageUrls).containsExactly("D:/hoppingmall/product/images/default-product.jpg")
 
-            // 저장된 객체 검증
             val savedProduct = productCaptor.firstValue
             assertThat(savedProduct.name).isEqualTo(request.name)
             assertThat(savedProduct.sellerId).isEqualTo(request.sellerId)
 
-            val savedImage = imageCaptor.firstValue
-            assertThat(savedImage.imageUrl).isEqualTo("D:/hoppingmall/product/images/default-product.jpg")
+            val savedImages = imagesCaptor.firstValue
+            assertThat(savedImages[0].imageUrl).isEqualTo("D:/hoppingmall/product/images/default-product.jpg")
 
             verify(categoryRepository).existsById(request.categoryId)
             verify(productRepository).save(any())
-            verify(productImageRepository).save(any())
+            verify(productImageRepository).saveAll(any<List<ProductImage>>())
         }
 
         @Test
@@ -169,24 +208,24 @@ class ProductCommandServiceImplTest {
                 name = "수정된 상품명",
                 description = "수정된 상품 설명",
                 price = BigDecimal("20000"),
-                imageUrl = "https://example.com/updated-image.jpg",
+                imageUrls = listOf("https://example.com/updated-image.jpg"),
                 status = ProductStatus.SOLD_OUT
             )
 
             val existingProduct = Product.fixture().withId(productId)
             val productCaptor = argumentCaptor<Product>()
-            val imageCaptor = argumentCaptor<ProductImage>()
+            val imagesCaptor = argumentCaptor<List<ProductImage>>()
 
-            val existingImage = ProductImage.fixture(productId = productId)
+            val existingImages = listOf(ProductImage.fixture(productId = productId))
             // Context
             whenever(categoryRepository.existsById(request.categoryId)).thenReturn(true)
             whenever(productRepository.findById(productId)).thenReturn(java.util.Optional.of(existingProduct))
             whenever(productRepository.save(productCaptor.capture())).thenAnswer {
                 productCaptor.firstValue.withId(productId)
             }
-            whenever(productImageRepository.findByProductId(productId)).thenReturn(existingImage)
-            whenever(productImageRepository.save(imageCaptor.capture())).thenAnswer {
-                imageCaptor.firstValue.withId(1L)
+            whenever(productImageRepository.findByProductIdOrderBySortOrder(productId)).thenReturn(existingImages)
+            whenever(productImageRepository.saveAll(imagesCaptor.capture())).thenAnswer {
+                imagesCaptor.firstValue.mapIndexed { index, image -> image.withId(index.toLong() + 1) }
             }
 
             // Interaction
@@ -200,13 +239,13 @@ class ProductCommandServiceImplTest {
             assertThat(result.description).isEqualTo(request.description)
             assertThat(result.price).isEqualTo(request.price)
             assertThat(result.status).isEqualTo(request.status)
-            assertThat(result.imageUrl).isEqualTo(request.imageUrl)
+            assertThat(result.imageUrls).containsExactly("https://example.com/updated-image.jpg")
 
             verify(categoryRepository).existsById(request.categoryId)
             verify(productRepository).findById(productId)
             verify(productRepository).save(any())
-            verify(productImageRepository).findByProductId(productId)
-            verify(productImageRepository).save(any())
+            verify(productImageRepository).findByProductIdOrderBySortOrder(productId)
+            verify(productImageRepository).saveAll(any<List<ProductImage>>())
         }
 
         @Test
@@ -218,7 +257,7 @@ class ProductCommandServiceImplTest {
                 name = "수정된 상품명",
                 description = "수정된 상품 설명",
                 price = BigDecimal("20000"),
-                imageUrl = "https://example.com/updated-image.jpg",
+                imageUrls = listOf("https://example.com/updated-image.jpg"),
                 status = ProductStatus.AVAILABLE
             )
 
@@ -231,8 +270,8 @@ class ProductCommandServiceImplTest {
                 .isInstanceOf(ProductNotFoundException::class.java)
 
             verify(productRepository).findById(productId)
-            verify(productImageRepository, never()).findByProductId(any())
-            verify(productImageRepository, never()).save(any())
+            verify(productImageRepository, never()).findByProductIdOrderBySortOrder(any())
+            verify(productImageRepository, never()).saveAll(any<List<ProductImage>>())
         }
 
         @Test
@@ -267,13 +306,13 @@ class ProductCommandServiceImplTest {
                 name = "수정된 상품명",
                 description = "수정된 상품 설명",
                 price = BigDecimal("20000"),
-                imageUrl = "https://example.com/new-image.jpg",
+                imageUrls = listOf("https://example.com/new-image.jpg"),
                 status = ProductStatus.AVAILABLE
             )
 
             val existingProduct = Product.fixture().withId(productId)
             val productCaptor = argumentCaptor<Product>()
-            val imageCaptor = argumentCaptor<ProductImage>()
+            val imagesCaptor = argumentCaptor<List<ProductImage>>()
 
             // Context
             whenever(categoryRepository.existsById(request.categoryId)).thenReturn(true)
@@ -281,9 +320,9 @@ class ProductCommandServiceImplTest {
             whenever(productRepository.save(productCaptor.capture())).thenAnswer {
                 productCaptor.firstValue.withId(productId)
             }
-            whenever(productImageRepository.findByProductId(productId)).thenReturn(null)
-            whenever(productImageRepository.save(imageCaptor.capture())).thenAnswer {
-                imageCaptor.firstValue.withId(1L)
+            whenever(productImageRepository.findByProductIdOrderBySortOrder(productId)).thenReturn(emptyList())
+            whenever(productImageRepository.saveAll(imagesCaptor.capture())).thenAnswer {
+                imagesCaptor.firstValue.mapIndexed { index, image -> image.withId(index.toLong() + 1) }
             }
 
             // Interaction
@@ -293,12 +332,12 @@ class ProductCommandServiceImplTest {
             assertThat(result).isNotNull()
             assertThat(result.id).isEqualTo(productId)
             assertThat(result.name).isEqualTo(request.name)
-            assertThat(result.imageUrl).isEqualTo(request.imageUrl)
+            assertThat(result.imageUrls).containsExactly("https://example.com/new-image.jpg")
 
             verify(productRepository).findById(productId)
             verify(productRepository).save(any())
-            verify(productImageRepository).findByProductId(productId)
-            verify(productImageRepository).save(any())
+            verify(productImageRepository).findByProductIdOrderBySortOrder(productId)
+            verify(productImageRepository).saveAll(any<List<ProductImage>>())
         }
 
         @Test
@@ -310,13 +349,13 @@ class ProductCommandServiceImplTest {
                 name = "수정된 상품명",
                 description = "수정된 상품 설명",
                 price = BigDecimal("20000"),
-                imageUrl = null,
+                imageUrls = null,
                 status = ProductStatus.AVAILABLE
             )
 
             val existingProduct = Product.fixture().withId(productId)
             val productCaptor = argumentCaptor<Product>()
-            val imageCaptor = argumentCaptor<ProductImage>()
+            val imagesCaptor = argumentCaptor<List<ProductImage>>()
 
             // Context
             whenever(categoryRepository.existsById(request.categoryId)).thenReturn(true)
@@ -324,9 +363,9 @@ class ProductCommandServiceImplTest {
             whenever(productRepository.save(productCaptor.capture())).thenAnswer {
                 productCaptor.firstValue.withId(productId)
             }
-            whenever(productImageRepository.findByProductId(productId)).thenReturn(null)
-            whenever(productImageRepository.save(imageCaptor.capture())).thenAnswer {
-                imageCaptor.firstValue.withId(1L)
+            whenever(productImageRepository.findByProductIdOrderBySortOrder(productId)).thenReturn(emptyList())
+            whenever(productImageRepository.saveAll(imagesCaptor.capture())).thenAnswer {
+                imagesCaptor.firstValue.mapIndexed { index, image -> image.withId(index.toLong() + 1) }
             }
 
             // Interaction
@@ -336,12 +375,12 @@ class ProductCommandServiceImplTest {
             assertThat(result).isNotNull()
             assertThat(result.id).isEqualTo(productId)
             assertThat(result.name).isEqualTo(request.name)
-            assertThat(result.imageUrl).isEqualTo("D:/hoppingmall/product/images/default-product.jpg")
+            assertThat(result.imageUrls).containsExactly("D:/hoppingmall/product/images/default-product.jpg")
 
             verify(productRepository).findById(productId)
             verify(productRepository).save(any())
-            verify(productImageRepository).findByProductId(productId)
-            verify(productImageRepository).save(any())
+            verify(productImageRepository).findByProductIdOrderBySortOrder(productId)
+            verify(productImageRepository).saveAll(any<List<ProductImage>>())
         }
     }
 
@@ -357,7 +396,7 @@ class ProductCommandServiceImplTest {
 
             // Context
             whenever(productRepository.findById(productId)).thenReturn(java.util.Optional.of(product))
-            whenever(productImageRepository.findByProductId(productId)).thenReturn(productImage)
+            whenever(productImageRepository.findByProductIdOrderBySortOrder(productId)).thenReturn(listOf(productImage))
 
             // Interaction
             productCommandService.deleteProduct(productId)
@@ -379,7 +418,7 @@ class ProductCommandServiceImplTest {
             assertThatThrownBy { productCommandService.deleteProduct(productId) }
                 .isInstanceOf(ProductNotFoundException::class.java)
 
-            verify(productImageRepository, never()).findByProductId(any())
+            verify(productImageRepository, never()).findByProductIdOrderBySortOrder(any())
         }
 
         @Test
@@ -390,7 +429,7 @@ class ProductCommandServiceImplTest {
 
             // Context
             whenever(productRepository.findById(productId)).thenReturn(java.util.Optional.of(product))
-            whenever(productImageRepository.findByProductId(productId)).thenReturn(null)
+            whenever(productImageRepository.findByProductIdOrderBySortOrder(productId)).thenReturn(emptyList())
 
             // Interaction
             productCommandService.deleteProduct(productId)

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductQueryServiceImplTest.kt
@@ -61,9 +61,9 @@ class ProductQueryServiceImplTest {
 
             assertEquals(2, result.content.size)
             assertEquals("상품1", result.content[0].name)
-            assertEquals("https://example.com/image1.jpg", result.content[0].imageUrl)
+            assertEquals(listOf("https://example.com/image1.jpg"), result.content[0].imageUrls)
             assertEquals("상품2", result.content[1].name)
-            assertEquals("https://example.com/image2.jpg", result.content[1].imageUrl)
+            assertEquals(listOf("https://example.com/image2.jpg"), result.content[1].imageUrls)
             verify(productRepository).findBy(pageable)
             verify(productImageRepository).findByProductIdIn(listOf(1L, 2L))
         }
@@ -76,20 +76,20 @@ class ProductQueryServiceImplTest {
         fun 상품_상세_조회_성공() {
             val productId = 1L
             val product = Product.create(1L, 1L, "상품1", "설명1", BigDecimal("10000"), ProductStatus.AVAILABLE).withId(productId)
-            val image = ProductImage.create(productId, "https://example.com/image.jpg")
+            val images = listOf(ProductImage.create(productId, "https://example.com/image.jpg"))
 
             whenever(cacheManager.getCache("product:notfound")).thenReturn(notFoundCache)
             whenever(notFoundCache.get(productId)).thenReturn(null)
             whenever(productRepository.findNullableById(productId)).thenReturn(product)
-            whenever(productImageRepository.findByProductId(productId)).thenReturn(image)
+            whenever(productImageRepository.findByProductIdOrderBySortOrder(productId)).thenReturn(images)
 
             val result = productQueryService.getProductById(productId)
 
             assertEquals(productId, result!!.id)
             assertEquals(product.name, result.name)
-            assertEquals(image.imageUrl, result.imageUrl)
+            assertEquals(listOf("https://example.com/image.jpg"), result.imageUrls)
             verify(productRepository).findNullableById(productId)
-            verify(productImageRepository).findByProductId(productId)
+            verify(productImageRepository).findByProductIdOrderBySortOrder(productId)
         }
 
         @Test
@@ -130,15 +130,15 @@ class ProductQueryServiceImplTest {
             whenever(cacheManager.getCache("product:notfound")).thenReturn(notFoundCache)
             whenever(notFoundCache.get(productId)).thenReturn(null)
             whenever(productRepository.findNullableById(productId)).thenReturn(product)
-            whenever(productImageRepository.findByProductId(productId)).thenReturn(null)
+            whenever(productImageRepository.findByProductIdOrderBySortOrder(productId)).thenReturn(emptyList())
 
             val result = productQueryService.getProductById(productId)
 
             assertEquals(productId, result!!.id)
             assertEquals(product.name, result.name)
-            assertEquals(null, result.imageUrl)
+            assertEquals(emptyList<String>(), result.imageUrls)
             verify(productRepository).findNullableById(productId)
-            verify(productImageRepository).findByProductId(productId)
+            verify(productImageRepository).findByProductIdOrderBySortOrder(productId)
         }
     }
 
@@ -166,10 +166,10 @@ class ProductQueryServiceImplTest {
             assertEquals(2, result.content.size)
             assertEquals(sellerId, result.content[0].sellerId)
             assertEquals("상품1", result.content[0].name)
-            assertEquals("https://example.com/image1.jpg", result.content[0].imageUrl)
+            assertEquals(listOf("https://example.com/image1.jpg"), result.content[0].imageUrls)
             assertEquals(sellerId, result.content[1].sellerId)
             assertEquals("상품2", result.content[1].name)
-            assertEquals("https://example.com/image2.jpg", result.content[1].imageUrl)
+            assertEquals(listOf("https://example.com/image2.jpg"), result.content[1].imageUrls)
             verify(productRepository).findBySellerId(sellerId, pageable)
             verify(productImageRepository).findByProductIdIn(listOf(1L, 2L))
         }
@@ -199,10 +199,10 @@ class ProductQueryServiceImplTest {
             assertEquals(2, result.content.size)
             assertEquals(categoryId, result.content[0].categoryId)
             assertEquals("상품1", result.content[0].name)
-            assertEquals("https://example.com/image1.jpg", result.content[0].imageUrl)
+            assertEquals(listOf("https://example.com/image1.jpg"), result.content[0].imageUrls)
             assertEquals(categoryId, result.content[1].categoryId)
             assertEquals("상품2", result.content[1].name)
-            assertEquals("https://example.com/image2.jpg", result.content[1].imageUrl)
+            assertEquals(listOf("https://example.com/image2.jpg"), result.content[1].imageUrls)
             verify(productRepository).findByCategoryId(categoryId, pageable)
             verify(productImageRepository).findByProductIdIn(listOf(1L, 2L))
         }
@@ -281,7 +281,7 @@ class ProductQueryServiceImplTest {
 
             assertEquals(1, result.content.size)
             assertEquals("상품1", result.content[0].name)
-            assertEquals("https://example.com/image1.jpg", result.content[0].imageUrl)
+            assertEquals(listOf("https://example.com/image1.jpg"), result.content[0].imageUrls)
         }
 
         @Test

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/ProductImageFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/ProductImageFixture.kt
@@ -4,7 +4,8 @@ import com.hoppingmall.mall.product.domain.ProductImage
 
 fun ProductImage.Companion.fixture(
     productId: Long = 1L,
-    imageUrl: String? = "https://example.com/default-image.jpg"
+    imageUrl: String? = "https://example.com/default-image.jpg",
+    sortOrder: Int = 0
 ): ProductImage {
-    return ProductImage.create(productId, imageUrl ?: "https://example.com/default-image.jpg")
-} 
+    return ProductImage.create(productId, imageUrl ?: "https://example.com/default-image.jpg", sortOrder)
+}


### PR DESCRIPTION
Closes #129

### 📌 작업 개요
상품당 이미지 1개 제한을 해제하여 다중 이미지를 지원합니다.
ProductImage에 sortOrder 필드를 추가하고, DTO를 단일 imageUrl에서 imageUrls 목록으로 변경합니다.
상품 수정 시 기존 이미지를 soft delete 후 새 목록으로 재생성하는 방식으로 구현합니다.

---

### ✅ 주요 변경 사항

- `product.domain`
  - `ProductImage`: `sortOrder: Int` 필드 추가 (이미지 순서 관리)
  - `ProductImageRepository`: `findByProductId` → `findByProductIdOrderBySortOrder` (List 반환)

- `product.dto.request`
  - `ProductCreateRequest`: `imageUrl: String?` → `imageUrls: List<String>?`
  - `ProductUpdateRequest`: `imageUrl: String?` → `imageUrls: List<String>?`

- `product.dto.response`
  - `ProductResponse`: `imageUrl: String?` → `imageUrls: List<String>`

- `product.service`
  - `ProductCommandServiceImpl`: 다중 이미지 생성/수정/삭제 처리
  - `ProductQueryServiceImpl`: 이미지 조회를 groupBy로 변경

- `cartItem.service`
  - `CartItemCommandServiceImpl`: 대표 이미지(첫 번째) 사용으로 변경

---

### 🧪 테스트

- `ProductCommandServiceImplTest`: 다중 이미지 생성, sortOrder 검증, 수정 시 재생성 테스트
- `ProductQueryServiceImplTest`: 이미지 목록 조회 테스트
- `ProductControllerTest`: imageUrls 응답 검증
- `CartItemCommandServiceImplTest`: 대표 이미지 조회 방식 변경

---

### 📎 관련 이슈
- #129