### PR TITLE
feat: 정산 시스템 구현

### DIFF
--- a/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
@@ -90,6 +90,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/api/v1/inventories").hasRole("SELLER")
                 it.requestMatchers(HttpMethod.PATCH, "/api/v1/inventories/{productId}").hasRole("SELLER")
                 it.requestMatchers("/api/v1/seller/dashboard/**").hasRole("SELLER")
+                it.requestMatchers("/api/v1/seller/settlements/**").hasRole("SELLER")
                 it.requestMatchers(HttpMethod.POST, "/api/v1/files/upload").hasRole("SELLER")
                 it.requestMatchers(HttpMethod.POST, "/api/v1/shipping").hasRole("SELLER")
                 it.requestMatchers(HttpMethod.PATCH, "/api/v1/shipping/{shippingId}/status").hasRole("SELLER")

--- a/src/main/kotlin/com/hoppingmall/mall/order/domain/repository/OrderItemRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/order/domain/repository/OrderItemRepository.kt
@@ -6,12 +6,31 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 interface OrderItemRepository : JpaRepository<OrderItem, Long> {
     fun findByOrderId(orderId: Long): List<OrderItem>
 
     fun findByOrderIdIn(orderIds: List<Long>): List<OrderItem>
+
+    @Query(
+        value = """
+            SELECT oi.* FROM order_items oi
+            JOIN orders o ON oi.order_id = o.id
+            WHERE oi.seller_id = :sellerId
+              AND o.status = 'DELIVERED'
+              AND o.updated_at BETWEEN :startDate AND :endDate
+              AND oi.deleted_at IS NULL
+              AND o.deleted_at IS NULL
+        """,
+        nativeQuery = true
+    )
+    fun findDeliveredItemsBySellerAndPeriod(
+        @Param("sellerId") sellerId: Long,
+        @Param("startDate") startDate: LocalDateTime,
+        @Param("endDate") endDate: LocalDateTime
+    ): List<OrderItem>
 
     @Query(
         value = """

--- a/src/main/kotlin/com/hoppingmall/mall/refund/domain/repository/RefundRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/refund/domain/repository/RefundRepository.kt
@@ -6,10 +6,14 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 interface RefundRepository : JpaRepository<Refund, Long> {
     fun findByOrderIdAndStatusNot(orderId: Long, status: RefundStatus): List<Refund>
     fun findByBuyerId(buyerId: Long, pageable: Pageable): Page<Refund>
     fun findBySellerId(sellerId: Long, pageable: Pageable): Page<Refund>
+    fun findBySellerIdAndStatusAndCompletedAtBetween(
+        sellerId: Long, status: RefundStatus, startDate: LocalDateTime, endDate: LocalDateTime
+    ): List<Refund>
 }

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/controller/SettlementController.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/controller/SettlementController.kt
@@ -1,0 +1,93 @@
+package com.hoppingmall.mall.settlement.controller
+
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import com.hoppingmall.mall.global.common.response.ApiResponse
+import com.hoppingmall.mall.settlement.dto.request.CreateSettlementRequest
+import com.hoppingmall.mall.settlement.dto.response.SettlementDetailResponse
+import com.hoppingmall.mall.settlement.dto.response.SettlementResponse
+import com.hoppingmall.mall.settlement.enum.SettlementStatus
+import com.hoppingmall.mall.settlement.service.SettlementCommandService
+import com.hoppingmall.mall.settlement.service.SettlementQueryService
+import com.hoppingmall.mall.user.domain.repository.SellerRepository
+import com.hoppingmall.mall.user.exception.seller.SellerNotFoundException
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@Tag(name = "정산")
+class SettlementController(
+    private val settlementCommandService: SettlementCommandService,
+    private val settlementQueryService: SettlementQueryService,
+    private val sellerRepository: SellerRepository
+) {
+
+    @PostMapping("/api/v1/admin/settlements")
+    fun createSettlement(
+        @RequestBody request: CreateSettlementRequest
+    ): ResponseEntity<ApiResponse<SettlementResponse>> {
+        val result = settlementCommandService.createSettlement(request)
+        return ResponseEntity.ok(ApiResponse.success(result))
+    }
+
+    @PatchMapping("/api/v1/admin/settlements/{settlementId}/confirm")
+    fun confirmSettlement(
+        @PathVariable settlementId: Long
+    ): ResponseEntity<ApiResponse<SettlementResponse>> {
+        val result = settlementCommandService.confirmSettlement(settlementId)
+        return ResponseEntity.ok(ApiResponse.success(result))
+    }
+
+    @PatchMapping("/api/v1/admin/settlements/{settlementId}/pay")
+    fun paySettlement(
+        @PathVariable settlementId: Long
+    ): ResponseEntity<ApiResponse<SettlementResponse>> {
+        val result = settlementCommandService.paySettlement(settlementId)
+        return ResponseEntity.ok(ApiResponse.success(result))
+    }
+
+    @GetMapping("/api/v1/admin/settlements")
+    fun getSettlementsForAdmin(
+        @RequestParam(required = false) sellerId: Long?,
+        @RequestParam(required = false) status: SettlementStatus?,
+        @PageableDefault(size = 20, sort = ["createdAt"]) pageable: Pageable
+    ): ResponseEntity<ApiResponse<Page<SettlementResponse>>> {
+        val result = settlementQueryService.getSettlements(sellerId, status, pageable)
+        return ResponseEntity.ok(ApiResponse.success(result))
+    }
+
+    @GetMapping("/api/v1/admin/settlements/{settlementId}")
+    fun getSettlementDetailForAdmin(
+        @PathVariable settlementId: Long
+    ): ResponseEntity<ApiResponse<SettlementDetailResponse>> {
+        val result = settlementQueryService.getSettlementDetail(settlementId, null)
+        return ResponseEntity.ok(ApiResponse.success(result))
+    }
+
+    @GetMapping("/api/v1/seller/settlements")
+    fun getSettlementsForSeller(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @RequestParam(required = false) status: SettlementStatus?,
+        @PageableDefault(size = 20, sort = ["createdAt"]) pageable: Pageable
+    ): ResponseEntity<ApiResponse<Page<SettlementResponse>>> {
+        val seller = sellerRepository.findNullableByUserId(userPrincipal.getUserId())
+            ?: throw SellerNotFoundException()
+        val result = settlementQueryService.getSettlements(seller.id, status, pageable)
+        return ResponseEntity.ok(ApiResponse.success(result))
+    }
+
+    @GetMapping("/api/v1/seller/settlements/{settlementId}")
+    fun getSettlementDetailForSeller(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PathVariable settlementId: Long
+    ): ResponseEntity<ApiResponse<SettlementDetailResponse>> {
+        val seller = sellerRepository.findNullableByUserId(userPrincipal.getUserId())
+            ?: throw SellerNotFoundException()
+        val result = settlementQueryService.getSettlementDetail(settlementId, seller.id)
+        return ResponseEntity.ok(ApiResponse.success(result))
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/domain/Settlement.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/domain/Settlement.kt
@@ -1,0 +1,106 @@
+package com.hoppingmall.mall.settlement.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import com.hoppingmall.mall.settlement.enum.SettlementStatus
+import com.hoppingmall.mall.settlement.exception.SettlementInvalidStatusException
+import jakarta.persistence.*
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "settlements",
+    indexes = [
+        Index(name = "idx_settlements_seller_id", columnList = "sellerId"),
+        Index(name = "idx_settlements_status", columnList = "status")
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_settlements_seller_period", columnNames = ["sellerId", "periodStart", "periodEnd"])
+    ]
+)
+class Settlement private constructor(
+    @Column(nullable = false)
+    val sellerId: Long,
+
+    @Column(nullable = false)
+    val periodStart: LocalDate,
+
+    @Column(nullable = false)
+    val periodEnd: LocalDate,
+
+    @Column(nullable = false, precision = 12, scale = 2)
+    val totalSalesAmount: BigDecimal,
+
+    @Column(nullable = false, precision = 12, scale = 2)
+    val totalRefundAmount: BigDecimal,
+
+    @Column(nullable = false, precision = 5, scale = 4)
+    val commissionRate: BigDecimal,
+
+    @Column(nullable = false, precision = 12, scale = 2)
+    val commissionAmount: BigDecimal,
+
+    @Column(nullable = false, precision = 12, scale = 2)
+    val settlementAmount: BigDecimal,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var status: SettlementStatus = SettlementStatus.CALCULATED,
+
+    @Column
+    var confirmedAt: LocalDateTime? = null,
+
+    @Column
+    var paidAt: LocalDateTime? = null
+) : BaseEntity() {
+
+    companion object {
+        private val allowedTransitions: Map<SettlementStatus, Set<SettlementStatus>> = mapOf(
+            SettlementStatus.CALCULATED to setOf(SettlementStatus.CONFIRMED),
+            SettlementStatus.CONFIRMED to setOf(SettlementStatus.PAID),
+            SettlementStatus.PAID to emptySet()
+        )
+
+        fun create(
+            sellerId: Long,
+            periodStart: LocalDate,
+            periodEnd: LocalDate,
+            totalSalesAmount: BigDecimal,
+            totalRefundAmount: BigDecimal,
+            commissionRate: BigDecimal,
+            commissionAmount: BigDecimal,
+            settlementAmount: BigDecimal
+        ): Settlement {
+            return Settlement(
+                sellerId = sellerId,
+                periodStart = periodStart,
+                periodEnd = periodEnd,
+                totalSalesAmount = totalSalesAmount,
+                totalRefundAmount = totalRefundAmount,
+                commissionRate = commissionRate,
+                commissionAmount = commissionAmount,
+                settlementAmount = settlementAmount
+            )
+        }
+    }
+
+    fun confirm() {
+        validateTransition(SettlementStatus.CONFIRMED)
+        this.status = SettlementStatus.CONFIRMED
+        this.confirmedAt = LocalDateTime.now()
+    }
+
+    fun pay() {
+        validateTransition(SettlementStatus.PAID)
+        this.status = SettlementStatus.PAID
+        this.paidAt = LocalDateTime.now()
+    }
+
+    private fun validateTransition(newStatus: SettlementStatus) {
+        val allowed = allowedTransitions[this.status] ?: emptySet()
+        if (newStatus !in allowed) {
+            throw SettlementInvalidStatusException()
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/domain/SettlementItem.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/domain/SettlementItem.kt
@@ -1,0 +1,57 @@
+package com.hoppingmall.mall.settlement.domain
+
+import com.hoppingmall.mall.global.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.math.BigDecimal
+
+@Entity
+@Table(
+    name = "settlement_items",
+    indexes = [
+        Index(name = "idx_settlement_items_settlement_id", columnList = "settlementId"),
+        Index(name = "idx_settlement_items_order_id", columnList = "orderId")
+    ]
+)
+class SettlementItem private constructor(
+    @Column(nullable = false)
+    val settlementId: Long,
+
+    @Column(nullable = false)
+    val orderId: Long,
+
+    @Column(nullable = false)
+    val orderItemId: Long,
+
+    @Column(nullable = false)
+    val productName: String,
+
+    @Column(nullable = false)
+    val quantity: Int,
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    val salesAmount: BigDecimal
+) : BaseEntity() {
+
+    companion object {
+        fun create(
+            settlementId: Long,
+            orderId: Long,
+            orderItemId: Long,
+            productName: String,
+            quantity: Int,
+            salesAmount: BigDecimal
+        ): SettlementItem {
+            return SettlementItem(
+                settlementId = settlementId,
+                orderId = orderId,
+                orderItemId = orderItemId,
+                productName = productName,
+                quantity = quantity,
+                salesAmount = salesAmount
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/domain/repository/SettlementItemRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/domain/repository/SettlementItemRepository.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.mall.settlement.domain.repository
+
+import com.hoppingmall.mall.settlement.domain.SettlementItem
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface SettlementItemRepository : JpaRepository<SettlementItem, Long> {
+    fun findBySettlementId(settlementId: Long): List<SettlementItem>
+}

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/domain/repository/SettlementRepository.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/domain/repository/SettlementRepository.kt
@@ -1,0 +1,17 @@
+package com.hoppingmall.mall.settlement.domain.repository
+
+import com.hoppingmall.mall.settlement.domain.Settlement
+import com.hoppingmall.mall.settlement.enum.SettlementStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+interface SettlementRepository : JpaRepository<Settlement, Long> {
+    fun existsBySellerIdAndPeriodStartAndPeriodEnd(sellerId: Long, periodStart: LocalDate, periodEnd: LocalDate): Boolean
+    fun findBySellerId(sellerId: Long, pageable: Pageable): Page<Settlement>
+    fun findBySellerIdAndStatus(sellerId: Long, status: SettlementStatus, pageable: Pageable): Page<Settlement>
+    fun findByStatus(status: SettlementStatus, pageable: Pageable): Page<Settlement>
+}

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/dto/request/CreateSettlementRequest.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/dto/request/CreateSettlementRequest.kt
@@ -1,0 +1,11 @@
+package com.hoppingmall.mall.settlement.dto.request
+
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class CreateSettlementRequest(
+    val sellerId: Long,
+    val periodStart: LocalDate,
+    val periodEnd: LocalDate,
+    val commissionRate: BigDecimal
+)

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/dto/response/SettlementDetailResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/dto/response/SettlementDetailResponse.kt
@@ -1,0 +1,68 @@
+package com.hoppingmall.mall.settlement.dto.response
+
+import com.hoppingmall.mall.settlement.domain.Settlement
+import com.hoppingmall.mall.settlement.domain.SettlementItem
+import com.hoppingmall.mall.settlement.enum.SettlementStatus
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class SettlementDetailResponse(
+    val id: Long,
+    val sellerId: Long,
+    val periodStart: LocalDate,
+    val periodEnd: LocalDate,
+    val totalSalesAmount: BigDecimal,
+    val totalRefundAmount: BigDecimal,
+    val commissionRate: BigDecimal,
+    val commissionAmount: BigDecimal,
+    val settlementAmount: BigDecimal,
+    val status: SettlementStatus,
+    val confirmedAt: LocalDateTime?,
+    val paidAt: LocalDateTime?,
+    val createdAt: LocalDateTime,
+    val items: List<SettlementItemResponse>
+) {
+    companion object {
+        fun from(settlement: Settlement, items: List<SettlementItem>): SettlementDetailResponse {
+            return SettlementDetailResponse(
+                id = settlement.id!!,
+                sellerId = settlement.sellerId,
+                periodStart = settlement.periodStart,
+                periodEnd = settlement.periodEnd,
+                totalSalesAmount = settlement.totalSalesAmount,
+                totalRefundAmount = settlement.totalRefundAmount,
+                commissionRate = settlement.commissionRate,
+                commissionAmount = settlement.commissionAmount,
+                settlementAmount = settlement.settlementAmount,
+                status = settlement.status,
+                confirmedAt = settlement.confirmedAt,
+                paidAt = settlement.paidAt,
+                createdAt = settlement.createdAt,
+                items = items.map { SettlementItemResponse.from(it) }
+            )
+        }
+    }
+}
+
+data class SettlementItemResponse(
+    val id: Long,
+    val orderId: Long,
+    val orderItemId: Long,
+    val productName: String,
+    val quantity: Int,
+    val salesAmount: BigDecimal
+) {
+    companion object {
+        fun from(item: SettlementItem): SettlementItemResponse {
+            return SettlementItemResponse(
+                id = item.id!!,
+                orderId = item.orderId,
+                orderItemId = item.orderItemId,
+                productName = item.productName,
+                quantity = item.quantity,
+                salesAmount = item.salesAmount
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/dto/response/SettlementResponse.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/dto/response/SettlementResponse.kt
@@ -1,0 +1,43 @@
+package com.hoppingmall.mall.settlement.dto.response
+
+import com.hoppingmall.mall.settlement.domain.Settlement
+import com.hoppingmall.mall.settlement.enum.SettlementStatus
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class SettlementResponse(
+    val id: Long,
+    val sellerId: Long,
+    val periodStart: LocalDate,
+    val periodEnd: LocalDate,
+    val totalSalesAmount: BigDecimal,
+    val totalRefundAmount: BigDecimal,
+    val commissionRate: BigDecimal,
+    val commissionAmount: BigDecimal,
+    val settlementAmount: BigDecimal,
+    val status: SettlementStatus,
+    val confirmedAt: LocalDateTime?,
+    val paidAt: LocalDateTime?,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(settlement: Settlement): SettlementResponse {
+            return SettlementResponse(
+                id = settlement.id!!,
+                sellerId = settlement.sellerId,
+                periodStart = settlement.periodStart,
+                periodEnd = settlement.periodEnd,
+                totalSalesAmount = settlement.totalSalesAmount,
+                totalRefundAmount = settlement.totalRefundAmount,
+                commissionRate = settlement.commissionRate,
+                commissionAmount = settlement.commissionAmount,
+                settlementAmount = settlement.settlementAmount,
+                status = settlement.status,
+                confirmedAt = settlement.confirmedAt,
+                paidAt = settlement.paidAt,
+                createdAt = settlement.createdAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/enum/SettlementStatus.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/enum/SettlementStatus.kt
@@ -1,0 +1,7 @@
+package com.hoppingmall.mall.settlement.enum
+
+enum class SettlementStatus {
+    CALCULATED,
+    CONFIRMED,
+    PAID
+}

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/exception/SettlementAccessDeniedException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/exception/SettlementAccessDeniedException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.settlement.exception
+
+import com.hoppingmall.mall.settlement.exception.code.SettlementErrorCode
+
+class SettlementAccessDeniedException : SettlementException(SettlementErrorCode.SETTLEMENT_ACCESS_DENIED)

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/exception/SettlementAlreadyExistsException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/exception/SettlementAlreadyExistsException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.settlement.exception
+
+import com.hoppingmall.mall.settlement.exception.code.SettlementErrorCode
+
+class SettlementAlreadyExistsException : SettlementException(SettlementErrorCode.SETTLEMENT_ALREADY_EXISTS)

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/exception/SettlementException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/exception/SettlementException.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.mall.settlement.exception
+
+import com.hoppingmall.mall.global.common.error.exception.BusinessException
+import com.hoppingmall.mall.settlement.exception.code.SettlementErrorCode
+
+open class SettlementException(
+    errorCode: SettlementErrorCode
+) : BusinessException(errorCode)

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/exception/SettlementInvalidPeriodException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/exception/SettlementInvalidPeriodException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.settlement.exception
+
+import com.hoppingmall.mall.settlement.exception.code.SettlementErrorCode
+
+class SettlementInvalidPeriodException : SettlementException(SettlementErrorCode.SETTLEMENT_INVALID_PERIOD)

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/exception/SettlementInvalidStatusException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/exception/SettlementInvalidStatusException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.settlement.exception
+
+import com.hoppingmall.mall.settlement.exception.code.SettlementErrorCode
+
+class SettlementInvalidStatusException : SettlementException(SettlementErrorCode.SETTLEMENT_INVALID_STATUS)

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/exception/SettlementNoSalesDataException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/exception/SettlementNoSalesDataException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.settlement.exception
+
+import com.hoppingmall.mall.settlement.exception.code.SettlementErrorCode
+
+class SettlementNoSalesDataException : SettlementException(SettlementErrorCode.SETTLEMENT_NO_SALES_DATA)

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/exception/SettlementNotFoundException.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/exception/SettlementNotFoundException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.mall.settlement.exception
+
+import com.hoppingmall.mall.settlement.exception.code.SettlementErrorCode
+
+class SettlementNotFoundException : SettlementException(SettlementErrorCode.SETTLEMENT_NOT_FOUND)

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/exception/code/SettlementErrorCode.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/exception/code/SettlementErrorCode.kt
@@ -1,0 +1,17 @@
+package com.hoppingmall.mall.settlement.exception.code
+
+import com.hoppingmall.mall.global.common.error.code.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class SettlementErrorCode(
+    override val code: String,
+    override val message: String,
+    override val status: HttpStatus
+) : ErrorCode {
+    SETTLEMENT_NOT_FOUND("STL001", "정산 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    SETTLEMENT_INVALID_STATUS("STL002", "정산 상태가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    SETTLEMENT_ALREADY_EXISTS("STL003", "해당 기간의 정산이 이미 존재합니다.", HttpStatus.CONFLICT),
+    SETTLEMENT_INVALID_PERIOD("STL004", "정산 기간이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    SETTLEMENT_ACCESS_DENIED("STL005", "정산에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    SETTLEMENT_NO_SALES_DATA("STL006", "해당 기간에 정산할 매출 데이터가 없습니다.", HttpStatus.BAD_REQUEST)
+}

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/service/SettlementCommandService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/service/SettlementCommandService.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.mall.settlement.service
+
+import com.hoppingmall.mall.settlement.dto.request.CreateSettlementRequest
+import com.hoppingmall.mall.settlement.dto.response.SettlementResponse
+
+interface SettlementCommandService {
+    fun createSettlement(request: CreateSettlementRequest): SettlementResponse
+    fun confirmSettlement(settlementId: Long): SettlementResponse
+    fun paySettlement(settlementId: Long): SettlementResponse
+}

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/service/SettlementCommandServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/service/SettlementCommandServiceImpl.kt
@@ -1,0 +1,105 @@
+package com.hoppingmall.mall.settlement.service
+
+import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
+import com.hoppingmall.mall.refund.domain.repository.RefundRepository
+import com.hoppingmall.mall.refund.enum.RefundStatus
+import com.hoppingmall.mall.settlement.domain.Settlement
+import com.hoppingmall.mall.settlement.domain.SettlementItem
+import com.hoppingmall.mall.settlement.domain.repository.SettlementItemRepository
+import com.hoppingmall.mall.settlement.domain.repository.SettlementRepository
+import com.hoppingmall.mall.settlement.dto.request.CreateSettlementRequest
+import com.hoppingmall.mall.settlement.dto.response.SettlementResponse
+import com.hoppingmall.mall.settlement.exception.SettlementAlreadyExistsException
+import com.hoppingmall.mall.settlement.exception.SettlementInvalidPeriodException
+import com.hoppingmall.mall.settlement.exception.SettlementNoSalesDataException
+import com.hoppingmall.mall.settlement.exception.SettlementNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@Service
+@Transactional
+class SettlementCommandServiceImpl(
+    private val settlementRepository: SettlementRepository,
+    private val settlementItemRepository: SettlementItemRepository,
+    private val orderItemRepository: OrderItemRepository,
+    private val refundRepository: RefundRepository
+) : SettlementCommandService {
+
+    override fun createSettlement(request: CreateSettlementRequest): SettlementResponse {
+        if (request.periodEnd.isBefore(request.periodStart)) {
+            throw SettlementInvalidPeriodException()
+        }
+
+        if (settlementRepository.existsBySellerIdAndPeriodStartAndPeriodEnd(
+                request.sellerId, request.periodStart, request.periodEnd
+            )
+        ) {
+            throw SettlementAlreadyExistsException()
+        }
+
+        val startDateTime = request.periodStart.atStartOfDay()
+        val endDateTime = request.periodEnd.plusDays(1).atStartOfDay()
+
+        val orderItems = orderItemRepository.findDeliveredItemsBySellerAndPeriod(
+            request.sellerId, startDateTime, endDateTime
+        )
+
+        if (orderItems.isEmpty()) {
+            throw SettlementNoSalesDataException()
+        }
+
+        val totalSalesAmount = orderItems.sumOf { it.totalPrice }
+
+        val refunds = refundRepository.findBySellerIdAndStatusAndCompletedAtBetween(
+            request.sellerId, RefundStatus.COMPLETED, startDateTime, endDateTime
+        )
+        val totalRefundAmount = refunds.sumOf { it.refundAmount }
+
+        val commissionAmount = totalSalesAmount.multiply(request.commissionRate)
+            .setScale(2, RoundingMode.HALF_UP)
+        val settlementAmount = totalSalesAmount.subtract(totalRefundAmount).subtract(commissionAmount)
+
+        val settlement = settlementRepository.save(
+            Settlement.create(
+                sellerId = request.sellerId,
+                periodStart = request.periodStart,
+                periodEnd = request.periodEnd,
+                totalSalesAmount = totalSalesAmount,
+                totalRefundAmount = totalRefundAmount,
+                commissionRate = request.commissionRate,
+                commissionAmount = commissionAmount,
+                settlementAmount = settlementAmount
+            )
+        )
+
+        val settlementItems = orderItems.map { orderItem ->
+            SettlementItem.create(
+                settlementId = settlement.id!!,
+                orderId = orderItem.orderId,
+                orderItemId = orderItem.id!!,
+                productName = orderItem.productName,
+                quantity = orderItem.quantity,
+                salesAmount = orderItem.totalPrice
+            )
+        }
+        settlementItemRepository.saveAll(settlementItems)
+
+        return SettlementResponse.from(settlement)
+    }
+
+    override fun confirmSettlement(settlementId: Long): SettlementResponse {
+        val settlement = settlementRepository.findById(settlementId)
+            .orElseThrow { SettlementNotFoundException() }
+        settlement.confirm()
+        return SettlementResponse.from(settlement)
+    }
+
+    override fun paySettlement(settlementId: Long): SettlementResponse {
+        val settlement = settlementRepository.findById(settlementId)
+            .orElseThrow { SettlementNotFoundException() }
+        settlement.pay()
+        return SettlementResponse.from(settlement)
+    }
+}

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/service/SettlementQueryService.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/service/SettlementQueryService.kt
@@ -1,0 +1,12 @@
+package com.hoppingmall.mall.settlement.service
+
+import com.hoppingmall.mall.settlement.dto.response.SettlementDetailResponse
+import com.hoppingmall.mall.settlement.dto.response.SettlementResponse
+import com.hoppingmall.mall.settlement.enum.SettlementStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface SettlementQueryService {
+    fun getSettlements(sellerId: Long?, status: SettlementStatus?, pageable: Pageable): Page<SettlementResponse>
+    fun getSettlementDetail(settlementId: Long, sellerId: Long?): SettlementDetailResponse
+}

--- a/src/main/kotlin/com/hoppingmall/mall/settlement/service/SettlementQueryServiceImpl.kt
+++ b/src/main/kotlin/com/hoppingmall/mall/settlement/service/SettlementQueryServiceImpl.kt
@@ -1,0 +1,51 @@
+package com.hoppingmall.mall.settlement.service
+
+import com.hoppingmall.mall.settlement.domain.repository.SettlementItemRepository
+import com.hoppingmall.mall.settlement.domain.repository.SettlementRepository
+import com.hoppingmall.mall.settlement.dto.response.SettlementDetailResponse
+import com.hoppingmall.mall.settlement.dto.response.SettlementResponse
+import com.hoppingmall.mall.settlement.enum.SettlementStatus
+import com.hoppingmall.mall.settlement.exception.SettlementAccessDeniedException
+import com.hoppingmall.mall.settlement.exception.SettlementNotFoundException
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class SettlementQueryServiceImpl(
+    private val settlementRepository: SettlementRepository,
+    private val settlementItemRepository: SettlementItemRepository
+) : SettlementQueryService {
+
+    override fun getSettlements(
+        sellerId: Long?,
+        status: SettlementStatus?,
+        pageable: Pageable
+    ): Page<SettlementResponse> {
+        val settlements = when {
+            sellerId != null && status != null ->
+                settlementRepository.findBySellerIdAndStatus(sellerId, status, pageable)
+            sellerId != null ->
+                settlementRepository.findBySellerId(sellerId, pageable)
+            status != null ->
+                settlementRepository.findByStatus(status, pageable)
+            else ->
+                settlementRepository.findAll(pageable)
+        }
+        return settlements.map { SettlementResponse.from(it) }
+    }
+
+    override fun getSettlementDetail(settlementId: Long, sellerId: Long?): SettlementDetailResponse {
+        val settlement = settlementRepository.findById(settlementId)
+            .orElseThrow { SettlementNotFoundException() }
+
+        if (sellerId != null && settlement.sellerId != sellerId) {
+            throw SettlementAccessDeniedException()
+        }
+
+        val items = settlementItemRepository.findBySettlementId(settlementId)
+        return SettlementDetailResponse.from(settlement, items)
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/settlement/controller/SettlementControllerTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/settlement/controller/SettlementControllerTest.kt
@@ -1,0 +1,158 @@
+package com.hoppingmall.mall.settlement.controller
+
+import com.hoppingmall.mall.global.auth.UserPrincipal
+import com.hoppingmall.mall.settlement.domain.Settlement
+import com.hoppingmall.mall.settlement.domain.SettlementItem
+import com.hoppingmall.mall.settlement.dto.request.CreateSettlementRequest
+import com.hoppingmall.mall.settlement.dto.response.SettlementDetailResponse
+import com.hoppingmall.mall.settlement.dto.response.SettlementResponse
+import com.hoppingmall.mall.settlement.enum.SettlementStatus
+import com.hoppingmall.mall.settlement.service.SettlementCommandService
+import com.hoppingmall.mall.settlement.service.SettlementQueryService
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
+import com.hoppingmall.mall.user.domain.Seller
+import com.hoppingmall.mall.user.domain.repository.SellerRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.http.HttpStatus
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@DisplayName("SettlementController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class SettlementControllerTest {
+
+    private val settlementCommandService: SettlementCommandService = mock()
+    private val settlementQueryService: SettlementQueryService = mock()
+    private val sellerRepository: SellerRepository = mock()
+    private val controller = SettlementController(
+        settlementCommandService, settlementQueryService, sellerRepository
+    )
+
+    private val adminPrincipal = UserPrincipal(1L, "admin@example.com", "ADMIN")
+    private val sellerPrincipal = UserPrincipal(2L, "seller@example.com", "SELLER")
+
+    private fun createSettlementResponse(): SettlementResponse {
+        val settlement = Settlement.fixture(sellerId = 1L).withId(1L)
+        return SettlementResponse.from(settlement)
+    }
+
+    @Nested
+    @DisplayName("createSettlement")
+    inner class CreateSettlement {
+
+        @Test
+        fun 정산을_생성한다() {
+            val request = CreateSettlementRequest(
+                sellerId = 1L,
+                periodStart = LocalDate.of(2026, 3, 1),
+                periodEnd = LocalDate.of(2026, 3, 31),
+                commissionRate = BigDecimal("0.10")
+            )
+            whenever(settlementCommandService.createSettlement(any())).thenReturn(createSettlementResponse())
+
+            val response = controller.createSettlement(request)
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals("SUCCESS", response.body?.code)
+        }
+    }
+
+    @Nested
+    @DisplayName("confirmSettlement")
+    inner class ConfirmSettlement {
+
+        @Test
+        fun 정산을_확정한다() {
+            whenever(settlementCommandService.confirmSettlement(1L)).thenReturn(createSettlementResponse())
+
+            val response = controller.confirmSettlement(1L)
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("paySettlement")
+    inner class PaySettlement {
+
+        @Test
+        fun 정산을_지급_처리한다() {
+            whenever(settlementCommandService.paySettlement(1L)).thenReturn(createSettlementResponse())
+
+            val response = controller.paySettlement(1L)
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("getSettlementsForAdmin")
+    inner class GetSettlementsForAdmin {
+
+        @Test
+        fun 관리자가_정산_목록을_조회한다() {
+            val pageable = PageRequest.of(0, 20)
+            whenever(settlementQueryService.getSettlements(eq(null), eq(null), any()))
+                .thenReturn(PageImpl(listOf(createSettlementResponse())))
+
+            val response = controller.getSettlementsForAdmin(null, null, pageable)
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals(1, response.body?.data?.totalElements)
+        }
+    }
+
+    @Nested
+    @DisplayName("getSettlementsForSeller")
+    inner class GetSettlementsForSeller {
+
+        @Test
+        fun 판매자가_본인_정산_목록을_조회한다() {
+            val seller = mock<Seller>()
+            whenever(seller.id).thenReturn(10L)
+            whenever(sellerRepository.findNullableByUserId(2L)).thenReturn(seller)
+
+            val pageable = PageRequest.of(0, 20)
+            whenever(settlementQueryService.getSettlements(eq(10L), eq(null), any()))
+                .thenReturn(PageImpl(listOf(createSettlementResponse())))
+
+            val response = controller.getSettlementsForSeller(sellerPrincipal, null, pageable)
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("getSettlementDetailForSeller")
+    inner class GetSettlementDetailForSeller {
+
+        @Test
+        fun 판매자가_정산_상세를_조회한다() {
+            val seller = mock<Seller>()
+            whenever(seller.id).thenReturn(10L)
+            whenever(sellerRepository.findNullableByUserId(2L)).thenReturn(seller)
+
+            val settlement = Settlement.fixture(sellerId = 10L).withId(1L)
+            val item = SettlementItem.fixture(settlementId = 1L).withId(1L)
+            val detail = SettlementDetailResponse.from(settlement, listOf(item))
+            whenever(settlementQueryService.getSettlementDetail(eq(1L), eq(10L))).thenReturn(detail)
+
+            val response = controller.getSettlementDetailForSeller(sellerPrincipal, 1L)
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals(1, response.body?.data?.items?.size)
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/settlement/service/SettlementCommandServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/settlement/service/SettlementCommandServiceImplTest.kt
@@ -1,0 +1,230 @@
+package com.hoppingmall.mall.settlement.service
+
+import com.hoppingmall.mall.order.domain.OrderItem
+import com.hoppingmall.mall.order.domain.repository.OrderItemRepository
+import com.hoppingmall.mall.refund.domain.Refund
+import com.hoppingmall.mall.refund.domain.repository.RefundRepository
+import com.hoppingmall.mall.refund.enum.RefundReason
+import com.hoppingmall.mall.refund.enum.RefundStatus
+import com.hoppingmall.mall.settlement.domain.Settlement
+import com.hoppingmall.mall.settlement.domain.SettlementItem
+import com.hoppingmall.mall.settlement.domain.repository.SettlementItemRepository
+import com.hoppingmall.mall.settlement.domain.repository.SettlementRepository
+import com.hoppingmall.mall.settlement.dto.request.CreateSettlementRequest
+import com.hoppingmall.mall.settlement.enum.SettlementStatus
+import com.hoppingmall.mall.settlement.exception.SettlementAlreadyExistsException
+import com.hoppingmall.mall.settlement.exception.SettlementInvalidPeriodException
+import com.hoppingmall.mall.settlement.exception.SettlementInvalidStatusException
+import com.hoppingmall.mall.settlement.exception.SettlementNoSalesDataException
+import com.hoppingmall.mall.settlement.exception.SettlementNotFoundException
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+@DisplayName("SettlementCommandServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class SettlementCommandServiceImplTest {
+
+    private val settlementRepository: SettlementRepository = mock()
+    private val settlementItemRepository: SettlementItemRepository = mock()
+    private val orderItemRepository: OrderItemRepository = mock()
+    private val refundRepository: RefundRepository = mock()
+    private val service = SettlementCommandServiceImpl(
+        settlementRepository, settlementItemRepository, orderItemRepository, refundRepository
+    )
+
+    @Nested
+    @DisplayName("createSettlement")
+    inner class CreateSettlement {
+
+        private val request = CreateSettlementRequest(
+            sellerId = 1L,
+            periodStart = LocalDate.of(2026, 3, 1),
+            periodEnd = LocalDate.of(2026, 3, 31),
+            commissionRate = BigDecimal("0.10")
+        )
+
+        @Test
+        fun 정산을_생성한다() {
+            whenever(settlementRepository.existsBySellerIdAndPeriodStartAndPeriodEnd(
+                request.sellerId, request.periodStart, request.periodEnd
+            )).thenReturn(false)
+
+            val orderItem = OrderItem.create(
+                orderId = 1L, sellerId = 1L, productId = 10L,
+                productName = "테스트 상품", productPrice = BigDecimal("50000"), quantity = 2
+            ).withId(1L)
+
+            whenever(orderItemRepository.findDeliveredItemsBySellerAndPeriod(
+                any(), any(), any()
+            )).thenReturn(listOf(orderItem))
+
+            whenever(refundRepository.findBySellerIdAndStatusAndCompletedAtBetween(
+                any(), any(), any(), any()
+            )).thenReturn(emptyList())
+
+            whenever(settlementRepository.save(any<Settlement>())).thenAnswer { invocation ->
+                (invocation.arguments[0] as Settlement).withId(1L)
+            }
+
+            val result = service.createSettlement(request)
+
+            assertEquals(1L, result.sellerId)
+            assertEquals(BigDecimal("100000"), result.totalSalesAmount)
+            assertEquals(BigDecimal.ZERO, result.totalRefundAmount)
+            assertEquals(BigDecimal("10000.00"), result.commissionAmount)
+            assertEquals(BigDecimal("90000.00"), result.settlementAmount)
+            assertEquals(SettlementStatus.CALCULATED, result.status)
+            verify(settlementItemRepository).saveAll(any<List<SettlementItem>>())
+        }
+
+        @Test
+        fun 환불_금액을_차감하여_정산한다() {
+            whenever(settlementRepository.existsBySellerIdAndPeriodStartAndPeriodEnd(
+                request.sellerId, request.periodStart, request.periodEnd
+            )).thenReturn(false)
+
+            val orderItem = OrderItem.create(
+                orderId = 1L, sellerId = 1L, productId = 10L,
+                productName = "테스트 상품", productPrice = BigDecimal("50000"), quantity = 2
+            ).withId(1L)
+
+            whenever(orderItemRepository.findDeliveredItemsBySellerAndPeriod(
+                any(), any(), any()
+            )).thenReturn(listOf(orderItem))
+
+            val refund = Refund.create(
+                orderId = 1L, paymentId = 1L, buyerId = 2L, sellerId = 1L,
+                reason = RefundReason.CHANGE_OF_MIND, reasonDetail = null,
+                refundAmount = BigDecimal("20000"), isFullRefund = false
+            )
+
+            whenever(refundRepository.findBySellerIdAndStatusAndCompletedAtBetween(
+                any(), any(), any(), any()
+            )).thenReturn(listOf(refund))
+
+            whenever(settlementRepository.save(any<Settlement>())).thenAnswer { invocation ->
+                (invocation.arguments[0] as Settlement).withId(1L)
+            }
+
+            val result = service.createSettlement(request)
+
+            assertEquals(BigDecimal("100000"), result.totalSalesAmount)
+            assertEquals(BigDecimal("20000"), result.totalRefundAmount)
+            assertEquals(BigDecimal("10000.00"), result.commissionAmount)
+            assertEquals(BigDecimal("70000.00"), result.settlementAmount)
+        }
+
+        @Test
+        fun 기간이_잘못되면_예외가_발생한다() {
+            val invalidRequest = request.copy(
+                periodStart = LocalDate.of(2026, 3, 31),
+                periodEnd = LocalDate.of(2026, 3, 1)
+            )
+
+            assertThrows<SettlementInvalidPeriodException> {
+                service.createSettlement(invalidRequest)
+            }
+        }
+
+        @Test
+        fun 이미_존재하는_정산이면_예외가_발생한다() {
+            whenever(settlementRepository.existsBySellerIdAndPeriodStartAndPeriodEnd(
+                request.sellerId, request.periodStart, request.periodEnd
+            )).thenReturn(true)
+
+            assertThrows<SettlementAlreadyExistsException> {
+                service.createSettlement(request)
+            }
+        }
+
+        @Test
+        fun 매출_데이터가_없으면_예외가_발생한다() {
+            whenever(settlementRepository.existsBySellerIdAndPeriodStartAndPeriodEnd(
+                request.sellerId, request.periodStart, request.periodEnd
+            )).thenReturn(false)
+
+            whenever(orderItemRepository.findDeliveredItemsBySellerAndPeriod(
+                any(), any(), any()
+            )).thenReturn(emptyList())
+
+            assertThrows<SettlementNoSalesDataException> {
+                service.createSettlement(request)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("confirmSettlement")
+    inner class ConfirmSettlement {
+
+        @Test
+        fun 정산을_확정한다() {
+            val settlement = Settlement.fixture().withId(1L)
+            whenever(settlementRepository.findById(1L)).thenReturn(Optional.of(settlement))
+
+            val result = service.confirmSettlement(1L)
+
+            assertEquals(SettlementStatus.CONFIRMED, result.status)
+        }
+
+        @Test
+        fun 존재하지_않는_정산이면_예외가_발생한다() {
+            whenever(settlementRepository.findById(1L)).thenReturn(Optional.empty())
+
+            assertThrows<SettlementNotFoundException> {
+                service.confirmSettlement(1L)
+            }
+        }
+
+        @Test
+        fun 이미_확정된_정산은_다시_확정할_수_없다() {
+            val settlement = Settlement.fixture().withId(1L)
+            settlement.confirm()
+            whenever(settlementRepository.findById(1L)).thenReturn(Optional.of(settlement))
+
+            assertThrows<SettlementInvalidStatusException> {
+                service.confirmSettlement(1L)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("paySettlement")
+    inner class PaySettlement {
+
+        @Test
+        fun 정산_지급을_처리한다() {
+            val settlement = Settlement.fixture().withId(1L)
+            settlement.confirm()
+            whenever(settlementRepository.findById(1L)).thenReturn(Optional.of(settlement))
+
+            val result = service.paySettlement(1L)
+
+            assertEquals(SettlementStatus.PAID, result.status)
+        }
+
+        @Test
+        fun 확정되지_않은_정산은_지급할_수_없다() {
+            val settlement = Settlement.fixture().withId(1L)
+            whenever(settlementRepository.findById(1L)).thenReturn(Optional.of(settlement))
+
+            assertThrows<SettlementInvalidStatusException> {
+                service.paySettlement(1L)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/settlement/service/SettlementQueryServiceImplTest.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/settlement/service/SettlementQueryServiceImplTest.kt
@@ -1,0 +1,123 @@
+package com.hoppingmall.mall.settlement.service
+
+import com.hoppingmall.mall.settlement.domain.SettlementItem
+import com.hoppingmall.mall.settlement.domain.repository.SettlementItemRepository
+import com.hoppingmall.mall.settlement.domain.repository.SettlementRepository
+import com.hoppingmall.mall.settlement.enum.SettlementStatus
+import com.hoppingmall.mall.settlement.exception.SettlementAccessDeniedException
+import com.hoppingmall.mall.settlement.exception.SettlementNotFoundException
+import com.hoppingmall.mall.support.fixture.fixture
+import com.hoppingmall.mall.support.withId
+import com.hoppingmall.mall.settlement.domain.Settlement
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.math.BigDecimal
+import java.util.Optional
+
+@DisplayName("SettlementQueryServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class SettlementQueryServiceImplTest {
+
+    private val settlementRepository: SettlementRepository = mock()
+    private val settlementItemRepository: SettlementItemRepository = mock()
+    private val service = SettlementQueryServiceImpl(settlementRepository, settlementItemRepository)
+
+    private val pageable = PageRequest.of(0, 20)
+
+    @Nested
+    @DisplayName("getSettlements")
+    inner class GetSettlements {
+
+        @Test
+        fun 판매자별_정산_목록을_조회한다() {
+            val settlement = Settlement.fixture(sellerId = 1L).withId(1L)
+            whenever(settlementRepository.findBySellerId(any(), any()))
+                .thenReturn(PageImpl(listOf(settlement)))
+
+            val result = service.getSettlements(sellerId = 1L, status = null, pageable = pageable)
+
+            assertEquals(1, result.totalElements)
+            assertEquals(1L, result.content[0].sellerId)
+        }
+
+        @Test
+        fun 상태별_정산_목록을_조회한다() {
+            val settlement = Settlement.fixture().withId(1L)
+            whenever(settlementRepository.findByStatus(any(), any()))
+                .thenReturn(PageImpl(listOf(settlement)))
+
+            val result = service.getSettlements(sellerId = null, status = SettlementStatus.CALCULATED, pageable = pageable)
+
+            assertEquals(1, result.totalElements)
+        }
+
+        @Test
+        fun 판매자_및_상태별_정산_목록을_조회한다() {
+            val settlement = Settlement.fixture(sellerId = 1L).withId(1L)
+            whenever(settlementRepository.findBySellerIdAndStatus(any(), any(), any()))
+                .thenReturn(PageImpl(listOf(settlement)))
+
+            val result = service.getSettlements(sellerId = 1L, status = SettlementStatus.CALCULATED, pageable = pageable)
+
+            assertEquals(1, result.totalElements)
+        }
+
+        @Test
+        fun 전체_정산_목록을_조회한다() {
+            whenever(settlementRepository.findAll(pageable))
+                .thenReturn(PageImpl(emptyList()))
+
+            val result = service.getSettlements(sellerId = null, status = null, pageable = pageable)
+
+            assertEquals(0, result.totalElements)
+        }
+    }
+
+    @Nested
+    @DisplayName("getSettlementDetail")
+    inner class GetSettlementDetail {
+
+        @Test
+        fun 정산_상세를_조회한다() {
+            val settlement = Settlement.fixture(sellerId = 1L).withId(1L)
+            val item = SettlementItem.fixture(settlementId = 1L).withId(1L)
+
+            whenever(settlementRepository.findById(1L)).thenReturn(Optional.of(settlement))
+            whenever(settlementItemRepository.findBySettlementId(1L)).thenReturn(listOf(item))
+
+            val result = service.getSettlementDetail(1L, null)
+
+            assertEquals(1L, result.id)
+            assertEquals(1, result.items.size)
+        }
+
+        @Test
+        fun 판매자_본인_정산만_조회_가능하다() {
+            val settlement = Settlement.fixture(sellerId = 1L).withId(1L)
+            whenever(settlementRepository.findById(1L)).thenReturn(Optional.of(settlement))
+
+            assertThrows<SettlementAccessDeniedException> {
+                service.getSettlementDetail(1L, 999L)
+            }
+        }
+
+        @Test
+        fun 존재하지_않는_정산이면_예외가_발생한다() {
+            whenever(settlementRepository.findById(1L)).thenReturn(Optional.empty())
+
+            assertThrows<SettlementNotFoundException> {
+                service.getSettlementDetail(1L, null)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/hoppingmall/mall/support/fixture/SettlementFixture.kt
+++ b/src/test/kotlin/com/hoppingmall/mall/support/fixture/SettlementFixture.kt
@@ -1,0 +1,46 @@
+package com.hoppingmall.mall.support.fixture
+
+import com.hoppingmall.mall.settlement.domain.Settlement
+import com.hoppingmall.mall.settlement.domain.SettlementItem
+import java.math.BigDecimal
+import java.time.LocalDate
+
+fun Settlement.Companion.fixture(
+    sellerId: Long = 1L,
+    periodStart: LocalDate = LocalDate.of(2026, 3, 1),
+    periodEnd: LocalDate = LocalDate.of(2026, 3, 31),
+    totalSalesAmount: BigDecimal = BigDecimal("1000000"),
+    totalRefundAmount: BigDecimal = BigDecimal("50000"),
+    commissionRate: BigDecimal = BigDecimal("0.1000"),
+    commissionAmount: BigDecimal = BigDecimal("100000"),
+    settlementAmount: BigDecimal = BigDecimal("850000")
+): Settlement {
+    return Settlement.create(
+        sellerId = sellerId,
+        periodStart = periodStart,
+        periodEnd = periodEnd,
+        totalSalesAmount = totalSalesAmount,
+        totalRefundAmount = totalRefundAmount,
+        commissionRate = commissionRate,
+        commissionAmount = commissionAmount,
+        settlementAmount = settlementAmount
+    )
+}
+
+fun SettlementItem.Companion.fixture(
+    settlementId: Long = 1L,
+    orderId: Long = 1L,
+    orderItemId: Long = 1L,
+    productName: String = "테스트 상품",
+    quantity: Int = 2,
+    salesAmount: BigDecimal = BigDecimal("50000")
+): SettlementItem {
+    return SettlementItem.create(
+        settlementId = settlementId,
+        orderId = orderId,
+        orderItemId = orderItemId,
+        productName = productName,
+        quantity = quantity,
+        salesAmount = salesAmount
+    )
+}


### PR DESCRIPTION
Closes #149

### 📌 작업 개요
판매자별 기간 정산 시스템을 DDD 패턴으로 구현했습니다.
배송 완료(DELIVERED) 주문의 매출을 집계하고, 완료된 환불을 차감한 뒤,
수수료를 계산하여 정산 금액을 산출합니다. 관리자가 정산 생성/확정/지급을 관리하고,
판매자는 본인 정산 내역을 조회할 수 있습니다.

---

### ✅ 주요 변경 사항

- `settlement.domain`
  - `Settlement`: 판매자별 기간 정산 엔티티 (상태 전이: CALCULATED → CONFIRMED → PAID)
  - `SettlementItem`: 정산 내역 (주문 아이템 단위)
  - `SettlementRepository`, `SettlementItemRepository`

- `settlement.service`
  - `SettlementCommandServiceImpl`: 정산 생성 (매출 집계, 환불 차감, 수수료 계산), 확정, 지급
  - `SettlementQueryServiceImpl`: 목록/상세 조회 (판매자 접근 제어)

- `settlement.controller`
  - `SettlementController`: 관리자 API (CRUD), 판매자 API (조회)

- `order.domain.repository`
  - `OrderItemRepository`: DELIVERED 주문 아이템 기간 조회 네이티브 쿼리 추가

- `refund.domain.repository`
  - `RefundRepository`: COMPLETED 환불 기간 조회 쿼리 추가

- `global.common.config`
  - `SecurityConfig`: 판매자 정산 API 권한 설정 추가

---

### 🧪 테스트

- `SettlementCommandServiceImplTest`: 생성, 환불 차감, 확정, 지급, 예외 케이스 (10건)
- `SettlementQueryServiceImplTest`: 목록 조회 (4가지 필터), 상세 조회, 접근 제어 (7건)
- `SettlementControllerTest`: API 엔드포인트 테스트 (6건)

---

### 📎 관련 이슈
- #149