### PR TITLE
feat: 서비스 간 Internal Token 인증 + Gateway Rate Limiting

### DIFF
--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 
 	implementation("org.springframework.cloud:spring-cloud-starter-gateway")
+	implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 
 	implementation("io.jsonwebtoken:jjwt-api:0.11.5")

--- a/api-gateway/src/main/kotlin/com/hoppingmall/gateway/config/RateLimitConfig.kt
+++ b/api-gateway/src/main/kotlin/com/hoppingmall/gateway/config/RateLimitConfig.kt
@@ -1,0 +1,22 @@
+package com.hoppingmall.gateway.config
+
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import reactor.core.publisher.Mono
+
+@Configuration
+class RateLimitConfig {
+
+    @Bean
+    fun userKeyResolver(): KeyResolver {
+        return KeyResolver { exchange ->
+            val userId = exchange.request.headers.getFirst("x-user-id")
+            if (userId != null) {
+                Mono.just(userId)
+            } else {
+                Mono.just(exchange.request.remoteAddress?.address?.hostAddress ?: "anonymous")
+            }
+        }
+    }
+}

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -2,8 +2,21 @@ spring:
   application:
     name: api-gateway
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
   cloud:
     gateway:
+      default-filters:
+        - name: RequestRateLimiter
+          args:
+            redis-rate-limiter.replenishRate: 20
+            redis-rate-limiter.burstCapacity: 40
+            redis-rate-limiter.requestedTokens: 1
+            key-resolver: "#{@userKeyResolver}"
+            deny-empty-key: false
       routes:
         - id: user-service-public
           uri: ${ROUTES_USER_SERVICE:http://localhost:8082}

--- a/app/src/main/resources/application-docker.yml
+++ b/app/src/main/resources/application-docker.yml
@@ -55,3 +55,7 @@ file:
     allowed-domains:
       - product
     sub-directory: images
+
+internal:
+  service:
+    token: ${INTERNAL_SERVICE_TOKEN}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -133,3 +133,7 @@ file:
     allowed-domains:
       - product
     sub-directory: images
+
+internal:
+  service:
+    token: ${INTERNAL_SERVICE_TOKEN:dev-internal-token-2026}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,6 +232,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: docker
       JWT_SECRET: ${JWT_SECRET:-default-docker-secret-key-for-development-only-32chars!}
+      INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-docker-internal-token-2026}
     ports:
       - "8080:8080"
 
@@ -282,6 +283,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: docker
       JWT_SECRET: ${JWT_SECRET:-default-docker-secret-key-for-development-only-32chars!}
+      INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-docker-internal-token-2026}
     ports:
       - "8083:8083"
 
@@ -300,6 +302,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: docker
       JWT_SECRET: ${JWT_SECRET:-default-docker-secret-key-for-development-only-32chars!}
+      INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-docker-internal-token-2026}
     ports:
       - "8084:8084"
 
@@ -318,6 +321,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: docker
       JWT_SECRET: ${JWT_SECRET:-default-docker-secret-key-for-development-only-32chars!}
+      INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-docker-internal-token-2026}
     ports:
       - "8085:8085"
 

--- a/infra/src/main/kotlin/com/hoppingmall/mall/global/common/config/InternalTokenFilter.kt
+++ b/infra/src/main/kotlin/com/hoppingmall/mall/global/common/config/InternalTokenFilter.kt
@@ -1,0 +1,34 @@
+package com.hoppingmall.mall.global.common.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class InternalTokenFilter(
+    @Value("\${internal.service.token}") private val serviceToken: String
+) : OncePerRequestFilter() {
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        return !request.requestURI.startsWith("/internal/")
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val token = request.getHeader("X-Internal-Token")
+        if (token == null || token != serviceToken) {
+            response.status = HttpServletResponse.SC_UNAUTHORIZED
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            response.writer.write("""{"code":"UNAUTHORIZED","message":"Invalid internal service token"}""")
+            return
+        }
+        filterChain.doFilter(request, response)
+    }
+}

