### PR TITLE
feat: 알림 조회/관리 API 추가

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/notification/controller/NotificationController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/controller/NotificationController.kt
@@ -1,0 +1,60 @@
+package com.hoppingmall.mall.notification.controller
+
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.notification.dto.response.NotificationResponse
+import com.hoppingmall.mall.notification.dto.response.UnreadCountResponse
+import com.hoppingmall.mall.notification.enum.NotificationType
+import com.hoppingmall.mall.notification.service.NotificationCommandService
+import com.hoppingmall.mall.notification.service.NotificationQueryService
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+class NotificationController(
+    private val notificationQueryService: NotificationQueryService,
+    private val notificationCommandService: NotificationCommandService
+) {
+
+    @GetMapping
+    fun getNotifications(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @RequestParam(required = false) type: NotificationType?,
+        @PageableDefault(size = 20, sort = ["createdAt"]) pageable: Pageable
+    ): ResponseEntity<ApiResponse<Slice<NotificationResponse>>> {
+        val notifications = notificationQueryService.getNotifications(
+            userPrincipal.getUserId(), type, pageable
+        )
+        return ResponseEntity.ok(ApiResponse.success(notifications))
+    }
+
+    @GetMapping("/unread-count")
+    fun getUnreadCount(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ): ResponseEntity<ApiResponse<UnreadCountResponse>> {
+        val count = notificationQueryService.getUnreadCount(userPrincipal.getUserId())
+        return ResponseEntity.ok(ApiResponse.success(count))
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    fun markAsRead(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PathVariable notificationId: Long
+    ): ResponseEntity<ApiResponse<Unit>> {
+        notificationCommandService.markAsRead(notificationId, userPrincipal.getUserId())
+        return ResponseEntity.ok(ApiResponse.success(Unit))
+    }
+
+    @PatchMapping("/read-all")
+    fun markAllAsRead(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ): ResponseEntity<ApiResponse<Unit>> {
+        notificationCommandService.markAllAsRead(userPrincipal.getUserId())
+        return ResponseEntity.ok(ApiResponse.success(Unit))
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/notification/domain/Notification.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/domain/Notification.kt
@@ -7,7 +7,10 @@ import jakarta.persistence.*
 @Entity
 @Table(
     name = "notifications",
-    indexes = [Index(name = "idx_notifications_user_id", columnList = "userId")]
+    indexes = [
+        Index(name = "idx_notifications_user_id", columnList = "userId"),
+        Index(name = "idx_notifications_user_id_is_read", columnList = "userId, isRead")
+    ]
 )
 class Notification(
     @Column(nullable = false, unique = true)
@@ -31,4 +34,9 @@ class Notification(
 
     @Column
     var isRead: Boolean = false
-) : BaseEntity() 
+) : BaseEntity() {
+
+    fun markAsRead() {
+        this.isRead = true
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/notification/domain/NotificationRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/domain/NotificationRepository.kt
@@ -1,23 +1,28 @@
 package com.hoppingmall.mall.notification.domain
 
 import com.hoppingmall.mall.notification.enum.NotificationType
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
 interface NotificationRepository : JpaRepository<Notification, Long> {
 
     fun existsByEventId(eventId: String): Boolean
-    
+
     fun findByUserId(userId: Long): List<Notification>
-    
-    fun findByUserId(userId: Long, pageable: Pageable): Page<Notification>
-    
-    fun findByUserIdAndType(userId: Long, type: NotificationType): List<Notification>
-    
-    fun findByUserIdAndIsRead(userId: Long, isRead: Boolean): List<Notification>
-    
+
+    fun findByUserId(userId: Long, pageable: Pageable): Slice<Notification>
+
+    fun findByUserIdAndType(userId: Long, type: NotificationType, pageable: Pageable): Slice<Notification>
+
     fun countByUserIdAndIsRead(userId: Long, isRead: Boolean): Long
-} 
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = true WHERE n.userId = :userId AND n.isRead = false")
+    fun markAllAsRead(@Param("userId") userId: Long): Int
+}

--- a/src/main/kotlin/com/hoppingmall/mall/notification/dto/response/NotificationResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/dto/response/NotificationResponse.kt
@@ -1,0 +1,29 @@
+package com.hoppingmall.mall.notification.dto.response
+
+import com.hoppingmall.mall.notification.domain.Notification
+import com.hoppingmall.mall.notification.enum.NotificationType
+import java.time.LocalDateTime
+
+data class NotificationResponse(
+    val id: Long,
+    val type: NotificationType,
+    val title: String,
+    val content: String,
+    val metadata: String?,
+    val isRead: Boolean,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(notification: Notification): NotificationResponse {
+            return NotificationResponse(
+                id = notification.id!!,
+                type = notification.type,
+                title = notification.title,
+                content = notification.content,
+                metadata = notification.metadata,
+                isRead = notification.isRead,
+                createdAt = notification.createdAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/notification/dto/response/UnreadCountResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/dto/response/UnreadCountResponse.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.notification.dto.response
+
+data class UnreadCountResponse(
+    val count: Long
+)

--- a/src/main/kotlin/com/hoppingmall/mall/notification/exception/NotificationAccessDeniedException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/exception/NotificationAccessDeniedException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.notification.exception
+
+import com.hoppingmall.mall.notification.exception.code.NotificationErrorCode
+
+class NotificationAccessDeniedException : NotificationException(NotificationErrorCode.NOTIFICATION_ACCESS_DENIED)

--- a/src/main/kotlin/com/hoppingmall/mall/notification/exception/NotificationException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/exception/NotificationException.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.mall.notification.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.notification.exception.code.NotificationErrorCode
+
+open class NotificationException(
+    errorCode: NotificationErrorCode
+) : BusinessException(errorCode)

--- a/src/main/kotlin/com/hoppingmall/mall/notification/exception/NotificationNotFoundException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/exception/NotificationNotFoundException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.notification.exception
+
+import com.hoppingmall.mall.notification.exception.code.NotificationErrorCode
+
+class NotificationNotFoundException : NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND)

--- a/src/main/kotlin/com/hoppingmall/mall/notification/exception/code/NotificationErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/exception/code/NotificationErrorCode.kt
@@ -1,0 +1,13 @@
+package com.hoppingmall.mall.notification.exception.code
+
+import com.hoppingmall.mall.global.common.error.code.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class NotificationErrorCode(
+    override val code: String,
+    override val message: String,
+    override val status: HttpStatus
+) : ErrorCode {
+    NOTIFICATION_NOT_FOUND("NTF001", "알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    NOTIFICATION_ACCESS_DENIED("NTF002", "알림에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN)
+}

--- a/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationCommandService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationCommandService.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.mall.notification.service
+
+interface NotificationCommandService {
+    fun markAsRead(notificationId: Long, userId: Long)
+    fun markAllAsRead(userId: Long)
+}

--- a/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationCommandServiceImpl.kt
@@ -1,0 +1,29 @@
+package com.hoppingmall.mall.notification.service
+
+import com.hoppingmall.mall.notification.domain.NotificationRepository
+import com.hoppingmall.mall.notification.exception.NotificationAccessDeniedException
+import com.hoppingmall.mall.notification.exception.NotificationNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class NotificationCommandServiceImpl(
+    private val notificationRepository: NotificationRepository
+) : NotificationCommandService {
+
+    override fun markAsRead(notificationId: Long, userId: Long) {
+        val notification = notificationRepository.findById(notificationId)
+            .orElseThrow { NotificationNotFoundException() }
+
+        if (notification.userId != userId) {
+            throw NotificationAccessDeniedException()
+        }
+
+        notification.markAsRead()
+    }
+
+    override fun markAllAsRead(userId: Long) {
+        notificationRepository.markAllAsRead(userId)
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationQueryService.kt
@@ -1,0 +1,12 @@
+package com.hoppingmall.mall.notification.service
+
+import com.hoppingmall.mall.notification.dto.response.NotificationResponse
+import com.hoppingmall.mall.notification.dto.response.UnreadCountResponse
+import com.hoppingmall.mall.notification.enum.NotificationType
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+
+interface NotificationQueryService {
+    fun getNotifications(userId: Long, type: NotificationType?, pageable: Pageable): Slice<NotificationResponse>
+    fun getUnreadCount(userId: Long): UnreadCountResponse
+}

--- a/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationQueryServiceImpl.kt
@@ -1,0 +1,35 @@
+package com.hoppingmall.mall.notification.service
+
+import com.hoppingmall.mall.notification.domain.NotificationRepository
+import com.hoppingmall.mall.notification.dto.response.NotificationResponse
+import com.hoppingmall.mall.notification.dto.response.UnreadCountResponse
+import com.hoppingmall.mall.notification.enum.NotificationType
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class NotificationQueryServiceImpl(
+    private val notificationRepository: NotificationRepository
+) : NotificationQueryService {
+
+    override fun getNotifications(
+        userId: Long,
+        type: NotificationType?,
+        pageable: Pageable
+    ): Slice<NotificationResponse> {
+        val notifications = if (type != null) {
+            notificationRepository.findByUserIdAndType(userId, type, pageable)
+        } else {
+            notificationRepository.findByUserId(userId, pageable)
+        }
+        return notifications.map { NotificationResponse.from(it) }
+    }
+
+    override fun getUnreadCount(userId: Long): UnreadCountResponse {
+        val count = notificationRepository.countByUserIdAndIsRead(userId, false)
+        return UnreadCountResponse(count)
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/notification/controller/NotificationControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/notification/controller/NotificationControllerTest.kt
@@ -1,0 +1,130 @@
+package com.hoppingmall.mall.notification.controller
+
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.notification.dto.response.NotificationResponse
+import com.hoppingmall.mall.notification.dto.response.UnreadCountResponse
+import com.hoppingmall.mall.notification.enum.NotificationType
+import com.hoppingmall.mall.notification.service.NotificationCommandService
+import com.hoppingmall.mall.notification.service.NotificationQueryService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
+import org.springframework.data.domain.Sort
+import org.springframework.http.HttpStatus
+import java.time.LocalDateTime
+
+@DisplayName("NotificationController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class NotificationControllerTest {
+
+    private val notificationQueryService: NotificationQueryService = mock()
+    private val notificationCommandService: NotificationCommandService = mock()
+    private val controller = NotificationController(notificationQueryService, notificationCommandService)
+
+    private val userPrincipal = UserPrincipal(1L, "test@example.com", "BUYER")
+    private val now = LocalDateTime.now()
+
+    private fun createNotificationResponse(
+        id: Long = 1L,
+        type: NotificationType = NotificationType.PAYMENT_COMPLETED
+    ): NotificationResponse {
+        return NotificationResponse(
+            id = id,
+            type = type,
+            title = "테스트 알림",
+            content = "테스트 내용",
+            metadata = null,
+            isRead = false,
+            createdAt = now
+        )
+    }
+
+    @Nested
+    @DisplayName("getNotifications")
+    inner class GetNotifications {
+
+        @Test
+        fun 알림_목록을_조회한다() {
+            val pageable = PageRequest.of(0, 20, Sort.by("createdAt"))
+            val notifications = listOf(createNotificationResponse(id = 1L), createNotificationResponse(id = 2L))
+            val slice: Slice<NotificationResponse> = SliceImpl(notifications, pageable, false)
+
+            whenever(notificationQueryService.getNotifications(1L, null, pageable))
+                .thenReturn(slice)
+
+            val response = controller.getNotifications(userPrincipal, null, pageable)
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals("SUCCESS", response.body?.code)
+            assertEquals(2, response.body?.data?.content?.size)
+        }
+
+        @Test
+        fun 타입_필터로_조회한다() {
+            val type = NotificationType.POINT_EARNED
+            val pageable = PageRequest.of(0, 20, Sort.by("createdAt"))
+            val notifications = listOf(createNotificationResponse(id = 1L, type = type))
+            val slice: Slice<NotificationResponse> = SliceImpl(notifications, pageable, false)
+
+            whenever(notificationQueryService.getNotifications(1L, type, pageable))
+                .thenReturn(slice)
+
+            val response = controller.getNotifications(userPrincipal, type, pageable)
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals(1, response.body?.data?.content?.size)
+        }
+    }
+
+    @Nested
+    @DisplayName("getUnreadCount")
+    inner class GetUnreadCount {
+
+        @Test
+        fun 안읽은_알림_수를_조회한다() {
+            whenever(notificationQueryService.getUnreadCount(1L))
+                .thenReturn(UnreadCountResponse(3L))
+
+            val response = controller.getUnreadCount(userPrincipal)
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals(3L, response.body?.data?.count)
+        }
+    }
+
+    @Nested
+    @DisplayName("markAsRead")
+    inner class MarkAsRead {
+
+        @Test
+        fun 알림을_읽음_처리한다() {
+            val response = controller.markAsRead(userPrincipal, 1L)
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            verify(notificationCommandService).markAsRead(1L, 1L)
+        }
+    }
+
+    @Nested
+    @DisplayName("markAllAsRead")
+    inner class MarkAllAsRead {
+
+        @Test
+        fun 전체_알림을_읽음_처리한다() {
+            val response = controller.markAllAsRead(userPrincipal)
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            verify(notificationCommandService).markAllAsRead(1L)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/notification/service/NotificationCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/notification/service/NotificationCommandServiceImplTest.kt
@@ -1,0 +1,122 @@
+package com.hoppingmall.mall.notification.service
+
+import com.hoppingmall.mall.notification.domain.Notification
+import com.hoppingmall.mall.notification.domain.NotificationRepository
+import com.hoppingmall.mall.notification.enum.NotificationType
+import com.hoppingmall.mall.notification.exception.NotificationAccessDeniedException
+import com.hoppingmall.mall.notification.exception.NotificationNotFoundException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.*
+
+@DisplayName("NotificationCommandServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class NotificationCommandServiceImplTest {
+
+    private val notificationRepository: NotificationRepository = mock()
+    private val notificationCommandService = NotificationCommandServiceImpl(notificationRepository)
+
+    private fun createNotification(
+        id: Long = 1L,
+        userId: Long = 1L,
+        isRead: Boolean = false
+    ): Notification {
+        val notification = Notification(
+            eventId = "event-$id",
+            userId = userId,
+            type = NotificationType.PAYMENT_COMPLETED,
+            title = "테스트 알림",
+            content = "테스트 내용",
+            isRead = isRead
+        )
+        val idField = notification.javaClass.superclass.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(notification, id)
+        return notification
+    }
+
+    @Nested
+    @DisplayName("markAsRead")
+    inner class MarkAsRead {
+
+        @Test
+        fun 알림을_읽음_처리한다() {
+            val userId = 1L
+            val notificationId = 1L
+            val notification = createNotification(id = notificationId, userId = userId)
+
+            whenever(notificationRepository.findById(notificationId))
+                .thenReturn(Optional.of(notification))
+
+            notificationCommandService.markAsRead(notificationId, userId)
+
+            assertTrue(notification.isRead)
+        }
+
+        @Test
+        fun 존재하지_않는_알림이면_예외가_발생한다() {
+            val notificationId = 999L
+
+            whenever(notificationRepository.findById(notificationId))
+                .thenReturn(Optional.empty())
+
+            assertThrows<NotificationNotFoundException> {
+                notificationCommandService.markAsRead(notificationId, 1L)
+            }
+        }
+
+        @Test
+        fun 타인의_알림이면_예외가_발생한다() {
+            val ownerId = 1L
+            val otherUserId = 2L
+            val notificationId = 1L
+            val notification = createNotification(id = notificationId, userId = ownerId)
+
+            whenever(notificationRepository.findById(notificationId))
+                .thenReturn(Optional.of(notification))
+
+            assertThrows<NotificationAccessDeniedException> {
+                notificationCommandService.markAsRead(notificationId, otherUserId)
+            }
+        }
+
+        @Test
+        fun 이미_읽은_알림도_정상_처리된다() {
+            val userId = 1L
+            val notificationId = 1L
+            val notification = createNotification(id = notificationId, userId = userId, isRead = true)
+
+            whenever(notificationRepository.findById(notificationId))
+                .thenReturn(Optional.of(notification))
+
+            notificationCommandService.markAsRead(notificationId, userId)
+
+            assertTrue(notification.isRead)
+        }
+    }
+
+    @Nested
+    @DisplayName("markAllAsRead")
+    inner class MarkAllAsRead {
+
+        @Test
+        fun 전체_알림을_읽음_처리한다() {
+            val userId = 1L
+
+            whenever(notificationRepository.markAllAsRead(userId)).thenReturn(3)
+
+            notificationCommandService.markAllAsRead(userId)
+
+            verify(notificationRepository).markAllAsRead(userId)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/notification/service/NotificationQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/notification/service/NotificationQueryServiceImplTest.kt
@@ -1,0 +1,115 @@
+package com.hoppingmall.mall.notification.service
+
+import com.hoppingmall.mall.notification.domain.Notification
+import com.hoppingmall.mall.notification.domain.NotificationRepository
+import com.hoppingmall.mall.notification.enum.NotificationType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import org.springframework.data.domain.Sort
+
+@DisplayName("NotificationQueryServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class NotificationQueryServiceImplTest {
+
+    private val notificationRepository: NotificationRepository = mock()
+    private val notificationQueryService = NotificationQueryServiceImpl(notificationRepository)
+
+    private fun createNotification(
+        id: Long = 1L,
+        userId: Long = 1L,
+        type: NotificationType = NotificationType.PAYMENT_COMPLETED,
+        isRead: Boolean = false
+    ): Notification {
+        val notification = Notification(
+            eventId = "event-$id",
+            userId = userId,
+            type = type,
+            title = "테스트 알림 $id",
+            content = "테스트 내용 $id",
+            isRead = isRead
+        )
+        val idField = notification.javaClass.superclass.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(notification, id)
+        return notification
+    }
+
+    @Nested
+    @DisplayName("getNotifications")
+    inner class GetNotifications {
+
+        @Test
+        fun 알림_목록을_페이지네이션으로_조회한다() {
+            val userId = 1L
+            val pageable = PageRequest.of(0, 20, Sort.by("createdAt"))
+            val notifications = listOf(
+                createNotification(id = 1L, userId = userId),
+                createNotification(id = 2L, userId = userId)
+            )
+
+            whenever(notificationRepository.findByUserId(userId, pageable))
+                .thenReturn(SliceImpl(notifications, pageable, false))
+
+            val result = notificationQueryService.getNotifications(userId, null, pageable)
+
+            assertEquals(2, result.content.size)
+            assertEquals(1L, result.content[0].id)
+            assertEquals(2L, result.content[1].id)
+        }
+
+        @Test
+        fun 타입_필터로_알림을_조회한다() {
+            val userId = 1L
+            val type = NotificationType.POINT_EARNED
+            val pageable = PageRequest.of(0, 20, Sort.by("createdAt"))
+            val notifications = listOf(
+                createNotification(id = 3L, userId = userId, type = type)
+            )
+
+            whenever(notificationRepository.findByUserIdAndType(userId, type, pageable))
+                .thenReturn(SliceImpl(notifications, pageable, false))
+
+            val result = notificationQueryService.getNotifications(userId, type, pageable)
+
+            assertEquals(1, result.content.size)
+            assertEquals(NotificationType.POINT_EARNED, result.content[0].type)
+        }
+    }
+
+    @Nested
+    @DisplayName("getUnreadCount")
+    inner class GetUnreadCount {
+
+        @Test
+        fun 안읽은_알림_수를_조회한다() {
+            val userId = 1L
+
+            whenever(notificationRepository.countByUserIdAndIsRead(userId, false))
+                .thenReturn(5L)
+
+            val result = notificationQueryService.getUnreadCount(userId)
+
+            assertEquals(5L, result.count)
+        }
+
+        @Test
+        fun 안읽은_알림이_없으면_0을_반환한다() {
+            val userId = 1L
+
+            whenever(notificationRepository.countByUserIdAndIsRead(userId, false))
+                .thenReturn(0L)
+
+            val result = notificationQueryService.getUnreadCount(userId)
+
+            assertEquals(0L, result.count)
+        }
+    }
+}


### PR DESCRIPTION
Closes #138

### 📌 작업 개요
Kafka Consumer로 DB에 저장된 알림을 사용자가 조회하고 읽음 처리할 수 있는 REST API를 구현했습니다.
DDD 패턴에 맞춰 QueryService/CommandService를 분리하고, Slice 페이지네이션과 타입 필터를 적용했습니다.

---

### ✅ 주요 변경 사항

- `notification.dto.response`
  - `NotificationResponse`: 알림 응답 DTO (from 팩토리 메서드)
  - `UnreadCountResponse`: 안읽은 알림 수 응답 DTO

- `notification.domain`
  - `Notification`: 복합 인덱스 (userId, isRead) 추가, `markAsRead()` 메서드 추가
  - `NotificationRepository`: Slice 페이지네이션, 타입 필터 조회, `markAllAsRead()` bulk update 추가

- `notification.exception`
  - `NotificationErrorCode`: NTF001 NOT_FOUND, NTF002 ACCESS_DENIED
  - `NotificationException`, `NotificationNotFoundException`, `NotificationAccessDeniedException`

- `notification.service`
  - `NotificationQueryService/Impl`: 목록 조회 (타입 필터, Slice), 안읽은 수 조회
  - `NotificationCommandService/Impl`: 단건 읽음 처리 (본인 확인, 멱등), 전체 읽음 처리

- `notification.controller`
  - `NotificationController`: 4개 API 엔드포인트

---

### 🧪 테스트

- `NotificationQueryServiceImplTest`: 목록 조회, 타입 필터 조회, 안읽은 수 조회
- `NotificationCommandServiceImplTest`: 읽음 처리, 타인 알림 접근 예외, 이미 읽은 알림, 전체 읽음
- `NotificationControllerTest`: API 레벨 요청/응답 테스트
- `./gradlew test jacocoTestCoverageVerification` 통과

---

### 📎 관련 이슈
- #138