### PR TITLE
feat: 분산 트레이싱 전파 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,24 @@ jobs:
 
       - name: Docker 빌드 검증
         run: docker build -t ${{ matrix.service }}:ci-test ./${{ matrix.service }}
+
+  final-check:
+    name: CI 최종 검증
+    runs-on: ubuntu-latest
+    needs:
+      - monolith-test
+      - services-test
+      - services-docker-build
+    if: always()
+    steps:
+      - name: 실패 여부 확인
+        run: |
+          if [[ "${{ needs.monolith-test.result }}" != "success" ]]; then
+            exit 1
+          fi
+          if [[ "${{ needs.services-test.result }}" != "success" ]]; then
+            exit 1
+          fi
+          if [[ "${{ needs.services-docker-build.result }}" != "success" ]]; then
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
   monolith-test:
     name: Monolith 테스트
     runs-on: ubuntu-latest
-
     steps:
       - name: 소스 체크아웃
         uses: actions/checkout@v3
@@ -103,14 +102,20 @@ jobs:
       - services-docker-build
     if: always()
     steps:
-      - name: 실패 여부 확인
+      - name: 모든 선행 job 결과 확인
         run: |
-          if [[ "${{ needs.monolith-test.result }}" != "success" ]]; then
+          echo "monolith-test=${{ needs.monolith-test.result }}"
+          echo "services-test=${{ needs.services-test.result }}"
+          echo "services-docker-build=${{ needs.services-docker-build.result }}"
+
+          if [ "${{ needs.monolith-test.result }}" != "success" ]; then
             exit 1
           fi
-          if [[ "${{ needs.services-test.result }}" != "success" ]]; then
+
+          if [ "${{ needs.services-test.result }}" != "success" ]; then
             exit 1
           fi
-          if [[ "${{ needs.services-docker-build.result }}" != "success" ]]; then
+
+          if [ "${{ needs.services-docker-build.result }}" != "success" ]; then
             exit 1
           fi

--- a/api-gateway/src/main/kotlin/com/hoppingmall/gateway/filter/TracingGlobalFilter.kt
+++ b/api-gateway/src/main/kotlin/com/hoppingmall/gateway/filter/TracingGlobalFilter.kt
@@ -1,0 +1,35 @@
+package com.hoppingmall.gateway.filter
+
+import org.springframework.cloud.gateway.filter.GatewayFilterChain
+import org.springframework.cloud.gateway.filter.GlobalFilter
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+import java.util.UUID
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class TracingGlobalFilter : GlobalFilter {
+    override fun filter(exchange: ServerWebExchange, chain: GatewayFilterChain): Mono<Void> {
+        val incomingTraceId = exchange.request.headers.getFirst(TRACE_ID_HEADER)
+        val traceId = if (isValidTraceId(incomingTraceId)) incomingTraceId!! else generateTraceId()
+        val modifiedRequest = exchange.request.mutate()
+            .header(TRACE_ID_HEADER, traceId)
+            .build()
+        val modifiedExchange = exchange.mutate().request(modifiedRequest).build()
+        modifiedExchange.response.headers.set(TRACE_ID_HEADER, traceId)
+        return chain.filter(modifiedExchange)
+    }
+
+    private fun isValidTraceId(traceId: String?): Boolean =
+        traceId != null && traceId.length in 1..64 && traceId.matches(TRACE_ID_PATTERN)
+
+    private fun generateTraceId(): String = UUID.randomUUID().toString().replace("-", "").take(16)
+
+    companion object {
+        const val TRACE_ID_HEADER = "X-Trace-Id"
+        private val TRACE_ID_PATTERN = Regex("[a-zA-Z0-9\\-]+")
+    }
+}

