### PR TITLE
feat: gRPC 기반 서비스 간 조회 통신 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 	kotlin("plugin.jpa")
 	id("org.springframework.boot")
 	id("io.spring.dependency-management")
+	id("com.google.protobuf")
 	jacoco
 }
 
@@ -18,6 +19,10 @@ kotlin {
 		freeCompilerArgs.addAll("-Xjsr305=strict")
 	}
 }
+
+val grpcVersion = "1.62.2"
+val grpcKotlinVersion = "1.4.1"
+val protobufVersion = "3.25.3"
 
 configurations {
 	compileOnly {
@@ -72,6 +77,13 @@ dependencies {
 	testImplementation("org.springframework.kafka:spring-kafka-test")
 	testImplementation("org.springframework.security:spring-security-test")
 
+	implementation("io.grpc:grpc-protobuf:$grpcVersion")
+	implementation("io.grpc:grpc-stub:$grpcVersion")
+	implementation("io.grpc:grpc-kotlin-stub:$grpcKotlinVersion")
+	implementation("com.google.protobuf:protobuf-kotlin:$protobufVersion")
+	implementation("net.devh:grpc-spring-boot-starter:3.1.0.RELEASE")
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
+
 	implementation("org.springframework.boot:spring-boot-starter-data-redis") {
 		exclude(group = "io.lettuce", module = "lettuce-core")
 	}
@@ -114,7 +126,8 @@ val jacocoExcludedDirs = listOf(
 	"**/com/hoppingmall/mall/global/common/repository/OutboxEventRepository*",
 	"**/com/hoppingmall/mall/refund/service/RefundCompletionConsumer*",
 	"**/com/hoppingmall/mall/global/adapter/**",
-	"**/com/hoppingmall/mall/*/controller/Internal*"
+	"**/com/hoppingmall/mall/*/controller/Internal*",
+	"**/grpc/**"
 )
 
 tasks.jacocoTestReport {
@@ -156,6 +169,31 @@ tasks.jacocoTestCoverageVerification {
 				counter = "LINE"
 				value = "COVEREDRATIO"
 				minimum = "0.80".toBigDecimal()
+			}
+		}
+	}
+}
+
+protobuf {
+	protoc {
+		artifact = "com.google.protobuf:protoc:$protobufVersion"
+	}
+	plugins {
+		create("grpc") {
+			artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion"
+		}
+		create("grpckt") {
+			artifact = "io.grpc:protoc-gen-grpc-kotlin:$grpcKotlinVersion:jdk8@jar"
+		}
+	}
+	generateProtoTasks {
+		all().forEach {
+			it.plugins {
+				create("grpc")
+				create("grpckt")
+			}
+			it.builtins {
+				create("kotlin")
 			}
 		}
 	}

--- a/app/src/main/kotlin/com/hoppingmall/mall/membership/grpc/GrpcMembershipQueryService.kt
+++ b/app/src/main/kotlin/com/hoppingmall/mall/membership/grpc/GrpcMembershipQueryService.kt
@@ -1,0 +1,17 @@
+package com.hoppingmall.mall.membership.grpc
+
+import com.hoppingmall.mall.membership.domain.repository.MembershipRepository
+import com.hoppingmall.mall.membership.enum.MembershipGrade
+import net.devh.boot.grpc.server.service.GrpcService
+
+@GrpcService
+class GrpcMembershipQueryService(
+    private val membershipRepository: MembershipRepository
+) : MembershipQueryServiceGrpcKt.MembershipQueryServiceCoroutineImplBase() {
+
+    override suspend fun getPointEarningRate(request: UserIdRequest): EarningRateResponse {
+        val membership = membershipRepository.findByUserId(request.userId)
+        val rate = membership?.grade?.pointEarningRate ?: MembershipGrade.BRONZE.pointEarningRate
+        return earningRateResponse { earningRate = rate.toPlainString() }
+    }
+}

--- a/app/src/main/kotlin/com/hoppingmall/mall/membership/grpc/InternalTokenServerInterceptor.kt
+++ b/app/src/main/kotlin/com/hoppingmall/mall/membership/grpc/InternalTokenServerInterceptor.kt
@@ -1,0 +1,33 @@
+package com.hoppingmall.mall.membership.grpc
+
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import io.grpc.Status
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor
+import org.springframework.beans.factory.annotation.Value
+
+@GrpcGlobalServerInterceptor
+class InternalTokenServerInterceptor(
+    @Value("\${internal.service.token}") private val expectedToken: String
+) : ServerInterceptor {
+
+    companion object {
+        val INTERNAL_TOKEN_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-internal-token", Metadata.ASCII_STRING_MARSHALLER)
+    }
+
+    override fun <ReqT, RespT> interceptCall(
+        call: ServerCall<ReqT, RespT>,
+        headers: Metadata,
+        next: ServerCallHandler<ReqT, RespT>
+    ): ServerCall.Listener<ReqT> {
+        val clientToken = headers.get(INTERNAL_TOKEN_KEY)
+        if (clientToken != expectedToken) {
+            call.close(Status.UNAUTHENTICATED.withDescription("Invalid internal token"), Metadata())
+            return object : ServerCall.Listener<ReqT>() {}
+        }
+        return next.startCall(call, headers)
+    }
+}

--- a/app/src/main/kotlin/com/hoppingmall/mall/membership/grpc/TracingServerInterceptor.kt
+++ b/app/src/main/kotlin/com/hoppingmall/mall/membership/grpc/TracingServerInterceptor.kt
@@ -1,0 +1,51 @@
+package com.hoppingmall.mall.membership.grpc
+
+import io.grpc.ForwardingServerCallListener
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor
+import org.slf4j.MDC
+
+@GrpcGlobalServerInterceptor
+class TracingServerInterceptor : ServerInterceptor {
+
+    companion object {
+        val TRACE_ID_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-trace-id", Metadata.ASCII_STRING_MARSHALLER)
+        val USER_ID_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER)
+    }
+
+    override fun <ReqT, RespT> interceptCall(
+        call: ServerCall<ReqT, RespT>,
+        headers: Metadata,
+        next: ServerCallHandler<ReqT, RespT>
+    ): ServerCall.Listener<ReqT> {
+        headers.get(TRACE_ID_KEY)?.let { MDC.put("traceId", it) }
+        headers.get(USER_ID_KEY)?.let { MDC.put("userId", it) }
+
+        return object : ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(
+            next.startCall(call, headers)
+        ) {
+            override fun onComplete() {
+                try {
+                    super.onComplete()
+                } finally {
+                    MDC.remove("traceId")
+                    MDC.remove("userId")
+                }
+            }
+
+            override fun onCancel() {
+                try {
+                    super.onCancel()
+                } finally {
+                    MDC.remove("traceId")
+                    MDC.remove("userId")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/proto/membership_query.proto
+++ b/app/src/main/proto/membership_query.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+package hoppingmall.membership;
+option java_package = "com.hoppingmall.mall.membership.grpc";
+option java_multiple_files = true;
+
+service MembershipQueryService {
+  rpc GetPointEarningRate (UserIdRequest) returns (EarningRateResponse);
+}
+
+message UserIdRequest { int64 user_id = 1; }
+message EarningRateResponse { string earning_rate = 1; }

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -137,3 +137,7 @@ file:
 internal:
   service:
     token: ${INTERNAL_SERVICE_TOKEN:dev-internal-token-2026}
+
+grpc:
+  server:
+    port: 9080

--- a/app/src/test/resources/application-test.yml
+++ b/app/src/test/resources/application-test.yml
@@ -1,3 +1,7 @@
+grpc:
+  server:
+    port: -1
+
 spring:
   autoconfigure:
     exclude:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 	kotlin("plugin.jpa") version "1.9.25" apply false
 	id("org.springframework.boot") version "3.5.0" apply false
 	id("io.spring.dependency-management") version "1.1.7" apply false
+	id("com.google.protobuf") version "0.9.4" apply false
 }
 
 allprojects {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -230,11 +230,12 @@ services:
       redis-cluster-init:
         condition: service_started
     environment:
-      SPRING_PROFILES_ACTIVE: docker
+      SPRING_PROFILES_ACTIVE: docker,grpc
       JWT_SECRET: ${JWT_SECRET:-default-docker-secret-key-for-development-only-32chars!}
       INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-docker-internal-token-2026}
     ports:
       - "8080:8080"
+      - "9080:9080"
 
   notification-service:
     build:
@@ -281,11 +282,12 @@ services:
       redis-cluster-init:
         condition: service_started
     environment:
-      SPRING_PROFILES_ACTIVE: docker
+      SPRING_PROFILES_ACTIVE: docker,grpc
       JWT_SECRET: ${JWT_SECRET:-default-docker-secret-key-for-development-only-32chars!}
       INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-docker-internal-token-2026}
     ports:
       - "8083:8083"
+      - "9093:9093"
 
   order-service:
     build:
@@ -300,11 +302,12 @@ services:
       redis-cluster-init:
         condition: service_started
     environment:
-      SPRING_PROFILES_ACTIVE: docker
+      SPRING_PROFILES_ACTIVE: docker,grpc
       JWT_SECRET: ${JWT_SECRET:-default-docker-secret-key-for-development-only-32chars!}
       INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-docker-internal-token-2026}
     ports:
       - "8084:8084"
+      - "9094:9094"
 
   payment-service:
     build:
@@ -319,11 +322,12 @@ services:
       redis-cluster-init:
         condition: service_started
     environment:
-      SPRING_PROFILES_ACTIVE: docker
+      SPRING_PROFILES_ACTIVE: docker,grpc
       JWT_SECRET: ${JWT_SECRET:-default-docker-secret-key-for-development-only-32chars!}
       INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-docker-internal-token-2026}
     ports:
       - "8085:8085"
+      - "9095:9095"
 
   api-gateway:
     build:

--- a/order-service/Dockerfile
+++ b/order-service/Dockerfile
@@ -1,4 +1,5 @@
 FROM eclipse-temurin:21-jdk-alpine AS build
+RUN apk add --no-cache libc6-compat
 WORKDIR /app
 COPY gradlew ./
 COPY gradle ./gradle

--- a/order-service/build.gradle.kts
+++ b/order-service/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 	kotlin("plugin.jpa") version "1.9.25"
 	id("org.springframework.boot") version "3.5.0"
 	id("io.spring.dependency-management") version "1.1.7"
+	id("com.google.protobuf") version "0.9.4"
 }
 
 group = "com.hoppingmall"
@@ -24,6 +25,10 @@ kotlin {
 repositories {
 	mavenCentral()
 }
+
+val grpcVersion = "1.62.2"
+val grpcKotlinVersion = "1.4.1"
+val protobufVersion = "3.25.3"
 
 dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-stdlib")
@@ -62,8 +67,40 @@ dependencies {
 	testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
 	testImplementation("org.assertj:assertj-core:3.24.2")
 	testImplementation("org.springframework.security:spring-security-test")
+
+	implementation("io.grpc:grpc-protobuf:$grpcVersion")
+	implementation("io.grpc:grpc-stub:$grpcVersion")
+	implementation("io.grpc:grpc-kotlin-stub:$grpcKotlinVersion")
+	implementation("com.google.protobuf:protobuf-kotlin:$protobufVersion")
+	implementation("net.devh:grpc-spring-boot-starter:3.1.0.RELEASE")
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
 }
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+}
+
+protobuf {
+	protoc {
+		artifact = "com.google.protobuf:protoc:$protobufVersion"
+	}
+	plugins {
+		create("grpc") {
+			artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion"
+		}
+		create("grpckt") {
+			artifact = "io.grpc:protoc-gen-grpc-kotlin:$grpcKotlinVersion:jdk8@jar"
+		}
+	}
+	generateProtoTasks {
+		all().forEach {
+			it.plugins {
+				create("grpc")
+				create("grpckt")
+			}
+			it.builtins {
+				create("kotlin")
+			}
+		}
+	}
 }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcCartItemQueryService.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcCartItemQueryService.kt
@@ -1,0 +1,22 @@
+package com.hoppingmall.order.grpc
+
+import net.devh.boot.grpc.server.service.GrpcService
+import com.hoppingmall.order.cartItem.domain.repository.CartItemRepository
+
+@GrpcService
+class GrpcCartItemQueryService(
+    private val cartItemRepository: CartItemRepository
+) : CartItemQueryServiceGrpcKt.CartItemQueryServiceCoroutineImplBase() {
+
+    override suspend fun aggregateCartByProduct(request: Empty): CartAggregateResponse {
+        val cartAggregations = cartItemRepository.aggregateCartByProduct()
+        return cartAggregateResponse {
+            aggregations += cartAggregations.map { agg ->
+                cartAggregation {
+                    productId = agg.getProductId()
+                    buyerCount = agg.getBuyerCount()
+                }
+            }
+        }
+    }
+}

--- a/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcOrderQueryService.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcOrderQueryService.kt
@@ -1,0 +1,59 @@
+package com.hoppingmall.order.grpc
+
+import io.grpc.Status
+import io.grpc.StatusException
+import net.devh.boot.grpc.server.service.GrpcService
+import com.hoppingmall.order.order.domain.repository.OrderItemRepository
+import com.hoppingmall.order.order.domain.repository.OrderRepository
+import com.hoppingmall.order.shipping.domain.repository.ShippingRepository
+import com.hoppingmall.order.shipping.enum.ShippingStatus
+
+@GrpcService
+class GrpcOrderQueryService(
+    private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository,
+    private val shippingRepository: ShippingRepository
+) : OrderQueryServiceGrpcKt.OrderQueryServiceCoroutineImplBase() {
+
+    override suspend fun findOrderItemsByOrderId(request: OrderIdRequest): OrderItemListResponse {
+        val orderItems = orderItemRepository.findByOrderId(request.orderId)
+        return orderItemListResponse {
+            items += orderItems.map { item ->
+                orderItemResponse {
+                    id = item.id!!
+                    orderId = item.orderId
+                    sellerId = item.sellerId
+                    productId = item.productId
+                    productName = item.productName
+                    productPrice = item.productPrice.toPlainString()
+                    quantity = item.quantity
+                    totalPrice = item.totalPrice.toPlainString()
+                }
+            }
+        }
+    }
+
+    override suspend fun isDelivered(request: DeliveredCheckRequest): DeliveredResponse {
+        val order = orderRepository.findById(request.orderId).orElse(null)
+        if (order == null || order.buyerId != request.buyerId) {
+            return deliveredResponse { delivered = false }
+        }
+        val shipping = shippingRepository.findByOrderId(request.orderId)
+        return deliveredResponse { delivered = shipping?.status == ShippingStatus.DELIVERED }
+    }
+
+    override suspend fun findOrderItemById(request: OrderItemIdRequest): OrderItemResponse {
+        val item = orderItemRepository.findById(request.orderItemId).orElse(null)
+            ?: throw StatusException(Status.NOT_FOUND.withDescription("OrderItem not found: ${request.orderItemId}"))
+        return orderItemResponse {
+            id = item.id!!
+            orderId = item.orderId
+            sellerId = item.sellerId
+            productId = item.productId
+            productName = item.productName
+            productPrice = item.productPrice.toPlainString()
+            quantity = item.quantity
+            totalPrice = item.totalPrice.toPlainString()
+        }
+    }
+}

--- a/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcPaymentQueryAdapter.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcPaymentQueryAdapter.kt
@@ -1,0 +1,63 @@
+package com.hoppingmall.order.grpc
+
+import com.hoppingmall.order.port.PaymentInfo
+import com.hoppingmall.order.port.PaymentQueryPort
+import com.hoppingmall.payment.grpc.PaymentIdRequest
+import com.hoppingmall.payment.grpc.PaymentOrderIdRequest
+import com.hoppingmall.payment.grpc.PaymentQueryServiceGrpc
+import com.hoppingmall.payment.grpc.PaymentResponse
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import net.devh.boot.grpc.client.inject.GrpcClient
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+
+@Component
+@Profile("grpc")
+class GrpcPaymentQueryAdapter(
+    @GrpcClient("payment-service") private val stub: PaymentQueryServiceGrpc.PaymentQueryServiceBlockingStub
+) : PaymentQueryPort {
+
+    private val log = LoggerFactory.getLogger(GrpcPaymentQueryAdapter::class.java)
+
+    override fun findByOrderId(orderId: Long): PaymentInfo? {
+        return try {
+            val response = stub.findPaymentByOrderId(
+                PaymentOrderIdRequest.newBuilder().setOrderId(orderId).build()
+            )
+            response.toPaymentInfo()
+        } catch (e: StatusRuntimeException) {
+            if (e.status.code == Status.Code.NOT_FOUND) null
+            else {
+                log.warn("결제 조회 실패: orderId=$orderId", e)
+                null
+            }
+        }
+    }
+
+    override fun findById(paymentId: Long): PaymentInfo? {
+        return try {
+            val response = stub.findPaymentById(
+                PaymentIdRequest.newBuilder().setPaymentId(paymentId).build()
+            )
+            response.toPaymentInfo()
+        } catch (e: StatusRuntimeException) {
+            if (e.status.code == Status.Code.NOT_FOUND) null
+            else {
+                log.warn("결제 조회 실패: paymentId=$paymentId", e)
+                null
+            }
+        }
+    }
+
+    private fun PaymentResponse.toPaymentInfo() = PaymentInfo(
+        id = id,
+        orderId = orderId,
+        amount = amount.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+        pointAmount = pointAmount.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+        couponId = if (hasCouponId()) couponId else null,
+        status = status
+    )
+}

--- a/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcProductQueryAdapter.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcProductQueryAdapter.kt
@@ -1,0 +1,74 @@
+package com.hoppingmall.order.grpc
+
+import com.hoppingmall.order.port.ProductInfo
+import com.hoppingmall.order.port.ProductQueryPort
+import com.hoppingmall.product.grpc.ProductIdRequest
+import com.hoppingmall.product.grpc.ProductIdsRequest
+import com.hoppingmall.product.grpc.ProductQueryServiceGrpc
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import net.devh.boot.grpc.client.inject.GrpcClient
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+
+@Component
+@Profile("grpc")
+class GrpcProductQueryAdapter(
+    @GrpcClient("product-service") private val stub: ProductQueryServiceGrpc.ProductQueryServiceBlockingStub
+) : ProductQueryPort {
+
+    private val log = LoggerFactory.getLogger(GrpcProductQueryAdapter::class.java)
+
+    override fun findProductById(productId: Long): ProductInfo? {
+        return try {
+            val response = stub.findProductById(
+                ProductIdRequest.newBuilder().setProductId(productId).build()
+            )
+            ProductInfo(
+                id = response.id,
+                name = response.name,
+                price = response.price.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+                sellerId = response.sellerId
+            )
+        } catch (e: StatusRuntimeException) {
+            if (e.status.code == Status.Code.NOT_FOUND) null
+            else {
+                log.warn("상품 조회 실패: productId=$productId", e)
+                null
+            }
+        }
+    }
+
+    override fun findProductsByIds(productIds: List<Long>): List<ProductInfo> {
+        return try {
+            val response = stub.findProductsByIds(
+                ProductIdsRequest.newBuilder().addAllProductIds(productIds).build()
+            )
+            response.productsList.map {
+                ProductInfo(
+                    id = it.id,
+                    name = it.name,
+                    price = it.price.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+                    sellerId = it.sellerId
+                )
+            }
+        } catch (e: StatusRuntimeException) {
+            log.warn("상품 목록 조회 실패: productIds=$productIds", e)
+            emptyList()
+        }
+    }
+
+    override fun findProductImageUrl(productId: Long): String? {
+        return try {
+            val response = stub.findProductImageUrl(
+                ProductIdRequest.newBuilder().setProductId(productId).build()
+            )
+            if (response.found) response.imageUrl else null
+        } catch (e: StatusRuntimeException) {
+            log.warn("상품 이미지 URL 조회 실패: productId=$productId", e)
+            null
+        }
+    }
+}

--- a/order-service/src/main/kotlin/com/hoppingmall/order/grpc/InternalTokenClientInterceptor.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/grpc/InternalTokenClientInterceptor.kt
@@ -1,0 +1,31 @@
+package com.hoppingmall.order.grpc
+
+import io.grpc.*
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor
+import org.springframework.beans.factory.annotation.Value
+
+@GrpcGlobalClientInterceptor
+class InternalTokenClientInterceptor(
+    @Value("\${internal.service.token}") private val token: String
+) : ClientInterceptor {
+
+    companion object {
+        val INTERNAL_TOKEN_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-internal-token", Metadata.ASCII_STRING_MARSHALLER)
+    }
+
+    override fun <ReqT, RespT> interceptCall(
+        method: MethodDescriptor<ReqT, RespT>,
+        callOptions: CallOptions,
+        next: Channel
+    ): ClientCall<ReqT, RespT> {
+        return object : ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+            next.newCall(method, callOptions)
+        ) {
+            override fun start(responseListener: Listener<RespT>, headers: Metadata) {
+                headers.put(INTERNAL_TOKEN_KEY, token)
+                super.start(responseListener, headers)
+            }
+        }
+    }
+}

