### PR TITLE
config: 서비스별 CI/CD 매트릭스 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,13 @@ on:
     branches: [develop]
 
 jobs:
-  build-and-test:
+  monolith-test:
+    name: Monolith 테스트
     runs-on: ubuntu-latest
 
     steps:
       - name: 소스 체크아웃
         uses: actions/checkout@v3
-
-      #      - name: applicaion_local 디코딩 후 파일에 넣기
-      #        run: |
-      #          echo "${{ secrets.APPLICATION_LOCAL_BASE64 }}" | base64 -d > ./src/main/resources/application-local.yml
 
       - name: gradlew에 실행 권한 부여
         run: chmod +x ./gradlew
@@ -37,3 +34,55 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           flags: unittests
+
+  services-test:
+    name: ${{ matrix.service }} 테스트
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - api-gateway
+          - notification-service
+          - order-service
+          - payment-service
+          - product-service
+          - user-service
+
+    steps:
+      - name: 소스 체크아웃
+        uses: actions/checkout@v3
+
+      - name: gradlew에 실행 권한 부여
+        run: chmod +x ./${{ matrix.service }}/gradlew
+
+      - name: JDK 21 설정
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: 테스트
+        run: cd ${{ matrix.service }} && ./gradlew test --no-daemon --build-cache --quiet
+
+  services-docker-build:
+    name: ${{ matrix.service }} Docker 빌드
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - api-gateway
+          - notification-service
+          - order-service
+          - payment-service
+          - product-service
+          - user-service
+
+    steps:
+      - name: 소스 체크아웃
+        uses: actions/checkout@v3
+
+      - name: Docker 빌드 검증
+        run: docker build -t ${{ matrix.service }}:ci-test ./${{ matrix.service }}


### PR DESCRIPTION
Closes #171

### 📌 작업 개요

독립 서비스들이 별도 Gradle 프로젝트로 존재하지만 CI에서 테스트되지 않던 문제를 해결합니다.
기존 모놀리스 테스트에 더해 6개 서비스의 테스트 및 Docker 빌드 검증을 매트릭스로 추가합니다.

---

### ✅ 주요 변경 사항

- `.github/workflows/ci.yml`
  - `monolith-test`: 기존 루트 `./gradlew test` + jacoco 검증 (이름만 변경)
  - `services-test`: 6개 서비스 매트릭스 테스트 (`api-gateway`, `notification-service`, `order-service`, `payment-service`, `product-service`, `user-service`)
  - `services-docker-build`: 6개 서비스 Dockerfile 빌드 검증 (push 없이 빌드만)
  - `fail-fast: false`로 개별 서비스 실패가 다른 서비스 테스트를 중단시키지 않도록 설정

---

### 📎 관련 이슈
- #171