--- a/api-gateway/src/test/kotlin/com/hoppingmall/gateway/filter/TracingGlobalFilterTest.kt
+++ b/api-gateway/src/test/kotlin/com/hoppingmall/gateway/filter/TracingGlobalFilterTest.kt
@@ -1,0 +1,99 @@
+package com.hoppingmall.gateway.filter
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+
+@DisplayName("TracingGlobalFilter")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class TracingGlobalFilterTest {
+
+    private val filter = TracingGlobalFilter()
+
+    private fun chainCapturing(captured: MutableList<ServerWebExchange>) =
+        org.springframework.cloud.gateway.filter.GatewayFilterChain { exchange ->
+            captured.add(exchange)
+            Mono.empty()
+        }
+
+    @Test
+    fun X_Trace_Id_미전송시_16자_traceId를_자동_생성하여_요청_헤더에_포함한다() {
+        val request = MockServerHttpRequest.get("/test").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        filter.filter(exchange, chainCapturing(captured)).block()
+
+        val traceId = captured[0].request.headers.getFirst(TracingGlobalFilter.TRACE_ID_HEADER)
+        assertThat(traceId).isNotNull().hasSize(16)
+        assertThat(traceId).matches("[a-zA-Z0-9]+")
+    }
+
+    @Test
+    fun 유효한_X_Trace_Id_전송시_기존_값을_그대로_전파한다() {
+        val existingTraceId = "abc123def456"
+        val request = MockServerHttpRequest.get("/test")
+            .header(TracingGlobalFilter.TRACE_ID_HEADER, existingTraceId)
+            .build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        filter.filter(exchange, chainCapturing(captured)).block()
+
+        val traceId = captured[0].request.headers.getFirst(TracingGlobalFilter.TRACE_ID_HEADER)
+        assertThat(traceId).isEqualTo(existingTraceId)
+    }
+
+    @Test
+    fun X_Trace_Id가_65자_이상이면_새_traceId를_생성한다() {
+        val longTraceId = "a".repeat(65)
+        val request = MockServerHttpRequest.get("/test")
+            .header(TracingGlobalFilter.TRACE_ID_HEADER, longTraceId)
+            .build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        filter.filter(exchange, chainCapturing(captured)).block()
+
+        val traceId = captured[0].request.headers.getFirst(TracingGlobalFilter.TRACE_ID_HEADER)
+        assertThat(traceId).isNotEqualTo(longTraceId)
+        assertThat(traceId).isNotNull().hasSize(16)
+    }
+
+    @Test
+    fun X_Trace_Id에_특수문자가_포함되면_새_traceId를_생성한다() {
+        val invalidTraceId = "invalid@trace#id!"
+        val request = MockServerHttpRequest.get("/test")
+            .header(TracingGlobalFilter.TRACE_ID_HEADER, invalidTraceId)
+            .build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        filter.filter(exchange, chainCapturing(captured)).block()
+
+        val traceId = captured[0].request.headers.getFirst(TracingGlobalFilter.TRACE_ID_HEADER)
+        assertThat(traceId).isNotEqualTo(invalidTraceId)
+        assertThat(traceId).isNotNull().hasSize(16)
+    }
+
+    @Test
+    fun 응답_헤더에_X_Trace_Id가_포함된다() {
+        val existingTraceId = "resp-trace-check"
+        val request = MockServerHttpRequest.get("/test")
+            .header(TracingGlobalFilter.TRACE_ID_HEADER, existingTraceId)
+            .build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        filter.filter(exchange, chainCapturing(captured)).block()
+
+        val responseTraceId = captured[0].response.headers.getFirst(TracingGlobalFilter.TRACE_ID_HEADER)
+        assertThat(responseTraceId).isEqualTo(existingTraceId)
+    }
+}