--- a/infra/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
+++ b/infra/src/main/kotlin/com/hoppingmall/mall/global/common/config/SecurityConfig.kt
@@ -21,7 +21,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 class SecurityConfig(
     private val jwtAuthenticationFilter: Filter,
     private val jwtAuthenticationEntryPoint: AuthenticationEntryPoint,
-    private val corsProperties: CorsProperties
+    private val corsProperties: CorsProperties,
+    private val internalTokenFilter: InternalTokenFilter
 ) {
 
     @Bean
@@ -98,6 +99,7 @@ class SecurityConfig(
                 it.requestMatchers("/api/v1/**").authenticated()
                 it.anyRequest().denyAll()
             }
+            .addFilterBefore(internalTokenFilter, UsernamePasswordAuthenticationFilter::class.java)
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
 
         return http.build()

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/InternalRestTemplateConfig.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/InternalRestTemplateConfig.kt
@@ -1,0 +1,40 @@
+package com.hoppingmall.order.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.web.client.RestTemplateCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpRequest
+import org.springframework.http.client.ClientHttpRequestExecution
+import org.springframework.http.client.ClientHttpRequestInterceptor
+import org.springframework.http.client.ClientHttpResponse
+
+@Configuration
+class InternalRestTemplateConfig(
+    @Value("\${internal.service.token}") private val serviceToken: String
+) {
+
+    @Bean
+    fun internalTokenRestTemplateCustomizer(): RestTemplateCustomizer {
+        return RestTemplateCustomizer { restTemplate ->
+            val interceptors = restTemplate.interceptors.toMutableList()
+            interceptors.add(InternalTokenInterceptor(serviceToken))
+            restTemplate.interceptors = interceptors
+        }
+    }
+
+    private class InternalTokenInterceptor(
+        private val token: String
+    ) : ClientHttpRequestInterceptor {
+        override fun intercept(
+            request: HttpRequest,
+            body: ByteArray,
+            execution: ClientHttpRequestExecution
+        ): ClientHttpResponse {
+            if (request.uri.path.startsWith("/internal/")) {
+                request.headers.set("X-Internal-Token", token)
+            }
+            return execution.execute(request, body)
+        }
+    }
+}

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/InternalTokenFilter.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/InternalTokenFilter.kt
@@ -1,0 +1,34 @@
+package com.hoppingmall.order.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class InternalTokenFilter(
+    @Value("\${internal.service.token}") private val serviceToken: String
+) : OncePerRequestFilter() {
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        return !request.requestURI.startsWith("/internal/")
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val token = request.getHeader("X-Internal-Token")
+        if (token == null || token != serviceToken) {
+            response.status = HttpServletResponse.SC_UNAUTHORIZED
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            response.writer.write("""{"code":"UNAUTHORIZED","message":"Invalid internal service token"}""")
+            return
+        }
+        filterChain.doFilter(request, response)
+    }
+}

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/SecurityConfig.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/SecurityConfig.kt
@@ -12,7 +12,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
-    private val jwtAuthenticationFilter: JwtAuthenticationFilter
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val internalTokenFilter: InternalTokenFilter
 ) {
 
     @Bean
@@ -27,6 +28,7 @@ class SecurityConfig(
                     .requestMatchers("/internal/**").permitAll()
                     .anyRequest().authenticated()
             }
+            .addFilterBefore(internalTokenFilter, UsernamePasswordAuthenticationFilter::class.java)
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
         return http.build()
     }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/InternalRestTemplateConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/InternalRestTemplateConfig.kt
@@ -1,0 +1,40 @@
+package com.hoppingmall.payment.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.web.client.RestTemplateCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpRequest
+import org.springframework.http.client.ClientHttpRequestExecution
+import org.springframework.http.client.ClientHttpRequestInterceptor
+import org.springframework.http.client.ClientHttpResponse
+
+@Configuration
+class InternalRestTemplateConfig(
+    @Value("\${internal.service.token}") private val serviceToken: String
+) {
+
+    @Bean
+    fun internalTokenRestTemplateCustomizer(): RestTemplateCustomizer {
+        return RestTemplateCustomizer { restTemplate ->
+            val interceptors = restTemplate.interceptors.toMutableList()
+            interceptors.add(InternalTokenInterceptor(serviceToken))
+            restTemplate.interceptors = interceptors
+        }
+    }
+
+    private class InternalTokenInterceptor(
+        private val token: String
+    ) : ClientHttpRequestInterceptor {
+        override fun intercept(
+            request: HttpRequest,
+            body: ByteArray,
+            execution: ClientHttpRequestExecution
+        ): ClientHttpResponse {
+            if (request.uri.path.startsWith("/internal/")) {
+                request.headers.set("X-Internal-Token", token)
+            }
+            return execution.execute(request, body)
+        }
+    }
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/InternalTokenFilter.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/InternalTokenFilter.kt
@@ -1,0 +1,34 @@
+package com.hoppingmall.payment.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class InternalTokenFilter(
+    @Value("\${internal.service.token}") private val serviceToken: String
+) : OncePerRequestFilter() {
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        return !request.requestURI.startsWith("/internal/")
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val token = request.getHeader("X-Internal-Token")
+        if (token == null || token != serviceToken) {
+            response.status = HttpServletResponse.SC_UNAUTHORIZED
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            response.writer.write("""{"code":"UNAUTHORIZED","message":"Invalid internal service token"}""")
+            return
+        }
+        filterChain.doFilter(request, response)
+    }
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/SecurityConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/SecurityConfig.kt
@@ -12,7 +12,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
-    private val jwtAuthenticationFilter: JwtAuthenticationFilter
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val internalTokenFilter: InternalTokenFilter
 ) {
 
     @Bean
@@ -27,6 +28,7 @@ class SecurityConfig(
                     .requestMatchers("/internal/**").permitAll()
                     .anyRequest().authenticated()
             }
+            .addFilterBefore(internalTokenFilter, UsernamePasswordAuthenticationFilter::class.java)
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
         return http.build()
     }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/InternalRestTemplateConfig.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/InternalRestTemplateConfig.kt
