### PR TITLE
fix: Gateway 라우트 미스매치 수정

### DIFF
--- a/api-gateway/src/main/resources/application-docker.yml
+++ b/api-gateway/src/main/resources/application-docker.yml
@@ -7,10 +7,38 @@ spring:
           predicates:
             - Path=/api/v1/users/signup,/api/v1/users/login,/api/v1/auth/refresh
 
+        - id: product-service-statistics
+          uri: http://product-service:8083
+          predicates:
+            - Path=/api/v1/admin/product-statistics/**
+          filters:
+            - name: JwtValidation
+
+        - id: payment-service-admin-coupons
+          uri: http://payment-service:8085
+          predicates:
+            - Path=/api/v1/admin/coupons/**
+          filters:
+            - name: JwtValidation
+
+        - id: monolith-admin-settlements
+          uri: http://monolith:8080
+          predicates:
+            - Path=/api/v1/admin/settlements/**
+          filters:
+            - JwtValidation
+
+        - id: monolith-admin-dlq
+          uri: http://monolith:8080
+          predicates:
+            - Path=/api/v1/admin/dlq/**
+          filters:
+            - JwtValidation
+
         - id: user-service
           uri: http://user-service:8082
           predicates:
-            - Path=/api/v1/users/**,/api/v1/auth/**,/api/v1/sellers/**,/api/v1/admin/**,/api/v1/memberships/**
+            - Path=/api/v1/users/**,/api/v1/auth/**,/api/v1/sellers/**,/api/v1/admin/sellers/**,/api/v1/memberships/**
           filters:
             - JwtValidation
 
@@ -35,10 +63,10 @@ spring:
           filters:
             - name: JwtValidation
 
-        - id: product-service-inventory
+        - id: product-service-inventories
           uri: http://product-service:8083
           predicates:
-            - Path=/api/v1/inventory/**
+            - Path=/api/v1/inventories/**
           filters:
             - name: JwtValidation
 
@@ -56,19 +84,19 @@ spring:
           filters:
             - name: JwtValidation
 
-        - id: product-service-statistics
-          uri: http://product-service:8083
-          predicates:
-            - Path=/api/v1/statistics/**
-          filters:
-            - name: JwtValidation
-
         - id: product-service-dashboard
           uri: http://product-service:8083
           predicates:
             - Path=/api/v1/seller/dashboard/**
           filters:
             - name: JwtValidation
+
+        - id: monolith-seller-settlements
+          uri: http://monolith:8080
+          predicates:
+            - Path=/api/v1/seller/settlements/**
+          filters:
+            - JwtValidation
 
         - id: order-service-orders
           uri: http://order-service:8084

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -23,10 +23,38 @@ spring:
           predicates:
             - Path=/api/v1/users/signup,/api/v1/users/login,/api/v1/auth/refresh
 
+        - id: product-service-statistics
+          uri: ${ROUTES_PRODUCT_SERVICE:http://localhost:8083}
+          predicates:
+            - Path=/api/v1/admin/product-statistics/**
+          filters:
+            - name: JwtValidation
+
+        - id: payment-service-admin-coupons
+          uri: ${ROUTES_PAYMENT_SERVICE:http://localhost:8085}
+          predicates:
+            - Path=/api/v1/admin/coupons/**
+          filters:
+            - name: JwtValidation
+
+        - id: monolith-admin-settlements
+          uri: ${ROUTES_MONOLITH:http://localhost:8080}
+          predicates:
+            - Path=/api/v1/admin/settlements/**
+          filters:
+            - JwtValidation
+
+        - id: monolith-admin-dlq
+          uri: ${ROUTES_MONOLITH:http://localhost:8080}
+          predicates:
+            - Path=/api/v1/admin/dlq/**
+          filters:
+            - JwtValidation
+
         - id: user-service
           uri: ${ROUTES_USER_SERVICE:http://localhost:8082}
           predicates:
-            - Path=/api/v1/users/**,/api/v1/auth/**,/api/v1/sellers/**,/api/v1/admin/**,/api/v1/memberships/**
+            - Path=/api/v1/users/**,/api/v1/auth/**,/api/v1/sellers/**,/api/v1/admin/sellers/**,/api/v1/memberships/**
           filters:
             - JwtValidation
 
@@ -38,53 +66,53 @@ spring:
             - JwtValidation
 
         - id: product-service-products
-          uri: http://localhost:8083
+          uri: ${ROUTES_PRODUCT_SERVICE:http://localhost:8083}
           predicates:
             - Path=/api/v1/products/**
           filters:
             - name: JwtValidation
 
         - id: product-service-categories
-          uri: http://localhost:8083
+          uri: ${ROUTES_PRODUCT_SERVICE:http://localhost:8083}
           predicates:
             - Path=/api/v1/categories/**
           filters:
             - name: JwtValidation
 
-        - id: product-service-inventory
-          uri: http://localhost:8083
+        - id: product-service-inventories
+          uri: ${ROUTES_PRODUCT_SERVICE:http://localhost:8083}
           predicates:
-            - Path=/api/v1/inventory/**
+            - Path=/api/v1/inventories/**
           filters:
             - name: JwtValidation
 
         - id: product-service-reviews
-          uri: http://localhost:8083
+          uri: ${ROUTES_PRODUCT_SERVICE:http://localhost:8083}
           predicates:
             - Path=/api/v1/reviews/**
           filters:
             - name: JwtValidation
 
         - id: product-service-wishlists
-          uri: http://localhost:8083
+          uri: ${ROUTES_PRODUCT_SERVICE:http://localhost:8083}
           predicates:
             - Path=/api/v1/wishlists/**
           filters:
             - name: JwtValidation
 
-        - id: product-service-statistics
-          uri: http://localhost:8083
-          predicates:
-            - Path=/api/v1/statistics/**
-          filters:
-            - name: JwtValidation
-
         - id: product-service-dashboard
-          uri: http://localhost:8083
+          uri: ${ROUTES_PRODUCT_SERVICE:http://localhost:8083}
           predicates:
             - Path=/api/v1/seller/dashboard/**
           filters:
             - name: JwtValidation
+
+        - id: monolith-seller-settlements
+          uri: ${ROUTES_MONOLITH:http://localhost:8080}
+          predicates:
+            - Path=/api/v1/seller/settlements/**
+          filters:
+            - JwtValidation
 
         - id: order-service-orders
           uri: ${ROUTES_ORDER_SERVICE:http://localhost:8084}


### PR DESCRIPTION
Closes #167

### 📌 작업 개요
Gateway 라우트와 실제 컨트롤러 @RequestMapping 경로 불일치를 수정하고,
admin 라우트 catch-all 문제를 해결하여 모든 라우트가 올바른 서비스로 도달하도록 합니다.

---

### ✅ 주요 변경 사항

- `api-gateway/src/main/resources/application.yml`, `application-docker.yml`
  - `/api/v1/inventory/**` → `/api/v1/inventories/**` (InventoryController 매핑 일치)
  - `/api/v1/statistics/**` → `/api/v1/admin/product-statistics/**` (ProductStatisticsController 매핑 일치)
  - user-service `/api/v1/admin/**` → `/api/v1/admin/sellers/**` 축소 (AdminController가 sellers 엔드포인트만 처리)
  - `/api/v1/admin/coupons/**` → payment-service 명시적 라우트 추가
  - `/api/v1/admin/settlements/**`, `/api/v1/admin/dlq/**` → monolith 명시적 라우트 추가
  - `/api/v1/seller/settlements/**` → monolith 명시적 라우트 추가
  - product-service URI를 `${ROUTES_PRODUCT_SERVICE:http://localhost:8083}` 환경변수 패턴으로 통일

---

### 🧪 테스트

- `api-gateway compileKotlin` 빌드 성공 확인

---

### 📎 관련 이슈
- #167