--- a/order-service/src/main/kotlin/com/hoppingmall/order/grpc/InternalTokenServerInterceptor.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/grpc/InternalTokenServerInterceptor.kt
@@ -1,0 +1,33 @@
+package com.hoppingmall.order.grpc
+
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import io.grpc.Status
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor
+import org.springframework.beans.factory.annotation.Value
+
+@GrpcGlobalServerInterceptor
+class InternalTokenServerInterceptor(
+    @Value("\${internal.service.token}") private val expectedToken: String
+) : ServerInterceptor {
+
+    companion object {
+        val INTERNAL_TOKEN_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-internal-token", Metadata.ASCII_STRING_MARSHALLER)
+    }
+
+    override fun <ReqT, RespT> interceptCall(
+        call: ServerCall<ReqT, RespT>,
+        headers: Metadata,
+        next: ServerCallHandler<ReqT, RespT>
+    ): ServerCall.Listener<ReqT> {
+        val clientToken = headers.get(INTERNAL_TOKEN_KEY)
+        if (clientToken != expectedToken) {
+            call.close(Status.UNAUTHENTICATED.withDescription("Invalid internal token"), Metadata())
+            return object : ServerCall.Listener<ReqT>() {}
+        }
+        return next.startCall(call, headers)
+    }
+}