@@ -1,0 +1,40 @@
+package com.hoppingmall.product.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.web.client.RestTemplateCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpRequest
+import org.springframework.http.client.ClientHttpRequestExecution
+import org.springframework.http.client.ClientHttpRequestInterceptor
+import org.springframework.http.client.ClientHttpResponse
+
+@Configuration
+class InternalRestTemplateConfig(
+    @Value("\${internal.service.token}") private val serviceToken: String
+) {
+
+    @Bean
+    fun internalTokenRestTemplateCustomizer(): RestTemplateCustomizer {
+        return RestTemplateCustomizer { restTemplate ->
+            val interceptors = restTemplate.interceptors.toMutableList()
+            interceptors.add(InternalTokenInterceptor(serviceToken))
+            restTemplate.interceptors = interceptors
+        }
+    }
+
+    private class InternalTokenInterceptor(
+        private val token: String
+    ) : ClientHttpRequestInterceptor {
+        override fun intercept(
+            request: HttpRequest,
+            body: ByteArray,
+            execution: ClientHttpRequestExecution
+        ): ClientHttpResponse {
+            if (request.uri.path.startsWith("/internal/")) {
+                request.headers.set("X-Internal-Token", token)
+            }
+            return execution.execute(request, body)
+        }
+    }
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/InternalTokenFilter.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/InternalTokenFilter.kt
@@ -1,0 +1,34 @@
+package com.hoppingmall.product.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class InternalTokenFilter(
+    @Value("\${internal.service.token}") private val serviceToken: String
+) : OncePerRequestFilter() {
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        return !request.requestURI.startsWith("/internal/")
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val token = request.getHeader("X-Internal-Token")
+        if (token == null || token != serviceToken) {
+            response.status = HttpServletResponse.SC_UNAUTHORIZED
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            response.writer.write("""{"code":"UNAUTHORIZED","message":"Invalid internal service token"}""")
+            return
+        }
+        filterChain.doFilter(request, response)
+    }
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/SecurityConfig.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/SecurityConfig.kt
@@ -12,7 +12,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
-    private val jwtAuthenticationFilter: JwtAuthenticationFilter
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val internalTokenFilter: InternalTokenFilter
 ) {
 
     @Bean
@@ -27,6 +28,7 @@ class SecurityConfig(
                     .requestMatchers("/internal/**").permitAll()
                     .anyRequest().authenticated()
             }
+            .addFilterBefore(internalTokenFilter, UsernamePasswordAuthenticationFilter::class.java)
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
         return http.build()
     }

--- a/product-service/src/main/resources/application-docker.yml
+++ b/product-service/src/main/resources/application-docker.yml
@@ -39,3 +39,7 @@ services:
     url: http://monolith:8080
   order-service:
     url: http://order-service:8084
+
+internal:
+  service:
+    token: ${INTERNAL_SERVICE_TOKEN}

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -77,3 +77,7 @@ file:
     allowed-domains:
       - product
     sub-directory: images
+
+internal:
+  service:
+    token: ${INTERNAL_SERVICE_TOKEN:dev-internal-token-2026}


### PR DESCRIPTION
Closes #165

### 📌 작업 개요
/internal/** 엔드포인트의 무인증 접근 취약점을 해소하기 위해 X-Internal-Token 기반 서비스 간 인증 체계를 구축하고,
API Gateway에 Redis 기반 Rate Limiting을 적용했습니다.

---

### ✅ 주요 변경 사항

- `order-service/config`
  - `InternalTokenFilter`: /internal/** 요청의 X-Internal-Token 헤더 검증
  - `InternalRestTemplateConfig`: RestTemplateCustomizer로 내부 호출 시 토큰 자동 주입
  - `SecurityConfig`: InternalTokenFilter 필터 체인 등록

- `product-service/config`
  - `InternalTokenFilter`, `InternalRestTemplateConfig`, `SecurityConfig`: 동일 패턴 적용

- `payment-service/config`
  - `InternalTokenFilter`, `InternalRestTemplateConfig`, `SecurityConfig`: 동일 패턴 적용

- `infra/global/common/config`
  - `InternalTokenFilter`, `SecurityConfig`: 모놀리스에도 동일 적용

- `api-gateway`
  - `RateLimitConfig`: userKeyResolver (x-user-id → IP 폴백)
  - `build.gradle.kts`: spring-boot-starter-data-redis-reactive 추가
  - `application.yml`: RequestRateLimiter (20req/s, burst 40) + Redis 설정

- `docker-compose.yml`: INTERNAL_SERVICE_TOKEN 환경변수 추가 (monolith, product, order, payment)
- `application.yml` / `application-docker.yml`: internal.service.token 속성 추가

---

### 📎 관련 이슈
- #165