### PR TITLE
feat: API 멱등성 키 (Phase 2)

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/coupon/controller/CouponController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/coupon/controller/CouponController.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.mall.coupon.controller
 
+import com.hoppingmall.mall.global.idempotency.Idempotent
 import com.hoppingmall.mall.coupon.dto.request.CouponCreateRequest
 import com.hoppingmall.mall.coupon.dto.response.CouponResponse
 import com.hoppingmall.mall.coupon.dto.response.UserCouponResponse
@@ -24,6 +25,7 @@ class CouponController(
     private val couponQueryService: CouponQueryService
 ) {
 
+    @Idempotent(ttlHours = 24)
     @PostMapping("/admin/coupons")
     fun createCoupon(
         @Valid @RequestBody request: CouponCreateRequest
@@ -39,6 +41,7 @@ class CouponController(
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 
+    @Idempotent(ttlHours = 24)
     @PatchMapping("/admin/coupons/{couponId}/status")
     fun changeCouponStatus(
         @PathVariable couponId: Long,
@@ -54,6 +57,7 @@ class CouponController(
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 
+    @Idempotent(ttlHours = 24)
     @PostMapping("/coupons/{couponId}/issue")
     fun issueCoupon(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/controller/InventoryController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/controller/InventoryController.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.mall.inventory.controller
 
 import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.global.idempotency.Idempotent
 import com.hoppingmall.mall.inventory.dto.request.InventoryInitRequest
 import com.hoppingmall.mall.inventory.dto.request.InventoryUpdateRequest
 import com.hoppingmall.mall.inventory.dto.response.InventoryResponse
@@ -18,6 +19,7 @@ class InventoryController(
     private val inventoryQueryService: InventoryQueryService
 ) {
 
+    @Idempotent(ttlHours = 24)
     @PostMapping
     fun initStock(
         @Valid @RequestBody request: InventoryInitRequest
@@ -35,6 +37,7 @@ class InventoryController(
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 
+    @Idempotent(ttlHours = 24)
     @PatchMapping("/{productId}")
     fun updateStock(
         @PathVariable productId: Long,

--- a/src/main/kotlin/com/hoppingmall/mall/order/controller/OrderController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/controller/OrderController.kt
@@ -53,6 +53,7 @@ class OrderController(
         return ResponseEntity.ok(ApiResponse.success(orders))
     }
 
+    @Idempotent(ttlHours = 24)
     @PatchMapping("/{orderId}/cancel")
     fun cancelOrder(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
@@ -62,6 +63,7 @@ class OrderController(
         return ResponseEntity.ok(ApiResponse.success(order))
     }
 
+    @Idempotent(ttlHours = 24)
     @PatchMapping("/{orderId}/status")
     fun updateOrderStatus(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,

--- a/src/main/kotlin/com/hoppingmall/mall/payment/controller/PaymentController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/controller/PaymentController.kt
@@ -63,6 +63,7 @@ class PaymentController(
         return ResponseEntity.ok(payments)
     }
 
+    @Idempotent(ttlHours = 24)
     @PostMapping("/{paymentId}/cancel")
     fun cancelPayment(
         @PathVariable paymentId: Long,

--- a/src/main/kotlin/com/hoppingmall/mall/point/controller/PointController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/controller/PointController.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.mall.point.controller
 
+import com.hoppingmall.mall.global.idempotency.Idempotent
 import com.hoppingmall.mall.point.dto.request.PointUseRequest
 import com.hoppingmall.mall.point.dto.response.PointBalanceResponse
 import com.hoppingmall.mall.point.dto.response.PointHistoryResponse
@@ -42,6 +43,7 @@ class PointController(
         return ResponseEntity.ok(history)
     }
     
+    @Idempotent(ttlHours = 24)
     @PostMapping("/use")
     fun usePoint(
         @Valid @RequestBody request: PointUseRequest,

--- a/src/main/kotlin/com/hoppingmall/mall/refund/controller/RefundController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/controller/RefundController.kt
@@ -66,6 +66,7 @@ class RefundController(
         return ResponseEntity.ok(refunds)
     }
 
+    @Idempotent(ttlHours = 24)
     @PatchMapping("/{refundId}/approve")
     fun approveRefund(
         @PathVariable refundId: Long,
@@ -76,6 +77,7 @@ class RefundController(
         return ResponseEntity.ok(response)
     }
 
+    @Idempotent(ttlHours = 24)
     @PatchMapping("/{refundId}/reject")
     fun rejectRefund(
         @PathVariable refundId: Long,

--- a/src/main/kotlin/com/hoppingmall/mall/review/controller/ReviewController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/controller/ReviewController.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.review.controller
 
 import com.hoppingmall.mall.global.auth.UserPrincipal
 import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.global.idempotency.Idempotent
 import com.hoppingmall.mall.review.dto.request.ReviewCreateRequest
 import com.hoppingmall.mall.review.dto.request.ReviewUpdateRequest
 import com.hoppingmall.mall.review.dto.response.ReviewResponse
@@ -23,6 +24,7 @@ class ReviewController(
     private val reviewQueryService: ReviewQueryService
 ) {
 
+    @Idempotent(ttlHours = 24)
     @PostMapping("/reviews")
     fun createReview(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
@@ -59,6 +61,7 @@ class ReviewController(
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 
+    @Idempotent(ttlHours = 24)
     @PutMapping("/reviews/{reviewId}")
     fun updateReview(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
@@ -69,6 +72,7 @@ class ReviewController(
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 
+    @Idempotent(ttlHours = 24)
     @DeleteMapping("/reviews/{reviewId}")
     fun deleteReview(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,

--- a/src/main/kotlin/com/hoppingmall/mall/shipping/controller/ShippingController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/shipping/controller/ShippingController.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.shipping.controller
 
 import com.hoppingmall.mall.global.auth.UserPrincipal
 import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.global.idempotency.Idempotent
 import com.hoppingmall.mall.shipping.dto.request.ShippingCreateRequest
 import com.hoppingmall.mall.shipping.dto.request.ShippingStatusUpdateRequest
 import com.hoppingmall.mall.shipping.dto.response.ShippingResponse
@@ -20,6 +21,7 @@ class ShippingController(
     private val shippingQueryService: ShippingQueryService
 ) {
 
+    @Idempotent(ttlHours = 24)
     @PostMapping
     fun createShipping(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
@@ -30,6 +32,7 @@ class ShippingController(
             .body(ApiResponse.success(shipping))
     }
 
+    @Idempotent(ttlHours = 24)
     @PatchMapping("/{shippingId}/status")
     fun updateShippingStatus(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,

--- a/src/main/kotlin/com/hoppingmall/mall/wishlist/controller/WishlistController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/wishlist/controller/WishlistController.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.wishlist.controller
 
 import com.hoppingmall.mall.global.auth.UserPrincipal
 import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.global.idempotency.Idempotent
 import com.hoppingmall.mall.wishlist.dto.request.WishlistCreateRequest
 import com.hoppingmall.mall.wishlist.dto.response.WishlistResponse
 import com.hoppingmall.mall.wishlist.service.WishlistCommandService
@@ -22,6 +23,7 @@ class WishlistController(
     private val wishlistQueryService: WishlistQueryService
 ) {
 
+    @Idempotent(ttlHours = 24)
     @PostMapping
     fun addWishlist(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
@@ -32,6 +34,7 @@ class WishlistController(
             .body(ApiResponse.success(wishlist))
     }
 
+    @Idempotent(ttlHours = 24)
     @DeleteMapping("/{wishlistId}")
     fun removeWishlist(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,


### PR DESCRIPTION
Closes #135

### 📌 작업 개요
Phase 1(PR #122)에서 Payment, Order, Refund 생성에만 적용했던 `@Idempotent`를 전체 도메인 변경 API로 확장했습니다.
기존 AOP 기반 멱등성 인프라(Redis 분산 락 + DB 캐싱)를 그대로 활용하여 어노테이션 추가만으로 적용 완료.

---

### ✅ 주요 변경 사항

- `payment.controller`
  - `PaymentController`: `cancelPayment` 멱등성 적용

- `order.controller`
  - `OrderController`: `cancelOrder`, `updateOrderStatus` 멱등성 적용

- `refund.controller`
  - `RefundController`: `approveRefund`, `rejectRefund` 멱등성 적용

- `shipping.controller`
  - `ShippingController`: `createShipping`, `updateShippingStatus` 멱등성 적용

- `inventory.controller`
  - `InventoryController`: `initStock`, `updateStock` 멱등성 적용

- `point.controller`
  - `PointController`: `usePoint` 멱등성 적용

- `coupon.controller`
  - `CouponController`: `createCoupon`, `changeCouponStatus`, `issueCoupon` 멱등성 적용

- `review.controller`
  - `ReviewController`: `createReview`, `updateReview`, `deleteReview` 멱등성 적용

- `wishlist.controller`
  - `WishlistController`: `addWishlist`, `removeWishlist` 멱등성 적용

---

### 🧪 테스트

- `./gradlew test jacocoTestCoverageVerification` 통과
- 멱등성 AOP 인프라는 Phase 1에서 이미 검증 완료

---

### 📎 관련 이슈
- #135