--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/config/MdcFilter.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/config/MdcFilter.kt
@@ -1,0 +1,50 @@
+package com.hoppingmall.notification.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.UUID
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class MdcFilter(
+    @Value("\${spring.application.name}") private val serviceName: String
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val rawTraceId = request.getHeader(TRACE_ID_HEADER)
+        val traceId = if (isValidTraceId(rawTraceId)) rawTraceId!! else generateTraceId()
+        try {
+            MDC.put(TRACE_ID_KEY, traceId)
+            MDC.put(SERVICE_KEY, serviceName)
+            request.getHeader("x-user-id")?.let { MDC.put(USER_ID_KEY, it) }
+            response.setHeader(TRACE_ID_HEADER, traceId)
+            filterChain.doFilter(request, response)
+        } finally {
+            MDC.clear()
+        }
+    }
+
+    private fun isValidTraceId(traceId: String?): Boolean =
+        traceId != null && traceId.length in 1..64 && traceId.matches(TRACE_ID_PATTERN)
+
+    private fun generateTraceId(): String = UUID.randomUUID().toString().replace("-", "").take(16)
+
+    companion object {
+        const val TRACE_ID_KEY = "traceId"
+        const val TRACE_ID_HEADER = "X-Trace-Id"
+        const val USER_ID_KEY = "userId"
+        const val SERVICE_KEY = "service"
+        private val TRACE_ID_PATTERN = Regex("[a-zA-Z0-9\\-]+")
+    }
+}