--- a/order-service/src/main/kotlin/com/hoppingmall/order/grpc/TracingClientInterceptor.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/grpc/TracingClientInterceptor.kt
@@ -1,0 +1,32 @@
+package com.hoppingmall.order.grpc
+
+import io.grpc.*
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor
+import org.slf4j.MDC
+
+@GrpcGlobalClientInterceptor
+class TracingClientInterceptor : ClientInterceptor {
+
+    companion object {
+        val TRACE_ID_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-trace-id", Metadata.ASCII_STRING_MARSHALLER)
+        val USER_ID_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER)
+    }
+
+    override fun <ReqT, RespT> interceptCall(
+        method: MethodDescriptor<ReqT, RespT>,
+        callOptions: CallOptions,
+        next: Channel
+    ): ClientCall<ReqT, RespT> {
+        return object : ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+            next.newCall(method, callOptions)
+        ) {
+            override fun start(responseListener: Listener<RespT>, headers: Metadata) {
+                MDC.get("traceId")?.let { headers.put(TRACE_ID_KEY, it) }
+                MDC.get("userId")?.let { headers.put(USER_ID_KEY, it) }
+                super.start(responseListener, headers)
+            }
+        }
+    }
+}

--- a/order-service/src/main/kotlin/com/hoppingmall/order/grpc/TracingServerInterceptor.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/grpc/TracingServerInterceptor.kt
@@ -1,0 +1,51 @@
+package com.hoppingmall.order.grpc
+
+import io.grpc.ForwardingServerCallListener
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor
+import org.slf4j.MDC
+
+@GrpcGlobalServerInterceptor
+class TracingServerInterceptor : ServerInterceptor {
+
+    companion object {
+        val TRACE_ID_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-trace-id", Metadata.ASCII_STRING_MARSHALLER)
+        val USER_ID_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER)
+    }
+
+    override fun <ReqT, RespT> interceptCall(
+        call: ServerCall<ReqT, RespT>,
+        headers: Metadata,
+        next: ServerCallHandler<ReqT, RespT>
+    ): ServerCall.Listener<ReqT> {
+        headers.get(TRACE_ID_KEY)?.let { MDC.put("traceId", it) }
+        headers.get(USER_ID_KEY)?.let { MDC.put("userId", it) }
+
+        return object : ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(
+            next.startCall(call, headers)
+        ) {
+            override fun onComplete() {
+                try {
+                    super.onComplete()
+                } finally {
+                    MDC.remove("traceId")
+                    MDC.remove("userId")
+                }
+            }
+
+            override fun onCancel() {
+                try {
+                    super.onCancel()
+                } finally {
+                    MDC.remove("traceId")
+                    MDC.remove("userId")
+                }
+            }
+        }
+    }
+}

--- a/order-service/src/main/kotlin/com/hoppingmall/order/port/HttpPaymentQueryAdapter.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/port/HttpPaymentQueryAdapter.kt
@@ -3,11 +3,13 @@ package com.hoppingmall.order.port
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
 import java.time.Duration
 
 @Component
