### PR TITLE
config: Docker Rate Limiting 활성화 + Redis 포트 수정

### DIFF
--- a/api-gateway/src/main/resources/application-docker.yml
+++ b/api-gateway/src/main/resources/application-docker.yml
@@ -1,4 +1,14 @@
 spring:
+  data:
+    redis:
+      host: ""
+      port: 0
+      cluster:
+        nodes:
+          - redis-node-1:7001
+          - redis-node-2:7002
+          - redis-node-3:7003
+
   cloud:
     gateway:
       routes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,11 @@ services:
       --cluster-announce-port 7001
       --cluster-announce-bus-port 17001
       --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "7001", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   redis-node-2:
     image: redis:7.2-alpine
@@ -77,6 +82,11 @@ services:
       --cluster-announce-port 7002
       --cluster-announce-bus-port 17002
       --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "7002", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   redis-node-3:
     image: redis:7.2-alpine
@@ -94,6 +104,11 @@ services:
       --cluster-announce-port 7003
       --cluster-announce-bus-port 17003
       --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "7003", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   redis-node-4:
     image: redis:7.2-alpine
@@ -111,6 +126,11 @@ services:
       --cluster-announce-port 7004
       --cluster-announce-bus-port 17004
       --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "7004", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   redis-node-5:
     image: redis:7.2-alpine
@@ -128,6 +148,11 @@ services:
       --cluster-announce-port 7005
       --cluster-announce-bus-port 17005
       --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "7005", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   redis-node-6:
     image: redis:7.2-alpine
@@ -145,17 +170,28 @@ services:
       --cluster-announce-port 7006
       --cluster-announce-bus-port 17006
       --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "7006", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   redis-cluster-init:
     image: redis:7.2-alpine
     container_name: redis-cluster-init
     depends_on:
-      - redis-node-1
-      - redis-node-2
-      - redis-node-3
-      - redis-node-4
-      - redis-node-5
-      - redis-node-6
+      redis-node-1:
+        condition: service_healthy
+      redis-node-2:
+        condition: service_healthy
+      redis-node-3:
+        condition: service_healthy
+      redis-node-4:
+        condition: service_healthy
+      redis-node-5:
+        condition: service_healthy
+      redis-node-6:
+        condition: service_healthy
     command: >
       sh -c "sleep 3 &&
       redis-cli --cluster create
@@ -331,6 +367,8 @@ services:
       dockerfile: Dockerfile
     container_name: api-gateway
     depends_on:
+      redis-cluster-init:
+        condition: service_completed_successfully
       monolith:
         condition: service_started
       user-service:

--- a/product-service/src/main/resources/application-docker.yml
+++ b/product-service/src/main/resources/application-docker.yml
@@ -14,9 +14,9 @@ spring:
         config: |
           clusterServersConfig:
             nodeAddresses:
-              - "redis://redis-node-1:6379"
-              - "redis://redis-node-2:6379"
-              - "redis://redis-node-3:6379"
+              - "redis://redis-node-1:7001"
+              - "redis://redis-node-2:7002"
+              - "redis://redis-node-3:7003"
             scanInterval: 1000
 
   kafka:


### PR DESCRIPTION
Closes #177

### 📌 작업 개요
Docker 환경에서 API Gateway Rate Limiting이 비활성 상태인 문제를 해결합니다.
Lettuce Cluster 모드로 Redis 연결을 구성하고, docker-compose의 Redis 의존성 관리를 개선합니다.

---

### ✅ 주요 변경 사항

- `api-gateway/application-docker.yml`
  - Redis Cluster 노드 설정 추가 (redis-node-1:7001, redis-node-2:7002, redis-node-3:7003)
  - base config의 standalone host/port 명시적 무효화 (host: "", port: 0)

- `docker-compose.yml`
  - redis-node-{1..6}에 healthcheck 추가 (redis-cli -p {port} ping)
  - redis-cluster-init depends_on을 service_healthy 조건으로 변경
  - api-gateway depends_on에 redis-cluster-init: service_completed_successfully 추가

- `product-service/application-docker.yml`
  - Redisson nodeAddresses 포트 수정 (6379 → 7001/7002/7003)

---

### 📎 관련 이슈
- #177