### PR TITLE
feat: FileUploadController 인증 강화 + 하드코딩 경로 제거

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
@@ -83,6 +83,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.DELETE, "/api/v1/products/{productId}").hasRole("SELLER")
                 it.requestMatchers(HttpMethod.POST, "/api/v1/inventories").hasRole("SELLER")
                 it.requestMatchers(HttpMethod.PATCH, "/api/v1/inventories/{productId}").hasRole("SELLER")
+                it.requestMatchers(HttpMethod.POST, "/api/v1/files/upload").hasRole("SELLER")
                 it.requestMatchers(HttpMethod.POST, "/api/v1/shipping").hasRole("SELLER")
                 it.requestMatchers(HttpMethod.PATCH, "/api/v1/shipping/{shippingId}/status").hasRole("SELLER")
 

--- a/src/main/kotlin/com/hoppingmall/mall/global/file/config/FileUploadConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/file/config/FileUploadConfig.kt
@@ -6,10 +6,13 @@ import org.springframework.stereotype.Component
 @Component
 @ConfigurationProperties(prefix = "file.upload")
 class FileUploadConfig {
-    
-    var baseUploadDir: String = "D:/hoppingmall"
+
+    var baseUploadDir: String = "${System.getProperty("user.home")}/hoppingmall"
     var maxFileSize: Long = 5 * 1024 * 1024
     var allowedExtensions: Set<String> = setOf("jpg", "jpeg", "png", "gif", "webp")
     var allowedDomains: Set<String> = setOf("product")
     var subDirectory: String = "images"
-} 
+
+    val defaultImagePath: String
+        get() = "$baseUploadDir/product/images/default-product.jpg"
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/BulkImportService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/BulkImportService.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.product.service
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.hoppingmall.mall.category.domain.repository.CategoryRepository
 import com.hoppingmall.mall.global.enums.ProductStatus
+import com.hoppingmall.mall.global.file.config.FileUploadConfig
 import com.hoppingmall.mall.inventory.dto.request.InventoryInitRequest
 import com.hoppingmall.mall.inventory.service.InventoryCommandService
 import com.hoppingmall.mall.product.domain.BulkImportJob
@@ -33,13 +34,13 @@ class BulkImportService(
     private val categoryRepository: CategoryRepository,
     private val inventoryCommandService: InventoryCommandService,
     private val objectMapper: ObjectMapper,
-    private val cacheManager: CacheManager
+    private val cacheManager: CacheManager,
+    private val fileUploadConfig: FileUploadConfig
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
     companion object {
-        private const val DEFAULT_IMAGE_PATH = "D:/hoppingmall/product/images/default-product.jpg"
         private const val CHUNK_SIZE = 50
     }
 
@@ -155,7 +156,7 @@ class BulkImportService(
                     )
                 )
 
