### PR TITLE
feat: SSE 실시간 알림 + Redis Pub/Sub 구현

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/RedisConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/RedisConfig.kt
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.StringRedisSerializer
@@ -38,6 +39,13 @@ class RedisConfig {
             hashKeySerializer = StringRedisSerializer()
             hashValueSerializer = GenericJackson2JsonRedisSerializer(objectMapper)
             afterPropertiesSet()
+        }
+    }
+
+    @Bean
+    fun redisMessageListenerContainer(connectionFactory: RedisConnectionFactory): RedisMessageListenerContainer {
+        return RedisMessageListenerContainer().apply {
+            setConnectionFactory(connectionFactory)
         }
     }
 

--- a/src/main/kotlin/com/hoppingmall/mall/notification/controller/NotificationController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/controller/NotificationController.kt
@@ -7,21 +7,32 @@ import com.hoppingmall.mall.notification.dto.response.UnreadCountResponse
 import com.hoppingmall.mall.notification.enum.NotificationType
 import com.hoppingmall.mall.notification.service.NotificationCommandService
 import com.hoppingmall.mall.notification.service.NotificationQueryService
+import com.hoppingmall.mall.notification.service.NotificationSseService
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.web.PageableDefault
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 
 @RestController
 @RequestMapping("/api/v1/notifications")
 @Tag(name = "알림")
 class NotificationController(
     private val notificationQueryService: NotificationQueryService,
-    private val notificationCommandService: NotificationCommandService
+    private val notificationCommandService: NotificationCommandService,
+    private val notificationSseService: NotificationSseService
 ) {
+
+    @GetMapping("/subscribe", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
+    fun subscribe(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ): SseEmitter {
+        return notificationSseService.connect(userPrincipal.getUserId())
+    }
 
     @GetMapping
     fun getNotifications(

--- a/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationEventConsumer.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationEventConsumer.kt
@@ -1,10 +1,14 @@
 package com.hoppingmall.mall.notification.service
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.hoppingmall.mall.notification.domain.Notification
 import com.hoppingmall.mall.notification.domain.NotificationRepository
 import com.hoppingmall.mall.notification.dto.event.NotificationEvent
+import com.hoppingmall.mall.notification.dto.response.NotificationResponse
 import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Service
@@ -13,7 +17,9 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional
 class NotificationEventConsumer(
-    private val notificationRepository: NotificationRepository
+    private val notificationRepository: NotificationRepository,
+    @Qualifier("customStringRedisTemplate") private val redisTemplate: RedisTemplate<String, String>,
+    private val objectMapper: ObjectMapper
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -37,17 +43,34 @@ class NotificationEventConsumer(
                 metadata = event.metadata
             )
 
+            val saved: Notification
             try {
-                notificationRepository.save(notification)
+                saved = notificationRepository.save(notification)
             } catch (e: DataIntegrityViolationException) {
                 log.info("이미 처리된 알림 이벤트: eventId={}", event.eventId)
                 return
             }
 
+            publishSseEvent(saved)
             log.info("알림 처리 완료: userId={}, type={}, title={}", event.userId, event.type, event.title)
         } catch (e: Exception) {
             log.error("알림 처리 실패: eventId={}, userId={}, 오류={}", event.eventId, event.userId, e.message)
             throw e
+        }
+    }
+
+    private fun publishSseEvent(notification: Notification) {
+        try {
+            val message = SseNotificationMessage(
+                userId = notification.userId,
+                notification = NotificationResponse.from(notification)
+            )
+            redisTemplate.convertAndSend(
+                NotificationSseService.CHANNEL_NAME,
+                objectMapper.writeValueAsString(message)
+            )
+        } catch (e: Exception) {
+            log.warn("SSE Redis publish 실패: userId={}, error={}", notification.userId, e.message)
         }
     }
 }

--- a/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationSseService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/service/NotificationSseService.kt
@@ -1,0 +1,82 @@
+package com.hoppingmall.mall.notification.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.mall.notification.dto.response.NotificationResponse
+import jakarta.annotation.PostConstruct
+import jakarta.annotation.PreDestroy
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.connection.Message
+import org.springframework.data.redis.connection.MessageListener
+import org.springframework.data.redis.listener.ChannelTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.stereotype.Service
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.io.IOException
+
+@Service
+class NotificationSseService(
+    private val sseEmitterRepository: SseEmitterRepository,
+    private val redisMessageListenerContainer: RedisMessageListenerContainer,
+    private val objectMapper: ObjectMapper
+) : MessageListener {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        const val CHANNEL_NAME = "notification:sse"
+        const val SSE_TIMEOUT = 1800000L
+    }
+
+    @PostConstruct
+    fun subscribe() {
+        redisMessageListenerContainer.addMessageListener(this, ChannelTopic(CHANNEL_NAME))
+    }
+
+    @PreDestroy
+    fun unsubscribe() {
+        redisMessageListenerContainer.removeMessageListener(this)
+    }
+
+    fun connect(userId: Long): SseEmitter {
+        val emitter = SseEmitter(SSE_TIMEOUT)
+
+        sseEmitterRepository.save(userId, emitter)
+
+        emitter.onCompletion { sseEmitterRepository.remove(userId, emitter) }
+        emitter.onTimeout { sseEmitterRepository.remove(userId, emitter) }
+        emitter.onError { sseEmitterRepository.remove(userId, emitter) }
+
+        try {
+            emitter.send(SseEmitter.event().name("connect").data("connected"))
+        } catch (e: IOException) {
+            sseEmitterRepository.remove(userId, emitter)
+        }
+
+        return emitter
+    }
+
+    fun sendToUser(userId: Long, response: NotificationResponse) {
+        val emitters = sseEmitterRepository.findByUserId(userId)
+        emitters.forEach { emitter ->
+            try {
+                emitter.send(SseEmitter.event().name("notification").data(response))
+            } catch (e: IOException) {
+                sseEmitterRepository.remove(userId, emitter)
+            }
+        }
+    }
+
+    override fun onMessage(message: Message, pattern: ByteArray?) {
+        try {
+            val sseMessage = objectMapper.readValue(message.body, SseNotificationMessage::class.java)
+            sendToUser(sseMessage.userId, sseMessage.notification)
+        } catch (e: Exception) {
+            log.error("Redis SSE 메시지 처리 실패: {}", e.message)
+        }
+    }
+}
+
+data class SseNotificationMessage(
+    val userId: Long,
+    val notification: NotificationResponse
+)

