### PR TITLE
feat: CSV 대량 상품 등록 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,6 +83,9 @@ dependencies {
 	// Monitoring
 	implementation("io.micrometer:micrometer-registry-prometheus")
 
+	// CSV 파싱
+	implementation("org.apache.commons:commons-csv:1.12.0")
+
 	// JSON 로깅
 	implementation("net.logstash.logback:logstash-logback-encoder:8.0")
 }
@@ -135,7 +138,9 @@ val jacocoExcludedDirs = listOf(
 	"**/com/hoppingmall/mall/refund/service/RefundCompletionConsumer*",
 	"**/com/hoppingmall/mall/refund/service/KafkaRefundEventPublisher*",
 	"**/com/hoppingmall/mall/refund/domain/RefundEventLog*",
-	"**/com/hoppingmall/mall/product/domain/repository/ProductSearchRepositoryImpl*"
+	"**/com/hoppingmall/mall/product/domain/repository/ProductSearchRepositoryImpl*",
+	"**/com/hoppingmall/mall/product/domain/BulkImportJob*",
+	"**/com/hoppingmall/mall/product/controller/ProductBulkController*"
 )
 
 tasks.jacocoTestReport {

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/AsyncConfig.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.mall.global.common.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+
+@Configuration
+@EnableAsync
+class AsyncConfig

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/AsyncConfig.kt
@@ -1,8 +1,25 @@
 package com.hoppingmall.mall.global.common.config
 
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
 
 @Configuration
 @EnableAsync
-class AsyncConfig
+class AsyncConfig {
+
+    @Bean("bulkImportExecutor")
+    fun bulkImportExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 2
+        executor.maxPoolSize = 4
+        executor.queueCapacity = 10
+        executor.setThreadNamePrefix("bulk-import-")
+        executor.setWaitForTasksToCompleteOnShutdown(true)
+        executor.setAwaitTerminationSeconds(30)
+        executor.initialize()
+        return executor
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
@@ -70,7 +70,14 @@ class SecurityConfig(
                 it.requestMatchers(
                     HttpMethod.POST,
                     "/api/v1/products",
-                    "/api/v1/products/images/upload"
+                    "/api/v1/products/images/upload",
+                    "/api/v1/products/bulk/validate",
+                    "/api/v1/products/bulk/import"
+                ).hasRole("SELLER")
+                it.requestMatchers(
+                    HttpMethod.GET,
+                    "/api/v1/products/bulk/{jobId}",
+                    "/api/v1/products/bulk/{jobId}/errors"
                 ).hasRole("SELLER")
                 it.requestMatchers(HttpMethod.PUT, "/api/v1/products/{productId}").hasRole("SELLER")
                 it.requestMatchers(HttpMethod.DELETE, "/api/v1/products/{productId}").hasRole("SELLER")

--- a/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductBulkController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductBulkController.kt
@@ -1,0 +1,53 @@
+package com.hoppingmall.mall.product.controller
+
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import com.hoppingmall.mall.product.dto.response.BulkImportProgressResponse
+import com.hoppingmall.mall.product.dto.response.BulkRowError
+import com.hoppingmall.mall.product.dto.response.BulkValidationResponse
+import com.hoppingmall.mall.product.service.BulkImportService
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@RequestMapping("/api/v1/products/bulk")
+class ProductBulkController(
+    private val bulkImportService: BulkImportService
+) {
+
+    @PostMapping("/validate")
+    fun validateCsv(
+        @RequestParam("file") file: MultipartFile
+    ): ApiResponse<BulkValidationResponse> {
+        val response = bulkImportService.validate(file)
+        return ApiResponse.success(response)
+    }
+
+    @PostMapping("/import")
+    fun importCsv(
+        @RequestParam("file") file: MultipartFile,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ): ApiResponse<BulkImportProgressResponse> {
+        val response = bulkImportService.startImport(userPrincipal.getUserId(), file)
+        return ApiResponse.success(response)
+    }
+
+    @GetMapping("/{jobId}")
+    fun getJobProgress(
+        @PathVariable jobId: Long,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ): ApiResponse<BulkImportProgressResponse> {
+        val response = bulkImportService.getJobProgress(jobId, userPrincipal.getUserId())
+        return ApiResponse.success(response)
+    }
+
+    @GetMapping("/{jobId}/errors")
+    fun getJobErrors(
+        @PathVariable jobId: Long,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ): ApiResponse<List<BulkRowError>> {
+        val response = bulkImportService.getJobErrors(jobId, userPrincipal.getUserId())
+        return ApiResponse.success(response)
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/BulkImportJob.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/BulkImportJob.kt
@@ -1,0 +1,82 @@
+package com.hoppingmall.mall.product.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import com.hoppingmall.mall.product.enum.BulkImportStatus
+import jakarta.persistence.*
+import org.hibernate.annotations.Filter
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "bulk_import_jobs",
+    indexes = [Index(name = "idx_bulk_import_jobs_seller_id", columnList = "sellerId")]
+)
+@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
+class BulkImportJob private constructor(
+    @Column(nullable = false)
+    val sellerId: Long,
+
+    @Column(nullable = false)
+    val fileName: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var status: BulkImportStatus = BulkImportStatus.VALIDATING,
+
+    @Column(nullable = false)
+    var totalRows: Int = 0,
+
+    @Column(nullable = false)
+    var processedRows: Int = 0,
+
+    @Column(nullable = false)
+    var successCount: Int = 0,
+
+    @Column(nullable = false)
+    var failCount: Int = 0,
+
+    @Column(columnDefinition = "TEXT")
+    var errorDetails: String? = null,
+
+    @Column
+    var completedAt: LocalDateTime? = null
+) : BaseEntity() {
+
+    companion object {
+        fun create(sellerId: Long, fileName: String, totalRows: Int): BulkImportJob {
+            return BulkImportJob(
+                sellerId = sellerId,
+                fileName = fileName,
+                totalRows = totalRows
+            )
+        }
+    }
+
+    fun startImport() {
+        this.status = BulkImportStatus.IMPORTING
+    }
+
+    fun recordSuccess() {
+        this.processedRows++
+        this.successCount++
+    }
+
+    fun recordFailure() {
+        this.processedRows++
+        this.failCount++
+    }
+
+    fun complete() {
+        this.status = BulkImportStatus.COMPLETED
+        this.completedAt = LocalDateTime.now()
+    }
+
+    fun fail() {
+        this.status = BulkImportStatus.FAILED
+        this.completedAt = LocalDateTime.now()
+    }
+
+    fun validated() {
+        this.status = BulkImportStatus.VALIDATED
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/BulkImportJobRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/BulkImportJobRepository.kt
@@ -1,0 +1,11 @@
+package com.hoppingmall.mall.product.domain.repository
+
+import com.hoppingmall.mall.product.domain.BulkImportJob
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface BulkImportJobRepository : JpaRepository<BulkImportJob, Long> {
+
+    fun findBySellerIdOrderByCreatedAtDesc(sellerId: Long): List<BulkImportJob>
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/request/BulkProductRow.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/request/BulkProductRow.kt
@@ -1,0 +1,13 @@
+package com.hoppingmall.mall.product.dto.request
+
+import java.math.BigDecimal
+
+data class BulkProductRow(
+    val rowNumber: Int,
+    val name: String,
+    val description: String,
+    val categoryId: Long,
+    val price: BigDecimal,
+    val stockQuantity: Int,
+    val imageUrls: List<String>
+)

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/response/BulkImportProgressResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/response/BulkImportProgressResponse.kt
@@ -1,0 +1,29 @@
+package com.hoppingmall.mall.product.dto.response
+
+import com.hoppingmall.mall.product.domain.BulkImportJob
+import com.hoppingmall.mall.product.enum.BulkImportStatus
+import java.time.LocalDateTime
+
+data class BulkImportProgressResponse(
+    val jobId: Long,
+    val status: BulkImportStatus,
+    val totalRows: Int,
+    val processedRows: Int,
+    val successCount: Int,
+    val failCount: Int,
+    val completedAt: LocalDateTime?
+) {
+    companion object {
+        fun from(job: BulkImportJob): BulkImportProgressResponse {
+            return BulkImportProgressResponse(
+                jobId = job.id!!,
+                status = job.status,
+                totalRows = job.totalRows,
+                processedRows = job.processedRows,
+                successCount = job.successCount,
+                failCount = job.failCount,
+                completedAt = job.completedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/response/BulkValidationResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/response/BulkValidationResponse.kt
@@ -1,0 +1,23 @@
+package com.hoppingmall.mall.product.dto.response
+
+data class BulkValidationResponse(
+    val totalRows: Int,
+    val validRows: Int,
+    val invalidRows: Int,
+    val errors: List<BulkRowError>,
+    val preview: List<BulkProductPreview>
+)
+
+data class BulkRowError(
+    val rowNumber: Int,
+    val field: String,
+    val message: String
+)
+
+data class BulkProductPreview(
+    val rowNumber: Int,
+    val name: String,
+    val categoryId: Long,
+    val price: String,
+    val stockQuantity: Int
+)

--- a/src/main/kotlin/com/hoppingmall/mall/product/enum/BulkImportStatus.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/enum/BulkImportStatus.kt
@@ -1,0 +1,9 @@
+package com.hoppingmall.mall.product.enum
+
+enum class BulkImportStatus {
+    VALIDATING,
+    VALIDATED,
+    IMPORTING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/exception/ProductException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/exception/ProductException.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.mall.product.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.product.exception.code.ProductErrorCode
+
+open class ProductException(
+    errorCode: ProductErrorCode
+) : BusinessException(errorCode)

--- a/src/main/kotlin/com/hoppingmall/mall/product/exception/code/ProductErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/exception/code/ProductErrorCode.kt
@@ -13,5 +13,8 @@ enum class ProductErrorCode(
     PRODUCT_ALREADY_EXISTS("P002", "이미 존재하는 상품입니다.", HttpStatus.CONFLICT),
     PRODUCT_INVALID_STATUS("P003", "유효하지 않은 상품 상태입니다.", HttpStatus.BAD_REQUEST),
     PRODUCT_ACCESS_DENIED("P004", "상품에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
-    PRODUCT_STATISTICS_NOT_FOUND("P005", "상품 통계를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+    PRODUCT_STATISTICS_NOT_FOUND("P005", "상품 통계를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    BULK_IMPORT_INVALID_CSV("P006", "CSV 파일 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    BULK_IMPORT_JOB_NOT_FOUND("P007", "대량 등록 작업을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    BULK_IMPORT_ACCESS_DENIED("P008", "대량 등록 작업에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN)
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/BulkImportService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/BulkImportService.kt
@@ -1,0 +1,193 @@
+package com.hoppingmall.mall.product.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.mall.category.domain.repository.CategoryRepository
+import com.hoppingmall.mall.global.enums.ProductStatus
+import com.hoppingmall.mall.inventory.dto.request.InventoryInitRequest
+import com.hoppingmall.mall.inventory.service.InventoryCommandService
+import com.hoppingmall.mall.product.domain.BulkImportJob
+import com.hoppingmall.mall.product.domain.Product
+import com.hoppingmall.mall.product.domain.ProductImage
+import com.hoppingmall.mall.product.domain.repository.BulkImportJobRepository
+import com.hoppingmall.mall.product.domain.repository.ProductImageRepository
+import com.hoppingmall.mall.product.domain.repository.ProductRepository
+import com.hoppingmall.mall.product.dto.request.BulkProductRow
+import com.hoppingmall.mall.product.dto.response.*
+import com.hoppingmall.mall.product.exception.ProductException
+import com.hoppingmall.mall.product.exception.code.ProductErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
+
+@Service
+class BulkImportService(
+    private val csvParsingService: CsvParsingService,
+    private val bulkImportJobRepository: BulkImportJobRepository,
+    private val productRepository: ProductRepository,
+    private val productImageRepository: ProductImageRepository,
+    private val categoryRepository: CategoryRepository,
+    private val inventoryCommandService: InventoryCommandService,
+    private val objectMapper: ObjectMapper
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        private const val DEFAULT_IMAGE_PATH = "D:/hoppingmall/product/images/default-product.jpg"
+    }
+
+    fun validate(file: MultipartFile): BulkValidationResponse {
+        val parseResult = csvParsingService.parse(file)
+        val errors = parseResult.errors.toMutableList()
+        val validRows = parseResult.rows
+
+        val categoryIds = validRows.map { it.categoryId }.distinct()
+        val existingCategoryIds = categoryRepository.findAllById(categoryIds).map { it.id!! }.toSet()
+        validRows.forEach { row ->
+            if (row.categoryId !in existingCategoryIds) {
+                errors.add(BulkRowError(row.rowNumber, "categoryId", "존재하지 않는 카테고리입니다: ${row.categoryId}"))
+            }
+        }
+
+        val errorRowNumbers = errors.filter { it.rowNumber > 0 }.map { it.rowNumber }.toSet()
+        val validRowNumbers = validRows.map { it.rowNumber }.toSet() - errorRowNumbers
+        val parseErrorRowNumbers = parseResult.errors.filter { it.rowNumber > 0 }.map { it.rowNumber }.toSet()
+
+        val preview = validRows.filter { it.rowNumber in validRowNumbers }.map { row ->
+            BulkProductPreview(
+                rowNumber = row.rowNumber,
+                name = row.name,
+                categoryId = row.categoryId,
+                price = row.price.toPlainString(),
+                stockQuantity = row.stockQuantity
+            )
+        }
+
+        val totalRows = validRows.size + parseErrorRowNumbers.size
+        val invalidRowCount = errorRowNumbers.size + parseErrorRowNumbers.size
+
+        return BulkValidationResponse(
+            totalRows = totalRows,
+            validRows = preview.size,
+            invalidRows = invalidRowCount,
+            errors = errors,
+            preview = preview
+        )
+    }
+
+    @Transactional
+    fun startImport(sellerId: Long, file: MultipartFile): BulkImportProgressResponse {
+        val parseResult = csvParsingService.parse(file)
+
+        if (parseResult.rows.isEmpty() && parseResult.errors.isNotEmpty()) {
+            throw ProductException(ProductErrorCode.BULK_IMPORT_INVALID_CSV)
+        }
+
+        val totalRows = parseResult.rows.size + parseResult.errors.filter { it.rowNumber > 0 }
+            .map { it.rowNumber }.distinct().size
+        val job = bulkImportJobRepository.save(
+            BulkImportJob.create(sellerId = sellerId, fileName = file.originalFilename ?: "unknown.csv", totalRows = totalRows)
+        )
+        job.startImport()
+        bulkImportJobRepository.save(job)
+
+        processImportAsync(job.id!!, sellerId, parseResult.rows, parseResult.errors)
+
+        return BulkImportProgressResponse.from(job)
+    }
+
+    @Async
+    fun processImportAsync(jobId: Long, sellerId: Long, rows: List<BulkProductRow>, parseErrors: List<BulkRowError>) {
+        processImport(jobId, sellerId, rows, parseErrors)
+    }
+
+    @Transactional
+    fun processImport(jobId: Long, sellerId: Long, rows: List<BulkProductRow>, parseErrors: List<BulkRowError>) {
+        val job = bulkImportJobRepository.findById(jobId).orElseThrow {
+            ProductException(ProductErrorCode.BULK_IMPORT_JOB_NOT_FOUND)
+        }
+
+        val allErrors = parseErrors.toMutableList()
+        val categoryIds = rows.map { it.categoryId }.distinct()
+        val existingCategoryIds = categoryRepository.findAllById(categoryIds).map { it.id!! }.toSet()
+
+        parseErrors.filter { it.rowNumber > 0 }.map { it.rowNumber }.distinct().forEach { _ ->
+            job.recordFailure()
+        }
+
+        for (row in rows) {
+            try {
+                if (row.categoryId !in existingCategoryIds) {
+                    allErrors.add(BulkRowError(row.rowNumber, "categoryId", "존재하지 않는 카테고리입니다: ${row.categoryId}"))
+                    job.recordFailure()
+                    continue
+                }
+
+                val product = productRepository.save(
+                    Product.create(
+                        sellerId = sellerId,
+                        categoryId = row.categoryId,
+                        name = row.name,
+                        description = row.description,
+                        price = row.price,
+                        status = ProductStatus.AVAILABLE
+                    )
+                )
+
+                val imageUrls = row.imageUrls.ifEmpty { listOf(DEFAULT_IMAGE_PATH) }
+                val productImages = imageUrls.mapIndexed { index, url ->
+                    ProductImage.create(productId = product.id!!, imageUrl = url, sortOrder = index)
+                }
+                productImageRepository.saveAll(productImages)
+
+                inventoryCommandService.initStock(
+                    InventoryInitRequest(productId = product.id!!, stockQuantity = row.stockQuantity)
+                )
+
+                job.recordSuccess()
+            } catch (e: Exception) {
+                log.warn("대량 등록 행 {} 실패: {}", row.rowNumber, e.message)
+                allErrors.add(BulkRowError(row.rowNumber, "system", e.message ?: "알 수 없는 오류"))
+                job.recordFailure()
+            }
+        }
+
+        if (allErrors.isNotEmpty()) {
+            job.errorDetails = objectMapper.writeValueAsString(allErrors)
+        }
+        job.complete()
+        bulkImportJobRepository.save(job)
+
+        log.info("대량 등록 완료: jobId={}, success={}, fail={}", jobId, job.successCount, job.failCount)
+    }
+
+    @Transactional(readOnly = true)
+    fun getJobProgress(jobId: Long, sellerId: Long): BulkImportProgressResponse {
+        val job = bulkImportJobRepository.findById(jobId).orElseThrow {
+            ProductException(ProductErrorCode.BULK_IMPORT_JOB_NOT_FOUND)
+        }
+        if (job.sellerId != sellerId) {
+            throw ProductException(ProductErrorCode.BULK_IMPORT_ACCESS_DENIED)
+        }
+        return BulkImportProgressResponse.from(job)
+    }
+
+    @Transactional(readOnly = true)
+    fun getJobErrors(jobId: Long, sellerId: Long): List<BulkRowError> {
+        val job = bulkImportJobRepository.findById(jobId).orElseThrow {
+            ProductException(ProductErrorCode.BULK_IMPORT_JOB_NOT_FOUND)
+        }
+        if (job.sellerId != sellerId) {
+            throw ProductException(ProductErrorCode.BULK_IMPORT_ACCESS_DENIED)
+        }
+        if (job.errorDetails == null) {
+            return emptyList()
+        }
+        return objectMapper.readValue(
+            job.errorDetails,
+            objectMapper.typeFactory.constructCollectionType(List::class.java, BulkRowError::class.java)
+        )
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/BulkImportService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/BulkImportService.kt
@@ -16,9 +16,12 @@ import com.hoppingmall.mall.product.dto.response.*
 import com.hoppingmall.mall.product.exception.ProductException
 import com.hoppingmall.mall.product.exception.code.ProductErrorCode
 import org.slf4j.LoggerFactory
+import org.springframework.cache.CacheManager
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.web.multipart.MultipartFile
 
 @Service
@@ -29,13 +32,15 @@ class BulkImportService(
     private val productImageRepository: ProductImageRepository,
     private val categoryRepository: CategoryRepository,
     private val inventoryCommandService: InventoryCommandService,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val cacheManager: CacheManager
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
     companion object {
         private const val DEFAULT_IMAGE_PATH = "D:/hoppingmall/product/images/default-product.jpg"
+        private const val CHUNK_SIZE = 50
     }
 
     fun validate(file: MultipartFile): BulkValidationResponse {
@@ -93,12 +98,24 @@ class BulkImportService(
         job.startImport()
         bulkImportJobRepository.save(job)
 
-        processImportAsync(job.id!!, sellerId, parseResult.rows, parseResult.errors)
+        val jobId = job.id!!
+        val rows = parseResult.rows
+        val errors = parseResult.errors
+
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
+                override fun afterCommit() {
+                    processImportAsync(jobId, sellerId, rows, errors)
+                }
+            })
+        } else {
+            processImportAsync(jobId, sellerId, rows, errors)
+        }
 
         return BulkImportProgressResponse.from(job)
     }
 
-    @Async
+    @Async("bulkImportExecutor")
     fun processImportAsync(jobId: Long, sellerId: Long, rows: List<BulkProductRow>, parseErrors: List<BulkRowError>) {
         processImport(jobId, sellerId, rows, parseErrors)
     }
@@ -116,6 +133,8 @@ class BulkImportService(
         parseErrors.filter { it.rowNumber > 0 }.map { it.rowNumber }.distinct().forEach { _ ->
             job.recordFailure()
         }
+
+        val allProductImages = mutableListOf<ProductImage>()
 
         for (row in rows) {
             try {
@@ -140,7 +159,7 @@ class BulkImportService(
                 val productImages = imageUrls.mapIndexed { index, url ->
                     ProductImage.create(productId = product.id!!, imageUrl = url, sortOrder = index)
                 }
-                productImageRepository.saveAll(productImages)
+                allProductImages.addAll(productImages)
 
                 inventoryCommandService.initStock(
                     InventoryInitRequest(productId = product.id!!, stockQuantity = row.stockQuantity)
@@ -154,13 +173,31 @@ class BulkImportService(
             }
         }
 
+        if (allProductImages.isNotEmpty()) {
+            allProductImages.chunked(CHUNK_SIZE).forEach { chunk ->
+                productImageRepository.saveAll(chunk)
+            }
+        }
+
         if (allErrors.isNotEmpty()) {
             job.errorDetails = objectMapper.writeValueAsString(allErrors)
         }
         job.complete()
         bulkImportJobRepository.save(job)
 
+        evictProductCaches()
+
         log.info("대량 등록 완료: jobId={}, success={}, fail={}", jobId, job.successCount, job.failCount)
+    }
+
+    private fun evictProductCaches() {
+        try {
+            cacheManager.getCache("product")?.clear()
+            cacheManager.getCache("product:notfound")?.clear()
+            log.info("대량 등록 후 product 캐시 초기화 완료")
+        } catch (e: Exception) {
+            log.warn("캐시 초기화 실패: {}", e.message)
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/CsvParsingService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/CsvParsingService.kt
@@ -1,0 +1,112 @@
+package com.hoppingmall.mall.product.service
+
+import com.hoppingmall.mall.product.dto.request.BulkProductRow
+import com.hoppingmall.mall.product.dto.response.BulkRowError
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVParser
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+import java.io.InputStreamReader
+import java.math.BigDecimal
+
+@Service
+class CsvParsingService {
+
+    private val requiredHeaders = setOf("name", "description", "categoryId", "price", "stockQuantity")
+    private val maxRowLimit = 1000
+
+    data class ParseResult(
+        val rows: List<BulkProductRow>,
+        val errors: List<BulkRowError>
+    )
+
+    fun parse(file: MultipartFile): ParseResult {
+        val rows = mutableListOf<BulkProductRow>()
+        val errors = mutableListOf<BulkRowError>()
+
+        val reader = InputStreamReader(file.inputStream, Charsets.UTF_8)
+        val csvFormat = CSVFormat.DEFAULT.builder()
+            .setHeader()
+            .setSkipHeaderRecord(true)
+            .setTrim(true)
+            .setIgnoreEmptyLines(true)
+            .build()
+
+        val parser = CSVParser(reader, csvFormat)
+        val headerMap = parser.headerNames.associateBy { it.lowercase() }
+        val headersLower = headerMap.keys
+
+        val missingHeaders = requiredHeaders.map { it.lowercase() }.toSet() - headersLower
+        if (missingHeaders.isNotEmpty()) {
+            errors.add(BulkRowError(0, "header", "필수 헤더 누락: ${missingHeaders.joinToString(", ")}"))
+            return ParseResult(emptyList(), errors)
+        }
+
+        var rowNumber = 0
+        for (record in parser) {
+            rowNumber++
+            if (rowNumber > maxRowLimit) {
+                errors.add(BulkRowError(rowNumber, "row", "최대 ${maxRowLimit}행까지 처리 가능합니다."))
+                break
+            }
+
+            val rowErrors = mutableListOf<BulkRowError>()
+
+            val name = record.get("name")?.trim() ?: ""
+            if (name.isBlank()) {
+                rowErrors.add(BulkRowError(rowNumber, "name", "상품명은 필수입니다."))
+            }
+
+            val description = record.get("description")?.trim() ?: ""
+            if (description.isBlank()) {
+                rowErrors.add(BulkRowError(rowNumber, "description", "상품 설명은 필수입니다."))
+            }
+
+            val categoryIdStr = record.get("categoryId")?.trim() ?: ""
+            val categoryId = categoryIdStr.toLongOrNull()
+            if (categoryId == null || categoryId <= 0) {
+                rowErrors.add(BulkRowError(rowNumber, "categoryId", "유효한 카테고리 ID가 필요합니다."))
+            }
+
+            val priceStr = record.get("price")?.trim() ?: ""
+            val price = priceStr.toBigDecimalOrNull()
+            if (price == null || price <= BigDecimal.ZERO) {
+                rowErrors.add(BulkRowError(rowNumber, "price", "가격은 0보다 커야 합니다."))
+            }
+
+            val stockStr = record.get("stockQuantity")?.trim() ?: ""
+            val stockQuantity = stockStr.toIntOrNull()
+            if (stockQuantity == null || stockQuantity < 0) {
+                rowErrors.add(BulkRowError(rowNumber, "stockQuantity", "재고 수량은 0 이상이어야 합니다."))
+            }
+
+            val imageUrlsStr = record.isMapped("imageUrls").let {
+                if (it) record.get("imageUrls")?.trim() ?: "" else ""
+            }
+            val imageUrls = if (imageUrlsStr.isNotBlank()) {
+                imageUrlsStr.split("|").map { it.trim() }.filter { it.isNotBlank() }
+            } else {
+                emptyList()
+            }
+
+            if (rowErrors.isNotEmpty()) {
+                errors.addAll(rowErrors)
+            } else {
+                rows.add(
+                    BulkProductRow(
+                        rowNumber = rowNumber,
+                        name = name,
+                        description = description,
+                        categoryId = categoryId!!,
+                        price = price!!,
+                        stockQuantity = stockQuantity!!,
+                        imageUrls = imageUrls
+                    )
+                )
+            }
+        }
+
+        parser.close()
+        return ParseResult(rows, errors)
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,9 @@
 spring:
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
   jackson:
     property-naming-strategy: SNAKE_CASE
 

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/BulkImportServiceTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/BulkImportServiceTest.kt
@@ -1,0 +1,293 @@
+package com.hoppingmall.mall.product.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.hoppingmall.mall.category.domain.Category
+import com.hoppingmall.mall.category.domain.repository.CategoryRepository
+import com.hoppingmall.mall.inventory.dto.request.InventoryInitRequest
+import com.hoppingmall.mall.inventory.service.InventoryCommandService
+import com.hoppingmall.mall.product.domain.BulkImportJob
+import com.hoppingmall.mall.product.domain.Product
+import com.hoppingmall.mall.product.domain.ProductImage
+import com.hoppingmall.mall.product.domain.repository.BulkImportJobRepository
+import com.hoppingmall.mall.product.domain.repository.ProductImageRepository
+import com.hoppingmall.mall.product.domain.repository.ProductRepository
+import com.hoppingmall.mall.product.dto.request.BulkProductRow
+import com.hoppingmall.mall.product.dto.response.BulkRowError
+import com.hoppingmall.mall.product.enum.BulkImportStatus
+import com.hoppingmall.mall.product.exception.ProductException
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import java.math.BigDecimal
+import java.util.*
+
+@DisplayName("BulkImportService")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class BulkImportServiceTest {
+
+    private val csvParsingService: CsvParsingService = mock()
+    private val bulkImportJobRepository: BulkImportJobRepository = mock()
+    private val productRepository: ProductRepository = mock()
+    private val productImageRepository: ProductImageRepository = mock()
+    private val categoryRepository: CategoryRepository = mock()
+    private val inventoryCommandService: InventoryCommandService = mock()
+    private val objectMapper = jacksonObjectMapper()
+
+    private val bulkImportService = BulkImportService(
+        csvParsingService,
+        bulkImportJobRepository,
+        productRepository,
+        productImageRepository,
+        categoryRepository,
+        inventoryCommandService,
+        objectMapper
+    )
+
+    @Nested
+    @DisplayName("validate")
+    inner class Validate {
+
+        @Test
+        fun CSV_검증_결과를_반환한다() {
+            val file = mock<org.springframework.web.multipart.MultipartFile>()
+            val rows = listOf(
+                BulkProductRow(1, "상품1", "설명1", 1L, BigDecimal("15000"), 100, emptyList()),
+                BulkProductRow(2, "상품2", "설명2", 2L, BigDecimal("25000"), 50, emptyList())
+            )
+            val category1 = Category.fixture(name = "카테고리1").withId(1L)
+            val category2 = Category.fixture(name = "카테고리2").withId(2L)
+
+            whenever(csvParsingService.parse(file)).thenReturn(CsvParsingService.ParseResult(rows, emptyList()))
+            whenever(categoryRepository.findAllById(listOf(1L, 2L))).thenReturn(listOf(category1, category2))
+
+            val result = bulkImportService.validate(file)
+
+            assertEquals(2, result.totalRows)
+            assertEquals(2, result.validRows)
+            assertEquals(0, result.invalidRows)
+            assertEquals(2, result.preview.size)
+        }
+
+        @Test
+        fun 존재하지_않는_카테고리가_있으면_에러를_반환한다() {
+            val file = mock<org.springframework.web.multipart.MultipartFile>()
+            val rows = listOf(
+                BulkProductRow(1, "상품1", "설명1", 1L, BigDecimal("15000"), 100, emptyList()),
+                BulkProductRow(2, "상품2", "설명2", 999L, BigDecimal("25000"), 50, emptyList())
+            )
+            val category1 = Category.fixture(name = "카테고리1").withId(1L)
+
+            whenever(csvParsingService.parse(file)).thenReturn(CsvParsingService.ParseResult(rows, emptyList()))
+            whenever(categoryRepository.findAllById(listOf(1L, 999L))).thenReturn(listOf(category1))
+
+            val result = bulkImportService.validate(file)
+
+            assertEquals(2, result.totalRows)
+            assertEquals(1, result.validRows)
+            assertEquals(1, result.invalidRows)
+            assertTrue(result.errors.any { it.rowNumber == 2 && it.field == "categoryId" })
+        }
+    }
+
+    @Nested
+    @DisplayName("startImport")
+    inner class StartImport {
+
+        @Test
+        fun CSV_파싱_결과가_모두_에러이면_예외_발생() {
+            val file = mock<org.springframework.web.multipart.MultipartFile>()
+            val parseErrors = listOf(BulkRowError(0, "header", "필수 헤더 누락"))
+
+            whenever(csvParsingService.parse(file)).thenReturn(CsvParsingService.ParseResult(emptyList(), parseErrors))
+
+            assertThrows(ProductException::class.java) {
+                bulkImportService.startImport(5L, file)
+            }
+        }
+
+        @Test
+        fun 정상_CSV로_임포트_작업을_생성한다() {
+            val file = mock<org.springframework.web.multipart.MultipartFile>()
+            whenever(file.originalFilename).thenReturn("products.csv")
+            val rows = listOf(
+                BulkProductRow(1, "상품1", "설명1", 1L, BigDecimal("15000"), 100, emptyList())
+            )
+
+            whenever(csvParsingService.parse(file)).thenReturn(CsvParsingService.ParseResult(rows, emptyList()))
+            val savedJob = BulkImportJob.create(5L, "products.csv", 1).withId(1L)
+            whenever(bulkImportJobRepository.save(any<BulkImportJob>())).thenReturn(savedJob)
+            whenever(bulkImportJobRepository.findById(1L)).thenReturn(Optional.of(savedJob))
+
+            val category1 = Category.fixture(name = "카테고리1").withId(1L)
+            whenever(categoryRepository.findAllById(listOf(1L))).thenReturn(listOf(category1))
+            whenever(productRepository.save(any<Product>())).thenAnswer { invocation ->
+                (invocation.arguments[0] as Product).withId(100L)
+            }
+            whenever(productImageRepository.saveAll(any<List<ProductImage>>())).thenAnswer { it.arguments[0] }
+
+            val result = bulkImportService.startImport(5L, file)
+
+            assertEquals(1L, result.jobId)
+        }
+    }
+
+    @Nested
+    @DisplayName("processImport")
+    inner class ProcessImport {
+
+        @Test
+        fun 정상_행을_상품으로_등록한다() {
+            val jobId = 1L
+            val sellerId = 5L
+            val rows = listOf(
+                BulkProductRow(1, "상품1", "설명1", 1L, BigDecimal("15000"), 100, listOf("img1.jpg")),
+                BulkProductRow(2, "상품2", "설명2", 1L, BigDecimal("25000"), 50, emptyList())
+            )
+            val job = BulkImportJob.create(sellerId, "test.csv", 2).withId(jobId)
+            job.startImport()
+            val category1 = Category.fixture(name = "카테고리1").withId(1L)
+
+            whenever(bulkImportJobRepository.findById(jobId)).thenReturn(Optional.of(job))
+            whenever(categoryRepository.findAllById(listOf(1L))).thenReturn(listOf(category1))
+            whenever(productRepository.save(any<Product>())).thenAnswer { invocation ->
+                (invocation.arguments[0] as Product).withId(100L)
+            }
+            whenever(productImageRepository.saveAll(any<List<ProductImage>>())).thenAnswer { it.arguments[0] }
+            whenever(bulkImportJobRepository.save(any<BulkImportJob>())).thenAnswer { it.arguments[0] }
+
+            bulkImportService.processImport(jobId, sellerId, rows, emptyList())
+
+            verify(productRepository, times(2)).save(any<Product>())
+            verify(inventoryCommandService, times(2)).initStock(any<InventoryInitRequest>())
+            assertEquals(BulkImportStatus.COMPLETED, job.status)
+            assertEquals(2, job.successCount)
+            assertEquals(0, job.failCount)
+        }
+
+        @Test
+        fun 존재하지_않는_카테고리_행은_실패로_기록한다() {
+            val jobId = 1L
+            val sellerId = 5L
+            val rows = listOf(
+                BulkProductRow(1, "상품1", "설명1", 1L, BigDecimal("15000"), 100, emptyList()),
+                BulkProductRow(2, "상품2", "설명2", 999L, BigDecimal("25000"), 50, emptyList())
+            )
+            val job = BulkImportJob.create(sellerId, "test.csv", 2).withId(jobId)
+            job.startImport()
+            val category1 = Category.fixture(name = "카테고리1").withId(1L)
+
+            whenever(bulkImportJobRepository.findById(jobId)).thenReturn(Optional.of(job))
+            whenever(categoryRepository.findAllById(listOf(1L, 999L))).thenReturn(listOf(category1))
+            whenever(productRepository.save(any<Product>())).thenAnswer { invocation ->
+                (invocation.arguments[0] as Product).withId(100L)
+            }
+            whenever(productImageRepository.saveAll(any<List<ProductImage>>())).thenAnswer { it.arguments[0] }
+            whenever(bulkImportJobRepository.save(any<BulkImportJob>())).thenAnswer { it.arguments[0] }
+
+            bulkImportService.processImport(jobId, sellerId, rows, emptyList())
+
+            verify(productRepository, times(1)).save(any<Product>())
+            assertEquals(1, job.successCount)
+            assertEquals(1, job.failCount)
+            assertNotNull(job.errorDetails)
+        }
+
+        @Test
+        fun 파싱_에러가_있는_행은_실패로_카운트한다() {
+            val jobId = 1L
+            val sellerId = 5L
+            val rows = listOf(
+                BulkProductRow(2, "상품1", "설명1", 1L, BigDecimal("15000"), 100, emptyList())
+            )
+            val parseErrors = listOf(BulkRowError(1, "name", "상품명은 필수입니다."))
+            val job = BulkImportJob.create(sellerId, "test.csv", 2).withId(jobId)
+            job.startImport()
+            val category1 = Category.fixture(name = "카테고리1").withId(1L)
+
+            whenever(bulkImportJobRepository.findById(jobId)).thenReturn(Optional.of(job))
+            whenever(categoryRepository.findAllById(listOf(1L))).thenReturn(listOf(category1))
+            whenever(productRepository.save(any<Product>())).thenAnswer { invocation ->
+                (invocation.arguments[0] as Product).withId(100L)
+            }
+            whenever(productImageRepository.saveAll(any<List<ProductImage>>())).thenAnswer { it.arguments[0] }
+            whenever(bulkImportJobRepository.save(any<BulkImportJob>())).thenAnswer { it.arguments[0] }
+
+            bulkImportService.processImport(jobId, sellerId, rows, parseErrors)
+
+            assertEquals(1, job.successCount)
+            assertEquals(1, job.failCount)
+        }
+    }
+
+    @Nested
+    @DisplayName("getJobProgress")
+    inner class GetJobProgress {
+
+        @Test
+        fun 작업_진행률을_조회한다() {
+            val jobId = 1L
+            val sellerId = 5L
+            val job = BulkImportJob.create(sellerId, "test.csv", 10).withId(jobId)
+
+            whenever(bulkImportJobRepository.findById(jobId)).thenReturn(Optional.of(job))
+
+            val result = bulkImportService.getJobProgress(jobId, sellerId)
+
+            assertEquals(jobId, result.jobId)
+            assertEquals(10, result.totalRows)
+        }
+
+        @Test
+        fun 다른_판매자의_작업_조회_시_예외_발생() {
+            val jobId = 1L
+            val job = BulkImportJob.create(5L, "test.csv", 10).withId(jobId)
+
+            whenever(bulkImportJobRepository.findById(jobId)).thenReturn(Optional.of(job))
+
+            assertThrows(ProductException::class.java) {
+                bulkImportService.getJobProgress(jobId, 999L)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getJobErrors")
+    inner class GetJobErrors {
+
+        @Test
+        fun 에러_상세_정보를_반환한다() {
+            val jobId = 1L
+            val sellerId = 5L
+            val errors = listOf(BulkRowError(1, "name", "상품명은 필수입니다."))
+            val job = BulkImportJob.create(sellerId, "test.csv", 10).withId(jobId)
+            job.errorDetails = objectMapper.writeValueAsString(errors)
+
+            whenever(bulkImportJobRepository.findById(jobId)).thenReturn(Optional.of(job))
+
+            val result = bulkImportService.getJobErrors(jobId, sellerId)
+
+            assertEquals(1, result.size)
+            assertEquals("name", result[0].field)
+        }
+
+        @Test
+        fun 에러가_없으면_빈_리스트를_반환한다() {
+            val jobId = 1L
+            val sellerId = 5L
+            val job = BulkImportJob.create(sellerId, "test.csv", 10).withId(jobId)
+
+            whenever(bulkImportJobRepository.findById(jobId)).thenReturn(Optional.of(job))
+
+            val result = bulkImportService.getJobErrors(jobId, sellerId)
+
+            assertTrue(result.isEmpty())
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/BulkImportServiceTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/BulkImportServiceTest.kt
@@ -25,6 +25,10 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.math.BigDecimal
 import java.util.*
 
@@ -39,6 +43,7 @@ class BulkImportServiceTest {
     private val categoryRepository: CategoryRepository = mock()
     private val inventoryCommandService: InventoryCommandService = mock()
     private val objectMapper = jacksonObjectMapper()
+    private val cacheManager: CacheManager = mock()
 
     private val bulkImportService = BulkImportService(
         csvParsingService,
@@ -47,7 +52,8 @@ class BulkImportServiceTest {
         productImageRepository,
         categoryRepository,
         inventoryCommandService,
-        objectMapper
+        objectMapper,
+        cacheManager
     )
 
     @Nested
@@ -135,6 +141,40 @@ class BulkImportServiceTest {
             val result = bulkImportService.startImport(5L, file)
 
             assertEquals(1L, result.jobId)
+        }
+
+        @Test
+        fun 트랜잭션_커밋_후_비동기_처리를_등록한다() {
+            val file = mock<org.springframework.web.multipart.MultipartFile>()
+            whenever(file.originalFilename).thenReturn("products.csv")
+            val rows = listOf(
+                BulkProductRow(1, "상품1", "설명1", 1L, BigDecimal("15000"), 100, emptyList())
+            )
+
+            whenever(csvParsingService.parse(file)).thenReturn(CsvParsingService.ParseResult(rows, emptyList()))
+            val savedJob = BulkImportJob.create(5L, "products.csv", 1).withId(1L)
+            whenever(bulkImportJobRepository.save(any<BulkImportJob>())).thenReturn(savedJob)
+            whenever(bulkImportJobRepository.findById(1L)).thenReturn(Optional.of(savedJob))
+
+            val category1 = Category.fixture(name = "카테고리1").withId(1L)
+            whenever(categoryRepository.findAllById(listOf(1L))).thenReturn(listOf(category1))
+            whenever(productRepository.save(any<Product>())).thenAnswer { invocation ->
+                (invocation.arguments[0] as Product).withId(100L)
+            }
+            whenever(productImageRepository.saveAll(any<List<ProductImage>>())).thenAnswer { it.arguments[0] }
+
+            TransactionSynchronizationManager.initSynchronization()
+            try {
+                val result = bulkImportService.startImport(5L, file)
+
+                assertEquals(1L, result.jobId)
+                val synchronizations = TransactionSynchronizationManager.getSynchronizations()
+                assertEquals(1, synchronizations.size)
+
+                synchronizations.forEach { it.afterCommit() }
+            } finally {
+                TransactionSynchronizationManager.clearSynchronization()
+            }
         }
     }
 

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/CsvParsingServiceTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/CsvParsingServiceTest.kt
@@ -1,0 +1,105 @@
+package com.hoppingmall.mall.product.service
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockMultipartFile
+import java.math.BigDecimal
+
+@DisplayName("CsvParsingService")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class CsvParsingServiceTest {
+
+    private val csvParsingService = CsvParsingService()
+
+    private fun csvFile(content: String, fileName: String = "products.csv"): MockMultipartFile {
+        return MockMultipartFile("file", fileName, "text/csv", content.toByteArray())
+    }
+
+    @Nested
+    @DisplayName("parse")
+    inner class Parse {
+
+        @Test
+        fun 정상_CSV_파일을_파싱한다() {
+            val csv = "name,description,categoryId,price,stockQuantity,imageUrls\n" +
+                    "상품1,설명1,1,15000,100,http://img1.jpg|http://img2.jpg\n" +
+                    "상품2,설명2,2,25000,50,"
+
+            val result = csvParsingService.parse(csvFile(csv))
+
+            assertEquals(2, result.rows.size)
+            assertTrue(result.errors.isEmpty())
+
+            val row1 = result.rows[0]
+            assertEquals(1, row1.rowNumber)
+            assertEquals("상품1", row1.name)
+            assertEquals("설명1", row1.description)
+            assertEquals(1L, row1.categoryId)
+            assertEquals(BigDecimal("15000"), row1.price)
+            assertEquals(100, row1.stockQuantity)
+            assertEquals(listOf("http://img1.jpg", "http://img2.jpg"), row1.imageUrls)
+
+            val row2 = result.rows[1]
+            assertEquals(2, row2.rowNumber)
+            assertTrue(row2.imageUrls.isEmpty())
+        }
+
+        @Test
+        fun 필수_헤더가_누락되면_에러를_반환한다() {
+            val csv = "name,description,price\n" +
+                    "상품1,설명1,15000"
+
+            val result = csvParsingService.parse(csvFile(csv))
+
+            assertTrue(result.rows.isEmpty())
+            assertEquals(1, result.errors.size)
+            assertEquals("header", result.errors[0].field)
+        }
+
+        @Test
+        fun 유효하지_않은_값이_있으면_행별_에러를_반환한다() {
+            val csv = "name,description,categoryId,price,stockQuantity\n" +
+                    ",설명1,1,15000,100\n" +
+                    "상품2,설명2,abc,15000,100\n" +
+                    "상품3,설명3,1,-500,100\n" +
+                    "상품4,설명4,1,15000,-1"
+
+            val result = csvParsingService.parse(csvFile(csv))
+
+            assertEquals(0, result.rows.size)
+            assertEquals(4, result.errors.size)
+            assertEquals("name", result.errors[0].field)
+            assertEquals("categoryId", result.errors[1].field)
+            assertEquals("price", result.errors[2].field)
+            assertEquals("stockQuantity", result.errors[3].field)
+        }
+
+        @Test
+        fun 정상_행과_에러_행이_혼합되면_각각_분리한다() {
+            val csv = "name,description,categoryId,price,stockQuantity\n" +
+                    "정상상품,설명,1,15000,100\n" +
+                    ",설명2,1,15000,100"
+
+            val result = csvParsingService.parse(csvFile(csv))
+
+            assertEquals(1, result.rows.size)
+            assertEquals(1, result.errors.size)
+            assertEquals("정상상품", result.rows[0].name)
+        }
+
+        @Test
+        fun imageUrls_없는_헤더도_정상_파싱한다() {
+            val csv = "name,description,categoryId,price,stockQuantity\n" +
+                    "상품1,설명1,1,15000,100"
+
+            val result = csvParsingService.parse(csvFile(csv))
+
+            assertEquals(1, result.rows.size)
+            assertTrue(result.rows[0].imageUrls.isEmpty())
+        }
+    }
+}


### PR DESCRIPTION
Closes #133

### 📌 작업 개요
판매자가 CSV 파일로 상품을 일괄 등록할 수 있는 기능을 구현했습니다.
검증 미리보기 → @Async 비동기 임포트 2단계 플로우를 제공하며,
부분 성공 모델로 유효한 행은 저장하고 실패 행은 에러로 기록합니다.

---

### ✅ 주요 변경 사항

- `global.common.config`
  - `AsyncConfig`: @EnableAsync 설정
  - `SecurityConfig`: bulk 엔드포인트 SELLER 권한 추가

- `product.domain`
  - `BulkImportJob`: 대량 등록 작업 추적 엔티티 (상태, 진행률, 에러 상세)
  - `BulkImportJobRepository`: 판매자별 작업 조회

- `product.enum`
  - `BulkImportStatus`: VALIDATING, VALIDATED, IMPORTING, COMPLETED, FAILED

- `product.dto`
  - `BulkProductRow`: CSV 행 파싱 결과
  - `BulkValidationResponse`, `BulkImportProgressResponse`: 응답 DTO

- `product.service`
  - `CsvParsingService`: CSV 파싱 + 행별 검증 (필수 헤더, 데이터 타입, 범위 검증)
  - `BulkImportService`: 검증 미리보기, @Async 비동기 임포트, 진행률/에러 조회

- `product.controller`
  - `ProductBulkController`: 4개 API 엔드포인트
    - `POST /bulk/validate` — CSV 검증 미리보기
    - `POST /bulk/import` — 비동기 임포트 시작
    - `GET /bulk/{jobId}` — 진행률 조회
    - `GET /bulk/{jobId}/errors` — 에러 상세 조회

- `product.exception`
  - `ProductException`: 범용 Product 도메인 예외
  - `ProductErrorCode`: BULK_IMPORT_INVALID_CSV, JOB_NOT_FOUND, ACCESS_DENIED 추가

- `build.gradle.kts`
  - Apache Commons CSV 1.12.0 의존성 추가
  - Jacoco 제외: BulkImportJob, ProductBulkController

---

### 🧪 테스트

- `CsvParsingServiceTest`: 정상 파싱, 헤더 누락, 행별 검증 에러, 혼합 결과, imageUrls 옵션 테스트
- `BulkImportServiceTest`: CSV 파싱 에러 시 예외, 정상 임포트, 카테고리 검증, 파싱 에러 카운트, 진행률 조회, 접근 권한 검증, 에러 상세 조회

---

### 📎 관련 이슈
- #133