-                val imageUrls = row.imageUrls.ifEmpty { listOf(DEFAULT_IMAGE_PATH) }
+                val imageUrls = row.imageUrls.ifEmpty { listOf(fileUploadConfig.defaultImagePath) }
                 val productImages = imageUrls.mapIndexed { index, url ->
                     ProductImage.create(productId = product.id!!, imageUrl = url, sortOrder = index)
                 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImpl.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.mall.product.service
 
 import com.hoppingmall.mall.category.domain.repository.CategoryRepository
 import com.hoppingmall.mall.category.exception.CategoryNotFoundException
+import com.hoppingmall.mall.global.file.config.FileUploadConfig
 import com.hoppingmall.mall.product.domain.Product
 import com.hoppingmall.mall.product.domain.ProductImage
 import com.hoppingmall.mall.product.domain.repository.ProductImageRepository
@@ -19,12 +20,9 @@ import org.springframework.transaction.annotation.Transactional
 class ProductCommandServiceImpl(
     private val productRepository: ProductRepository,
     private val productImageRepository: ProductImageRepository,
-    private val categoryRepository: CategoryRepository
+    private val categoryRepository: CategoryRepository,
+    private val fileUploadConfig: FileUploadConfig
 ) : ProductCommandService {
-
-    companion object {
-        private const val DEFAULT_IMAGE_PATH = "D:/hoppingmall/product/images/default-product.jpg"
-    }
 
     override fun createProduct(request: ProductCreateRequest): ProductResponse {
         if (!categoryRepository.existsById(request.categoryId)) {
@@ -41,7 +39,7 @@ class ProductCommandServiceImpl(
         )
         val savedProduct = productRepository.save(product)
 
-        val imageUrls = request.imageUrls?.ifEmpty { null } ?: listOf(DEFAULT_IMAGE_PATH)
+        val imageUrls = request.imageUrls?.ifEmpty { null } ?: listOf(fileUploadConfig.defaultImagePath)
         val productImages = imageUrls.mapIndexed { index, url ->
             ProductImage.create(
                 productId = savedProduct.id!!,
@@ -74,7 +72,7 @@ class ProductCommandServiceImpl(
         val existingImages = productImageRepository.findByProductIdOrderBySortOrder(productId)
         existingImages.forEach { it.softDelete() }
 
-        val imageUrls = request.imageUrls?.ifEmpty { null } ?: listOf(DEFAULT_IMAGE_PATH)
+        val imageUrls = request.imageUrls?.ifEmpty { null } ?: listOf(fileUploadConfig.defaultImagePath)
         val newImages = imageUrls.mapIndexed { index, url ->
             ProductImage.create(
                 productId = productId,

--- a/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductControllerTest.kt
@@ -383,7 +383,7 @@ class ProductControllerTest {
             )
 
             val expectedResponse = ProductImageResponse(
-                imageUrl = "D:/hoppingmall/product/images/uuid.jpg",
+                imageUrl = "test-upload/product/images/uuid.jpg",
                 fileName = "uuid.jpg",
                 fileSize = imageContent.size.toLong()
             )

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/BulkImportServiceTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/BulkImportServiceTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.hoppingmall.mall.category.domain.Category
 import com.hoppingmall.mall.category.domain.repository.CategoryRepository
+import com.hoppingmall.mall.global.file.config.FileUploadConfig
 import com.hoppingmall.mall.inventory.dto.request.InventoryInitRequest
 import com.hoppingmall.mall.inventory.service.InventoryCommandService
 import com.hoppingmall.mall.product.domain.BulkImportJob
@@ -44,6 +45,9 @@ class BulkImportServiceTest {
     private val inventoryCommandService: InventoryCommandService = mock()
     private val objectMapper = jacksonObjectMapper()
     private val cacheManager: CacheManager = mock()
+    private val fileUploadConfig: FileUploadConfig = mock {
+        on { defaultImagePath } doReturn "test-upload/product/images/default-product.jpg"
+    }
 
     private val bulkImportService = BulkImportService(
         csvParsingService,
@@ -53,7 +57,8 @@ class BulkImportServiceTest {
         categoryRepository,
         inventoryCommandService,
         objectMapper,
-        cacheManager
+        cacheManager,
+        fileUploadConfig
     )
 
     @Nested

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductCommandServiceImplTest.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.mall.product.service
 import com.hoppingmall.mall.category.domain.repository.CategoryRepository
 import com.hoppingmall.mall.category.exception.CategoryNotFoundException
 import com.hoppingmall.mall.global.enums.ProductStatus
+import com.hoppingmall.mall.global.file.config.FileUploadConfig
 import com.hoppingmall.mall.product.domain.Product
 import java.math.BigDecimal
 import com.hoppingmall.mall.product.domain.ProductImage
@@ -29,7 +30,10 @@ class ProductCommandServiceImplTest {
     private val productRepository: ProductRepository = mock()
     private val productImageRepository: ProductImageRepository = mock()
     private val categoryRepository: CategoryRepository = mock()
-    private val productCommandService = ProductCommandServiceImpl(productRepository, productImageRepository, categoryRepository)
+    private val fileUploadConfig: FileUploadConfig = mock {
+        on { defaultImagePath } doReturn "test-upload/product/images/default-product.jpg"
+    }
+    private val productCommandService = ProductCommandServiceImpl(productRepository, productImageRepository, categoryRepository, fileUploadConfig)
 
     @Nested
     @DisplayName("createProduct")
@@ -158,14 +162,14 @@ class ProductCommandServiceImplTest {
             assertThat(result).isNotNull()
             assertThat(result.id).isEqualTo(1L)
             assertThat(result.name).isEqualTo(request.name)
-            assertThat(result.imageUrls).containsExactly("D:/hoppingmall/product/images/default-product.jpg")
+            assertThat(result.imageUrls).containsExactly("test-upload/product/images/default-product.jpg")
 
             val savedProduct = productCaptor.firstValue
             assertThat(savedProduct.name).isEqualTo(request.name)
             assertThat(savedProduct.sellerId).isEqualTo(request.sellerId)
 
             val savedImages = imagesCaptor.firstValue
-            assertThat(savedImages[0].imageUrl).isEqualTo("D:/hoppingmall/product/images/default-product.jpg")
+            assertThat(savedImages[0].imageUrl).isEqualTo("test-upload/product/images/default-product.jpg")
 
             verify(categoryRepository).existsById(request.categoryId)
             verify(productRepository).save(any())
@@ -375,7 +379,7 @@ class ProductCommandServiceImplTest {
             assertThat(result).isNotNull()
             assertThat(result.id).isEqualTo(productId)
             assertThat(result.name).isEqualTo(request.name)
-            assertThat(result.imageUrls).containsExactly("D:/hoppingmall/product/images/default-product.jpg")
+            assertThat(result.imageUrls).containsExactly("test-upload/product/images/default-product.jpg")
 
             verify(productRepository).findById(productId)
             verify(productRepository).save(any())


### PR DESCRIPTION
Closes #140

### 📌 작업 개요
FileUploadController에 SELLER 역할 제한을 추가하고, 하드코딩된 Windows 경로(`D:/hoppingmall`)를 OS 독립적 경로로 전환했습니다.

---

### ✅ 주요 변경 사항

- `global.common.config`
  - `SecurityConfig`: `POST /api/v1/files/upload`에 `hasRole("SELLER")` 적용

- `global.file.config`
  - `FileUploadConfig`: `baseUploadDir` 기본값을 `${user.home}/hoppingmall`로 변경, `defaultImagePath` 계산 프로퍼티 추가

- `product.service`
  - `ProductCommandServiceImpl`: `FileUploadConfig` 주입, `DEFAULT_IMAGE_PATH` companion object 제거
  - `BulkImportService`: `FileUploadConfig` 주입, `DEFAULT_IMAGE_PATH` 제거

---

### 🧪 테스트

- `ProductCommandServiceImplTest`: `FileUploadConfig` mock 추가, 하드코딩 경로 제거
- `BulkImportServiceTest`: `FileUploadConfig` mock 추가
- `ProductControllerTest`: 이미지 경로 assertion 수정
- `./gradlew test jacocoTestCoverageVerification` 통과

---

### 📎 관련 이슈
- #140