--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/config/MdcFilter.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/config/MdcFilter.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 class MdcFilter(
-    @Value("\${spring.application.name}") private val serviceName: String
+    @Value("\${spring.application.name:notification-service}") private val serviceName: String
 ) : OncePerRequestFilter() {
 
     override fun doFilterInternal(

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/InternalRestTemplateConfig.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/InternalRestTemplateConfig.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpRequest
 import org.springframework.http.client.ClientHttpRequestExecution
 import org.springframework.http.client.ClientHttpRequestInterceptor
 import org.springframework.http.client.ClientHttpResponse
+import org.slf4j.MDC
 
 @Configuration
 class InternalRestTemplateConfig(
@@ -31,6 +32,8 @@ class InternalRestTemplateConfig(
             body: ByteArray,
             execution: ClientHttpRequestExecution
         ): ClientHttpResponse {
+            MDC.get("traceId")?.let { request.headers.set("X-Trace-Id", it) }
+            MDC.get("userId")?.let { request.headers.set("X-User-Id", it) }
             if (request.uri.path.startsWith("/internal/")) {
                 request.headers.set("X-Internal-Token", token)
             }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/MdcFilter.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/MdcFilter.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 class MdcFilter(
-    @Value("\${spring.application.name}") private val serviceName: String
+    @Value("\${spring.application.name:order-service}") private val serviceName: String
 ) : OncePerRequestFilter() {
 
     override fun doFilterInternal(

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/MdcFilter.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/MdcFilter.kt
@@ -1,0 +1,50 @@
+package com.hoppingmall.order.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.UUID
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class MdcFilter(
+    @Value("\${spring.application.name}") private val serviceName: String
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val rawTraceId = request.getHeader(TRACE_ID_HEADER)
+        val traceId = if (isValidTraceId(rawTraceId)) rawTraceId!! else generateTraceId()
+        try {
+            MDC.put(TRACE_ID_KEY, traceId)
+            MDC.put(SERVICE_KEY, serviceName)
+            request.getHeader("x-user-id")?.let { MDC.put(USER_ID_KEY, it) }
+            response.setHeader(TRACE_ID_HEADER, traceId)
+            filterChain.doFilter(request, response)
+        } finally {
+            MDC.clear()
+        }
+    }
+
+    private fun isValidTraceId(traceId: String?): Boolean =
+        traceId != null && traceId.length in 1..64 && traceId.matches(TRACE_ID_PATTERN)
+
+    private fun generateTraceId(): String = UUID.randomUUID().toString().replace("-", "").take(16)
+
+    companion object {
+        const val TRACE_ID_KEY = "traceId"
+        const val TRACE_ID_HEADER = "X-Trace-Id"
+        const val USER_ID_KEY = "userId"
+        const val SERVICE_KEY = "service"
+        private val TRACE_ID_PATTERN = Regex("[a-zA-Z0-9\\-]+")
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/config/InternalRestTemplateConfigTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/config/InternalRestTemplateConfigTest.kt
@@ -1,0 +1,106 @@
+package com.hoppingmall.order.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.Test
+import org.slf4j.MDC
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.header
+import org.springframework.test.web.client.match.MockRestRequestMatchers.headerDoesNotExist
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.RestTemplate
+
+@DisplayName("InternalRestTemplateConfig")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class InternalRestTemplateConfigTest {
+
+    private val token = "test-internal-token"
+    private val config = InternalRestTemplateConfig(token)
+
+    @AfterEach
+    fun tearDown() {
+        MDC.clear()
+    }
+
+    private fun buildRestTemplate(): Pair<RestTemplate, MockRestServiceServer> {
+        val restTemplate = RestTemplate()
+        config.internalTokenRestTemplateCustomizer().customize(restTemplate)
+        val server = MockRestServiceServer.createServer(restTemplate)
+        return restTemplate to server
+    }
+
+    @Test
+    fun MDC에_traceId가_있으면_X_Trace_Id_헤더를_전파한다() {
+        MDC.put("traceId", "trace-abc")
+        val (restTemplate, server) = buildRestTemplate()
+        server.expect(requestTo("http://external/api"))
+            .andExpect(header("X-Trace-Id", "trace-abc"))
+            .andRespond(withSuccess("", MediaType.TEXT_PLAIN))
+
+        restTemplate.getForObject("http://external/api", String::class.java)
+
+        server.verify()
+    }
+
+    @Test
+    fun MDC에_userId가_있으면_X_User_Id_헤더를_전파한다() {
+        MDC.put("userId", "user-42")
+        val (restTemplate, server) = buildRestTemplate()
+        server.expect(requestTo("http://external/api"))
+            .andExpect(header("X-User-Id", "user-42"))
+            .andRespond(withSuccess("", MediaType.TEXT_PLAIN))
+
+        restTemplate.getForObject("http://external/api", String::class.java)
+
+        server.verify()
+    }
+
+    @Test
+    fun MDC가_비어있으면_trace_헤더를_설정하지_않는다() {
+        val (restTemplate, server) = buildRestTemplate()
+        server.expect(requestTo("http://external/api"))
+            .andExpect(headerDoesNotExist("X-Trace-Id"))
+            .andExpect(headerDoesNotExist("X-User-Id"))
+            .andRespond(withSuccess("", MediaType.TEXT_PLAIN))
+
+        restTemplate.getForObject("http://external/api", String::class.java)
+
+        server.verify()
+    }
+
+    @Test
+    fun internal_경로에서_Internal_Token과_trace_헤더가_함께_전파된다() {
+        MDC.put("traceId", "trace-xyz")
+        MDC.put("userId", "user-99")
+        val (restTemplate, server) = buildRestTemplate()
+        server.expect(requestTo("http://internal-service/internal/orders"))
+            .andExpect(header("X-Trace-Id", "trace-xyz"))
+            .andExpect(header("X-User-Id", "user-99"))
+            .andExpect(header("X-Internal-Token", token))
+            .andRespond(withSuccess("", MediaType.TEXT_PLAIN))
+
+        restTemplate.getForObject("http://internal-service/internal/orders", String::class.java)
+
+        server.verify()
+    }
+
+    @Test
+    fun external_경로에서_trace_헤더만_전파되고_Internal_Token은_전파되지_않는다() {
+        MDC.put("traceId", "trace-ext")
+        val (restTemplate, server) = buildRestTemplate()
+        server.expect(requestTo("http://external/api/orders"))
+            .andExpect(header("X-Trace-Id", "trace-ext"))
+            .andExpect(headerDoesNotExist("X-Internal-Token"))
+            .andRespond(withSuccess("", MediaType.TEXT_PLAIN))
+
+        restTemplate.getForObject("http://external/api/orders", String::class.java)
+
+        server.verify()
+    }
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/InternalRestTemplateConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/InternalRestTemplateConfig.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpRequest
 import org.springframework.http.client.ClientHttpRequestExecution
 import org.springframework.http.client.ClientHttpRequestInterceptor
 import org.springframework.http.client.ClientHttpResponse
+import org.slf4j.MDC
 
 @Configuration
 class InternalRestTemplateConfig(
@@ -31,6 +32,8 @@ class InternalRestTemplateConfig(
             body: ByteArray,
             execution: ClientHttpRequestExecution
         ): ClientHttpResponse {
+            MDC.get("traceId")?.let { request.headers.set("X-Trace-Id", it) }
+            MDC.get("userId")?.let { request.headers.set("X-User-Id", it) }
             if (request.uri.path.startsWith("/internal/")) {
                 request.headers.set("X-Internal-Token", token)
             }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/MdcFilter.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/MdcFilter.kt
@@ -1,0 +1,50 @@
+package com.hoppingmall.payment.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.UUID
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class MdcFilter(
+    @Value("\${spring.application.name}") private val serviceName: String
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val rawTraceId = request.getHeader(TRACE_ID_HEADER)
+        val traceId = if (isValidTraceId(rawTraceId)) rawTraceId!! else generateTraceId()
+        try {
+            MDC.put(TRACE_ID_KEY, traceId)
+            MDC.put(SERVICE_KEY, serviceName)
+            request.getHeader("x-user-id")?.let { MDC.put(USER_ID_KEY, it) }
+            response.setHeader(TRACE_ID_HEADER, traceId)
+            filterChain.doFilter(request, response)
+        } finally {
+            MDC.clear()
+        }
+    }
+
+    private fun isValidTraceId(traceId: String?): Boolean =
+        traceId != null && traceId.length in 1..64 && traceId.matches(TRACE_ID_PATTERN)
+
+    private fun generateTraceId(): String = UUID.randomUUID().toString().replace("-", "").take(16)
+
+    companion object {
+        const val TRACE_ID_KEY = "traceId"
+        const val TRACE_ID_HEADER = "X-Trace-Id"
+        const val USER_ID_KEY = "userId"
+        const val SERVICE_KEY = "service"
+        private val TRACE_ID_PATTERN = Regex("[a-zA-Z0-9\\-]+")
+    }
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/MdcFilter.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/MdcFilter.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 class MdcFilter(
-    @Value("\${spring.application.name}") private val serviceName: String
+    @Value("\${spring.application.name:payment-service}") private val serviceName: String
 ) : OncePerRequestFilter() {
 
     override fun doFilterInternal(

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/config/InternalRestTemplateConfigTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/config/InternalRestTemplateConfigTest.kt
@@ -1,0 +1,105 @@
+package com.hoppingmall.payment.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.Test
+import org.slf4j.MDC
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.header
+import org.springframework.test.web.client.match.MockRestRequestMatchers.headerDoesNotExist
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.RestTemplate
+
+@DisplayName("InternalRestTemplateConfig")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class InternalRestTemplateConfigTest {
+
+    private val token = "test-internal-token"
+    private val config = InternalRestTemplateConfig(token)
+
+    @AfterEach
+    fun tearDown() {
+        MDC.clear()
+    }
+
+    private fun buildRestTemplate(): Pair<RestTemplate, MockRestServiceServer> {
+        val restTemplate = RestTemplate()
+        config.internalTokenRestTemplateCustomizer().customize(restTemplate)
+        val server = MockRestServiceServer.createServer(restTemplate)
+        return restTemplate to server
+    }
+
+    @Test
+    fun MDC에_traceId가_있으면_X_Trace_Id_헤더를_전파한다() {
+        MDC.put("traceId", "trace-abc")
+        val (restTemplate, server) = buildRestTemplate()
+        server.expect(requestTo("http://external/api"))
+            .andExpect(header("X-Trace-Id", "trace-abc"))
+            .andRespond(withSuccess("", MediaType.TEXT_PLAIN))
+
+        restTemplate.getForObject("http://external/api", String::class.java)
+
+        server.verify()
+    }
+
+    @Test
+    fun MDC에_userId가_있으면_X_User_Id_헤더를_전파한다() {
+        MDC.put("userId", "user-42")
+        val (restTemplate, server) = buildRestTemplate()
+        server.expect(requestTo("http://external/api"))
+            .andExpect(header("X-User-Id", "user-42"))
+            .andRespond(withSuccess("", MediaType.TEXT_PLAIN))
+
+        restTemplate.getForObject("http://external/api", String::class.java)
+
+        server.verify()
+    }
+
+    @Test
+    fun MDC가_비어있으면_trace_헤더를_설정하지_않는다() {
+        val (restTemplate, server) = buildRestTemplate()
+        server.expect(requestTo("http://external/api"))
+            .andExpect(headerDoesNotExist("X-Trace-Id"))
+            .andExpect(headerDoesNotExist("X-User-Id"))
+            .andRespond(withSuccess("", MediaType.TEXT_PLAIN))
+
+        restTemplate.getForObject("http://external/api", String::class.java)
+
+        server.verify()
+    }
+
+    @Test
+    fun internal_경로에서_Internal_Token과_trace_헤더가_함께_전파된다() {
+        MDC.put("traceId", "trace-xyz")
+        MDC.put("userId", "user-99")
+        val (restTemplate, server) = buildRestTemplate()
+        server.expect(requestTo("http://internal-service/internal/payments"))
+            .andExpect(header("X-Trace-Id", "trace-xyz"))
+            .andExpect(header("X-User-Id", "user-99"))
+            .andExpect(header("X-Internal-Token", token))
+            .andRespond(withSuccess("", MediaType.TEXT_PLAIN))
+
+        restTemplate.getForObject("http://internal-service/internal/payments", String::class.java)
+
+        server.verify()
+    }
+
+    @Test
+    fun external_경로에서_trace_헤더만_전파되고_Internal_Token은_전파되지_않는다() {
+        MDC.put("traceId", "trace-ext")
+        val (restTemplate, server) = buildRestTemplate()
+        server.expect(requestTo("http://external/api/payments"))
+            .andExpect(header("X-Trace-Id", "trace-ext"))
+            .andExpect(headerDoesNotExist("X-Internal-Token"))
+            .andRespond(withSuccess("", MediaType.TEXT_PLAIN))
+
+        restTemplate.getForObject("http://external/api/payments", String::class.java)
+
+        server.verify()
+    }
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/InternalRestTemplateConfig.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/InternalRestTemplateConfig.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpRequest
 import org.springframework.http.client.ClientHttpRequestExecution
 import org.springframework.http.client.ClientHttpRequestInterceptor
 import org.springframework.http.client.ClientHttpResponse
+import org.slf4j.MDC
 
 @Configuration
 class InternalRestTemplateConfig(
@@ -31,6 +32,8 @@ class InternalRestTemplateConfig(
             body: ByteArray,
             execution: ClientHttpRequestExecution
         ): ClientHttpResponse {
+            MDC.get("traceId")?.let { request.headers.set("X-Trace-Id", it) }
+            MDC.get("userId")?.let { request.headers.set("X-User-Id", it) }
             if (request.uri.path.startsWith("/internal/")) {
                 request.headers.set("X-Internal-Token", token)
             }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/MdcFilter.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/MdcFilter.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 class MdcFilter(
-    @Value("\${spring.application.name}") private val serviceName: String
+    @Value("\${spring.application.name:product-service}") private val serviceName: String
 ) : OncePerRequestFilter() {
 
     override fun doFilterInternal(

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/MdcFilter.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/MdcFilter.kt
@@ -1,0 +1,50 @@
+package com.hoppingmall.product.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.UUID
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class MdcFilter(
+    @Value("\${spring.application.name}") private val serviceName: String
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val rawTraceId = request.getHeader(TRACE_ID_HEADER)
+        val traceId = if (isValidTraceId(rawTraceId)) rawTraceId!! else generateTraceId()
+        try {
+            MDC.put(TRACE_ID_KEY, traceId)
+            MDC.put(SERVICE_KEY, serviceName)
+            request.getHeader("x-user-id")?.let { MDC.put(USER_ID_KEY, it) }
+            response.setHeader(TRACE_ID_HEADER, traceId)
+            filterChain.doFilter(request, response)
+        } finally {
+            MDC.clear()
+        }
+    }
+
+    private fun isValidTraceId(traceId: String?): Boolean =
+        traceId != null && traceId.length in 1..64 && traceId.matches(TRACE_ID_PATTERN)
+
+    private fun generateTraceId(): String = UUID.randomUUID().toString().replace("-", "").take(16)
+
+    companion object {
+        const val TRACE_ID_KEY = "traceId"
+        const val TRACE_ID_HEADER = "X-Trace-Id"
+        const val USER_ID_KEY = "userId"
+        const val SERVICE_KEY = "service"
+        private val TRACE_ID_PATTERN = Regex("[a-zA-Z0-9\\-]+")
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/config/InternalRestTemplateConfigTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/config/InternalRestTemplateConfigTest.kt
@@ -1,0 +1,105 @@
+package com.hoppingmall.product.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.Test
+import org.slf4j.MDC
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.header
+import org.springframework.test.web.client.match.MockRestRequestMatchers.headerDoesNotExist
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.RestTemplate
+
+@DisplayName("InternalRestTemplateConfig")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class InternalRestTemplateConfigTest {
+
+    private val token = "test-internal-token"
+    private val config = InternalRestTemplateConfig(token)
+
+    @AfterEach
+    fun tearDown() {
+        MDC.clear()
+    }
+
+    private fun buildRestTemplate(): Pair<RestTemplate, MockRestServiceServer> {
+        val restTemplate = RestTemplate()
+        config.internalTokenRestTemplateCustomizer().customize(restTemplate)
+        val server = MockRestServiceServer.createServer(restTemplate)
+        return restTemplate to server
+    }
+
+    @Test
+    fun MDC에_traceId가_있으면_X_Trace_Id_헤더를_전파한다() {
+        MDC.put("traceId", "trace-abc")
+        val (restTemplate, server) = buildRestTemplate()
+        server.expect(requestTo("http://external/api"))
+            .andExpect(header("X-Trace-Id", "trace-abc"))
+            .andRespond(withSuccess("", MediaType.TEXT_PLAIN))
+
+        restTemplate.getForObject("http://external/api", String::class.java)
+
+        server.verify()
+    }
+
+    @Test
+    fun MDC에_userId가_있으면_X_User_Id_헤더를_전파한다() {
+        MDC.put("userId", "user-42")
+        val (restTemplate, server) = buildRestTemplate()
+        server.expect(requestTo("http://external/api"))
+            .andExpect(header("X-User-Id", "user-42"))
+            .andRespond(withSuccess("", MediaType.TEXT_PLAIN))
+
+        restTemplate.getForObject("http://external/api", String::class.java)
+
+        server.verify()
+    }
+
+    @Test
+    fun MDC가_비어있으면_trace_헤더를_설정하지_않는다() {
+        val (restTemplate, server) = buildRestTemplate()
+        server.expect(requestTo("http://external/api"))
+            .andExpect(headerDoesNotExist("X-Trace-Id"))
+            .andExpect(headerDoesNotExist("X-User-Id"))
+            .andRespond(withSuccess("", MediaType.TEXT_PLAIN))
+
+        restTemplate.getForObject("http://external/api", String::class.java)
+
+        server.verify()
+    }
+
+    @Test
+    fun internal_경로에서_Internal_Token과_trace_헤더가_함께_전파된다() {
+        MDC.put("traceId", "trace-xyz")
+        MDC.put("userId", "user-99")
+        val (restTemplate, server) = buildRestTemplate()
+        server.expect(requestTo("http://internal-service/internal/products"))
+            .andExpect(header("X-Trace-Id", "trace-xyz"))
+            .andExpect(header("X-User-Id", "user-99"))
+            .andExpect(header("X-Internal-Token", token))
+            .andRespond(withSuccess("", MediaType.TEXT_PLAIN))
+
+        restTemplate.getForObject("http://internal-service/internal/products", String::class.java)
+
+        server.verify()
+    }
+
+    @Test
+    fun external_경로에서_trace_헤더만_전파되고_Internal_Token은_전파되지_않는다() {
+        MDC.put("traceId", "trace-ext")
+        val (restTemplate, server) = buildRestTemplate()
+        server.expect(requestTo("http://external/api/products"))
+            .andExpect(header("X-Trace-Id", "trace-ext"))
+            .andExpect(headerDoesNotExist("X-Internal-Token"))
+            .andRespond(withSuccess("", MediaType.TEXT_PLAIN))
+
+        restTemplate.getForObject("http://external/api/products", String::class.java)
+
+        server.verify()
+    }
+}

--- a/user-service/src/main/kotlin/com/hoppingmall/user/config/MdcFilter.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/config/MdcFilter.kt
@@ -1,0 +1,50 @@
+package com.hoppingmall.user.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.UUID
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class MdcFilter(
+    @Value("\${spring.application.name}") private val serviceName: String
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val rawTraceId = request.getHeader(TRACE_ID_HEADER)
+        val traceId = if (isValidTraceId(rawTraceId)) rawTraceId!! else generateTraceId()
+        try {
+            MDC.put(TRACE_ID_KEY, traceId)
+            MDC.put(SERVICE_KEY, serviceName)
+            request.getHeader("x-user-id")?.let { MDC.put(USER_ID_KEY, it) }
+            response.setHeader(TRACE_ID_HEADER, traceId)
+            filterChain.doFilter(request, response)
+        } finally {
+            MDC.clear()
+        }
+    }
+
+    private fun isValidTraceId(traceId: String?): Boolean =
+        traceId != null && traceId.length in 1..64 && traceId.matches(TRACE_ID_PATTERN)
+
+    private fun generateTraceId(): String = UUID.randomUUID().toString().replace("-", "").take(16)
+
+    companion object {
+        const val TRACE_ID_KEY = "traceId"
+        const val TRACE_ID_HEADER = "X-Trace-Id"
+        const val USER_ID_KEY = "userId"
+        const val SERVICE_KEY = "service"
+        private val TRACE_ID_PATTERN = Regex("[a-zA-Z0-9\\-]+")
+    }
+}

--- a/user-service/src/main/kotlin/com/hoppingmall/user/config/MdcFilter.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/config/MdcFilter.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 class MdcFilter(
-    @Value("\${spring.application.name}") private val serviceName: String
+    @Value("\${spring.application.name:user-service}") private val serviceName: String
 ) : OncePerRequestFilter() {
 
     override fun doFilterInternal(


### PR DESCRIPTION
Closes #175

### 📌 작업 개요
Gateway → 마이크로서비스 → 서비스 간 호출에 걸친 X-Trace-Id 기반 분산 트레이싱 전파 체인을 구현했습니다.
각 계층에서 traceId를 생성/전파/검증하여 로그 상관관계 추적이 가능합니다.

---

### ✅ 주요 변경 사항

- `gateway.filter`
  - `TracingGlobalFilter`: X-Trace-Id 생성/전파 GlobalFilter (WebFlux, MDC 미사용)

- `{order,payment,product,user,notification}.config`
  - `MdcFilter`: OncePerRequestFilter 기반 MDC 컨텍스트 주입 (traceId, service, userId)

- `{order,payment,product}.config`
  - `InternalRestTemplateConfig`: InternalTokenInterceptor에서 MDC traceId/userId 헤더 전파 추가

---

### 🧪 테스트

- `TracingGlobalFilterTest`: 트레이스 ID 자동 생성, 유효 ID 전파, 64자 초과/특수문자 거부, 응답 헤더 설정 (5건)
- `InternalRestTemplateConfigTest` ×3: traceId/userId 전파, MDC 비어있을 때 NPE 방지, 내부/외부 경로 분기 (각 5건)

---

### 📎 관련 이슈
- #175