### PR TITLE
fix: 삭제된 상품 환불 시 sellerId 유실 문제 해결

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/order/domain/OrderItem.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/domain/OrderItem.kt
@@ -22,6 +22,9 @@ class OrderItem private constructor(
     val orderId: Long,
 
     @Column(nullable = false)
+    val sellerId: Long,
+
+    @Column(nullable = false)
     val productId: Long,
 
     @Column(nullable = false)
@@ -40,6 +43,7 @@ class OrderItem private constructor(
     companion object {
         fun create(
             orderId: Long,
+            sellerId: Long,
             productId: Long,
             productName: String,
             productPrice: BigDecimal,
@@ -47,6 +51,7 @@ class OrderItem private constructor(
         ): OrderItem {
             return OrderItem(
                 orderId = orderId,
+                sellerId = sellerId,
                 productId = productId,
                 productName = productName,
                 productPrice = productPrice,

--- a/src/main/kotlin/com/hoppingmall/mall/order/dto/response/OrderItemResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/dto/response/OrderItemResponse.kt
@@ -5,6 +5,7 @@ import java.math.BigDecimal
 
 data class OrderItemResponse(
     val id: Long,
+    val sellerId: Long,
     val productId: Long,
     val productName: String,
     val productPrice: BigDecimal,
@@ -15,6 +16,7 @@ data class OrderItemResponse(
         fun from(orderItem: OrderItem): OrderItemResponse {
             return OrderItemResponse(
                 id = orderItem.id!!,
+                sellerId = orderItem.sellerId,
                 productId = orderItem.productId,
                 productName = orderItem.productName,
                 productPrice = orderItem.productPrice,

--- a/src/main/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImpl.kt
@@ -13,6 +13,8 @@ import com.hoppingmall.mall.order.enum.OrderStatus
 import com.hoppingmall.mall.order.exception.OrderAccessDeniedException
 import com.hoppingmall.mall.order.exception.OrderEmptyItemsException
 import com.hoppingmall.mall.order.exception.OrderNotFoundException
+import com.hoppingmall.mall.product.domain.repository.ProductRepository
+import com.hoppingmall.mall.product.exception.ProductNotFoundException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -24,6 +26,7 @@ class OrderCommandServiceImpl(
     private val orderRepository: OrderRepository,
     private val orderItemRepository: OrderItemRepository,
     private val cartItemRepository: CartItemRepository,
+    private val productRepository: ProductRepository,
     private val inventoryCommandService: InventoryCommandService
 ) : OrderCommandService {
 
@@ -41,6 +44,12 @@ class OrderCommandServiceImpl(
             throw OrderAccessDeniedException()
         }
 
+        val productIds = cartItems.map { it.productId }.distinct()
+        val productMap = productRepository.findAllById(productIds).associateBy { it.id!! }
+        productIds.forEach { productId ->
+            if (!productMap.containsKey(productId)) throw ProductNotFoundException()
+        }
+
         cartItems.sortedBy { it.productId }.forEach { cartItem ->
             inventoryCommandService.decreaseStock(cartItem.productId, cartItem.quantity)
         }
@@ -52,6 +61,7 @@ class OrderCommandServiceImpl(
         val orderItems = cartItems.map { cartItem ->
             OrderItem.create(
                 orderId = order.id!!,
+                sellerId = productMap[cartItem.productId]!!.sellerId,
                 productId = cartItem.productId,
                 productName = cartItem.productName,
                 productPrice = cartItem.productPrice,

--- a/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImpl.kt
@@ -7,7 +7,6 @@ import com.hoppingmall.mall.order.exception.OrderNotFoundException
 import com.hoppingmall.mall.payment.domain.Payment
 import com.hoppingmall.mall.payment.domain.repository.PaymentRepository
 import com.hoppingmall.mall.payment.exception.PaymentNotFoundException
-import com.hoppingmall.mall.product.domain.repository.ProductRepository
 import com.hoppingmall.mall.refund.domain.Refund
 import com.hoppingmall.mall.refund.domain.RefundItem
 import com.hoppingmall.mall.refund.domain.repository.RefundItemRepository
@@ -35,7 +34,6 @@ class RefundCommandServiceImpl(
     private val orderRepository: OrderRepository,
     private val orderItemRepository: OrderItemRepository,
     private val paymentRepository: PaymentRepository,
-    private val productRepository: ProductRepository,
     private val shippingRepository: ShippingRepository,
     private val refundEventPublisher: RefundEventPublisher
 ) : RefundCommandService {
@@ -98,8 +96,7 @@ class RefundCommandServiceImpl(
         }
 
         val firstOrderItem = orderItemMap[request.items.first().orderItemId]!!
-        val product = productRepository.findById(firstOrderItem.productId).orElse(null)
-        val sellerId = product?.sellerId ?: 0L
+        val sellerId = firstOrderItem.sellerId
 
         val refund = Refund.create(
             orderId = request.orderId,

--- a/src/test/kotlin/com/hoppingmall/mall/order/controller/OrderControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/order/controller/OrderControllerTest.kt
@@ -43,6 +43,7 @@ class OrderControllerTest {
             items = listOf(
                 OrderItemResponse(
                     id = 1L,
+                    sellerId = 2L,
                     productId = 100L,
                     productName = "테스트 상품",
                     productPrice = BigDecimal("25000"),

--- a/src/test/kotlin/com/hoppingmall/mall/order/domain/OrderItemTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/order/domain/OrderItemTest.kt
@@ -19,6 +19,7 @@ class OrderItemTest {
         fun 주문_항목을_생성한다() {
             val orderItem = OrderItem.create(
                 orderId = 1L,
+                sellerId = 5L,
                 productId = 100L,
                 productName = "테스트 상품",
                 productPrice = BigDecimal("15000"),
@@ -26,6 +27,7 @@ class OrderItemTest {
             )
 
             assertEquals(1L, orderItem.orderId)
+            assertEquals(5L, orderItem.sellerId)
             assertEquals(100L, orderItem.productId)
             assertEquals("테스트 상품", orderItem.productName)
             assertEquals(BigDecimal("15000"), orderItem.productPrice)
@@ -37,6 +39,7 @@ class OrderItemTest {
         fun 총_가격이_자동_계산된다() {
             val orderItem = OrderItem.create(
                 orderId = 1L,
+                sellerId = 5L,
                 productId = 100L,
                 productName = "상품",
                 productPrice = BigDecimal("25000"),

--- a/src/test/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/order/service/OrderCommandServiceImplTest.kt
@@ -14,6 +14,9 @@ import com.hoppingmall.mall.order.exception.OrderAccessDeniedException
 import com.hoppingmall.mall.order.exception.OrderEmptyItemsException
 import com.hoppingmall.mall.order.exception.OrderInvalidStatusException
 import com.hoppingmall.mall.order.exception.OrderNotFoundException
+import com.hoppingmall.mall.product.domain.Product
+import com.hoppingmall.mall.product.domain.repository.ProductRepository
+import com.hoppingmall.mall.product.exception.ProductNotFoundException
 import com.hoppingmall.mall.support.fixture.fixture
 import com.hoppingmall.mall.support.fixture.paidFixture
 import com.hoppingmall.mall.support.withId
@@ -35,9 +38,10 @@ class OrderCommandServiceImplTest {
     private val orderRepository: OrderRepository = mock()
     private val orderItemRepository: OrderItemRepository = mock()
     private val cartItemRepository: CartItemRepository = mock()
+    private val productRepository: ProductRepository = mock()
     private val inventoryCommandService: InventoryCommandService = mock()
     private val orderCommandService = OrderCommandServiceImpl(
-        orderRepository, orderItemRepository, cartItemRepository, inventoryCommandService
+        orderRepository, orderItemRepository, cartItemRepository, productRepository, inventoryCommandService
     )
 
     @Nested
@@ -50,10 +54,13 @@ class OrderCommandServiceImplTest {
             val request = OrderCreateRequest(cartItemIds = listOf(1L, 2L))
             val cartItem1 = CartItem.fixture(buyerId = 1L, productId = 100L, productName = "상품1", productPrice = BigDecimal("15000"), quantity = 2).withId(1L)
             val cartItem2 = CartItem.fixture(buyerId = 1L, productId = 200L, productName = "상품2", productPrice = BigDecimal("20000"), quantity = 1).withId(2L)
+            val product1 = Product.fixture(sellerId = 10L).withId(100L)
+            val product2 = Product.fixture(sellerId = 20L).withId(200L)
 
             val orderCaptor = argumentCaptor<Order>()
 
             whenever(cartItemRepository.findAllById(request.cartItemIds)).thenReturn(listOf(cartItem1, cartItem2))
+            whenever(productRepository.findAllById(listOf(100L, 200L))).thenReturn(listOf(product1, product2))
             whenever(orderRepository.save(orderCaptor.capture())).thenAnswer {
                 orderCaptor.lastValue.withId(1L)
             }

--- a/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentCompensationConsumerIntegrationTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/service/PaymentCompensationConsumerIntegrationTest.kt
@@ -67,6 +67,7 @@ class PaymentCompensationConsumerIntegrationTest : IntegrationTestBase() {
         orderItemRepository.save(
             OrderItem.create(
                 orderId = order.id!!,
+                sellerId = 1L,
                 productId = 500L,
                 productName = "테스트 상품",
                 productPrice = BigDecimal("15000"),
@@ -115,6 +116,7 @@ class PaymentCompensationConsumerIntegrationTest : IntegrationTestBase() {
         orderItemRepository.save(
             OrderItem.create(
                 orderId = order.id!!,
+                sellerId = 2L,
                 productId = 600L,
                 productName = "테스트 상품2",
                 productPrice = BigDecimal("20000"),

--- a/src/test/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/refund/service/RefundCommandServiceImplTest.kt
@@ -9,8 +9,6 @@ import com.hoppingmall.mall.order.exception.OrderNotFoundException
 import com.hoppingmall.mall.payment.domain.Payment
 import com.hoppingmall.mall.payment.domain.repository.PaymentRepository
 import com.hoppingmall.mall.payment.exception.PaymentNotFoundException
-import com.hoppingmall.mall.product.domain.Product
-import com.hoppingmall.mall.product.domain.repository.ProductRepository
 import com.hoppingmall.mall.refund.domain.Refund
 import com.hoppingmall.mall.refund.domain.RefundItem
 import com.hoppingmall.mall.refund.domain.repository.RefundItemRepository
@@ -48,7 +46,6 @@ class RefundCommandServiceImplTest {
     private val orderRepository: OrderRepository = mock()
     private val orderItemRepository: OrderItemRepository = mock()
     private val paymentRepository: PaymentRepository = mock()
-    private val productRepository: ProductRepository = mock()
     private val shippingRepository: ShippingRepository = mock()
     private val refundEventPublisher: RefundEventPublisher = mock()
 
@@ -58,7 +55,6 @@ class RefundCommandServiceImplTest {
         orderRepository,
         orderItemRepository,
         paymentRepository,
-        productRepository,
         shippingRepository,
         refundEventPublisher
     )
@@ -74,8 +70,7 @@ class RefundCommandServiceImplTest {
             val orderId = 1L
             val order = Order.paidFixture(buyerId = buyerId)
             val payment = Payment.successFixture(orderId = orderId, pointAmount = BigDecimal("1000"))
-            val orderItem = OrderItem.fixture(orderId = orderId, productId = 100L, quantity = 2)
-            val product = Product.fixture(sellerId = 2L).withId(100L)
+            val orderItem = OrderItem.fixture(orderId = orderId, sellerId = 2L, productId = 100L, quantity = 2)
 
             val request = RefundCreateRequest(
                 orderId = orderId,
@@ -88,7 +83,6 @@ class RefundCommandServiceImplTest {
             whenever(paymentRepository.findByOrderId(orderId)).thenReturn(payment)
             whenever(refundItemRepository.findRefundedQuantitiesByOrderId(orderId)).thenReturn(emptyList())
             whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(listOf(orderItem))
-            whenever(productRepository.findById(100L)).thenReturn(Optional.of(product))
             whenever(shippingRepository.findByOrderId(orderId)).thenReturn(null)
             whenever(refundRepository.save(any<Refund>())).thenAnswer { invocation ->
                 (invocation.arguments[0] as Refund).withId(1L)
@@ -114,8 +108,7 @@ class RefundCommandServiceImplTest {
             val orderId = 1L
             val order = Order.fixture(buyerId = buyerId, status = OrderStatus.SHIPPED)
             val payment = Payment.successFixture(orderId = orderId)
-            val orderItem = OrderItem.fixture(orderId = orderId, productId = 100L, quantity = 2)
-            val product = Product.fixture(sellerId = 2L).withId(100L)
+            val orderItem = OrderItem.fixture(orderId = orderId, sellerId = 2L, productId = 100L, quantity = 2)
             val shipping = Shipping.inTransitFixture(orderId = orderId)
 
             val request = RefundCreateRequest(
@@ -129,7 +122,6 @@ class RefundCommandServiceImplTest {
             whenever(paymentRepository.findByOrderId(orderId)).thenReturn(payment)
             whenever(refundItemRepository.findRefundedQuantitiesByOrderId(orderId)).thenReturn(emptyList())
             whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(listOf(orderItem))
-            whenever(productRepository.findById(100L)).thenReturn(Optional.of(product))
             whenever(shippingRepository.findByOrderId(orderId)).thenReturn(shipping)
             whenever(refundRepository.save(any<Refund>())).thenAnswer { invocation ->
                 (invocation.arguments[0] as Refund).withId(1L)
@@ -154,9 +146,8 @@ class RefundCommandServiceImplTest {
             val orderId = 1L
             val order = Order.paidFixture(buyerId = buyerId)
             val payment = Payment.successFixture(orderId = orderId, amount = BigDecimal("50000"), pointAmount = BigDecimal("1000"))
-            val orderItem1 = OrderItem.fixture(orderId = orderId, productId = 100L, productPrice = BigDecimal("15000"), quantity = 2)
-            val orderItem2 = OrderItem.fixture(orderId = orderId, productId = 200L, productPrice = BigDecimal("20000"), quantity = 1).withId(2L)
-            val product = Product.fixture(sellerId = 2L).withId(100L)
+            val orderItem1 = OrderItem.fixture(orderId = orderId, sellerId = 2L, productId = 100L, productPrice = BigDecimal("15000"), quantity = 2)
+            val orderItem2 = OrderItem.fixture(orderId = orderId, sellerId = 2L, productId = 200L, productPrice = BigDecimal("20000"), quantity = 1).withId(2L)
 
             val request = RefundCreateRequest(
                 orderId = orderId,
@@ -168,7 +159,6 @@ class RefundCommandServiceImplTest {
             whenever(paymentRepository.findByOrderId(orderId)).thenReturn(payment)
             whenever(refundItemRepository.findRefundedQuantitiesByOrderId(orderId)).thenReturn(emptyList())
             whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(listOf(orderItem1, orderItem2))
-            whenever(productRepository.findById(100L)).thenReturn(Optional.of(product))
             whenever(shippingRepository.findByOrderId(orderId)).thenReturn(null)
             whenever(refundRepository.save(any<Refund>())).thenAnswer { invocation ->
                 (invocation.arguments[0] as Refund).withId(1L)
@@ -325,8 +315,7 @@ class RefundCommandServiceImplTest {
             val orderId = 1L
             val order = Order.paidFixture(buyerId = buyerId)
             val payment = Payment.successFixture(orderId = orderId, amount = BigDecimal("30000"), pointAmount = BigDecimal("1000"))
-            val orderItem = OrderItem.fixture(orderId = orderId, productId = 100L, productPrice = BigDecimal("10000"), quantity = 3)
-            val product = Product.fixture(sellerId = 2L).withId(100L)
+            val orderItem = OrderItem.fixture(orderId = orderId, sellerId = 2L, productId = 100L, productPrice = BigDecimal("10000"), quantity = 3)
 
             val request = RefundCreateRequest(
                 orderId = orderId,
@@ -340,7 +329,6 @@ class RefundCommandServiceImplTest {
             whenever(paymentRepository.findByOrderId(orderId)).thenReturn(payment)
             whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(listOf(orderItem))
             whenever(refundItemRepository.findRefundedQuantitiesByOrderId(orderId)).thenReturn(listOf(alreadyRefunded))
-            whenever(productRepository.findById(100L)).thenReturn(Optional.of(product))
             whenever(shippingRepository.findByOrderId(orderId)).thenReturn(null)
             whenever(refundRepository.save(any<Refund>())).thenAnswer { invocation ->
                 (invocation.arguments[0] as Refund).withId(2L)
@@ -365,8 +353,7 @@ class RefundCommandServiceImplTest {
             val orderId = 1L
             val order = Order.paidFixture(buyerId = buyerId)
             val payment = Payment.successFixture(orderId = orderId, amount = BigDecimal("30000"), pointAmount = BigDecimal("1000"))
-            val orderItem = OrderItem.fixture(orderId = orderId, productId = 100L, productPrice = BigDecimal("10000"), quantity = 3)
-            val product = Product.fixture(sellerId = 2L).withId(100L)
+            val orderItem = OrderItem.fixture(orderId = orderId, sellerId = 2L, productId = 100L, productPrice = BigDecimal("10000"), quantity = 3)
 
             val request = RefundCreateRequest(
                 orderId = orderId,
@@ -380,7 +367,6 @@ class RefundCommandServiceImplTest {
             whenever(paymentRepository.findByOrderId(orderId)).thenReturn(payment)
             whenever(orderItemRepository.findByOrderId(orderId)).thenReturn(listOf(orderItem))
             whenever(refundItemRepository.findRefundedQuantitiesByOrderId(orderId)).thenReturn(listOf(alreadyRefunded))
-            whenever(productRepository.findById(100L)).thenReturn(Optional.of(product))
             whenever(shippingRepository.findByOrderId(orderId)).thenReturn(null)
             whenever(refundRepository.save(any<Refund>())).thenAnswer { invocation ->
                 (invocation.arguments[0] as Refund).withId(2L)

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/OrderItemFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/OrderItemFixture.kt
@@ -6,6 +6,7 @@ import java.math.BigDecimal
 
 fun OrderItem.Companion.fixture(
     orderId: Long = 1L,
+    sellerId: Long = 2L,
     productId: Long = 100L,
     productName: String = "테스트 상품",
     productPrice: BigDecimal = BigDecimal("15000"),
@@ -13,6 +14,7 @@ fun OrderItem.Companion.fixture(
 ): OrderItem {
     return OrderItem.create(
         orderId = orderId,
+        sellerId = sellerId,
         productId = productId,
         productName = productName,
         productPrice = productPrice,


### PR DESCRIPTION
Closes #131

### 📌 작업 개요
상품 삭제 후 환불 요청 시 `productRepository.findById()`가 Soft Delete 필터로 인해 null을 반환하여
sellerId가 0L로 설정되는 문제를 해결합니다.
OrderItem에 sellerId를 비정규화하여 상품 삭제와 무관하게 환불 인가가 정상 동작하도록 변경했습니다.

---

### ✅ 주요 변경 사항

- `order.domain`
  - `OrderItem`: `sellerId` 필드 추가 (주문 생성 시 상품의 판매자 ID 캡처)

- `order.dto.response`
  - `OrderItemResponse`: `sellerId` 필드 포함

- `order.service`
  - `OrderCommandServiceImpl`: `ProductRepository` 의존성 추가, 주문 생성 시 상품에서 sellerId 일괄 조회 후 OrderItem에 전달

- `refund.service`
  - `RefundCommandServiceImpl`: `ProductRepository` 의존성 제거, `OrderItem.sellerId`에서 직접 조회하도록 변경

---

### 🧪 테스트

- `OrderItemTest`: sellerId 파라미터 추가
- `OrderCommandServiceImplTest`: ProductRepository 모킹 추가
- `RefundCommandServiceImplTest`: ProductRepository 의존성 제거, OrderItem에서 sellerId 조회 검증
- `PaymentCompensationConsumerIntegrationTest`: sellerId 전달 추가
- `OrderControllerTest`: OrderItemResponse sellerId 포함

---

### 📎 관련 이슈
- #131