--- a/src/main/kotlin/com/hoppingmall/mall/notification/service/SseEmitterRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/notification/service/SseEmitterRepository.kt
@@ -1,0 +1,27 @@
+package com.hoppingmall.mall.notification.service
+
+import org.springframework.stereotype.Repository
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.util.concurrent.ConcurrentHashMap
+
+@Repository
+class SseEmitterRepository {
+
+    private val emitters = ConcurrentHashMap<Long, MutableList<SseEmitter>>()
+
+    fun save(userId: Long, emitter: SseEmitter): SseEmitter {
+        emitters.computeIfAbsent(userId) { mutableListOf() }.add(emitter)
+        return emitter
+    }
+
+    fun findByUserId(userId: Long): List<SseEmitter> {
+        return emitters[userId]?.toList() ?: emptyList()
+    }
+
+    fun remove(userId: Long, emitter: SseEmitter) {
+        emitters[userId]?.remove(emitter)
+        if (emitters[userId]?.isEmpty() == true) {
+            emitters.remove(userId)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/MallApplicationTests.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/MallApplicationTests.kt
@@ -3,13 +3,18 @@ package com.hoppingmall.mall
 import com.hoppingmall.mall.global.common.config.TestRedisConfig
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
 import org.springframework.test.context.ActiveProfiles
 
-@SpringBootTest
+@SpringBootTest(properties = ["spring.main.allow-bean-definition-overriding=true"])
 @ActiveProfiles("test")
 @Import(TestRedisConfig::class)
 class MallApplicationTests {
+
+	@MockBean
+	private lateinit var redisMessageListenerContainer: RedisMessageListenerContainer
 
 	@Test
 	fun contextLoads() {

--- a/src/test/kotlin/com/hoppingmall/mall/global/common/service/DLQServiceIntegrationTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/global/common/service/DLQServiceIntegrationTest.kt
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
 import org.springframework.kafka.test.context.EmbeddedKafka
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
@@ -33,6 +34,9 @@ class DLQServiceIntegrationTest {
 
     @MockBean
     private lateinit var outboxEventService: OutboxEventService
+
+    @MockBean
+    private lateinit var redisMessageListenerContainer: RedisMessageListenerContainer
 
     @Autowired
     private lateinit var dlqService: DLQService

--- a/src/test/kotlin/com/hoppingmall/mall/notification/controller/NotificationControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/notification/controller/NotificationControllerTest.kt
@@ -7,6 +7,7 @@ import com.hoppingmall.mall.notification.dto.response.UnreadCountResponse
 import com.hoppingmall.mall.notification.enum.NotificationType
 import com.hoppingmall.mall.notification.service.NotificationCommandService
 import com.hoppingmall.mall.notification.service.NotificationQueryService
+import com.hoppingmall.mall.notification.service.NotificationSseService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
@@ -29,7 +30,8 @@ class NotificationControllerTest {
 
     private val notificationQueryService: NotificationQueryService = mock()
     private val notificationCommandService: NotificationCommandService = mock()
-    private val controller = NotificationController(notificationQueryService, notificationCommandService)
+    private val notificationSseService: NotificationSseService = mock()
+    private val controller = NotificationController(notificationQueryService, notificationCommandService, notificationSseService)
 
     private val userPrincipal = UserPrincipal(1L, "test@example.com", "BUYER")
     private val now = LocalDateTime.now()
@@ -47,6 +49,22 @@ class NotificationControllerTest {
             isRead = false,
             createdAt = now
         )
+    }
+
+    @Nested
+    @DisplayName("subscribe")
+    inner class Subscribe {
+
+        @Test
+        fun SSE_구독_연결을_생성한다() {
+            val emitter = org.springframework.web.servlet.mvc.method.annotation.SseEmitter()
+            whenever(notificationSseService.connect(1L)).thenReturn(emitter)
+
+            val result = controller.subscribe(userPrincipal)
+
+            assertEquals(emitter, result)
+            verify(notificationSseService).connect(1L)
+        }
     }
 
     @Nested

--- a/src/test/kotlin/com/hoppingmall/mall/notification/service/NotificationEventConsumerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/notification/service/NotificationEventConsumerTest.kt
@@ -1,9 +1,16 @@
 package com.hoppingmall.mall.notification.service
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.hoppingmall.mall.notification.domain.Notification
 import com.hoppingmall.mall.notification.domain.NotificationRepository
 import com.hoppingmall.mall.notification.dto.event.NotificationEvent
 import com.hoppingmall.mall.notification.enum.NotificationType
+import com.hoppingmall.mall.support.withId
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -11,16 +18,23 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.RedisTemplate
 import kotlin.test.assertEquals
 
+@DisplayName("NotificationEventConsumer")
+@DisplayNameGeneration(ReplaceUnderscores::class)
 class NotificationEventConsumerTest {
-    
+
     private val notificationRepository: NotificationRepository = mock()
-    private val notificationEventConsumer = NotificationEventConsumer(notificationRepository)
-    
+    private val redisTemplate: RedisTemplate<String, String> = mock()
+    private val objectMapper: ObjectMapper = ObjectMapper().apply {
+        registerModule(KotlinModule.Builder().build())
+        registerModule(JavaTimeModule())
+    }
+    private val notificationEventConsumer = NotificationEventConsumer(notificationRepository, redisTemplate, objectMapper)
+
     @Test
-    fun `결제 완료 알림 이벤트를 처리한다`() {
-        // given
+    fun 결제_완료_알림_이벤트를_처리한다() {
         val metadata = """
             {
                 "orderId": 123,
@@ -30,7 +44,7 @@ class NotificationEventConsumerTest {
                 "transactionId": "tx_123456"
             }
         """.trimIndent()
-        
+
         val event = NotificationEvent(
             eventId = "EVENT-1",
             userId = 1L,
@@ -39,13 +53,14 @@ class NotificationEventConsumerTest {
             content = "주문번호 123의 결제가 성공적으로 완료되었습니다. 결제 금액: 50000원",
             metadata = metadata
         )
-        
+
         val captor = argumentCaptor<Notification>()
-        
-        // when
+        whenever(notificationRepository.save(any<Notification>())).thenAnswer { invocation ->
+            (invocation.arguments[0] as Notification).withId(1L)
+        }
+
         notificationEventConsumer.handleNotificationEvent(event)
-        
-        // then
+
         verify(notificationRepository).save(captor.capture())
         val savedNotification = captor.firstValue
         assertEquals("EVENT-1", savedNotification.eventId)
@@ -55,11 +70,11 @@ class NotificationEventConsumerTest {
         assertEquals("주문번호 123의 결제가 성공적으로 완료되었습니다. 결제 금액: 50000원", savedNotification.content)
         assertEquals(metadata, savedNotification.metadata)
         assertEquals(false, savedNotification.isRead)
+        verify(redisTemplate).convertAndSend(any<String>(), any<String>())
     }
-    
+
     @Test
-    fun `포인트 적립 알림 이벤트를 처리한다`() {
-        // given
+    fun 포인트_적립_알림_이벤트를_처리한다() {
         val metadata = """
             {
                 "orderId": 123,
@@ -69,7 +84,7 @@ class NotificationEventConsumerTest {
                 "currentBalance": "1000"
             }
         """.trimIndent()
-        
+
         val event = NotificationEvent(
             eventId = "EVENT-2",
             userId = 2L,
@@ -78,13 +93,14 @@ class NotificationEventConsumerTest {
             content = "주문번호 123의 포인트 100점이 적립되었습니다. 현재 잔액: 1000점",
             metadata = metadata
         )
-        
+
         val captor = argumentCaptor<Notification>()
-        
-        // when
+        whenever(notificationRepository.save(any<Notification>())).thenAnswer { invocation ->
+            (invocation.arguments[0] as Notification).withId(2L)
+        }
+
         notificationEventConsumer.handleNotificationEvent(event)
-        
-        // then
+
         verify(notificationRepository).save(captor.capture())
         val savedNotification = captor.firstValue
         assertEquals("EVENT-2", savedNotification.eventId)
@@ -94,10 +110,11 @@ class NotificationEventConsumerTest {
         assertEquals("주문번호 123의 포인트 100점이 적립되었습니다. 현재 잔액: 1000점", savedNotification.content)
         assertEquals(metadata, savedNotification.metadata)
         assertEquals(false, savedNotification.isRead)
+        verify(redisTemplate).convertAndSend(any<String>(), any<String>())
     }
 
     @Test
-    fun `중복 알림 이벤트는 저장하지 않는다`() {
+    fun 중복_알림_이벤트는_저장하지_않는다() {
         val event = NotificationEvent(
             eventId = "EVENT-3",
             userId = 3L,
@@ -112,5 +129,6 @@ class NotificationEventConsumerTest {
         notificationEventConsumer.handleNotificationEvent(event)
 
         verify(notificationRepository, never()).save(any())
+        verify(redisTemplate, never()).convertAndSend(any<String>(), any<String>())
     }
 }

--- a/src/test/kotlin/com/hoppingmall/mall/notification/service/NotificationSseServiceTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/notification/service/NotificationSseServiceTest.kt
@@ -1,0 +1,130 @@
+package com.hoppingmall.mall.notification.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.hoppingmall.mall.notification.dto.response.NotificationResponse
+import com.hoppingmall.mall.notification.enum.NotificationType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.time.LocalDateTime
+
+@DisplayName("NotificationSseService")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class NotificationSseServiceTest {
+
+    private val sseEmitterRepository = SseEmitterRepository()
+    private val redisMessageListenerContainer: RedisMessageListenerContainer = mock()
+    private val objectMapper: ObjectMapper = ObjectMapper().apply {
+        registerModule(KotlinModule.Builder().build())
+        registerModule(JavaTimeModule())
+    }
+    private val notificationSseService = NotificationSseService(
+        sseEmitterRepository, redisMessageListenerContainer, objectMapper
+    )
+
+    private val now = LocalDateTime.now()
+
+    private fun createNotificationResponse(id: Long = 1L): NotificationResponse {
+        return NotificationResponse(
+            id = id,
+            type = NotificationType.PAYMENT_COMPLETED,
+            title = "테스트 알림",
+            content = "테스트 내용",
+            metadata = null,
+            isRead = false,
+            createdAt = now
+        )
+    }
+
+    @Nested
+    @DisplayName("connect")
+    inner class Connect {
+
+        @Test
+        fun SSE_연결을_생성한다() {
+            val emitter = notificationSseService.connect(1L)
+
+            assertNotNull(emitter)
+            assertEquals(1, sseEmitterRepository.findByUserId(1L).size)
+        }
+
+        @Test
+        fun 같은_사용자가_여러_연결을_생성한다() {
+            notificationSseService.connect(1L)
+            notificationSseService.connect(1L)
+
+            assertEquals(2, sseEmitterRepository.findByUserId(1L).size)
+        }
+    }
+
+    @Nested
+    @DisplayName("subscribe")
+    inner class Subscribe {
+
+        @Test
+        fun Redis_채널을_구독한다() {
+            notificationSseService.subscribe()
+
+            verify(redisMessageListenerContainer).addMessageListener(
+                org.mockito.kotlin.eq(notificationSseService),
+                org.mockito.kotlin.eq(org.springframework.data.redis.listener.ChannelTopic(NotificationSseService.CHANNEL_NAME))
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("unsubscribe")
+    inner class Unsubscribe {
+
+        @Test
+        fun Redis_채널_구독을_해제한다() {
+            notificationSseService.unsubscribe()
+
+            verify(redisMessageListenerContainer).removeMessageListener(notificationSseService)
+        }
+    }
+
+    @Nested
+    @DisplayName("sendToUser")
+    inner class SendToUser {
+
+        @Test
+        fun 연결이_없는_사용자에게_전송해도_오류가_발생하지_않는다() {
+            val response = createNotificationResponse()
+
+            notificationSseService.sendToUser(999L, response)
+        }
+    }
+
+    @Nested
+    @DisplayName("onMessage")
+    inner class OnMessage {
+
+        @Test
+        fun Redis_메시지를_수신하여_SSE로_전달한다() {
+            val notification = createNotificationResponse()
+            val sseMessage = SseNotificationMessage(userId = 1L, notification = notification)
+            val json = objectMapper.writeValueAsString(sseMessage)
+
+            val emitter = SseEmitter(30000L)
+            sseEmitterRepository.save(1L, emitter)
+
+            val redisMessage = object : org.springframework.data.redis.connection.Message {
+                override fun getBody(): ByteArray = json.toByteArray()
+                override fun getChannel(): ByteArray = NotificationSseService.CHANNEL_NAME.toByteArray()
+            }
+
+            notificationSseService.onMessage(redisMessage, null)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/notification/service/SseEmitterRepositoryTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/notification/service/SseEmitterRepositoryTest.kt
@@ -1,0 +1,101 @@
+package com.hoppingmall.mall.notification.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+
+@DisplayName("SseEmitterRepository")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class SseEmitterRepositoryTest {
+
+    private lateinit var sseEmitterRepository: SseEmitterRepository
+
+    @BeforeEach
+    fun setUp() {
+        sseEmitterRepository = SseEmitterRepository()
+    }
+
+    @Nested
+    @DisplayName("save")
+    inner class Save {
+
+        @Test
+        fun Emitter를_저장한다() {
+            val emitter = SseEmitter()
+
+            val result = sseEmitterRepository.save(1L, emitter)
+
+            assertEquals(emitter, result)
+            assertEquals(1, sseEmitterRepository.findByUserId(1L).size)
+        }
+
+        @Test
+        fun 같은_사용자에_여러_Emitter를_저장한다() {
+            val emitter1 = SseEmitter()
+            val emitter2 = SseEmitter()
+
+            sseEmitterRepository.save(1L, emitter1)
+            sseEmitterRepository.save(1L, emitter2)
+
+            assertEquals(2, sseEmitterRepository.findByUserId(1L).size)
+        }
+    }
+
+    @Nested
+    @DisplayName("findByUserId")
+    inner class FindByUserId {
+
+        @Test
+        fun 사용자의_Emitter_목록을_조회한다() {
+            val emitter = SseEmitter()
+            sseEmitterRepository.save(1L, emitter)
+
+            val result = sseEmitterRepository.findByUserId(1L)
+
+            assertEquals(1, result.size)
+            assertEquals(emitter, result[0])
+        }
+
+        @Test
+        fun 존재하지_않는_사용자는_빈_목록을_반환한다() {
+            val result = sseEmitterRepository.findByUserId(999L)
+
+            assertTrue(result.isEmpty())
+        }
+    }
+
+    @Nested
+    @DisplayName("remove")
+    inner class Remove {
+
+        @Test
+        fun Emitter를_제거한다() {
+            val emitter = SseEmitter()
+            sseEmitterRepository.save(1L, emitter)
+
+            sseEmitterRepository.remove(1L, emitter)
+
+            assertTrue(sseEmitterRepository.findByUserId(1L).isEmpty())
+        }
+
+        @Test
+        fun 여러_Emitter_중_하나만_제거한다() {
+            val emitter1 = SseEmitter()
+            val emitter2 = SseEmitter()
+            sseEmitterRepository.save(1L, emitter1)
+            sseEmitterRepository.save(1L, emitter2)
+
+            sseEmitterRepository.remove(1L, emitter1)
+
+            val remaining = sseEmitterRepository.findByUserId(1L)
+            assertEquals(1, remaining.size)
+            assertEquals(emitter2, remaining[0])
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/support/IntegrationTestBase.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/IntegrationTestBase.kt
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
 import org.springframework.kafka.test.context.EmbeddedKafka
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
@@ -27,6 +28,9 @@ abstract class IntegrationTestBase {
 
     @MockBean
     protected lateinit var outboxEventService: OutboxEventService
+
+    @MockBean
+    protected lateinit var redisMessageListenerContainer: RedisMessageListenerContainer
 
     @Autowired
     protected lateinit var entityManager: EntityManager


### PR DESCRIPTION
Closes #147

### 📌 작업 개요
알림 발생 시 SSE(Server-Sent Events)를 통해 클라이언트에 실시간 푸시하고,
Redis Pub/Sub를 활용하여 멀티 인스턴스 환경에서도 알림 브로드캐스팅을 지원합니다.
MSA 전환 시에도 HTTP 기반 SSE는 API Gateway를 자연스럽게 통과할 수 있어 확장성이 좋습니다.

---

### ✅ 주요 변경 사항

- `notification.service`
  - `SseEmitterRepository`: ConcurrentHashMap 기반 userId별 SseEmitter 관리
  - `NotificationSseService`: Redis Pub/Sub MessageListener, SSE 연결/전송/구독 처리
  - `NotificationEventConsumer`: 알림 저장 후 Redis 채널로 SSE 이벤트 publish

- `notification.controller`
  - `NotificationController`: `GET /api/v1/notifications/subscribe` SSE 엔드포인트 추가

- `global.common.config`
  - `RedisConfig`: `RedisMessageListenerContainer` 빈 추가

---

### 🧪 테스트

- `SseEmitterRepositoryTest`: Emitter 저장/조회/제거 테스트
- `NotificationSseServiceTest`: SSE 연결, Redis 구독/해제, 메시지 수신 테스트
- `NotificationControllerTest`: SSE 구독 엔드포인트 테스트 추가
- `NotificationEventConsumerTest`: Redis publish 검증 추가
- 통합 테스트: `RedisMessageListenerContainer` MockBean 처리

---

### 📎 관련 이슈
- #147