+@Profile("!grpc")
 class HttpPaymentQueryAdapter(
     @Value("\${services.monolith.url:http://localhost:8080}") private val monolithUrl: String,
     restTemplateBuilder: RestTemplateBuilder

--- a/order-service/src/main/kotlin/com/hoppingmall/order/port/HttpProductQueryAdapter.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/port/HttpProductQueryAdapter.kt
@@ -3,11 +3,13 @@ package com.hoppingmall.order.port
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
 import java.time.Duration
 
 @Component
+@Profile("!grpc")
 class HttpProductQueryAdapter(
     @Value("\${services.product-service.url:http://localhost:8083}") private val productServiceUrl: String,
     restTemplateBuilder: RestTemplateBuilder

--- a/order-service/src/main/proto/order_query.proto
+++ b/order-service/src/main/proto/order_query.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+package hoppingmall.order;
+option java_package = "com.hoppingmall.order.grpc";
+option java_multiple_files = true;
+
+service OrderQueryService {
+  rpc FindOrderItemsByOrderId (OrderIdRequest) returns (OrderItemListResponse);
+  rpc IsDelivered (DeliveredCheckRequest) returns (DeliveredResponse);
+  rpc FindOrderItemById (OrderItemIdRequest) returns (OrderItemResponse);
+}
+
+service CartItemQueryService {
+  rpc AggregateCartByProduct (Empty) returns (CartAggregateResponse);
+}
+
+message OrderIdRequest { int64 order_id = 1; }
+message OrderItemIdRequest { int64 order_item_id = 1; }
+message DeliveredCheckRequest {
+  int64 order_id = 1;
+  int64 buyer_id = 2;
+}
+message DeliveredResponse { bool delivered = 1; }
+message Empty {}
+
+message OrderItemResponse {
+  int64 id = 1;
+  int64 order_id = 2;
+  int64 seller_id = 3;
+  int64 product_id = 4;
+  string product_name = 5;
+  string product_price = 6;
+  int32 quantity = 7;
+  string total_price = 8;
+}
+message OrderItemListResponse { repeated OrderItemResponse items = 1; }
+
+message CartAggregation {
+  int64 product_id = 1;
+  int64 buyer_count = 2;
+}
+message CartAggregateResponse { repeated CartAggregation aggregations = 1; }

--- a/order-service/src/main/proto/payment_query.proto
+++ b/order-service/src/main/proto/payment_query.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+package hoppingmall.payment;
+option java_package = "com.hoppingmall.payment.grpc";
+option java_multiple_files = true;
+
+service PaymentQueryService {
+  rpc FindPaymentByOrderId (PaymentOrderIdRequest) returns (PaymentResponse);
+  rpc FindPaymentById (PaymentIdRequest) returns (PaymentResponse);
+}
+
+message PaymentOrderIdRequest { int64 order_id = 1; }
+message PaymentIdRequest { int64 payment_id = 1; }
+message PaymentResponse {
+  int64 id = 1;
+  int64 order_id = 2;
+  string amount = 3;
+  string point_amount = 4;
+  optional int64 coupon_id = 5;
+  string status = 6;
+}

--- a/order-service/src/main/proto/product_query.proto
+++ b/order-service/src/main/proto/product_query.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+package hoppingmall.product;
+option java_package = "com.hoppingmall.product.grpc";
+option java_multiple_files = true;
+
+service ProductQueryService {
+  rpc FindProductById (ProductIdRequest) returns (ProductResponse);
+  rpc FindProductsByIds (ProductIdsRequest) returns (ProductListResponse);
+  rpc FindProductImageUrl (ProductIdRequest) returns (ImageUrlResponse);
+}
+
+message ProductIdRequest { int64 product_id = 1; }
+message ProductIdsRequest { repeated int64 product_ids = 1; }
+message ProductResponse {
+  int64 id = 1;
+  string name = 2;
+  string price = 3;
+  int64 seller_id = 4;
+}
+message ProductListResponse { repeated ProductResponse products = 1; }
+message ImageUrlResponse {
+  string image_url = 1;
+  bool found = 2;
+}

--- a/order-service/src/main/resources/application-docker.yml
+++ b/order-service/src/main/resources/application-docker.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://mysql:3306/product_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://mysql:3306/order_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: root
     password: root
@@ -14,9 +14,9 @@ spring:
         config: |
           clusterServersConfig:
             nodeAddresses:
-              - "redis://redis-node-1:6379"
-              - "redis://redis-node-2:6379"
-              - "redis://redis-node-3:6379"
+              - "redis://redis-node-1:7001"
+              - "redis://redis-node-2:7002"
+              - "redis://redis-node-3:7003"
             scanInterval: 1000
 
   kafka:
@@ -37,8 +37,8 @@ management:
 services:
   monolith:
     url: http://monolith:8080
-  order-service:
-    url: http://order-service:8084
+  product-service:
+    url: http://product-service:8083
 
 internal:
   service:
@@ -46,6 +46,9 @@ internal:
 
 grpc:
   client:
-    order-service:
-      address: static://order-service:9094
+    product-service:
+      address: static://product-service:9093
+      negotiation-type: plaintext
+    payment-service:
+      address: static://payment-service:9095
       negotiation-type: plaintext

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 spring:
   application:
-    name: product-service
+    name: order-service
 
   datasource:
-    url: jdbc:h2:mem:productdb;DB_CLOSE_DELAY=-1;MODE=MYSQL
+    url: jdbc:h2:mem:orderdb;DB_CLOSE_DELAY=-1;MODE=MYSQL
     driver-class-name: org.h2.Driver
     username: sa
     password:
@@ -36,14 +36,19 @@ spring:
   kafka:
     consumer:
       bootstrap-servers: localhost:9092
+      group-id: order-service
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       properties:
         spring.json.trusted.packages: "*"
+    producer:
+      bootstrap-servers: localhost:9092
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
 server:
-  port: 8083
+  port: 8084
 
 management:
   endpoints:
@@ -52,7 +57,7 @@ management:
         include: health,metrics,prometheus
   metrics:
     tags:
-      application: product-service
+      application: order-service
   tracing:
     sampling:
       probability: 0.0
@@ -61,22 +66,8 @@ management:
 services:
   monolith:
     url: http://localhost:8080
-  order-service:
-    url: http://localhost:8084
-
-file:
-  upload:
-    base-upload-dir: ${FILE_UPLOAD_BASE_DIR:/tmp/hoppingmall}
-    max-file-size: 5242880
-    allowed-extensions:
-      - jpg
-      - jpeg
-      - png
-      - gif
-      - webp
-    allowed-domains:
-      - product
-    sub-directory: images
+  product-service:
+    url: http://localhost:8083
 
 internal:
   service:
@@ -84,8 +75,11 @@ internal:
 
 grpc:
   server:
-    port: 9093
+    port: 9094
   client:
-    order-service:
-      address: static://localhost:9094
+    product-service:
+      address: static://localhost:9093
+      negotiation-type: plaintext
+    payment-service:
+      address: static://localhost:9095
       negotiation-type: plaintext

--- a/payment-service/Dockerfile
+++ b/payment-service/Dockerfile
@@ -1,4 +1,5 @@
 FROM eclipse-temurin:21-jdk-alpine AS build
+RUN apk add --no-cache libc6-compat
 WORKDIR /app
 COPY gradlew ./
 COPY gradle ./gradle

--- a/payment-service/build.gradle.kts
+++ b/payment-service/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 	kotlin("plugin.jpa") version "1.9.25"
 	id("org.springframework.boot") version "3.5.0"
 	id("io.spring.dependency-management") version "1.1.7"
+	id("com.google.protobuf") version "0.9.4"
 }
 
 group = "com.hoppingmall"
@@ -24,6 +25,10 @@ kotlin {
 repositories {
 	mavenCentral()
 }
+
+val grpcVersion = "1.62.2"
+val grpcKotlinVersion = "1.4.1"
+val protobufVersion = "3.25.3"
 
 dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-stdlib")
@@ -62,8 +67,40 @@ dependencies {
 	testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
 	testImplementation("org.assertj:assertj-core:3.24.2")
 	testImplementation("org.springframework.security:spring-security-test")
+
+	implementation("io.grpc:grpc-protobuf:$grpcVersion")
+	implementation("io.grpc:grpc-stub:$grpcVersion")
+	implementation("io.grpc:grpc-kotlin-stub:$grpcKotlinVersion")
+	implementation("com.google.protobuf:protobuf-kotlin:$protobufVersion")
+	implementation("net.devh:grpc-spring-boot-starter:3.1.0.RELEASE")
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
 }
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+}
+
+protobuf {
+	protoc {
+		artifact = "com.google.protobuf:protoc:$protobufVersion"
+	}
+	plugins {
+		create("grpc") {
+			artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion"
+		}
+		create("grpckt") {
+			artifact = "io.grpc:protoc-gen-grpc-kotlin:$grpcKotlinVersion:jdk8@jar"
+		}
+	}
+	generateProtoTasks {
+		all().forEach {
+			it.plugins {
+				create("grpc")
+				create("grpckt")
+			}
+			it.builtins {
+				create("kotlin")
+			}
+		}
+	}
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/GrpcMembershipQueryAdapter.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/GrpcMembershipQueryAdapter.kt
@@ -1,0 +1,32 @@
+package com.hoppingmall.payment.grpc
+
+import com.hoppingmall.mall.membership.grpc.MembershipQueryServiceGrpc
+import com.hoppingmall.mall.membership.grpc.UserIdRequest
+import com.hoppingmall.payment.port.MembershipQueryPort
+import io.grpc.StatusRuntimeException
+import net.devh.boot.grpc.client.inject.GrpcClient
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+
+@Component
+@Profile("grpc")
+class GrpcMembershipQueryAdapter(
+    @GrpcClient("monolith") private val stub: MembershipQueryServiceGrpc.MembershipQueryServiceBlockingStub
+) : MembershipQueryPort {
+
+    private val log = LoggerFactory.getLogger(GrpcMembershipQueryAdapter::class.java)
+
+    override fun getPointEarningRate(userId: Long): BigDecimal {
+        return try {
+            val response = stub.getPointEarningRate(
+                UserIdRequest.newBuilder().setUserId(userId).build()
+            )
+            response.earningRate.toBigDecimalOrNull() ?: BigDecimal.ZERO
+        } catch (e: StatusRuntimeException) {
+            log.warn("멤버십 적립률 조회 실패: userId=$userId", e)
+            BigDecimal("0.01")
+        }
+    }
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/GrpcOrderQueryAdapter.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/GrpcOrderQueryAdapter.kt
@@ -1,0 +1,40 @@
+package com.hoppingmall.payment.grpc
+
+import com.hoppingmall.order.grpc.OrderIdRequest
+import com.hoppingmall.order.grpc.OrderQueryServiceGrpc
+import com.hoppingmall.payment.port.OrderItemInfo
+import com.hoppingmall.payment.port.OrderQueryPort
+import io.grpc.StatusRuntimeException
+import net.devh.boot.grpc.client.inject.GrpcClient
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+
+@Component
+@Profile("grpc")
+class GrpcOrderQueryAdapter(
+    @GrpcClient("order-service") private val stub: OrderQueryServiceGrpc.OrderQueryServiceBlockingStub
+) : OrderQueryPort {
+
+    private val log = LoggerFactory.getLogger(GrpcOrderQueryAdapter::class.java)
+
+    override fun findOrderItemsByOrderId(orderId: Long): List<OrderItemInfo> {
+        return try {
+            val response = stub.findOrderItemsByOrderId(
+                OrderIdRequest.newBuilder().setOrderId(orderId).build()
+            )
+            response.itemsList.map {
+                OrderItemInfo(
+                    id = it.id,
+                    productId = it.productId,
+                    quantity = it.quantity,
+                    totalPrice = it.totalPrice.toBigDecimalOrNull() ?: BigDecimal.ZERO
+                )
+            }
+        } catch (e: StatusRuntimeException) {
+            log.warn("주문 상품 조회 실패: orderId=$orderId", e)
+            emptyList()
+        }
+    }
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/GrpcPaymentQueryService.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/GrpcPaymentQueryService.kt
@@ -1,0 +1,38 @@
+package com.hoppingmall.payment.grpc
+
+import com.hoppingmall.payment.payment.domain.repository.PaymentRepository
+import io.grpc.Status
+import io.grpc.StatusException
+import net.devh.boot.grpc.server.service.GrpcService
+
+@GrpcService
+class GrpcPaymentQueryService(
+    private val paymentRepository: PaymentRepository
+) : PaymentQueryServiceGrpcKt.PaymentQueryServiceCoroutineImplBase() {
+
+    override suspend fun findPaymentByOrderId(request: PaymentOrderIdRequest): PaymentResponse {
+        val payment = paymentRepository.findByOrderId(request.orderId)
+            ?: throw StatusException(Status.NOT_FOUND.withDescription("Payment not found for orderId=${request.orderId}"))
+        return paymentResponse {
+            id = payment.id!!
+            orderId = payment.orderId
+            amount = payment.amount.toPlainString()
+            pointAmount = payment.pointAmount.toPlainString()
+            payment.couponId?.let { couponId = it }
+            status = payment.status.name
+        }
+    }
+
+    override suspend fun findPaymentById(request: PaymentIdRequest): PaymentResponse {
+        val payment = paymentRepository.findById(request.paymentId).orElse(null)
+            ?: throw StatusException(Status.NOT_FOUND.withDescription("Payment not found for id=${request.paymentId}"))
+        return paymentResponse {
+            id = payment.id!!
+            orderId = payment.orderId
+            amount = payment.amount.toPlainString()
+            pointAmount = payment.pointAmount.toPlainString()
+            payment.couponId?.let { couponId = it }
+            status = payment.status.name
+        }
+    }
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/InternalTokenClientInterceptor.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/InternalTokenClientInterceptor.kt
@@ -1,0 +1,31 @@
+package com.hoppingmall.payment.grpc
+
+import io.grpc.*
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor
+import org.springframework.beans.factory.annotation.Value
+
+@GrpcGlobalClientInterceptor
+class InternalTokenClientInterceptor(
+    @Value("\${internal.service.token}") private val token: String
+) : ClientInterceptor {
+
+    companion object {
+        val INTERNAL_TOKEN_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-internal-token", Metadata.ASCII_STRING_MARSHALLER)
+    }
+
+    override fun <ReqT, RespT> interceptCall(
+        method: MethodDescriptor<ReqT, RespT>,
+        callOptions: CallOptions,
+        next: Channel
+    ): ClientCall<ReqT, RespT> {
+        return object : ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+            next.newCall(method, callOptions)
+        ) {
+            override fun start(responseListener: Listener<RespT>, headers: Metadata) {
+                headers.put(INTERNAL_TOKEN_KEY, token)
+                super.start(responseListener, headers)
+            }
+        }
+    }
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/InternalTokenServerInterceptor.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/InternalTokenServerInterceptor.kt
@@ -1,0 +1,33 @@
+package com.hoppingmall.payment.grpc
+
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import io.grpc.Status
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor
+import org.springframework.beans.factory.annotation.Value
+
+@GrpcGlobalServerInterceptor
+class InternalTokenServerInterceptor(
+    @Value("\${internal.service.token}") private val expectedToken: String
+) : ServerInterceptor {
+
+    companion object {
+        val INTERNAL_TOKEN_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-internal-token", Metadata.ASCII_STRING_MARSHALLER)
+    }
+
+    override fun <ReqT, RespT> interceptCall(
+        call: ServerCall<ReqT, RespT>,
+        headers: Metadata,
+        next: ServerCallHandler<ReqT, RespT>
+    ): ServerCall.Listener<ReqT> {
+        val clientToken = headers.get(INTERNAL_TOKEN_KEY)
+        if (clientToken != expectedToken) {
+            call.close(Status.UNAUTHENTICATED.withDescription("Invalid internal token"), Metadata())
+            return object : ServerCall.Listener<ReqT>() {}
+        }
+        return next.startCall(call, headers)
+    }
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/TracingClientInterceptor.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/TracingClientInterceptor.kt
@@ -1,0 +1,32 @@
+package com.hoppingmall.payment.grpc
+
+import io.grpc.*
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor
+import org.slf4j.MDC
+
+@GrpcGlobalClientInterceptor
+class TracingClientInterceptor : ClientInterceptor {
+
+    companion object {
+        val TRACE_ID_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-trace-id", Metadata.ASCII_STRING_MARSHALLER)
+        val USER_ID_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER)
+    }
+
+    override fun <ReqT, RespT> interceptCall(
+        method: MethodDescriptor<ReqT, RespT>,
+        callOptions: CallOptions,
+        next: Channel
+    ): ClientCall<ReqT, RespT> {
+        return object : ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+            next.newCall(method, callOptions)
+        ) {
+            override fun start(responseListener: Listener<RespT>, headers: Metadata) {
+                MDC.get("traceId")?.let { headers.put(TRACE_ID_KEY, it) }
+                MDC.get("userId")?.let { headers.put(USER_ID_KEY, it) }
+                super.start(responseListener, headers)
+            }
+        }
+    }
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/TracingServerInterceptor.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/TracingServerInterceptor.kt
@@ -1,0 +1,51 @@
+package com.hoppingmall.payment.grpc
+
+import io.grpc.ForwardingServerCallListener
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor
+import org.slf4j.MDC
+
+@GrpcGlobalServerInterceptor
+class TracingServerInterceptor : ServerInterceptor {
+
+    companion object {
+        val TRACE_ID_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-trace-id", Metadata.ASCII_STRING_MARSHALLER)
+        val USER_ID_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER)
+    }
+
+    override fun <ReqT, RespT> interceptCall(
+        call: ServerCall<ReqT, RespT>,
+        headers: Metadata,
+        next: ServerCallHandler<ReqT, RespT>
+    ): ServerCall.Listener<ReqT> {
+        headers.get(TRACE_ID_KEY)?.let { MDC.put("traceId", it) }
+        headers.get(USER_ID_KEY)?.let { MDC.put("userId", it) }
+
+        return object : ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(
+            next.startCall(call, headers)
+        ) {
+            override fun onComplete() {
+                try {
+                    super.onComplete()
+                } finally {
+                    MDC.remove("traceId")
+                    MDC.remove("userId")
+                }
+            }
+
+            override fun onCancel() {
+                try {
+                    super.onCancel()
+                } finally {
+                    MDC.remove("traceId")
+                    MDC.remove("userId")
+                }
+            }
+        }
+    }
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/port/HttpMembershipQueryAdapter.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/port/HttpMembershipQueryAdapter.kt
@@ -3,12 +3,14 @@ package com.hoppingmall.payment.port
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
 import java.math.BigDecimal
 import java.time.Duration
 
 @Component
+@Profile("!grpc")
 class HttpMembershipQueryAdapter(
     @Value("\${services.monolith.url:http://localhost:8080}") private val monolithUrl: String,
     restTemplateBuilder: RestTemplateBuilder

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/port/HttpOrderQueryAdapter.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/port/HttpOrderQueryAdapter.kt
@@ -3,11 +3,13 @@ package com.hoppingmall.payment.port
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
 import java.time.Duration
 
 @Component
+@Profile("!grpc")
 class HttpOrderQueryAdapter(
     @Value("\${services.order-service.url:http://localhost:8084}") private val orderServiceUrl: String,
     restTemplateBuilder: RestTemplateBuilder

--- a/payment-service/src/main/proto/membership_query.proto
+++ b/payment-service/src/main/proto/membership_query.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+package hoppingmall.membership;
+option java_package = "com.hoppingmall.mall.membership.grpc";
+option java_multiple_files = true;
+
+service MembershipQueryService {
+  rpc GetPointEarningRate (UserIdRequest) returns (EarningRateResponse);
+}
+
+message UserIdRequest { int64 user_id = 1; }
+message EarningRateResponse { string earning_rate = 1; }

--- a/payment-service/src/main/proto/order_query.proto
+++ b/payment-service/src/main/proto/order_query.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+package hoppingmall.order;
+option java_package = "com.hoppingmall.order.grpc";
+option java_multiple_files = true;
+
+service OrderQueryService {
+  rpc FindOrderItemsByOrderId (OrderIdRequest) returns (OrderItemListResponse);
+  rpc IsDelivered (DeliveredCheckRequest) returns (DeliveredResponse);
+  rpc FindOrderItemById (OrderItemIdRequest) returns (OrderItemResponse);
+}
+
+service CartItemQueryService {
+  rpc AggregateCartByProduct (Empty) returns (CartAggregateResponse);
+}
+
+message OrderIdRequest { int64 order_id = 1; }
+message OrderItemIdRequest { int64 order_item_id = 1; }
+message DeliveredCheckRequest {
+  int64 order_id = 1;
+  int64 buyer_id = 2;
+}
+message DeliveredResponse { bool delivered = 1; }
+message Empty {}
+
+message OrderItemResponse {
+  int64 id = 1;
+  int64 order_id = 2;
+  int64 seller_id = 3;
+  int64 product_id = 4;
+  string product_name = 5;
+  string product_price = 6;
+  int32 quantity = 7;
+  string total_price = 8;
+}
+message OrderItemListResponse { repeated OrderItemResponse items = 1; }
+
+message CartAggregation {
+  int64 product_id = 1;
+  int64 buyer_count = 2;
+}
+message CartAggregateResponse { repeated CartAggregation aggregations = 1; }

--- a/payment-service/src/main/proto/payment_query.proto
+++ b/payment-service/src/main/proto/payment_query.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+package hoppingmall.payment;
+option java_package = "com.hoppingmall.payment.grpc";
+option java_multiple_files = true;
+
+service PaymentQueryService {
+  rpc FindPaymentByOrderId (PaymentOrderIdRequest) returns (PaymentResponse);
+  rpc FindPaymentById (PaymentIdRequest) returns (PaymentResponse);
+}
+
+message PaymentOrderIdRequest { int64 order_id = 1; }
+message PaymentIdRequest { int64 payment_id = 1; }
+message PaymentResponse {
+  int64 id = 1;
+  int64 order_id = 2;
+  string amount = 3;
+  string point_amount = 4;
+  optional int64 coupon_id = 5;
+  string status = 6;
+}

--- a/payment-service/src/main/resources/application-docker.yml
+++ b/payment-service/src/main/resources/application-docker.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://mysql:3306/product_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://mysql:3306/payment_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: root
     password: root
@@ -14,9 +14,9 @@ spring:
         config: |
           clusterServersConfig:
             nodeAddresses:
-              - "redis://redis-node-1:6379"
-              - "redis://redis-node-2:6379"
-              - "redis://redis-node-3:6379"
+              - "redis://redis-node-1:7001"
+              - "redis://redis-node-2:7002"
+              - "redis://redis-node-3:7003"
             scanInterval: 1000
 
   kafka:
@@ -39,6 +39,8 @@ services:
     url: http://monolith:8080
   order-service:
     url: http://order-service:8084
+  product-service:
+    url: http://product-service:8083
 
 internal:
   service:
@@ -48,4 +50,7 @@ grpc:
   client:
     order-service:
       address: static://order-service:9094
+      negotiation-type: plaintext
+    monolith:
+      address: static://monolith:9080
       negotiation-type: plaintext

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 spring:
   application:
-    name: product-service
+    name: payment-service
 
   datasource:
-    url: jdbc:h2:mem:productdb;DB_CLOSE_DELAY=-1;MODE=MYSQL
+    url: jdbc:h2:mem:paymentdb;DB_CLOSE_DELAY=-1;MODE=MYSQL
     driver-class-name: org.h2.Driver
     username: sa
     password:
@@ -19,9 +19,6 @@ spring:
         legacy_id_generator_strategy: true
         default_batch_fetch_size: 100
 
-  jackson:
-    property-naming-strategy: SNAKE_CASE
-
   data:
     redis:
       redisson:
@@ -36,14 +33,17 @@ spring:
   kafka:
     consumer:
       bootstrap-servers: localhost:9092
+      group-id: payment-service
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       properties:
         spring.json.trusted.packages: "*"
+    producer:
+      bootstrap-servers: localhost:9092
 
 server:
-  port: 8083
+  port: 8085
 
 management:
   endpoints:
@@ -52,7 +52,7 @@ management:
         include: health,metrics,prometheus
   metrics:
     tags:
-      application: product-service
+      application: payment-service
   tracing:
     sampling:
       probability: 0.0
@@ -63,20 +63,8 @@ services:
     url: http://localhost:8080
   order-service:
     url: http://localhost:8084
-
-file:
-  upload:
-    base-upload-dir: ${FILE_UPLOAD_BASE_DIR:/tmp/hoppingmall}
-    max-file-size: 5242880
-    allowed-extensions:
-      - jpg
-      - jpeg
-      - png
-      - gif
-      - webp
-    allowed-domains:
-      - product
-    sub-directory: images
+  product-service:
+    url: http://localhost:8083
 
 internal:
   service:
@@ -84,8 +72,11 @@ internal:
 
 grpc:
   server:
-    port: 9093
+    port: 9095
   client:
     order-service:
       address: static://localhost:9094
+      negotiation-type: plaintext
+    monolith:
+      address: static://localhost:9080
       negotiation-type: plaintext

--- a/product-domain/src/main/kotlin/com/hoppingmall/mall/product/domain/ProductHourlyStatistics.kt
+++ b/product-domain/src/main/kotlin/com/hoppingmall/mall/product/domain/ProductHourlyStatistics.kt
@@ -11,7 +11,7 @@ import java.time.LocalDate
 @Entity
 @Table(
     name = "product_hourly_statistics",
-    uniqueConstraints = [UniqueConstraint(columnNames = ["product_id", "statistics_date", "hour"])]
+    uniqueConstraints = [UniqueConstraint(columnNames = ["product_id", "statistics_date", "\"hour\""])]
 )
 class ProductHourlyStatistics(
     @Column(name = "product_id", nullable = false)

--- a/product-service/Dockerfile
+++ b/product-service/Dockerfile
@@ -1,4 +1,5 @@
 FROM eclipse-temurin:21-jdk-alpine AS build
+RUN apk add --no-cache libc6-compat
 WORKDIR /app
 COPY gradlew ./
 COPY gradle ./gradle

--- a/product-service/build.gradle.kts
+++ b/product-service/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 	kotlin("plugin.jpa") version "1.9.25"
 	id("org.springframework.boot") version "3.5.0"
 	id("io.spring.dependency-management") version "1.1.7"
+	id("com.google.protobuf") version "0.9.4"
 }
 
 group = "com.hoppingmall"
@@ -24,6 +25,10 @@ kotlin {
 repositories {
 	mavenCentral()
 }
+
+val grpcVersion = "1.62.2"
+val grpcKotlinVersion = "1.4.1"
+val protobufVersion = "3.25.3"
 
 dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-stdlib")
@@ -63,8 +68,40 @@ dependencies {
 	testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
 	testImplementation("org.assertj:assertj-core:3.24.2")
 	testImplementation("org.springframework.security:spring-security-test")
+
+	implementation("io.grpc:grpc-protobuf:$grpcVersion")
+	implementation("io.grpc:grpc-stub:$grpcVersion")
+	implementation("io.grpc:grpc-kotlin-stub:$grpcKotlinVersion")
+	implementation("com.google.protobuf:protobuf-kotlin:$protobufVersion")
+	implementation("net.devh:grpc-spring-boot-starter:3.1.0.RELEASE")
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
 }
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+}
+
+protobuf {
+	protoc {
+		artifact = "com.google.protobuf:protoc:$protobufVersion"
+	}
+	plugins {
+		create("grpc") {
+			artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion"
+		}
+		create("grpckt") {
+			artifact = "io.grpc:protoc-gen-grpc-kotlin:$grpcKotlinVersion:jdk8@jar"
+		}
+	}
+	generateProtoTasks {
+		all().forEach {
+			it.plugins {
+				create("grpc")
+				create("grpckt")
+			}
+			it.builtins {
+				create("kotlin")
+			}
+		}
+	}
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcCartItemQueryAdapter.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcCartItemQueryAdapter.kt
@@ -1,0 +1,35 @@
+package com.hoppingmall.product.grpc
+
+import com.hoppingmall.order.grpc.CartItemQueryServiceGrpc
+import com.hoppingmall.order.grpc.Empty
+import com.hoppingmall.product.statistics.port.CartAggregation
+import com.hoppingmall.product.statistics.port.CartItemQueryPort
+import io.grpc.StatusRuntimeException
+import net.devh.boot.grpc.client.inject.GrpcClient
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+
+@Component
+@Profile("grpc")
+class GrpcCartItemQueryAdapter(
+    @GrpcClient("order-service") private val stub: CartItemQueryServiceGrpc.CartItemQueryServiceBlockingStub
+) : CartItemQueryPort {
+
+    private val log = LoggerFactory.getLogger(GrpcCartItemQueryAdapter::class.java)
+
+    override fun aggregateCartByProduct(): List<CartAggregation> {
+        return try {
+            val response = stub.aggregateCartByProduct(Empty.getDefaultInstance())
+            response.aggregationsList.map {
+                CartAggregation(
+                    productId = it.productId,
+                    buyerCount = it.buyerCount
+                )
+            }
+        } catch (e: StatusRuntimeException) {
+            log.warn("장바구니 통계 조회 실패", e)
+            emptyList()
+        }
+    }
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcOrderItemQueryAdapter.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcOrderItemQueryAdapter.kt
@@ -1,0 +1,41 @@
+package com.hoppingmall.product.grpc
+
+import com.hoppingmall.order.grpc.OrderIdRequest
+import com.hoppingmall.order.grpc.OrderQueryServiceGrpc
+import com.hoppingmall.product.statistics.port.OrderItemInfo
+import com.hoppingmall.product.statistics.port.OrderItemQueryPort
+import io.grpc.StatusRuntimeException
+import net.devh.boot.grpc.client.inject.GrpcClient
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+
+@Component
+@Profile("grpc")
+class GrpcOrderItemQueryAdapter(
+    @GrpcClient("order-service") private val stub: OrderQueryServiceGrpc.OrderQueryServiceBlockingStub
+) : OrderItemQueryPort {
+
+    private val log = LoggerFactory.getLogger(GrpcOrderItemQueryAdapter::class.java)
+
+    override fun findByOrderId(orderId: Long): List<OrderItemInfo> {
+        return try {
+            val response = stub.findOrderItemsByOrderId(
+                OrderIdRequest.newBuilder().setOrderId(orderId).build()
+            )
+            response.itemsList.map {
+                OrderItemInfo(
+                    id = it.id,
+                    orderId = it.orderId,
+                    productId = it.productId,
+                    quantity = it.quantity,
+                    totalPrice = it.totalPrice.toBigDecimalOrNull() ?: BigDecimal.ZERO
+                )
+            }
+        } catch (e: StatusRuntimeException) {
+            log.warn("주문 상품 조회 실패: orderId=$orderId", e)
+            emptyList()
+        }
+    }
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcOrderQueryAdapter.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcOrderQueryAdapter.kt
@@ -1,0 +1,74 @@
+package com.hoppingmall.product.grpc
+
+import com.hoppingmall.order.grpc.*
+import com.hoppingmall.product.review.port.OrderItemInfo
+import com.hoppingmall.product.review.port.OrderQueryPort
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import net.devh.boot.grpc.client.inject.GrpcClient
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+
+@Component
+@Profile("grpc")
+class GrpcOrderQueryAdapter(
+    @GrpcClient("order-service") private val stub: OrderQueryServiceGrpc.OrderQueryServiceBlockingStub
+) : OrderQueryPort {
+
+    private val log = LoggerFactory.getLogger(GrpcOrderQueryAdapter::class.java)
+
+    override fun isDelivered(orderId: Long, buyerId: Long): Boolean {
+        return try {
+            val response = stub.isDelivered(
+                DeliveredCheckRequest.newBuilder()
+                    .setOrderId(orderId)
+                    .setBuyerId(buyerId)
+                    .build()
+            )
+            response.delivered
+        } catch (e: StatusRuntimeException) {
+            log.warn("배송 완료 확인 실패: orderId=$orderId, buyerId=$buyerId", e)
+            false
+        }
+    }
+
+    override fun findOrderItemById(orderItemId: Long): OrderItemInfo? {
+        return try {
+            val response = stub.findOrderItemById(
+                OrderItemIdRequest.newBuilder().setOrderItemId(orderItemId).build()
+            )
+            response.toReviewOrderItemInfo()
+        } catch (e: StatusRuntimeException) {
+            if (e.status.code == Status.Code.NOT_FOUND) null
+            else {
+                log.warn("주문 상품 조회 실패: orderItemId=$orderItemId", e)
+                null
+            }
+        }
+    }
+
+    override fun findOrderItemsByOrderId(orderId: Long): List<OrderItemInfo> {
+        return try {
+            val response = stub.findOrderItemsByOrderId(
+                OrderIdRequest.newBuilder().setOrderId(orderId).build()
+            )
+            response.itemsList.map { it.toReviewOrderItemInfo() }
+        } catch (e: StatusRuntimeException) {
+            log.warn("주문 상품 목록 조회 실패: orderId=$orderId", e)
+            emptyList()
+        }
+    }
+
+    private fun OrderItemResponse.toReviewOrderItemInfo() = OrderItemInfo(
+        id = id,
+        orderId = orderId,
+        sellerId = sellerId,
+        productId = productId,
+        productName = productName,
+        productPrice = productPrice.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+        quantity = quantity,
+        totalPrice = totalPrice.toBigDecimalOrNull() ?: BigDecimal.ZERO
+    )
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcProductQueryService.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcProductQueryService.kt
@@ -1,0 +1,50 @@
+package com.hoppingmall.product.grpc
+
+import com.hoppingmall.product.product.domain.repository.ProductImageRepository
+import com.hoppingmall.product.product.domain.repository.ProductRepository
+import io.grpc.Status
+import io.grpc.StatusException
+import net.devh.boot.grpc.server.service.GrpcService
+
+@GrpcService
+class GrpcProductQueryService(
+    private val productRepository: ProductRepository,
+    private val productImageRepository: ProductImageRepository
+) : ProductQueryServiceGrpcKt.ProductQueryServiceCoroutineImplBase() {
+
+    override suspend fun findProductById(request: ProductIdRequest): ProductResponse {
+        val product = productRepository.findNullableById(request.productId)
+            ?: throw StatusException(Status.NOT_FOUND)
+        return productResponse {
+            id = product.id!!
+            name = product.name
+            price = product.price.toPlainString()
+            sellerId = product.sellerId
+        }
+    }
+
+    override suspend fun findProductsByIds(request: ProductIdsRequest): ProductListResponse {
+        val found = productRepository.findAllById(request.productIdsList)
+        return productListResponse {
+            products.addAll(
+                found.map { product ->
+                    productResponse {
+                        id = product.id!!
+                        name = product.name
+                        price = product.price.toPlainString()
+                        sellerId = product.sellerId
+                    }
+                }
+            )
+        }
+    }
+
+    override suspend fun findProductImageUrl(request: ProductIdRequest): ImageUrlResponse {
+        val images = productImageRepository.findByProductIdOrderBySortOrder(request.productId)
+        val first = images.firstOrNull()
+        return imageUrlResponse {
+            imageUrl = first?.imageUrl ?: ""
+            found = first != null
+        }
+    }
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/grpc/InternalTokenClientInterceptor.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/grpc/InternalTokenClientInterceptor.kt
@@ -1,0 +1,31 @@
+package com.hoppingmall.product.grpc
+
+import io.grpc.*
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor
+import org.springframework.beans.factory.annotation.Value
+
+@GrpcGlobalClientInterceptor
+class InternalTokenClientInterceptor(
+    @Value("\${internal.service.token}") private val token: String
+) : ClientInterceptor {
+
+    companion object {
+        val INTERNAL_TOKEN_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-internal-token", Metadata.ASCII_STRING_MARSHALLER)
+    }
+
+    override fun <ReqT, RespT> interceptCall(
+        method: MethodDescriptor<ReqT, RespT>,
+        callOptions: CallOptions,
+        next: Channel
+    ): ClientCall<ReqT, RespT> {
+        return object : ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+            next.newCall(method, callOptions)
+        ) {
+            override fun start(responseListener: Listener<RespT>, headers: Metadata) {
+                headers.put(INTERNAL_TOKEN_KEY, token)
+                super.start(responseListener, headers)
+            }
+        }
+    }
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/grpc/InternalTokenServerInterceptor.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/grpc/InternalTokenServerInterceptor.kt
@@ -1,0 +1,33 @@
+package com.hoppingmall.product.grpc
+
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import io.grpc.Status
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor
+import org.springframework.beans.factory.annotation.Value
+
+@GrpcGlobalServerInterceptor
+class InternalTokenServerInterceptor(
+    @Value("\${internal.service.token}") private val expectedToken: String
+) : ServerInterceptor {
+
+    companion object {
+        val INTERNAL_TOKEN_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-internal-token", Metadata.ASCII_STRING_MARSHALLER)
+    }
+
+    override fun <ReqT, RespT> interceptCall(
+        call: ServerCall<ReqT, RespT>,
+        headers: Metadata,
+        next: ServerCallHandler<ReqT, RespT>
+    ): ServerCall.Listener<ReqT> {
+        val clientToken = headers.get(INTERNAL_TOKEN_KEY)
+        if (clientToken != expectedToken) {
+            call.close(Status.UNAUTHENTICATED.withDescription("Invalid internal token"), Metadata())
+            return object : ServerCall.Listener<ReqT>() {}
+        }
+        return next.startCall(call, headers)
+    }
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/grpc/TracingClientInterceptor.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/grpc/TracingClientInterceptor.kt
@@ -1,0 +1,32 @@
+package com.hoppingmall.product.grpc
+
+import io.grpc.*
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor
+import org.slf4j.MDC
+
+@GrpcGlobalClientInterceptor
+class TracingClientInterceptor : ClientInterceptor {
+
+    companion object {
+        val TRACE_ID_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-trace-id", Metadata.ASCII_STRING_MARSHALLER)
+        val USER_ID_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER)
+    }
+
+    override fun <ReqT, RespT> interceptCall(
+        method: MethodDescriptor<ReqT, RespT>,
+        callOptions: CallOptions,
+        next: Channel
+    ): ClientCall<ReqT, RespT> {
+        return object : ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+            next.newCall(method, callOptions)
+        ) {
+            override fun start(responseListener: Listener<RespT>, headers: Metadata) {
+                MDC.get("traceId")?.let { headers.put(TRACE_ID_KEY, it) }
+                MDC.get("userId")?.let { headers.put(USER_ID_KEY, it) }
+                super.start(responseListener, headers)
+            }
+        }
+    }
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/grpc/TracingServerInterceptor.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/grpc/TracingServerInterceptor.kt
@@ -1,0 +1,51 @@
+package com.hoppingmall.product.grpc
+
+import io.grpc.ForwardingServerCallListener
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor
+import org.slf4j.MDC
+
+@GrpcGlobalServerInterceptor
+class TracingServerInterceptor : ServerInterceptor {
+
+    companion object {
+        val TRACE_ID_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-trace-id", Metadata.ASCII_STRING_MARSHALLER)
+        val USER_ID_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER)
+    }
+
+    override fun <ReqT, RespT> interceptCall(
+        call: ServerCall<ReqT, RespT>,
+        headers: Metadata,
+        next: ServerCallHandler<ReqT, RespT>
+    ): ServerCall.Listener<ReqT> {
+        headers.get(TRACE_ID_KEY)?.let { MDC.put("traceId", it) }
+        headers.get(USER_ID_KEY)?.let { MDC.put("userId", it) }
+
+        return object : ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(
+            next.startCall(call, headers)
+        ) {
+            override fun onComplete() {
+                try {
+                    super.onComplete()
+                } finally {
+                    MDC.remove("traceId")
+                    MDC.remove("userId")
+                }
+            }
+
+            override fun onCancel() {
+                try {
+                    super.onCancel()
+                } finally {
+                    MDC.remove("traceId")
+                    MDC.remove("userId")
+                }
+            }
+        }
+    }
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/review/port/HttpOrderQueryAdapter.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/review/port/HttpOrderQueryAdapter.kt
@@ -3,11 +3,13 @@ package com.hoppingmall.product.review.port
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
 import java.time.Duration
 
 @Component
+@Profile("!grpc")
 class HttpOrderQueryAdapter(
     @Value("\${services.monolith.url:http://localhost:8080}") private val monolithUrl: String,
     restTemplateBuilder: RestTemplateBuilder

--- a/product-service/src/main/kotlin/com/hoppingmall/product/statistics/port/HttpCartItemQueryAdapter.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/statistics/port/HttpCartItemQueryAdapter.kt
@@ -3,11 +3,13 @@ package com.hoppingmall.product.statistics.port
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
 import java.time.Duration
 
 @Component
+@Profile("!grpc")
 class HttpCartItemQueryAdapter(
     @Value("\${services.order-service.url:http://localhost:8084}") private val orderServiceUrl: String,
     restTemplateBuilder: RestTemplateBuilder

--- a/product-service/src/main/kotlin/com/hoppingmall/product/statistics/port/HttpOrderItemQueryAdapter.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/statistics/port/HttpOrderItemQueryAdapter.kt
@@ -3,11 +3,13 @@ package com.hoppingmall.product.statistics.port
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
 import java.time.Duration
 
 @Component
+@Profile("!grpc")
 class HttpOrderItemQueryAdapter(
     @Value("\${services.order-service.url:http://localhost:8084}") private val orderServiceUrl: String,
     restTemplateBuilder: RestTemplateBuilder

--- a/product-service/src/main/proto/order_query.proto
+++ b/product-service/src/main/proto/order_query.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+package hoppingmall.order;
+option java_package = "com.hoppingmall.order.grpc";
+option java_multiple_files = true;
+
+service OrderQueryService {
+  rpc FindOrderItemsByOrderId (OrderIdRequest) returns (OrderItemListResponse);
+  rpc IsDelivered (DeliveredCheckRequest) returns (DeliveredResponse);
+  rpc FindOrderItemById (OrderItemIdRequest) returns (OrderItemResponse);
+}
+
+service CartItemQueryService {
+  rpc AggregateCartByProduct (Empty) returns (CartAggregateResponse);
+}
+
+message OrderIdRequest { int64 order_id = 1; }
+message OrderItemIdRequest { int64 order_item_id = 1; }
+message DeliveredCheckRequest {
+  int64 order_id = 1;
+  int64 buyer_id = 2;
+}
+message DeliveredResponse { bool delivered = 1; }
+message Empty {}
+
+message OrderItemResponse {
+  int64 id = 1;
+  int64 order_id = 2;
+  int64 seller_id = 3;
+  int64 product_id = 4;
+  string product_name = 5;
+  string product_price = 6;
+  int32 quantity = 7;
+  string total_price = 8;
+}
+message OrderItemListResponse { repeated OrderItemResponse items = 1; }
+
+message CartAggregation {
+  int64 product_id = 1;
+  int64 buyer_count = 2;
+}
+message CartAggregateResponse { repeated CartAggregation aggregations = 1; }

--- a/product-service/src/main/proto/product_query.proto
+++ b/product-service/src/main/proto/product_query.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+package hoppingmall.product;
+option java_package = "com.hoppingmall.product.grpc";
+option java_multiple_files = true;
+
+service ProductQueryService {
+  rpc FindProductById (ProductIdRequest) returns (ProductResponse);
+  rpc FindProductsByIds (ProductIdsRequest) returns (ProductListResponse);
+  rpc FindProductImageUrl (ProductIdRequest) returns (ImageUrlResponse);
+}
+
+message ProductIdRequest { int64 product_id = 1; }
+message ProductIdsRequest { repeated int64 product_ids = 1; }
+message ProductResponse {
+  int64 id = 1;
+  string name = 2;
+  string price = 3;
+  int64 seller_id = 4;
+}
+message ProductListResponse { repeated ProductResponse products = 1; }
+message ImageUrlResponse {
+  string image_url = 1;
+  bool found = 2;
+}

--- a/product-service/src/test/resources/application-test.yml
+++ b/product-service/src/test/resources/application-test.yml
@@ -1,3 +1,7 @@
+grpc:
+  server:
+    port: -1
+
 spring:
   autoconfigure:
     exclude:


### PR DESCRIPTION
Closes #179

### 📌 작업 개요
기존 HTTP 기반 서비스 간 내부 조회 통신을 gRPC로 전환할 수 있도록 구현했습니다.
@Profile 기반으로 HTTP/gRPC 전환이 가능하며, Docker 환경에서는 gRPC가 기본 활성화됩니다.

---

### ✅ 주요 변경 사항

- `build.gradle.kts`
  - Root: `com.google.protobuf` 플러그인 v0.9.4 추가
  - 4개 서비스: protobuf/gRPC 의존성 추가 (protobuf 3.25.3, grpc-java 1.62.2, grpc-kotlin 1.4.1)

- `Proto 파일 정의`
  - `product_query.proto`: FindProductById, FindProductsByIds, FindProductImageUrl
  - `order_query.proto`: OrderQueryService 3 RPC + CartItemQueryService 1 RPC
  - `payment_query.proto`: FindPaymentByOrderId, FindPaymentById
  - `membership_query.proto`: GetPointEarningRate
  - 클라이언트 서비스에 필요한 Proto 파일 복사 (5개)

- `gRPC 서버 구현`
  - `GrpcProductQueryService`: 3개 RPC
  - `GrpcOrderQueryService`: 3개 RPC, `GrpcCartItemQueryService`: 1개 RPC
  - `GrpcPaymentQueryService`: 2개 RPC
  - `GrpcMembershipQueryService`: 1개 RPC

- `gRPC 인터셉터`
  - `InternalTokenServerInterceptor`: x-internal-token 검증 (4개 서비스)
  - `TracingServerInterceptor`: traceId/userId MDC 전파 + onCancel 정리 (4개 서비스)
  - `InternalTokenClientInterceptor` + `TracingClientInterceptor` (3개 클라이언트 서비스)

- `gRPC 클라이언트 어댑터` (7개, @Profile("grpc"))
  - order-service: GrpcProductQueryAdapter, GrpcPaymentQueryAdapter
  - payment-service: GrpcOrderQueryAdapter, GrpcMembershipQueryAdapter
  - product-service: GrpcOrderQueryAdapter, GrpcOrderItemQueryAdapter, GrpcCartItemQueryAdapter

- `HTTP 어댑터 Profile 전환`
  - 기존 HTTP 어댑터 7개에 `@Profile("!grpc")` 추가

- `Docker 설정`
  - docker-compose.yml: gRPC 포트 매핑 (9080, 9093, 9094, 9095)
  - SPRING_PROFILES_ACTIVE: `docker` → `docker,grpc` (4개 서비스)

- `테스트 설정`
  - app/product-service 테스트 프로필에 `grpc.server.port: -1` 추가

- `버그 수정`
  - ProductHourlyStatistics: H2 hour 예약어 UniqueConstraint 이스케이프

---

### 🧪 테스트

- `./gradlew :app:test` → 282 tests passed
- `product-service ./gradlew build` → BUILD SUCCESSFUL
- `order-service ./gradlew build` → BUILD SUCCESSFUL
- `payment-service ./gradlew build` → BUILD SUCCESSFUL

---

### 📎 관련 이슈
- #179