### PR TITLE
refactor: UserDetails 캐스팅 통일 및 Actuator 접근 허용

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
@@ -37,7 +37,8 @@ class SecurityConfig(
                 it.requestMatchers(
                     "/swagger-ui/**",
                     "/swagger-ui.html",
-                    "/v3/api-docs/**"
+                    "/v3/api-docs/**",
+                    "/actuator/**"
                 ).permitAll()
                 it.requestMatchers("/api/v1/users/signup", "/api/v1/users/login").permitAll()
                 it.requestMatchers(

--- a/src/main/kotlin/com/hoppingmall/mall/payment/controller/PaymentController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/payment/controller/PaymentController.kt
@@ -9,8 +9,8 @@ import jakarta.validation.Valid
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
+import com.hoppingmall.mall.global.auth.UserPrincipal
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.security.core.userdetails.UserDetails
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
@@ -26,9 +26,9 @@ class PaymentController(
     @PostMapping
     fun processPayment(
         @Valid @RequestBody paymentRequest: PaymentRequest,
-        @AuthenticationPrincipal userDetails: UserDetails
+        @AuthenticationPrincipal principal: UserPrincipal
     ): ResponseEntity<PaymentResponse> {
-        val userId = userDetails.username.toLong()
+        val userId = principal.getUserId()
         val paymentResponse = paymentCommandService.processPayment(paymentRequest, userId)
         return ResponseEntity.ok(paymentResponse)
     }
@@ -36,20 +36,20 @@ class PaymentController(
     @GetMapping("/{paymentId}")
     fun getPaymentById(
         @PathVariable paymentId: Long,
-        @AuthenticationPrincipal userDetails: UserDetails
+        @AuthenticationPrincipal principal: UserPrincipal
     ): ResponseEntity<PaymentResponse> {
-        val userId = userDetails.username.toLong()
+        val userId = principal.getUserId()
         val paymentResponse = paymentQueryService.getPaymentById(paymentId, userId)
         return ResponseEntity.ok(paymentResponse)
     }
     
     @GetMapping
     fun getMyPayments(
-        @AuthenticationPrincipal userDetails: UserDetails,
+        @AuthenticationPrincipal principal: UserPrincipal,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int
     ): ResponseEntity<Page<PaymentResponse>> {
-        val userId = userDetails.username.toLong()
+        val userId = principal.getUserId()
         val pageable = PageRequest.of(page, size)
         val payments = paymentQueryService.getPaymentsByUserId(userId, pageable)
         return ResponseEntity.ok(payments)
@@ -58,9 +58,9 @@ class PaymentController(
     @GetMapping("/order/{orderId}")
     fun getPaymentsByOrderId(
         @PathVariable orderId: Long,
-        @AuthenticationPrincipal userDetails: UserDetails
+        @AuthenticationPrincipal principal: UserPrincipal
     ): ResponseEntity<List<PaymentResponse>> {
-        val userId = userDetails.username.toLong()
+        val userId = principal.getUserId()
         val payments = paymentQueryService.getPaymentsByOrderId(orderId, userId)
         return ResponseEntity.ok(payments)
     }
@@ -69,9 +69,9 @@ class PaymentController(
     @PostMapping("/{paymentId}/cancel")
     fun cancelPayment(
         @PathVariable paymentId: Long,
-        @AuthenticationPrincipal userDetails: UserDetails
+        @AuthenticationPrincipal principal: UserPrincipal
     ): ResponseEntity<PaymentResponse> {
-        val userId = userDetails.username.toLong()
+        val userId = principal.getUserId()
         val paymentResponse = paymentCommandService.cancelPayment(paymentId, userId)
         return ResponseEntity.ok(paymentResponse)
     }

--- a/src/main/kotlin/com/hoppingmall/mall/point/controller/PointController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/point/controller/PointController.kt
@@ -11,8 +11,8 @@ import jakarta.validation.Valid
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
+import com.hoppingmall.mall.global.auth.UserPrincipal
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.security.core.userdetails.UserDetails
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
@@ -26,20 +26,20 @@ class PointController(
     
     @GetMapping("/my-balance")
     fun getMyPointBalance(
-        @AuthenticationPrincipal userDetails: UserDetails
+        @AuthenticationPrincipal principal: UserPrincipal
     ): ResponseEntity<PointBalanceResponse> {
-        val userId = userDetails.username.toLong()
+        val userId = principal.getUserId()
         val balance = pointQueryService.getPointBalance(userId)
         return ResponseEntity.ok(balance)
     }
     
     @GetMapping("/my-history")
     fun getMyPointHistory(
-        @AuthenticationPrincipal userDetails: UserDetails,
+        @AuthenticationPrincipal principal: UserPrincipal,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int
     ): ResponseEntity<Page<PointHistoryResponse>> {
-        val userId = userDetails.username.toLong()
+        val userId = principal.getUserId()
         val pageable = PageRequest.of(page, size)
         val history = pointQueryService.getPointHistory(userId, pageable)
         return ResponseEntity.ok(history)
@@ -49,9 +49,9 @@ class PointController(
     @PostMapping("/use")
     fun usePoint(
         @Valid @RequestBody request: PointUseRequest,
-        @AuthenticationPrincipal userDetails: UserDetails
+        @AuthenticationPrincipal principal: UserPrincipal
     ): ResponseEntity<PointUseResponse> {
-        val userId = userDetails.username.toLong()
+        val userId = principal.getUserId()
         val result = pointCommandService.usePoint(userId, request)
         return ResponseEntity.ok(result)
     }

--- a/src/main/kotlin/com/hoppingmall/mall/refund/controller/RefundController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/controller/RefundController.kt
@@ -10,8 +10,8 @@ import jakarta.validation.Valid
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
+import com.hoppingmall.mall.global.auth.UserPrincipal
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.security.core.userdetails.UserDetails
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
@@ -27,9 +27,9 @@ class RefundController(
     @PostMapping
     fun requestRefund(
         @Valid @RequestBody request: RefundCreateRequest,
-        @AuthenticationPrincipal userDetails: UserDetails
+        @AuthenticationPrincipal principal: UserPrincipal
     ): ResponseEntity<RefundResponse> {
-        val buyerId = userDetails.username.toLong()
+        val buyerId = principal.getUserId()
         val response = refundCommandService.requestRefund(buyerId, request)
         return ResponseEntity.ok(response)
     }
@@ -37,20 +37,20 @@ class RefundController(
     @GetMapping("/{refundId}")
     fun getRefund(
         @PathVariable refundId: Long,
-        @AuthenticationPrincipal userDetails: UserDetails
+        @AuthenticationPrincipal principal: UserPrincipal
     ): ResponseEntity<RefundResponse> {
-        val userId = userDetails.username.toLong()
+        val userId = principal.getUserId()
         val response = refundQueryService.getRefund(refundId, userId)
         return ResponseEntity.ok(response)
     }
 
     @GetMapping("/my")
     fun getMyRefunds(
-        @AuthenticationPrincipal userDetails: UserDetails,
+        @AuthenticationPrincipal principal: UserPrincipal,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int
     ): ResponseEntity<Page<RefundResponse>> {
-        val buyerId = userDetails.username.toLong()
+        val buyerId = principal.getUserId()
         val pageable = PageRequest.of(page, size)
         val refunds = refundQueryService.getMyRefunds(buyerId, pageable)
         return ResponseEntity.ok(refunds)
@@ -58,11 +58,11 @@ class RefundController(
 
     @GetMapping("/seller")
     fun getSellerRefunds(
-        @AuthenticationPrincipal userDetails: UserDetails,
+        @AuthenticationPrincipal principal: UserPrincipal,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int
     ): ResponseEntity<Page<RefundResponse>> {
-        val sellerId = userDetails.username.toLong()
+        val sellerId = principal.getUserId()
         val pageable = PageRequest.of(page, size)
         val refunds = refundQueryService.getSellerRefunds(sellerId, pageable)
         return ResponseEntity.ok(refunds)
@@ -72,9 +72,9 @@ class RefundController(
     @PatchMapping("/{refundId}/approve")
     fun approveRefund(
         @PathVariable refundId: Long,
-        @AuthenticationPrincipal userDetails: UserDetails
+        @AuthenticationPrincipal principal: UserPrincipal
     ): ResponseEntity<RefundResponse> {
-        val approverId = userDetails.username.toLong()
+        val approverId = principal.getUserId()
         val response = refundCommandService.approveRefund(refundId, approverId)
         return ResponseEntity.ok(response)
     }
@@ -84,9 +84,9 @@ class RefundController(
     fun rejectRefund(
         @PathVariable refundId: Long,
         @RequestBody request: RefundApprovalRequest,
-        @AuthenticationPrincipal userDetails: UserDetails
+        @AuthenticationPrincipal principal: UserPrincipal
     ): ResponseEntity<RefundResponse> {
-        val approverId = userDetails.username.toLong()
+        val approverId = principal.getUserId()
         val response = refundCommandService.rejectRefund(refundId, approverId, request)
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/com/hoppingmall/mall/user/controller/seller/SellerController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/user/controller/seller/SellerController.kt
@@ -4,8 +4,8 @@ import com.hoppingmall.mall.global.common.response.ApiResponse
 import com.hoppingmall.mall.user.dto.request.seller.SellerApplyRequest
 import com.hoppingmall.mall.user.service.seller.SellerCommandService
 import jakarta.validation.Valid
+import com.hoppingmall.mall.global.auth.UserPrincipal
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -22,9 +22,9 @@ class SellerController(
     @PostMapping("/apply")
     fun applyForSeller(
         @RequestBody @Valid request: SellerApplyRequest,
-        @AuthenticationPrincipal userDetails: UserDetails
+        @AuthenticationPrincipal principal: UserPrincipal
     ): ApiResponse<Unit> {
-        val userId = userDetails.username.toLong()
+        val userId = principal.getUserId()
         sellerCommandService.apply(userId, request)
         return ApiResponse.Companion.success(Unit)
     }

--- a/src/main/kotlin/com/hoppingmall/mall/user/controller/user/UserController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/user/controller/user/UserController.kt
@@ -11,8 +11,8 @@ import com.hoppingmall.mall.user.dto.response.user.UserProfileResponse
 import com.hoppingmall.mall.user.service.user.UserCommandService
 import com.hoppingmall.mall.user.service.user.UserQueryService
 import jakarta.validation.Valid
+import com.hoppingmall.mall.global.auth.UserPrincipal
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.security.core.userdetails.UserDetails
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
@@ -43,9 +43,9 @@ class UserController(
 
     @GetMapping("/me")
     fun getMyProfile(
-        @AuthenticationPrincipal userDetails: UserDetails
+        @AuthenticationPrincipal principal: UserPrincipal
     ): ApiResponse<UserProfileResponse> {
-        val userId = userDetails.username.toLong()
+        val userId = principal.getUserId()
         val response = userQueryService.getUserProfile(userId)
         return ApiResponse.Companion.success(response)
     }
@@ -53,9 +53,9 @@ class UserController(
     @PatchMapping("/me")
     fun updateMyProfile(
         @RequestBody @Valid request: UpdateUserRequest,
-        @AuthenticationPrincipal userDetails: UserDetails
+        @AuthenticationPrincipal principal: UserPrincipal
     ): ApiResponse<Unit> {
-        val userId = userDetails.username.toLong()
+        val userId = principal.getUserId()
         userCommandService.updateUserProfile(userId, request)
         return ApiResponse.Companion.success(Unit)
     }

--- a/src/test/kotlin/com/hoppingmall/mall/payment/controller/PaymentControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/payment/controller/PaymentControllerTest.kt
@@ -16,7 +16,7 @@ import org.mockito.kotlin.*
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
-import org.springframework.security.core.userdetails.UserDetails
+import com.hoppingmall.mall.global.auth.UserPrincipal
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
@@ -57,13 +57,12 @@ class PaymentControllerTest {
                 createdAt = LocalDateTime.now(),
                 updatedAt = LocalDateTime.now()
             )
-            val userDetails: UserDetails = mock()
+            val principal = UserPrincipal(userId, "test@example.com", "BUYER")
 
-            whenever(userDetails.username).thenReturn(userId.toString())
             whenever(paymentCommandService.processPayment(request, userId)).thenReturn(response)
 
             // when
-            val result = paymentController.processPayment(request, userDetails)
+            val result = paymentController.processPayment(request, principal)
 
             // then
             assertEquals(HttpStatus.OK, result.statusCode)
@@ -96,13 +95,12 @@ class PaymentControllerTest {
                 createdAt = LocalDateTime.now(),
                 updatedAt = LocalDateTime.now()
             )
-            val userDetails: UserDetails = mock()
+            val principal = UserPrincipal(userId, "test@example.com", "BUYER")
 
-            whenever(userDetails.username).thenReturn(userId.toString())
             whenever(paymentQueryService.getPaymentById(paymentId, userId)).thenReturn(response)
 
             // when
-            val result = paymentController.getPaymentById(paymentId, userDetails)
+            val result = paymentController.getPaymentById(paymentId, principal)
 
             // then
             assertEquals(HttpStatus.OK, result.statusCode)
@@ -121,7 +119,7 @@ class PaymentControllerTest {
             val page = 0
             val size = 10
             val pageable = PageRequest.of(page, size)
-            val userDetails: UserDetails = mock()
+            val principal = UserPrincipal(userId, "test@example.com", "BUYER")
 
             val paymentResponse = PaymentResponse(
                 id = 1L,
@@ -143,11 +141,10 @@ class PaymentControllerTest {
             val payments = listOf(paymentResponse)
             val pageResponse = PageImpl(payments, pageable, 1)
 
-            whenever(userDetails.username).thenReturn(userId.toString())
             whenever(paymentQueryService.getPaymentsByUserId(userId, pageable)).thenReturn(pageResponse)
 
             // when
-            val result = paymentController.getMyPayments(userDetails, page, size)
+            val result = paymentController.getMyPayments(principal, page, size)
 
             // then
             assertEquals(HttpStatus.OK, result.statusCode)
@@ -183,13 +180,12 @@ class PaymentControllerTest {
             )
 
             val payments = listOf(paymentResponse)
-            val userDetails: UserDetails = mock()
+            val principal = UserPrincipal(userId, "test@example.com", "BUYER")
 
-            whenever(userDetails.username).thenReturn(userId.toString())
             whenever(paymentQueryService.getPaymentsByOrderId(orderId, userId)).thenReturn(payments)
 
             // when
-            val result = paymentController.getPaymentsByOrderId(orderId, userDetails)
+            val result = paymentController.getPaymentsByOrderId(orderId, principal)
 
             // then
             assertEquals(HttpStatus.OK, result.statusCode)
@@ -222,13 +218,12 @@ class PaymentControllerTest {
                 createdAt = LocalDateTime.now(),
                 updatedAt = LocalDateTime.now()
             )
-            val userDetails: UserDetails = mock()
+            val principal = UserPrincipal(userId, "test@example.com", "BUYER")
 
-            whenever(userDetails.username).thenReturn(userId.toString())
             whenever(paymentCommandService.cancelPayment(paymentId, userId)).thenReturn(response)
 
             // when
-            val result = paymentController.cancelPayment(paymentId, userDetails)
+            val result = paymentController.cancelPayment(paymentId, principal)
 
             // then
             assertEquals(HttpStatus.OK, result.statusCode)

--- a/src/test/kotlin/com/hoppingmall/mall/point/controller/PointControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/point/controller/PointControllerTest.kt
@@ -18,7 +18,7 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.security.core.userdetails.UserDetails
+import com.hoppingmall.mall.global.auth.UserPrincipal
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
@@ -37,13 +37,12 @@ class PointControllerTest {
         fun 포인트_잔액_조회_성공() {
             val userId = 1L
             val balance = BigDecimal("1000")
-            val userDetails: UserDetails = mock()
+            val principal = UserPrincipal(userId, "test@example.com", "BUYER")
             val balanceResponse = PointBalanceResponse(balance)
 
-            whenever(userDetails.username).thenReturn(userId.toString())
             whenever(pointQueryService.getPointBalance(userId)).thenReturn(balanceResponse)
 
-            val result = pointController.getMyPointBalance(userDetails)
+            val result = pointController.getMyPointBalance(principal)
 
             assertEquals(HttpStatus.OK, result.statusCode)
             assertEquals(balanceResponse, result.body)
@@ -57,7 +56,7 @@ class PointControllerTest {
         @Test
         fun 포인트_내역_조회_성공() {
             val userId = 1L
-            val userDetails: UserDetails = mock()
+            val principal = UserPrincipal(userId, "test@example.com", "BUYER")
             val page = 0
             val size = 10
             val pageable = PageRequest.of(page, size)
@@ -76,10 +75,9 @@ class PointControllerTest {
             val histories = listOf(historyResponse)
             val pageResponse = PageImpl(histories, pageable, 1)
 
-            whenever(userDetails.username).thenReturn(userId.toString())
             whenever(pointQueryService.getPointHistory(userId, pageable)).thenReturn(pageResponse)
 
-            val result = pointController.getMyPointHistory(userDetails, page, size)
+            val result = pointController.getMyPointHistory(principal, page, size)
 
             assertEquals(HttpStatus.OK, result.statusCode)
             assertEquals(pageResponse, result.body)
@@ -98,17 +96,16 @@ class PointControllerTest {
                 orderId = 1L,
                 reason = "상품 구매"
             )
-            val userDetails: UserDetails = mock()
+            val principal = UserPrincipal(userId, "test@example.com", "BUYER")
             val useResponse = PointUseResponse(
                 usedAmount = BigDecimal("500"),
                 remainingBalance = BigDecimal("500"),
                 orderId = 1L
             )
 
-            whenever(userDetails.username).thenReturn(userId.toString())
             whenever(pointCommandService.usePoint(userId, request)).thenReturn(useResponse)
 
-            val result = pointController.usePoint(request, userDetails)
+            val result = pointController.usePoint(request, principal)
 
             assertEquals(HttpStatus.OK, result.statusCode)
             assertEquals(useResponse, result.body)

--- a/src/test/kotlin/com/hoppingmall/mall/refund/controller/RefundControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/refund/controller/RefundControllerTest.kt
@@ -19,7 +19,7 @@ import org.mockito.kotlin.*
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
-import org.springframework.security.core.userdetails.UserDetails
+import com.hoppingmall.mall.global.auth.UserPrincipal
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
@@ -78,13 +78,12 @@ class RefundControllerTest {
                 items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 2))
             )
             val response = createRefundResponse()
-            val userDetails: UserDetails = mock()
+            val principal = UserPrincipal(userId, "test@example.com", "BUYER")
 
-            whenever(userDetails.username).thenReturn(userId.toString())
             whenever(refundCommandService.requestRefund(userId, request)).thenReturn(response)
 
             // when
-            val result = refundController.requestRefund(request, userDetails)
+            val result = refundController.requestRefund(request, principal)
 
             // then
             assertEquals(HttpStatus.OK, result.statusCode)
@@ -102,13 +101,12 @@ class RefundControllerTest {
             val refundId = 1L
             val userId = 1L
             val response = createRefundResponse()
-            val userDetails: UserDetails = mock()
+            val principal = UserPrincipal(userId, "test@example.com", "BUYER")
 
-            whenever(userDetails.username).thenReturn(userId.toString())
             whenever(refundQueryService.getRefund(refundId, userId)).thenReturn(response)
 
             // when
-            val result = refundController.getRefund(refundId, userDetails)
+            val result = refundController.getRefund(refundId, principal)
 
             // then
             assertEquals(HttpStatus.OK, result.statusCode)
@@ -127,15 +125,14 @@ class RefundControllerTest {
             val page = 0
             val size = 10
             val pageable = PageRequest.of(page, size)
-            val userDetails: UserDetails = mock()
+            val principal = UserPrincipal(userId, "test@example.com", "BUYER")
             val response = createRefundResponse()
             val pageResponse = PageImpl(listOf(response), pageable, 1)
 
-            whenever(userDetails.username).thenReturn(userId.toString())
             whenever(refundQueryService.getMyRefunds(userId, pageable)).thenReturn(pageResponse)
 
             // when
-            val result = refundController.getMyRefunds(userDetails, page, size)
+            val result = refundController.getMyRefunds(principal, page, size)
 
             // then
             assertEquals(HttpStatus.OK, result.statusCode)
@@ -154,15 +151,14 @@ class RefundControllerTest {
             val page = 0
             val size = 10
             val pageable = PageRequest.of(page, size)
-            val userDetails: UserDetails = mock()
+            val principal = UserPrincipal(sellerId, "seller@example.com", "SELLER")
             val response = createRefundResponse()
             val pageResponse = PageImpl(listOf(response), pageable, 1)
 
-            whenever(userDetails.username).thenReturn(sellerId.toString())
             whenever(refundQueryService.getSellerRefunds(sellerId, pageable)).thenReturn(pageResponse)
 
             // when
-            val result = refundController.getSellerRefunds(userDetails, page, size)
+            val result = refundController.getSellerRefunds(principal, page, size)
 
             // then
             assertEquals(HttpStatus.OK, result.statusCode)
@@ -180,13 +176,12 @@ class RefundControllerTest {
             val refundId = 1L
             val sellerId = 2L
             val response = createRefundResponse(status = RefundStatus.COMPLETED)
-            val userDetails: UserDetails = mock()
+            val principal = UserPrincipal(sellerId, "seller@example.com", "SELLER")
 
-            whenever(userDetails.username).thenReturn(sellerId.toString())
             whenever(refundCommandService.approveRefund(refundId, sellerId)).thenReturn(response)
 
             // when
-            val result = refundController.approveRefund(refundId, userDetails)
+            val result = refundController.approveRefund(refundId, principal)
 
             // then
             assertEquals(HttpStatus.OK, result.statusCode)
@@ -205,13 +200,12 @@ class RefundControllerTest {
             val sellerId = 2L
             val request = RefundApprovalRequest(rejectionReason = "반품 불가")
             val response = createRefundResponse(status = RefundStatus.REJECTED)
-            val userDetails: UserDetails = mock()
+            val principal = UserPrincipal(sellerId, "seller@example.com", "SELLER")
 
-            whenever(userDetails.username).thenReturn(sellerId.toString())
             whenever(refundCommandService.rejectRefund(refundId, sellerId, request)).thenReturn(response)
 
             // when
-            val result = refundController.rejectRefund(refundId, request, userDetails)
+            val result = refundController.rejectRefund(refundId, request, principal)
 
             // then
             assertEquals(HttpStatus.OK, result.statusCode)

--- a/src/test/kotlin/com/hoppingmall/mall/user/controller/seller/SellerControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/user/controller/seller/SellerControllerTest.kt
@@ -8,8 +8,7 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.springframework.security.core.userdetails.User
-import org.springframework.security.core.userdetails.UserDetails
+import com.hoppingmall.mall.global.auth.UserPrincipal
 
 @DisplayName("SellerController")
 @DisplayNameGeneration(ReplaceUnderscores::class)
@@ -24,9 +23,9 @@ class SellerControllerTest {
         @Test
         fun SELLER_사용자가_판매자_승인_신청을_하면_성공_응답이_반환된다() {
             val request = SellerApplyRequest("123-45-67890")
-            val userDetails: UserDetails = User.withUsername("10").password("pass").roles("SELLER").build()
+            val principal = UserPrincipal(10L, "seller@example.com", "SELLER")
 
-            val response: ApiResponse<Unit> = controller.applyForSeller(request, userDetails)
+            val response: ApiResponse<Unit> = controller.applyForSeller(request, principal)
 
             verify(sellerCommandService).apply(10L, request)
             assertEquals("SUCCESS", response.code)

--- a/src/test/kotlin/com/hoppingmall/mall/user/controller/user/UserControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/user/controller/user/UserControllerTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.*
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.mockito.kotlin.*
-import org.springframework.security.core.userdetails.UserDetails
+import com.hoppingmall.mall.global.auth.UserPrincipal
 
 @DisplayName("UserController")
 @DisplayNameGeneration(ReplaceUnderscores::class)
@@ -90,14 +90,13 @@ class UserControllerTest {
     inner class GetMyProfile {
         @Test
         fun 인증된_사용자의_프로필_조회_성공() {
-            val userDetails = mock<UserDetails>()
             val userId = 1L
+            val principal = UserPrincipal(userId, "test@example.com", "BUYER")
             val profileResponse = UserProfileResponse(userId, "test@example.com", "홍길동", Role.BUYER.name)
 
-            whenever(userDetails.username).thenReturn(userId.toString())
             whenever(userQueryService.getUserProfile(userId)).thenReturn(profileResponse)
 
-            val result = controller.getMyProfile(userDetails)
+            val result = controller.getMyProfile(principal)
 
             assertEquals(ApiResponse.success(profileResponse), result)
             verify(userQueryService).getUserProfile(userId)
@@ -109,14 +108,13 @@ class UserControllerTest {
     inner class UpdateMyProfile {
         @Test
         fun 인증된_사용자의_프로필_수정_성공() {
-            val userDetails = mock<UserDetails>()
             val userId = 1L
+            val principal = UserPrincipal(userId, "test@example.com", "BUYER")
             val request = UpdateUserRequest("새로운이름", "newPassword123!")
 
-            whenever(userDetails.username).thenReturn(userId.toString())
             doNothing().whenever(userCommandService).updateUserProfile(userId, request)
 
-            val result = controller.updateMyProfile(request, userDetails)
+            val result = controller.updateMyProfile(request, principal)
 
             assertEquals(ApiResponse.success(Unit), result)
             verify(userCommandService).updateUserProfile(userId, request)
@@ -124,14 +122,13 @@ class UserControllerTest {
 
         @Test
         fun 비밀번호_없이_이름만_수정_성공() {
-            val userDetails = mock<UserDetails>()
             val userId = 1L
+            val principal = UserPrincipal(userId, "test@example.com", "BUYER")
             val request = UpdateUserRequest("새로운이름", null)
 
-            whenever(userDetails.username).thenReturn(userId.toString())
             doNothing().whenever(userCommandService).updateUserProfile(userId, request)
 
-            val result = controller.updateMyProfile(request, userDetails)
+            val result = controller.updateMyProfile(request, principal)
 
             assertEquals(ApiResponse.success(Unit), result)
             verify(userCommandService).updateUserProfile(userId, request)


### PR DESCRIPTION
Closes #145

### 📌 작업 개요
5개 컨트롤러에서 `UserDetails.username.toLong()` 방식으로 사용자 ID를 추출하던 것을
`UserPrincipal.getUserId()`로 통일하고, Actuator 엔드포인트 접근을 허용했습니다.

---

### ✅ 주요 변경 사항

- `payment.controller`
  - `PaymentController`: UserDetails → UserPrincipal (5곳)

- `refund.controller`
  - `RefundController`: UserDetails → UserPrincipal (6곳)

- `point.controller`
  - `PointController`: UserDetails → UserPrincipal (3곳)

- `user.controller`
  - `UserController`: UserDetails → UserPrincipal (2곳)
  - `SellerController`: UserDetails → UserPrincipal (1곳)

- `global.common.config`
  - `SecurityConfig`: /actuator/** permitAll 추가

---

### 🧪 테스트

- `PaymentControllerTest`: UserPrincipal 생성자 방식으로 변경
- `RefundControllerTest`: UserPrincipal 생성자 방식으로 변경
- `PointControllerTest`: UserPrincipal 생성자 방식으로 변경
- `UserControllerTest`: UserPrincipal 생성자 방식으로 변경
- `SellerControllerTest`: UserPrincipal 생성자 방식으로 변경

---

### 📎 관련 이슈
- #145