### PR TITLE
feat: 시간대별 매출 분석 및 판매자 대시보드 구현

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
@@ -83,6 +83,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.DELETE, "/api/v1/products/{productId}").hasRole("SELLER")
                 it.requestMatchers(HttpMethod.POST, "/api/v1/inventories").hasRole("SELLER")
                 it.requestMatchers(HttpMethod.PATCH, "/api/v1/inventories/{productId}").hasRole("SELLER")
+                it.requestMatchers("/api/v1/seller/dashboard/**").hasRole("SELLER")
                 it.requestMatchers(HttpMethod.POST, "/api/v1/files/upload").hasRole("SELLER")
                 it.requestMatchers(HttpMethod.POST, "/api/v1/shipping").hasRole("SELLER")
                 it.requestMatchers(HttpMethod.PATCH, "/api/v1/shipping/{shippingId}/status").hasRole("SELLER")

--- a/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductStatisticsController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductStatisticsController.kt
@@ -74,4 +74,19 @@ class ProductStatisticsController(
     ): ApiResponse<List<TopProductResponse>> {
         return ApiResponse.success(productStatisticsQueryService.getTopRefundProducts(days, limit))
     }
+
+    @GetMapping("/hourly")
+    fun getHourlyStatistics(
+        @RequestParam productId: Long,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
+    ): ApiResponse<List<ProductHourlyStatisticsResponse>> {
+        return ApiResponse.success(productStatisticsQueryService.getHourlyStatistics(productId, date))
+    }
+
+    @GetMapping("/peak-hours")
+    fun getPeakHours(
+        @RequestParam(defaultValue = "7") days: Int
+    ): ApiResponse<List<PeakHourResponse>> {
+        return ApiResponse.success(productStatisticsQueryService.getPeakHours(days))
+    }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/controller/SellerDashboardController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/controller/SellerDashboardController.kt
@@ -1,0 +1,72 @@
+package com.hoppingmall.mall.product.controller
+
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.product.dto.response.ProductDailyStatisticsResponse
+import com.hoppingmall.mall.product.dto.response.ProductHourlyStatisticsResponse
+import com.hoppingmall.mall.product.dto.response.ProductStatisticsResponse
+import com.hoppingmall.mall.product.dto.response.SellerTodaySummaryResponse
+import com.hoppingmall.mall.product.service.SellerDashboardService
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/api/v1/seller/dashboard")
+class SellerDashboardController(
+    private val sellerDashboardService: SellerDashboardService
+) {
+
+    @GetMapping("/overview")
+    fun getOverview(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        pageable: Pageable
+    ): ApiResponse<Page<ProductStatisticsResponse>> {
+        return ApiResponse.success(sellerDashboardService.getOverview(principal.getUserId(), pageable))
+    }
+
+    @GetMapping("/products/{productId}")
+    fun getProductStatistics(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        @PathVariable productId: Long
+    ): ApiResponse<ProductStatisticsResponse> {
+        return ApiResponse.success(sellerDashboardService.getProductStatistics(principal.getUserId(), productId))
+    }
+
+    @GetMapping("/today")
+    fun getTodaySummary(
+        @AuthenticationPrincipal principal: UserPrincipal
+    ): ApiResponse<SellerTodaySummaryResponse> {
+        return ApiResponse.success(sellerDashboardService.getTodaySummary(principal.getUserId()))
+    }
+
+    @GetMapping("/daily")
+    fun getDailyStatistics(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        @RequestParam productId: Long,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate
+    ): ApiResponse<List<ProductDailyStatisticsResponse>> {
+        return ApiResponse.success(
+            sellerDashboardService.getDailyStatistics(principal.getUserId(), productId, startDate, endDate)
+        )
+    }
+
+    @GetMapping("/hourly")
+    fun getHourlyStatistics(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        @RequestParam productId: Long,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
+    ): ApiResponse<List<ProductHourlyStatisticsResponse>> {
+        return ApiResponse.success(
+            sellerDashboardService.getHourlyStatistics(principal.getUserId(), productId, date)
+        )
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/ProductHourlyStatistics.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/ProductHourlyStatistics.kt
@@ -1,0 +1,73 @@
+package com.hoppingmall.mall.product.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@Entity
+@Table(
+    name = "product_hourly_statistics",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["product_id", "statistics_date", "hour"])]
+)
+class ProductHourlyStatistics(
+    @Column(name = "product_id", nullable = false)
+    val productId: Long,
+
+    @Column(name = "statistics_date", nullable = false)
+    val statisticsDate: LocalDate,
+
+    @Column(nullable = false)
+    val hour: Int,
+
+    @Column(nullable = false)
+    var hourlySalesQuantity: Long = 0,
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    var hourlySalesAmount: BigDecimal = BigDecimal.ZERO,
+
+    @Column(nullable = false)
+    var hourlyOrderCount: Long = 0,
+
+    @Column(nullable = false)
+    var hourlyRefundQuantity: Long = 0,
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    var hourlyRefundAmount: BigDecimal = BigDecimal.ZERO
+) : BaseEntity() {
+
+    fun updateFromStatistics(stats: ProductStatistics) {
+        this.hourlySalesQuantity = stats.todaySalesQuantity
+        this.hourlySalesAmount = stats.todaySalesAmount
+        this.hourlyOrderCount = stats.todayOrderCount
+        this.hourlyRefundQuantity = stats.todayRefundQuantity
+        this.hourlyRefundAmount = stats.todayRefundAmount
+    }
+
+    companion object {
+        fun create(
+            productId: Long,
+            statisticsDate: LocalDate,
+            hour: Int,
+            hourlySalesQuantity: Long = 0,
+            hourlySalesAmount: BigDecimal = BigDecimal.ZERO,
+            hourlyOrderCount: Long = 0,
+            hourlyRefundQuantity: Long = 0,
+            hourlyRefundAmount: BigDecimal = BigDecimal.ZERO
+        ): ProductHourlyStatistics {
+            return ProductHourlyStatistics(
+                productId = productId,
+                statisticsDate = statisticsDate,
+                hour = hour,
+                hourlySalesQuantity = hourlySalesQuantity,
+                hourlySalesAmount = hourlySalesAmount,
+                hourlyOrderCount = hourlyOrderCount,
+                hourlyRefundQuantity = hourlyRefundQuantity,
+                hourlyRefundAmount = hourlyRefundAmount
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductHourlyStatisticsRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductHourlyStatisticsRepository.kt
@@ -1,0 +1,40 @@
+package com.hoppingmall.mall.product.domain.repository
+
+import com.hoppingmall.mall.product.domain.ProductHourlyStatistics
+import com.hoppingmall.mall.product.dto.HourlyAggregationProjection
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+interface ProductHourlyStatisticsRepository : JpaRepository<ProductHourlyStatistics, Long> {
+
+    fun findByProductIdAndStatisticsDateAndHour(
+        productId: Long,
+        statisticsDate: LocalDate,
+        hour: Int
+    ): ProductHourlyStatistics?
+
+    fun findByProductIdAndStatisticsDateOrderByHourAsc(
+        productId: Long,
+        statisticsDate: LocalDate
+    ): List<ProductHourlyStatistics>
+
+    @Query(
+        """
+        SELECT h.hour AS hour,
+               SUM(h.hourlySalesAmount) AS totalAmount,
+               SUM(h.hourlyOrderCount) AS totalOrders
+        FROM ProductHourlyStatistics h
+        WHERE h.statisticsDate BETWEEN :startDate AND :endDate
+        GROUP BY h.hour
+        ORDER BY SUM(h.hourlySalesAmount) DESC
+        """
+    )
+    fun findPeakHours(
+        @Param("startDate") startDate: LocalDate,
+        @Param("endDate") endDate: LocalDate
+    ): List<HourlyAggregationProjection>
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductStatisticsRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/domain/repository/ProductStatisticsRepository.kt
@@ -41,4 +41,18 @@ interface ProductStatisticsRepository : JpaRepository<ProductStatistics, Long> {
 
     @Query("SELECT COALESCE(SUM(ps.todayRefundAmount), 0) FROM ProductStatistics ps")
     fun sumTodayRefundAmount(): BigDecimal
+
+    fun countBySellerId(sellerId: Long): Long
+
+    @Query("SELECT COALESCE(SUM(ps.todaySalesAmount), 0) FROM ProductStatistics ps WHERE ps.sellerId = :sellerId")
+    fun sumTodaySalesAmountBySellerId(@Param("sellerId") sellerId: Long): BigDecimal
+
+    @Query("SELECT COALESCE(SUM(ps.todayOrderCount), 0) FROM ProductStatistics ps WHERE ps.sellerId = :sellerId")
+    fun sumTodayOrderCountBySellerId(@Param("sellerId") sellerId: Long): Long
+
+    @Query("SELECT COALESCE(SUM(ps.todayRefundAmount), 0) FROM ProductStatistics ps WHERE ps.sellerId = :sellerId")
+    fun sumTodayRefundAmountBySellerId(@Param("sellerId") sellerId: Long): BigDecimal
+
+    @Query("SELECT ps FROM ProductStatistics ps WHERE ps.sellerId = :sellerId ORDER BY ps.todaySalesAmount DESC LIMIT 1")
+    fun findTopSellingBySellerId(@Param("sellerId") sellerId: Long): ProductStatistics?
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/HourlyAggregationProjection.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/HourlyAggregationProjection.kt
@@ -1,0 +1,9 @@
+package com.hoppingmall.mall.product.dto
+
+import java.math.BigDecimal
+
+interface HourlyAggregationProjection {
+    fun getHour(): Int
+    fun getTotalAmount(): BigDecimal
+    fun getTotalOrders(): Long
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/response/PeakHourResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/response/PeakHourResponse.kt
@@ -1,0 +1,20 @@
+package com.hoppingmall.mall.product.dto.response
+
+import com.hoppingmall.mall.product.dto.HourlyAggregationProjection
+import java.math.BigDecimal
+
+data class PeakHourResponse(
+    val hour: Int,
+    val totalSalesAmount: BigDecimal,
+    val totalOrderCount: Long
+) {
+    companion object {
+        fun from(projection: HourlyAggregationProjection): PeakHourResponse {
+            return PeakHourResponse(
+                hour = projection.getHour(),
+                totalSalesAmount = projection.getTotalAmount(),
+                totalOrderCount = projection.getTotalOrders()
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/response/ProductHourlyStatisticsResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/response/ProductHourlyStatisticsResponse.kt
@@ -1,0 +1,31 @@
+package com.hoppingmall.mall.product.dto.response
+
+import com.hoppingmall.mall.product.domain.ProductHourlyStatistics
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class ProductHourlyStatisticsResponse(
+    val productId: Long,
+    val statisticsDate: LocalDate,
+    val hour: Int,
+    val hourlySalesQuantity: Long,
+    val hourlySalesAmount: BigDecimal,
+    val hourlyOrderCount: Long,
+    val hourlyRefundQuantity: Long,
+    val hourlyRefundAmount: BigDecimal
+) {
+    companion object {
+        fun from(entity: ProductHourlyStatistics): ProductHourlyStatisticsResponse {
+            return ProductHourlyStatisticsResponse(
+                productId = entity.productId,
+                statisticsDate = entity.statisticsDate,
+                hour = entity.hour,
+                hourlySalesQuantity = entity.hourlySalesQuantity,
+                hourlySalesAmount = entity.hourlySalesAmount,
+                hourlyOrderCount = entity.hourlyOrderCount,
+                hourlyRefundQuantity = entity.hourlyRefundQuantity,
+                hourlyRefundAmount = entity.hourlyRefundAmount
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/dto/response/SellerTodaySummaryResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/dto/response/SellerTodaySummaryResponse.kt
@@ -1,0 +1,12 @@
+package com.hoppingmall.mall.product.dto.response
+
+import java.math.BigDecimal
+
+data class SellerTodaySummaryResponse(
+    val totalProducts: Long,
+    val todaySalesAmount: BigDecimal,
+    val todayOrderCount: Long,
+    val todayRefundAmount: BigDecimal,
+    val topSellingProductId: Long?,
+    val topSellingProductName: String?
+)

--- a/src/main/kotlin/com/hoppingmall/mall/product/exception/code/ProductErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/exception/code/ProductErrorCode.kt
@@ -16,5 +16,6 @@ enum class ProductErrorCode(
     PRODUCT_STATISTICS_NOT_FOUND("P005", "상품 통계를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     BULK_IMPORT_INVALID_CSV("P006", "CSV 파일 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     BULK_IMPORT_JOB_NOT_FOUND("P007", "대량 등록 작업을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    BULK_IMPORT_ACCESS_DENIED("P008", "대량 등록 작업에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN)
+    BULK_IMPORT_ACCESS_DENIED("P008", "대량 등록 작업에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    SELLER_STATISTICS_ACCESS_DENIED("P009", "해당 상품의 통계에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN)
 } 

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsCommandService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsCommandService.kt
@@ -7,4 +7,5 @@ interface ProductStatisticsCommandService {
     fun decrementSalesStats(productId: Long, quantity: Long, amount: BigDecimal)
     fun incrementRefundStats(productId: Long, quantity: Long, amount: BigDecimal)
     fun flushDailySnapshot()
+    fun flushHourlySnapshot()
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsCommandServiceImpl.kt
@@ -1,8 +1,10 @@
 package com.hoppingmall.mall.product.service
 
 import com.hoppingmall.mall.product.domain.ProductDailyStatistics
+import com.hoppingmall.mall.product.domain.ProductHourlyStatistics
 import com.hoppingmall.mall.product.domain.ProductStatistics
 import com.hoppingmall.mall.product.domain.repository.ProductDailyStatisticsRepository
+import com.hoppingmall.mall.product.domain.repository.ProductHourlyStatisticsRepository
 import com.hoppingmall.mall.product.domain.repository.ProductRepository
 import com.hoppingmall.mall.product.domain.repository.ProductStatisticsRepository
 import org.slf4j.LoggerFactory
@@ -16,6 +18,7 @@ import java.time.LocalDate
 class ProductStatisticsCommandServiceImpl(
     private val productStatisticsRepository: ProductStatisticsRepository,
     private val productDailyStatisticsRepository: ProductDailyStatisticsRepository,
+    private val productHourlyStatisticsRepository: ProductHourlyStatisticsRepository,
     private val productRepository: ProductRepository
 ) : ProductStatisticsCommandService {
 
@@ -70,6 +73,32 @@ class ProductStatisticsCommandServiceImpl(
         }
 
         logger.info("일별 통계 스냅샷 완료: ${allStats.size}건")
+    }
+
+    override fun flushHourlySnapshot() {
+        val now = java.time.LocalDateTime.now()
+        val today = now.toLocalDate()
+        val currentHour = now.hour
+        val allStats = productStatisticsRepository.findAll()
+
+        var flushedCount = 0
+        for (stats in allStats) {
+            if (stats.todaySalesQuantity == 0L && stats.todayRefundQuantity == 0L) continue
+
+            val existing = productHourlyStatisticsRepository
+                .findByProductIdAndStatisticsDateAndHour(stats.productId, today, currentHour)
+
+            val hourly = existing ?: ProductHourlyStatistics.create(
+                productId = stats.productId,
+                statisticsDate = today,
+                hour = currentHour
+            )
+            hourly.updateFromStatistics(stats)
+            productHourlyStatisticsRepository.save(hourly)
+            flushedCount++
+        }
+
+        logger.info("시간별 통계 스냅샷 완료: ${flushedCount}건 (${currentHour}시)")
     }
 
     private fun getOrCreateStatistics(productId: Long): ProductStatistics {

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryService.kt
@@ -15,4 +15,6 @@ interface ProductStatisticsQueryService {
     fun getDailyStatistics(productId: Long, startDate: LocalDate, endDate: LocalDate): List<ProductDailyStatisticsResponse>
     fun getTopSellingProducts(days: Int, limit: Int): List<TopProductResponse>
     fun getTopRefundProducts(days: Int, limit: Int): List<TopProductResponse>
+    fun getHourlyStatistics(productId: Long, date: LocalDate): List<ProductHourlyStatisticsResponse>
+    fun getPeakHours(days: Int): List<PeakHourResponse>
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.mall.product.service
 
 import com.hoppingmall.mall.product.domain.repository.ProductDailyStatisticsRepository
+import com.hoppingmall.mall.product.domain.repository.ProductHourlyStatisticsRepository
 import com.hoppingmall.mall.product.domain.repository.ProductStatisticsRepository
 import com.hoppingmall.mall.product.dto.response.*
 import com.hoppingmall.mall.product.exception.ProductStatisticsNotFoundException
@@ -14,7 +15,8 @@ import java.time.LocalDate
 @Transactional(readOnly = true)
 class ProductStatisticsQueryServiceImpl(
     private val productStatisticsRepository: ProductStatisticsRepository,
-    private val productDailyStatisticsRepository: ProductDailyStatisticsRepository
+    private val productDailyStatisticsRepository: ProductDailyStatisticsRepository,
+    private val productHourlyStatisticsRepository: ProductHourlyStatisticsRepository
 ) : ProductStatisticsQueryService {
 
     override fun getAll(pageable: Pageable): Page<ProductStatisticsResponse> {
@@ -79,5 +81,19 @@ class ProductStatisticsQueryServiceImpl(
         return productDailyStatisticsRepository
             .findTopRefundProducts(startDate, endDate, limit)
             .map { TopProductResponse.from(it) }
+    }
+
+    override fun getHourlyStatistics(productId: Long, date: LocalDate): List<ProductHourlyStatisticsResponse> {
+        return productHourlyStatisticsRepository
+            .findByProductIdAndStatisticsDateOrderByHourAsc(productId, date)
+            .map { ProductHourlyStatisticsResponse.from(it) }
+    }
+
+    override fun getPeakHours(days: Int): List<PeakHourResponse> {
+        val endDate = LocalDate.now()
+        val startDate = endDate.minusDays(days.toLong() - 1)
+        return productHourlyStatisticsRepository
+            .findPeakHours(startDate, endDate)
+            .map { PeakHourResponse.from(it) }
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsScheduler.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsScheduler.kt
@@ -51,6 +51,8 @@ class ProductStatisticsScheduler(
         }
 
         logger.info("장바구니/재고 동기화 완료: ${updatedCount}건")
+
+        productStatisticsCommandService.flushHourlySnapshot()
     }
 
     @Scheduled(cron = "0 0 0 * * *")

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/SellerDashboardService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/SellerDashboardService.kt
@@ -1,0 +1,17 @@
+package com.hoppingmall.mall.product.service
+
+import com.hoppingmall.mall.product.dto.response.ProductDailyStatisticsResponse
+import com.hoppingmall.mall.product.dto.response.ProductHourlyStatisticsResponse
+import com.hoppingmall.mall.product.dto.response.ProductStatisticsResponse
+import com.hoppingmall.mall.product.dto.response.SellerTodaySummaryResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import java.time.LocalDate
+
+interface SellerDashboardService {
+    fun getOverview(sellerId: Long, pageable: Pageable): Page<ProductStatisticsResponse>
+    fun getProductStatistics(sellerId: Long, productId: Long): ProductStatisticsResponse
+    fun getTodaySummary(sellerId: Long): SellerTodaySummaryResponse
+    fun getDailyStatistics(sellerId: Long, productId: Long, startDate: LocalDate, endDate: LocalDate): List<ProductDailyStatisticsResponse>
+    fun getHourlyStatistics(sellerId: Long, productId: Long, date: LocalDate): List<ProductHourlyStatisticsResponse>
+}

--- a/src/main/kotlin/com/hoppingmall/mall/product/service/SellerDashboardServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/service/SellerDashboardServiceImpl.kt
@@ -1,0 +1,83 @@
+package com.hoppingmall.mall.product.service
+
+import com.hoppingmall.mall.product.domain.repository.ProductDailyStatisticsRepository
+import com.hoppingmall.mall.product.domain.repository.ProductHourlyStatisticsRepository
+import com.hoppingmall.mall.product.domain.repository.ProductStatisticsRepository
+import com.hoppingmall.mall.product.dto.response.ProductDailyStatisticsResponse
+import com.hoppingmall.mall.product.dto.response.ProductHourlyStatisticsResponse
+import com.hoppingmall.mall.product.dto.response.ProductStatisticsResponse
+import com.hoppingmall.mall.product.dto.response.SellerTodaySummaryResponse
+import com.hoppingmall.mall.product.exception.ProductException
+import com.hoppingmall.mall.product.exception.ProductStatisticsNotFoundException
+import com.hoppingmall.mall.product.exception.code.ProductErrorCode
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+@Transactional(readOnly = true)
+class SellerDashboardServiceImpl(
+    private val productStatisticsRepository: ProductStatisticsRepository,
+    private val productDailyStatisticsRepository: ProductDailyStatisticsRepository,
+    private val productHourlyStatisticsRepository: ProductHourlyStatisticsRepository
+) : SellerDashboardService {
+
+    override fun getOverview(sellerId: Long, pageable: Pageable): Page<ProductStatisticsResponse> {
+        return productStatisticsRepository.findBySellerId(sellerId, pageable)
+            .map { ProductStatisticsResponse.from(it) }
+    }
+
+    override fun getProductStatistics(sellerId: Long, productId: Long): ProductStatisticsResponse {
+        val stats = productStatisticsRepository.findByProductId(productId)
+            ?: throw ProductStatisticsNotFoundException()
+        if (stats.sellerId != sellerId) {
+            throw ProductException(ProductErrorCode.SELLER_STATISTICS_ACCESS_DENIED)
+        }
+        return ProductStatisticsResponse.from(stats)
+    }
+
+    override fun getTodaySummary(sellerId: Long): SellerTodaySummaryResponse {
+        val topSelling = productStatisticsRepository.findTopSellingBySellerId(sellerId)
+        return SellerTodaySummaryResponse(
+            totalProducts = productStatisticsRepository.countBySellerId(sellerId),
+            todaySalesAmount = productStatisticsRepository.sumTodaySalesAmountBySellerId(sellerId),
+            todayOrderCount = productStatisticsRepository.sumTodayOrderCountBySellerId(sellerId),
+            todayRefundAmount = productStatisticsRepository.sumTodayRefundAmountBySellerId(sellerId),
+            topSellingProductId = topSelling?.productId,
+            topSellingProductName = topSelling?.productName
+        )
+    }
+
+    override fun getDailyStatistics(
+        sellerId: Long,
+        productId: Long,
+        startDate: LocalDate,
+        endDate: LocalDate
+    ): List<ProductDailyStatisticsResponse> {
+        validateProductOwnership(sellerId, productId)
+        return productDailyStatisticsRepository
+            .findByProductIdAndStatisticsDateBetweenOrderByStatisticsDateAsc(productId, startDate, endDate)
+            .map { ProductDailyStatisticsResponse.from(it) }
+    }
+
+    override fun getHourlyStatistics(
+        sellerId: Long,
+        productId: Long,
+        date: LocalDate
+    ): List<ProductHourlyStatisticsResponse> {
+        validateProductOwnership(sellerId, productId)
+        return productHourlyStatisticsRepository
+            .findByProductIdAndStatisticsDateOrderByHourAsc(productId, date)
+            .map { ProductHourlyStatisticsResponse.from(it) }
+    }
+
+    private fun validateProductOwnership(sellerId: Long, productId: Long) {
+        val stats = productStatisticsRepository.findByProductId(productId)
+            ?: throw ProductStatisticsNotFoundException()
+        if (stats.sellerId != sellerId) {
+            throw ProductException(ProductErrorCode.SELLER_STATISTICS_ACCESS_DENIED)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductStatisticsControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/controller/ProductStatisticsControllerTest.kt
@@ -265,4 +265,57 @@ class ProductStatisticsControllerTest {
             verify(productStatisticsQueryService).getTopRefundProducts(30, 5)
         }
     }
+
+    @Nested
+    @DisplayName("getHourlyStatistics")
+    inner class GetHourlyStatistics {
+        @Test
+        fun 시간대별_통계_조회_성공() {
+            val productId = 1L
+            val date = LocalDate.of(2026, 3, 13)
+            val hourlyList = listOf(
+                ProductHourlyStatisticsResponse(
+                    productId = productId,
+                    statisticsDate = date,
+                    hour = 10,
+                    hourlySalesQuantity = 20,
+                    hourlySalesAmount = BigDecimal("200000"),
+                    hourlyOrderCount = 5,
+                    hourlyRefundQuantity = 0,
+                    hourlyRefundAmount = BigDecimal.ZERO
+                )
+            )
+
+            whenever(productStatisticsQueryService.getHourlyStatistics(productId, date))
+                .thenReturn(hourlyList)
+
+            val result: ApiResponse<List<ProductHourlyStatisticsResponse>> =
+                controller.getHourlyStatistics(productId, date)
+
+            assertEquals("SUCCESS", result.code)
+            assertEquals(1, result.data!!.size)
+            assertEquals(10, result.data!![0].hour)
+            verify(productStatisticsQueryService).getHourlyStatistics(productId, date)
+        }
+    }
+
+    @Nested
+    @DisplayName("getPeakHours")
+    inner class GetPeakHours {
+        @Test
+        fun 피크_타임_조회_성공() {
+            val peakList = listOf(
+                PeakHourResponse(hour = 14, totalSalesAmount = BigDecimal("1500000"), totalOrderCount = 75)
+            )
+
+            whenever(productStatisticsQueryService.getPeakHours(7)).thenReturn(peakList)
+
+            val result: ApiResponse<List<PeakHourResponse>> = controller.getPeakHours(7)
+
+            assertEquals("SUCCESS", result.code)
+            assertEquals(1, result.data!!.size)
+            assertEquals(14, result.data!![0].hour)
+            verify(productStatisticsQueryService).getPeakHours(7)
+        }
+    }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/product/controller/SellerDashboardControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/controller/SellerDashboardControllerTest.kt
@@ -1,0 +1,167 @@
+package com.hoppingmall.mall.product.controller
+
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.product.dto.response.*
+import com.hoppingmall.mall.product.service.SellerDashboardService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("SellerDashboardController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class SellerDashboardControllerTest {
+
+    private val sellerDashboardService: SellerDashboardService = mock()
+    private val controller = SellerDashboardController(sellerDashboardService)
+    private val sellerPrincipal = UserPrincipal(1L, "seller@example.com", "SELLER")
+
+    private fun createStatisticsResponse(productId: Long = 1L) = ProductStatisticsResponse(
+        productId = productId,
+        productName = "테스트 상품",
+        sellerId = 1L,
+        categoryId = 1L,
+        totalSalesQuantity = 100,
+        totalSalesAmount = BigDecimal("1000000"),
+        totalRefundQuantity = 5,
+        totalRefundAmount = BigDecimal("50000"),
+        currentCartCount = 10,
+        currentStock = 50,
+        refundRate = BigDecimal("0.0500"),
+        stockTurnoverRate = BigDecimal("2.0000"),
+        todaySalesQuantity = 10,
+        todaySalesAmount = BigDecimal("100000"),
+        todayOrderCount = 5,
+        todayRefundQuantity = 1,
+        todayRefundAmount = BigDecimal("10000"),
+        last7DaysSalesAmount = BigDecimal("700000"),
+        last30DaysSalesAmount = BigDecimal("3000000"),
+        salesGrowthRate = BigDecimal("20.0000"),
+        orderCount = 50,
+        netRevenue = BigDecimal("950000"),
+        averageOrderAmount = BigDecimal("20000.00"),
+        lastAggregatedAt = LocalDateTime.of(2026, 3, 13, 12, 0, 0)
+    )
+
+    @Nested
+    @DisplayName("getOverview")
+    inner class GetOverview {
+        @Test
+        fun 판매자_전체_통계를_조회한다() {
+            val pageable = PageRequest.of(0, 10)
+            val responses = listOf(createStatisticsResponse(1L), createStatisticsResponse(2L))
+            val page = PageImpl(responses, pageable, responses.size.toLong())
+
+            whenever(sellerDashboardService.getOverview(eq(1L), any())).thenReturn(page)
+
+            val result: ApiResponse<Page<ProductStatisticsResponse>> = controller.getOverview(sellerPrincipal, pageable)
+
+            assertEquals("SUCCESS", result.code)
+            assertEquals(2, result.data!!.content.size)
+        }
+    }
+
+    @Nested
+    @DisplayName("getProductStatistics")
+    inner class GetProductStatistics {
+        @Test
+        fun 개별_상품_통계를_조회한다() {
+            val response = createStatisticsResponse(1L)
+
+            whenever(sellerDashboardService.getProductStatistics(1L, 1L)).thenReturn(response)
+
+            val result: ApiResponse<ProductStatisticsResponse> = controller.getProductStatistics(sellerPrincipal, 1L)
+
+            assertEquals("SUCCESS", result.code)
+            assertEquals(1L, result.data!!.productId)
+        }
+    }
+
+    @Nested
+    @DisplayName("getTodaySummary")
+    inner class GetTodaySummary {
+        @Test
+        fun 오늘_매출_요약을_조회한다() {
+            val summary = SellerTodaySummaryResponse(
+                totalProducts = 3,
+                todaySalesAmount = BigDecimal("500000"),
+                todayOrderCount = 25,
+                todayRefundAmount = BigDecimal("10000"),
+                topSellingProductId = 1L,
+                topSellingProductName = "인기상품"
+            )
+
+            whenever(sellerDashboardService.getTodaySummary(1L)).thenReturn(summary)
+
+            val result: ApiResponse<SellerTodaySummaryResponse> = controller.getTodaySummary(sellerPrincipal)
+
+            assertEquals("SUCCESS", result.code)
+            assertEquals(3L, result.data!!.totalProducts)
+            assertEquals(BigDecimal("500000"), result.data!!.todaySalesAmount)
+        }
+    }
+
+    @Nested
+    @DisplayName("getDailyStatistics")
+    inner class GetDailyStatistics {
+        @Test
+        fun 일별_통계를_조회한다() {
+            val startDate = LocalDate.of(2026, 3, 6)
+            val endDate = LocalDate.of(2026, 3, 13)
+            val dailyList = listOf(
+                ProductDailyStatisticsResponse(
+                    productId = 1L, statisticsDate = startDate,
+                    dailySalesQuantity = 50, dailySalesAmount = BigDecimal("500000"),
+                    dailyOrderCount = 10, dailyRefundQuantity = 2,
+                    dailyRefundAmount = BigDecimal("20000"), endOfDayStock = 100
+                )
+            )
+
+            whenever(sellerDashboardService.getDailyStatistics(1L, 1L, startDate, endDate))
+                .thenReturn(dailyList)
+
+            val result: ApiResponse<List<ProductDailyStatisticsResponse>> =
+                controller.getDailyStatistics(sellerPrincipal, 1L, startDate, endDate)
+
+            assertEquals("SUCCESS", result.code)
+            assertEquals(1, result.data!!.size)
+        }
+    }
+
+    @Nested
+    @DisplayName("getHourlyStatistics")
+    inner class GetHourlyStatistics {
+        @Test
+        fun 시간별_통계를_조회한다() {
+            val date = LocalDate.of(2026, 3, 13)
+            val hourlyList = listOf(
+                ProductHourlyStatisticsResponse(
+                    productId = 1L, statisticsDate = date, hour = 14,
+                    hourlySalesQuantity = 30, hourlySalesAmount = BigDecimal("300000"),
+                    hourlyOrderCount = 8, hourlyRefundQuantity = 1,
+                    hourlyRefundAmount = BigDecimal("10000")
+                )
+            )
+
+            whenever(sellerDashboardService.getHourlyStatistics(1L, 1L, date))
+                .thenReturn(hourlyList)
+
+            val result: ApiResponse<List<ProductHourlyStatisticsResponse>> =
+                controller.getHourlyStatistics(sellerPrincipal, 1L, date)
+
+            assertEquals("SUCCESS", result.code)
+            assertEquals(1, result.data!!.size)
+            assertEquals(14, result.data!![0].hour)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsCommandServiceImplTest.kt
@@ -1,8 +1,10 @@
 package com.hoppingmall.mall.product.service
 
 import com.hoppingmall.mall.product.domain.ProductDailyStatistics
+import com.hoppingmall.mall.product.domain.ProductHourlyStatistics
 import com.hoppingmall.mall.product.domain.ProductStatistics
 import com.hoppingmall.mall.product.domain.repository.ProductDailyStatisticsRepository
+import com.hoppingmall.mall.product.domain.repository.ProductHourlyStatisticsRepository
 import com.hoppingmall.mall.product.domain.repository.ProductRepository
 import com.hoppingmall.mall.product.domain.repository.ProductStatisticsRepository
 import com.hoppingmall.mall.support.fixture.fixture
@@ -25,11 +27,13 @@ class ProductStatisticsCommandServiceImplTest {
 
     private val productStatisticsRepository: ProductStatisticsRepository = mock()
     private val productDailyStatisticsRepository: ProductDailyStatisticsRepository = mock()
+    private val productHourlyStatisticsRepository: ProductHourlyStatisticsRepository = mock()
     private val productRepository: ProductRepository = mock()
 
     private val service = ProductStatisticsCommandServiceImpl(
         productStatisticsRepository,
         productDailyStatisticsRepository,
+        productHourlyStatisticsRepository,
         productRepository
     )
 
@@ -165,6 +169,64 @@ class ProductStatisticsCommandServiceImplTest {
 
             assertEquals(3, existingDaily.dailySalesQuantity)
             verify(productDailyStatisticsRepository).save(existingDaily)
+        }
+    }
+
+    @Nested
+    @DisplayName("flushHourlySnapshot")
+    inner class FlushHourlySnapshot {
+        @Test
+        fun 시간별_스냅샷을_저장한다() {
+            val stats = ProductStatistics.fixture(productId = 1L).withId(1L)
+            stats.incrementSales(5, BigDecimal("50000"))
+
+            whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
+            whenever(productHourlyStatisticsRepository.findByProductIdAndStatisticsDateAndHour(eq(1L), any(), any()))
+                .thenReturn(null)
+            whenever(productHourlyStatisticsRepository.save(any<ProductHourlyStatistics>()))
+                .thenAnswer { it.arguments[0] }
+
+            service.flushHourlySnapshot()
+
+            verify(productHourlyStatisticsRepository).save(any<ProductHourlyStatistics>())
+        }
+
+        @Test
+        fun 오늘_매출이_없으면_스냅샷을_생략한다() {
+            val stats = ProductStatistics.fixture(
+                productId = 1L,
+                totalSalesQuantity = 100,
+                totalSalesAmount = BigDecimal("1000000")
+            ).withId(1L)
+
+            whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
+
+            service.flushHourlySnapshot()
+
+            verify(productHourlyStatisticsRepository, never()).save(any<ProductHourlyStatistics>())
+        }
+
+        @Test
+        fun 기존_시간별_통계가_있으면_업데이트한다() {
+            val stats = ProductStatistics.fixture(productId = 1L).withId(1L)
+            stats.incrementSales(3, BigDecimal("30000"))
+
+            val existingHourly = ProductHourlyStatistics.create(
+                productId = 1L,
+                statisticsDate = LocalDate.now(),
+                hour = java.time.LocalDateTime.now().hour
+            ).withId(1L)
+
+            whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
+            whenever(productHourlyStatisticsRepository.findByProductIdAndStatisticsDateAndHour(eq(1L), any(), any()))
+                .thenReturn(existingHourly)
+            whenever(productHourlyStatisticsRepository.save(any<ProductHourlyStatistics>()))
+                .thenAnswer { it.arguments[0] }
+
+            service.flushHourlySnapshot()
+
+            assertEquals(3, existingHourly.hourlySalesQuantity)
+            verify(productHourlyStatisticsRepository).save(existingHourly)
         }
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/ProductStatisticsQueryServiceImplTest.kt
@@ -1,9 +1,12 @@
 package com.hoppingmall.mall.product.service
 
 import com.hoppingmall.mall.product.domain.ProductDailyStatistics
+import com.hoppingmall.mall.product.domain.ProductHourlyStatistics
 import com.hoppingmall.mall.product.domain.ProductStatistics
 import com.hoppingmall.mall.product.domain.repository.ProductDailyStatisticsRepository
+import com.hoppingmall.mall.product.domain.repository.ProductHourlyStatisticsRepository
 import com.hoppingmall.mall.product.domain.repository.ProductStatisticsRepository
+import com.hoppingmall.mall.product.dto.HourlyAggregationProjection
 import com.hoppingmall.mall.product.dto.TopProductProjection
 import com.hoppingmall.mall.product.exception.ProductStatisticsNotFoundException
 import com.hoppingmall.mall.support.fixture.fixture
@@ -27,7 +30,8 @@ class ProductStatisticsQueryServiceImplTest {
 
     private val productStatisticsRepository: ProductStatisticsRepository = mock()
     private val productDailyStatisticsRepository: ProductDailyStatisticsRepository = mock()
-    private val service = ProductStatisticsQueryServiceImpl(productStatisticsRepository, productDailyStatisticsRepository)
+    private val productHourlyStatisticsRepository: ProductHourlyStatisticsRepository = mock()
+    private val service = ProductStatisticsQueryServiceImpl(productStatisticsRepository, productDailyStatisticsRepository, productHourlyStatisticsRepository)
 
     @Nested
     @DisplayName("getAll")
@@ -236,6 +240,54 @@ class ProductStatisticsQueryServiceImplTest {
             assertEquals(1, result.size)
             assertEquals(2L, result[0].productId)
             assertEquals(BigDecimal("100000"), result[0].totalAmount)
+        }
+    }
+
+    @Nested
+    @DisplayName("getHourlyStatistics")
+    inner class GetHourlyStatistics {
+        @Test
+        fun 시간대별_통계_조회_성공() {
+            val productId = 1L
+            val date = LocalDate.of(2026, 3, 13)
+            val hourlyList = listOf(
+                ProductHourlyStatistics.create(productId = productId, statisticsDate = date, hour = 10,
+                    hourlySalesQuantity = 20, hourlySalesAmount = BigDecimal("200000")).withId(1L),
+                ProductHourlyStatistics.create(productId = productId, statisticsDate = date, hour = 14,
+                    hourlySalesQuantity = 35, hourlySalesAmount = BigDecimal("350000")).withId(2L)
+            )
+
+            whenever(productHourlyStatisticsRepository.findByProductIdAndStatisticsDateOrderByHourAsc(productId, date))
+                .thenReturn(hourlyList)
+
+            val result = service.getHourlyStatistics(productId, date)
+
+            assertEquals(2, result.size)
+            assertEquals(10, result[0].hour)
+            assertEquals(14, result[1].hour)
+            assertEquals(BigDecimal("350000"), result[1].hourlySalesAmount)
+        }
+    }
+
+    @Nested
+    @DisplayName("getPeakHours")
+    inner class GetPeakHours {
+        @Test
+        fun 피크_타임_조회_성공() {
+            val projection = mock<HourlyAggregationProjection>()
+            whenever(projection.getHour()).thenReturn(14)
+            whenever(projection.getTotalAmount()).thenReturn(BigDecimal("1500000"))
+            whenever(projection.getTotalOrders()).thenReturn(75L)
+
+            whenever(productHourlyStatisticsRepository.findPeakHours(any(), any()))
+                .thenReturn(listOf(projection))
+
+            val result = service.getPeakHours(7)
+
+            assertEquals(1, result.size)
+            assertEquals(14, result[0].hour)
+            assertEquals(BigDecimal("1500000"), result[0].totalSalesAmount)
+            assertEquals(75L, result[0].totalOrderCount)
         }
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/product/service/SellerDashboardServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/product/service/SellerDashboardServiceImplTest.kt
@@ -1,0 +1,207 @@
+package com.hoppingmall.mall.product.service
+
+import com.hoppingmall.mall.product.domain.ProductHourlyStatistics
+import com.hoppingmall.mall.product.domain.ProductStatistics
+import com.hoppingmall.mall.product.domain.repository.ProductDailyStatisticsRepository
+import com.hoppingmall.mall.product.domain.repository.ProductHourlyStatisticsRepository
+import com.hoppingmall.mall.product.domain.repository.ProductStatisticsRepository
+import com.hoppingmall.mall.product.exception.ProductException
+import com.hoppingmall.mall.product.exception.ProductStatisticsNotFoundException
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.*
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@DisplayName("SellerDashboardServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class SellerDashboardServiceImplTest {
+
+    private val productStatisticsRepository: ProductStatisticsRepository = mock()
+    private val productDailyStatisticsRepository: ProductDailyStatisticsRepository = mock()
+    private val productHourlyStatisticsRepository: ProductHourlyStatisticsRepository = mock()
+
+    private val service = SellerDashboardServiceImpl(
+        productStatisticsRepository,
+        productDailyStatisticsRepository,
+        productHourlyStatisticsRepository
+    )
+
+    @Nested
+    @DisplayName("getOverview")
+    inner class GetOverview {
+        @Test
+        fun 판매자_전체_상품_통계를_조회한다() {
+            val sellerId = 1L
+            val pageable = PageRequest.of(0, 10)
+            val stats = listOf(
+                ProductStatistics.fixture(productId = 1L, sellerId = sellerId, productName = "상품1").withId(1L),
+                ProductStatistics.fixture(productId = 2L, sellerId = sellerId, productName = "상품2").withId(2L)
+            )
+            val page = PageImpl(stats, pageable, stats.size.toLong())
+
+            whenever(productStatisticsRepository.findBySellerId(sellerId, pageable)).thenReturn(page)
+
+            val result = service.getOverview(sellerId, pageable)
+
+            assertEquals(2, result.content.size)
+            verify(productStatisticsRepository).findBySellerId(sellerId, pageable)
+        }
+    }
+
+    @Nested
+    @DisplayName("getProductStatistics")
+    inner class GetProductStatistics {
+        @Test
+        fun 본인_상품_통계를_조회한다() {
+            val sellerId = 1L
+            val productId = 1L
+            val stats = ProductStatistics.fixture(productId = productId, sellerId = sellerId).withId(1L)
+
+            whenever(productStatisticsRepository.findByProductId(productId)).thenReturn(stats)
+
+            val result = service.getProductStatistics(sellerId, productId)
+
+            assertEquals(productId, result.productId)
+            assertEquals(sellerId, result.sellerId)
+        }
+
+        @Test
+        fun 존재하지_않는_상품이면_예외가_발생한다() {
+            whenever(productStatisticsRepository.findByProductId(999L)).thenReturn(null)
+
+            assertThrows<ProductStatisticsNotFoundException> {
+                service.getProductStatistics(1L, 999L)
+            }
+        }
+
+        @Test
+        fun 타인의_상품이면_접근_거부_예외가_발생한다() {
+            val stats = ProductStatistics.fixture(productId = 1L, sellerId = 2L).withId(1L)
+
+            whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(stats)
+
+            assertThrows<ProductException> {
+                service.getProductStatistics(1L, 1L)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getTodaySummary")
+    inner class GetTodaySummary {
+        @Test
+        fun 판매자_오늘_매출_요약을_조회한다() {
+            val sellerId = 1L
+            val topStats = ProductStatistics.fixture(productId = 1L, sellerId = sellerId, productName = "인기상품").withId(1L)
+
+            whenever(productStatisticsRepository.countBySellerId(sellerId)).thenReturn(3L)
+            whenever(productStatisticsRepository.sumTodaySalesAmountBySellerId(sellerId)).thenReturn(BigDecimal("500000"))
+            whenever(productStatisticsRepository.sumTodayOrderCountBySellerId(sellerId)).thenReturn(25L)
+            whenever(productStatisticsRepository.sumTodayRefundAmountBySellerId(sellerId)).thenReturn(BigDecimal("10000"))
+            whenever(productStatisticsRepository.findTopSellingBySellerId(sellerId)).thenReturn(topStats)
+
+            val result = service.getTodaySummary(sellerId)
+
+            assertEquals(3L, result.totalProducts)
+            assertEquals(BigDecimal("500000"), result.todaySalesAmount)
+            assertEquals(25L, result.todayOrderCount)
+            assertEquals(BigDecimal("10000"), result.todayRefundAmount)
+            assertEquals(1L, result.topSellingProductId)
+            assertEquals("인기상품", result.topSellingProductName)
+        }
+
+        @Test
+        fun 판매_상품이_없으면_null_값을_반환한다() {
+            val sellerId = 1L
+
+            whenever(productStatisticsRepository.countBySellerId(sellerId)).thenReturn(0L)
+            whenever(productStatisticsRepository.sumTodaySalesAmountBySellerId(sellerId)).thenReturn(BigDecimal.ZERO)
+            whenever(productStatisticsRepository.sumTodayOrderCountBySellerId(sellerId)).thenReturn(0L)
+            whenever(productStatisticsRepository.sumTodayRefundAmountBySellerId(sellerId)).thenReturn(BigDecimal.ZERO)
+            whenever(productStatisticsRepository.findTopSellingBySellerId(sellerId)).thenReturn(null)
+
+            val result = service.getTodaySummary(sellerId)
+
+            assertEquals(0L, result.totalProducts)
+            assertEquals(null, result.topSellingProductId)
+            assertEquals(null, result.topSellingProductName)
+        }
+    }
+
+    @Nested
+    @DisplayName("getDailyStatistics")
+    inner class GetDailyStatistics {
+        @Test
+        fun 본인_상품의_일별_통계를_조회한다() {
+            val sellerId = 1L
+            val productId = 1L
+            val stats = ProductStatistics.fixture(productId = productId, sellerId = sellerId).withId(1L)
+
+            whenever(productStatisticsRepository.findByProductId(productId)).thenReturn(stats)
+            whenever(productDailyStatisticsRepository.findByProductIdAndStatisticsDateBetweenOrderByStatisticsDateAsc(
+                eq(productId), any(), any()
+            )).thenReturn(emptyList())
+
+            val result = service.getDailyStatistics(sellerId, productId, LocalDate.now().minusDays(7), LocalDate.now())
+
+            assertEquals(0, result.size)
+            verify(productStatisticsRepository).findByProductId(productId)
+        }
+
+        @Test
+        fun 타인_상품의_일별_통계_조회_시_예외가_발생한다() {
+            val stats = ProductStatistics.fixture(productId = 1L, sellerId = 2L).withId(1L)
+
+            whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(stats)
+
+            assertThrows<ProductException> {
+                service.getDailyStatistics(1L, 1L, LocalDate.now().minusDays(7), LocalDate.now())
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getHourlyStatistics")
+    inner class GetHourlyStatistics {
+        @Test
+        fun 본인_상품의_시간별_통계를_조회한다() {
+            val sellerId = 1L
+            val productId = 1L
+            val date = LocalDate.of(2026, 3, 13)
+            val stats = ProductStatistics.fixture(productId = productId, sellerId = sellerId).withId(1L)
+            val hourlyList = listOf(
+                ProductHourlyStatistics.fixture(productId = productId, statisticsDate = date, hour = 10).withId(1L)
+            )
+
+            whenever(productStatisticsRepository.findByProductId(productId)).thenReturn(stats)
+            whenever(productHourlyStatisticsRepository.findByProductIdAndStatisticsDateOrderByHourAsc(productId, date))
+                .thenReturn(hourlyList)
+
+            val result = service.getHourlyStatistics(sellerId, productId, date)
+
+            assertEquals(1, result.size)
+            assertEquals(10, result[0].hour)
+        }
+
+        @Test
+        fun 타인_상품의_시간별_통계_조회_시_예외가_발생한다() {
+            val stats = ProductStatistics.fixture(productId = 1L, sellerId = 2L).withId(1L)
+
+            whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(stats)
+
+            assertThrows<ProductException> {
+                service.getHourlyStatistics(1L, 1L, LocalDate.now())
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/ProductHourlyStatisticsFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/ProductHourlyStatisticsFixture.kt
@@ -1,0 +1,27 @@
+package com.hoppingmall.mall.support.fixture
+
+import com.hoppingmall.mall.product.domain.ProductHourlyStatistics
+import java.math.BigDecimal
+import java.time.LocalDate
+
+fun ProductHourlyStatistics.Companion.fixture(
+    productId: Long = 1L,
+    statisticsDate: LocalDate = LocalDate.of(2026, 3, 13),
+    hour: Int = 14,
+    hourlySalesQuantity: Long = 30,
+    hourlySalesAmount: BigDecimal = BigDecimal("300000"),
+    hourlyOrderCount: Long = 8,
+    hourlyRefundQuantity: Long = 1,
+    hourlyRefundAmount: BigDecimal = BigDecimal("10000")
+): ProductHourlyStatistics {
+    return ProductHourlyStatistics.create(
+        productId = productId,
+        statisticsDate = statisticsDate,
+        hour = hour,
+        hourlySalesQuantity = hourlySalesQuantity,
+        hourlySalesAmount = hourlySalesAmount,
+        hourlyOrderCount = hourlyOrderCount,
+        hourlyRefundQuantity = hourlyRefundQuantity,
+        hourlyRefundAmount = hourlyRefundAmount
+    )
+}


### PR DESCRIPTION
Closes #142

### 📌 작업 개요
시간대별(0~23시) 매출 통계 스냅샷 및 피크 타임 분석 기능을 추가하고,
판매자 전용 대시보드 API 5개를 구현했습니다.
판매자 소유권 검증을 통해 본인 상품만 조회 가능하도록 제한합니다.

---

### ✅ 주요 변경 사항

- `product.domain`
  - `ProductHourlyStatistics`: 시간대별 매출/주문/환불 스냅샷 엔티티
  - `ProductHourlyStatisticsRepository`: 시간대별 조회 + 피크 타임 집계 JPQL

- `product.dto`
  - `HourlyAggregationProjection`: 피크 타임 집계 인터페이스 프로젝션
  - `PeakHourResponse`, `ProductHourlyStatisticsResponse`: 시간대별 통계 응답 DTO
  - `SellerTodaySummaryResponse`: 판매자 오늘 매출 요약 DTO

- `product.service`
  - `ProductStatisticsCommandServiceImpl`: flushHourlySnapshot() 시간별 스냅샷 생성/갱신
  - `ProductStatisticsQueryServiceImpl`: getHourlyStatistics(), getPeakHours() 구현
  - `SellerDashboardService`, `SellerDashboardServiceImpl`: 판매자 전용 통계 서비스 5개 메서드

- `product.controller`
  - `ProductStatisticsController`: 시간대별 통계, 피크 타임 엔드포인트 추가
  - `SellerDashboardController`: 판매자 대시보드 API 5개 엔드포인트

- `global.common.config`
  - `SecurityConfig`: /api/v1/seller/dashboard/** SELLER 역할 제한

- `product.exception.code`
  - `ProductErrorCode.SELLER_STATISTICS_ACCESS_DENIED` 추가

---

### 🧪 테스트

- `ProductStatisticsCommandServiceImplTest`: flushHourlySnapshot 신규/갱신/제로활동 스킵 테스트
- `ProductStatisticsQueryServiceImplTest`: 시간대별 통계 조회, 피크 타임 분석 테스트
- `ProductStatisticsControllerTest`: 시간대별/피크 타임 API 테스트
- `SellerDashboardServiceImplTest`: 전체 통계, 개별 상품, 오늘 요약, 일별/시간별 추이 + 소유권 검증 예외 테스트 9건
- `SellerDashboardControllerTest`: 판매자 대시보드 컨트롤러 테스트 5건

---

### 📎 관련 이슈
- #142