### PR TITLE
chore: SpringDoc API 문서화 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,6 +86,9 @@ dependencies {
 	// CSV 파싱
 	implementation("org.apache.commons:commons-csv:1.12.0")
 
+	// API 문서화
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
+
 	// JSON 로깅
 	implementation("net.logstash.logback:logstash-logback-encoder:8.0")
 }

--- a/src/main/kotlin/com/hoppingmall/mall/cartItem/controller/CartItemController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/cartItem/controller/CartItemController.kt
@@ -14,10 +14,12 @@ import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/cart-items")
+@Tag(name = "장바구니")
 class CartItemController(
     private val cartItemCommandService: CartItemCommandService,
     private val cartItemQueryService: CartItemQueryService

--- a/src/main/kotlin/com/hoppingmall/mall/category/controller/CategoryController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/category/controller/CategoryController.kt
@@ -10,10 +10,12 @@ import com.hoppingmall.mall.global.common.response.ApiResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/categories")
+@Tag(name = "카테고리")
 class CategoryController(
     private val categoryCommandService: CategoryCommandService,
     private val categoryQueryService: CategoryQueryService

--- a/src/main/kotlin/com/hoppingmall/mall/coupon/controller/CouponController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/coupon/controller/CouponController.kt
@@ -16,10 +16,12 @@ import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1")
+@Tag(name = "쿠폰")
 class CouponController(
     private val couponCommandService: CouponCommandService,
     private val couponQueryService: CouponQueryService

--- a/src/main/kotlin/com/hoppingmall/mall/global/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/auth/controller/AuthController.kt
@@ -4,11 +4,13 @@ import com.hoppingmall.mall.global.auth.dto.request.TokenRefreshRequest
 import com.hoppingmall.mall.global.auth.dto.response.TokenRefreshResponse
 import com.hoppingmall.mall.global.auth.service.AuthService
 import com.hoppingmall.mall.global.common.response.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/auth")
+@Tag(name = "인증")
 class AuthController(
     private val authService: AuthService
 ) {

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/OpenApiConfig.kt
@@ -1,0 +1,38 @@
+package com.hoppingmall.mall.global.common.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfig {
+
+    @Bean
+    fun openAPI(): OpenAPI {
+        val securitySchemeName = "Bearer Authentication"
+
+        return OpenAPI()
+            .info(
+                Info()
+                    .title("HoppingMall API")
+                    .version("1.0.0")
+                    .description("HoppingMall 쇼핑몰 REST API")
+            )
+            .addSecurityItem(SecurityRequirement().addList(securitySchemeName))
+            .components(
+                Components()
+                    .addSecuritySchemes(
+                        securitySchemeName,
+                        SecurityScheme()
+                            .name(securitySchemeName)
+                            .type(SecurityScheme.Type.HTTP)
+                            .scheme("bearer")
+                            .bearerFormat("JWT")
+                    )
+            )
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
@@ -34,6 +34,11 @@ class SecurityConfig(
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .exceptionHandling { it.authenticationEntryPoint(jwtAuthenticationEntryPoint) }
             .authorizeHttpRequests {
+                it.requestMatchers(
+                    "/swagger-ui/**",
+                    "/swagger-ui.html",
+                    "/v3/api-docs/**"
+                ).permitAll()
                 it.requestMatchers("/api/v1/users/signup", "/api/v1/users/login").permitAll()
                 it.requestMatchers(
                     HttpMethod.GET,

--- a/src/main/kotlin/com/hoppingmall/mall/global/common/controller/DLQController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/controller/DLQController.kt
@@ -5,10 +5,12 @@ import com.hoppingmall.mall.global.common.domain.DLQStatus
 import com.hoppingmall.mall.global.common.response.ApiResponse
 import com.hoppingmall.mall.global.common.service.DLQService
 import org.springframework.data.domain.Page
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/admin/dlq")
+@Tag(name = "DLQ (관리자)")
 class DLQController(
     private val dlqService: DLQService
 ) {

--- a/src/main/kotlin/com/hoppingmall/mall/global/file/controller/FileUploadController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/file/controller/FileUploadController.kt
@@ -7,11 +7,13 @@ import com.hoppingmall.mall.global.file.service.FileUploadService
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @RequestMapping("/api/v1/files")
+@Tag(name = "파일 업로드")
 class FileUploadController(
     private val fileUploadService: FileUploadService
 ) {

--- a/src/main/kotlin/com/hoppingmall/mall/inventory/controller/InventoryController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/inventory/controller/InventoryController.kt
@@ -10,10 +10,12 @@ import com.hoppingmall.mall.inventory.service.InventoryQueryService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/inventories")
+@Tag(name = "재고")
 class InventoryController(
     private val inventoryCommandService: InventoryCommandService,
     private val inventoryQueryService: InventoryQueryService

--- a/src/main/kotlin/com/hoppingmall/mall/membership/controller/MembershipController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/membership/controller/MembershipController.kt
@@ -8,10 +8,12 @@ import com.hoppingmall.mall.membership.service.MembershipQueryService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/memberships")
+@Tag(name = "멤버십")
 class MembershipController(
     private val membershipCommandService: MembershipCommandService,
     private val membershipQueryService: MembershipQueryService

--- a/src/main/kotlin/com/hoppingmall/mall/notification/controller/NotificationController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/controller/NotificationController.kt
@@ -12,10 +12,12 @@ import org.springframework.data.domain.Slice
 import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/notifications")
+@Tag(name = "알림")
 class NotificationController(
     private val notificationQueryService: NotificationQueryService,
     private val notificationCommandService: NotificationCommandService

--- a/src/main/kotlin/com/hoppingmall/mall/order/controller/OrderController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/controller/OrderController.kt
@@ -15,10 +15,12 @@ import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/orders")
+@Tag(name = "주문")
 class OrderController(
     private val orderCommandService: OrderCommandService,
     private val orderQueryService: OrderQueryService

--- a/src/main/kotlin/com/hoppingmall/mall/payment/controller/PaymentController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/controller/PaymentController.kt
@@ -11,10 +11,12 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.core.userdetails.UserDetails
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/payments")
+@Tag(name = "결제")
 class PaymentController(
     private val paymentCommandService: PaymentCommandService,
     private val paymentQueryService: PaymentQueryService

--- a/src/main/kotlin/com/hoppingmall/mall/point/controller/PointController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/controller/PointController.kt
@@ -13,10 +13,12 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.core.userdetails.UserDetails
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/points")
+@Tag(name = "포인트")
 class PointController(
     private val pointQueryService: PointQueryService,
     private val pointCommandService: PointCommandService

--- a/src/main/kotlin/com/hoppingmall/mall/point/controller/PointPolicyController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/controller/PointPolicyController.kt
@@ -5,10 +5,12 @@ import com.hoppingmall.mall.point.dto.response.PointPolicyResponse
 import com.hoppingmall.mall.point.service.PointPolicyService
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/point-policies")
+@Tag(name = "포인트 정책")
 class PointPolicyController(
     private val pointPolicyService: PointPolicyService
 ) {

--- a/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductBulkController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductBulkController.kt
@@ -7,11 +7,13 @@ import com.hoppingmall.mall.product.dto.response.BulkRowError
 import com.hoppingmall.mall.product.dto.response.BulkValidationResponse
 import com.hoppingmall.mall.product.service.BulkImportService
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @RequestMapping("/api/v1/products/bulk")
+@Tag(name = "상품 대량 등록")
 class ProductBulkController(
     private val bulkImportService: BulkImportService
 ) {

--- a/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductController.kt
@@ -13,11 +13,13 @@ import com.hoppingmall.mall.product.service.ProductQueryService
 import jakarta.validation.Valid
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @RequestMapping("/api/v1/products")
+@Tag(name = "상품")
 class ProductController(
     private val productQueryService: ProductQueryService,
     private val productCommandService: ProductCommandService,

--- a/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductStatisticsController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/controller/ProductStatisticsController.kt
@@ -6,11 +6,13 @@ import com.hoppingmall.mall.product.service.ProductStatisticsQueryService
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.format.annotation.DateTimeFormat
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 import java.time.LocalDate
 
 @RestController
 @RequestMapping("/api/v1/admin/product-statistics")
+@Tag(name = "상품 통계 (관리자)")
 class ProductStatisticsController(
     private val productStatisticsQueryService: ProductStatisticsQueryService
 ) {

--- a/src/main/kotlin/com/hoppingmall/mall/product/controller/SellerDashboardController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/product/controller/SellerDashboardController.kt
@@ -15,11 +15,13 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
 
 @RestController
 @RequestMapping("/api/v1/seller/dashboard")
+@Tag(name = "판매자 대시보드")
 class SellerDashboardController(
     private val sellerDashboardService: SellerDashboardService
 ) {

--- a/src/main/kotlin/com/hoppingmall/mall/refund/controller/RefundController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/controller/RefundController.kt
@@ -12,10 +12,12 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.core.userdetails.UserDetails
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/refunds")
+@Tag(name = "환불")
 class RefundController(
     private val refundCommandService: RefundCommandService,
     private val refundQueryService: RefundQueryService

--- a/src/main/kotlin/com/hoppingmall/mall/review/controller/ReviewController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/review/controller/ReviewController.kt
@@ -15,10 +15,12 @@ import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1")
+@Tag(name = "리뷰")
 class ReviewController(
     private val reviewCommandService: ReviewCommandService,
     private val reviewQueryService: ReviewQueryService

--- a/src/main/kotlin/com/hoppingmall/mall/shipping/controller/ShippingController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/shipping/controller/ShippingController.kt
@@ -12,10 +12,12 @@ import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/shipping")
+@Tag(name = "배송")
 class ShippingController(
     private val shippingCommandService: ShippingCommandService,
     private val shippingQueryService: ShippingQueryService

--- a/src/main/kotlin/com/hoppingmall/mall/user/controller/admin/AdminController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/user/controller/admin/AdminController.kt
@@ -6,10 +6,12 @@ import com.hoppingmall.mall.user.service.admin.AdminCommandService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/admin")
+@Tag(name = "관리자")
 class AdminController(
     private val adminCommandService: AdminCommandService
 ) {

--- a/src/main/kotlin/com/hoppingmall/mall/user/controller/seller/SellerController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/user/controller/seller/SellerController.kt
@@ -9,10 +9,12 @@ import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v1/sellers")
+@Tag(name = "판매자 신청")
 class SellerController(
     private val sellerCommandService: SellerCommandService
 ) {

--- a/src/main/kotlin/com/hoppingmall/mall/user/controller/user/UserController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/user/controller/user/UserController.kt
@@ -13,10 +13,12 @@ import com.hoppingmall.mall.user.service.user.UserQueryService
 import jakarta.validation.Valid
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.core.userdetails.UserDetails
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/users")
+@Tag(name = "회원")
 class UserController(
     private val userCommandService: UserCommandService,
     private val userQueryService: UserQueryService,

--- a/src/main/kotlin/com/hoppingmall/mall/wishlist/controller/WishlistController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/wishlist/controller/WishlistController.kt
@@ -14,10 +14,12 @@ import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/wishlists")
+@Tag(name = "위시리스트")
 class WishlistController(
     private val wishlistCommandService: WishlistCommandService,
     private val wishlistQueryService: WishlistQueryService

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,6 +93,16 @@ cors:
   allow-credentials: true
   max-age: 3600
 
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: method
+  default-produces-media-type: application/json
+  default-consumes-media-type: application/json
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
Closes #78

### 📌 작업 개요
SpringDoc OpenAPI 3.0 기반 API 문서화를 적용했습니다.
JWT Bearer 인증 스키마와 24개 컨트롤러에 대한 @Tag 그룹핑을 설정하여
Swagger UI(/swagger-ui.html)에서 전체 API를 확인할 수 있습니다.

---

### ✅ 주요 변경 사항

- `build.gradle.kts`
  - `springdoc-openapi-starter-webmvc-ui:2.8.8` 의존성 추가

- `global.common.config`
  - `OpenApiConfig`: OpenAPI 메타 정보 + JWT Bearer SecurityScheme 설정
  - `SecurityConfig`: `/swagger-ui/**`, `/v3/api-docs/**` permitAll 추가

- `application.yml`
  - springdoc 경로, 정렬, 미디어 타입 설정

- 전체 24개 컨트롤러
  - `@Tag(name = "...")` 어노테이션으로 도메인별 그룹핑
  - 인증, 회원, 관리자, 판매자, 상품, 주문, 결제, 환불, 배송, 재고, 장바구니, 위시리스트, 리뷰, 알림, 포인트, 멤버십, 쿠폰, DLQ, 파일 업로드 등

---

### 🧪 테스트

- 전체 테스트 통과 확인 (`./gradlew test`)

---

### 📎 관련 이슈
- #78