### PR TITLE
feat: Resilience4j Circuit Breaker + Retry 적용

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -247,6 +247,8 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: admin
     volumes:
       - ./docker/grafana-datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml
+      - ./docker/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
+      - ./docker/grafana/dashboards:/var/lib/grafana/dashboards
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus

--- a/docker/grafana/dashboards/circuit-breaker.json
+++ b/docker/grafana/dashboards/circuit-breaker.json
@@ -1,0 +1,126 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Circuit Breaker State",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "resilience4j_circuitbreaker_state{application=~\"$service\"}",
+          "legendFormat": "{{application}} - {{name}} ({{state}})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "options": { "0": { "text": "CLOSED", "color": "green" } }, "type": "value" },
+            { "options": { "1": { "text": "OPEN", "color": "red" } }, "type": "value" },
+            { "options": { "2": { "text": "HALF_OPEN", "color": "yellow" } }, "type": "value" }
+          ]
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Failure Rate (%)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "targets": [
+        {
+          "expr": "resilience4j_circuitbreaker_failure_rate{application=~\"$service\"}",
+          "legendFormat": "{{application}} - {{name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 30 },
+              { "color": "red", "value": 50 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Slow Call Rate (%)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "targets": [
+        {
+          "expr": "resilience4j_circuitbreaker_slow_call_rate{application=~\"$service\"}",
+          "legendFormat": "{{application}} - {{name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "percent" },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Total Calls (rate/min)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "targets": [
+        {
+          "expr": "rate(resilience4j_circuitbreaker_calls_seconds_count{application=~\"$service\"}[1m]) * 60",
+          "legendFormat": "{{application}} - {{name}} ({{kind}})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "cpm" },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Not Permitted Calls (CB Open)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "targets": [
+        {
+          "expr": "rate(resilience4j_circuitbreaker_not_permitted_calls_total{application=~\"$service\"}[1m]) * 60",
+          "legendFormat": "{{application}} - {{name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "cpm" },
+        "overrides": []
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["resilience4j", "circuit-breaker"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(resilience4j_circuitbreaker_state, application)",
+        "includeAll": true,
+        "multi": true,
+        "name": "service",
+        "query": "label_values(resilience4j_circuitbreaker_state, application)",
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "title": "Circuit Breaker Dashboard",
+  "uid": "circuit-breaker"
+}

--- a/docker/grafana/dashboards/retry-metrics.json
+++ b/docker/grafana/dashboards/retry-metrics.json
@@ -1,0 +1,87 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Retry Attempts (rate/min)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(resilience4j_retry_calls_total{application=~\"$service\"}[1m]) * 60",
+          "legendFormat": "{{application}} - {{name}} ({{kind}})"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "cpm" }, "overrides": [] }
+    },
+    {
+      "title": "Retry Success Rate (%)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(resilience4j_retry_calls_total{application=~\"$service\",kind=\"successful_without_retry\"}[5m]) / rate(resilience4j_retry_calls_total{application=~\"$service\"}[5m]) * 100",
+          "legendFormat": "{{application}} - {{name}} success without retry"
+        },
+        {
+          "expr": "rate(resilience4j_retry_calls_total{application=~\"$service\",kind=\"successful_with_retry\"}[5m]) / rate(resilience4j_retry_calls_total{application=~\"$service\"}[5m]) * 100",
+          "legendFormat": "{{application}} - {{name}} success with retry"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percent" }, "overrides": [] }
+    },
+    {
+      "title": "Failed After All Retries (rate/min)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "expr": "rate(resilience4j_retry_calls_total{application=~\"$service\",kind=\"failed_with_retry\"}[1m]) * 60",
+          "legendFormat": "{{application}} - {{name}} failed"
+        },
+        {
+          "expr": "rate(resilience4j_retry_calls_total{application=~\"$service\",kind=\"failed_without_retry\"}[1m]) * 60",
+          "legendFormat": "{{application}} - {{name}} failed (no retry)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cpm",
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["resilience4j", "retry"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(resilience4j_retry_calls_total, application)",
+        "includeAll": true,
+        "multi": true,
+        "name": "service",
+        "query": "label_values(resilience4j_retry_calls_total, application)",
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "title": "Retry Metrics Dashboard",
+  "uid": "retry-metrics"
+}

--- a/docker/grafana/dashboards/service-health.json
+++ b/docker/grafana/dashboards/service-health.json
@@ -1,0 +1,93 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "HTTP Request Rate (req/min)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(http_server_requests_seconds_count{application=~\"$service\"}[1m]) * 60",
+          "legendFormat": "{{application}} {{method}} {{uri}} ({{status}})"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqpm" }, "overrides": [] }
+    },
+    {
+      "title": "HTTP Response Time (p95)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(http_server_requests_seconds_bucket{application=~\"$service\"}[5m]))",
+          "legendFormat": "{{application}} p95"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] }
+    },
+    {
+      "title": "Error Rate (%)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "expr": "rate(http_server_requests_seconds_count{application=~\"$service\",status=~\"5..\"}[5m]) / rate(http_server_requests_seconds_count{application=~\"$service\"}[5m]) * 100",
+          "legendFormat": "{{application}} 5xx rate"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "JVM Memory Used",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "expr": "jvm_memory_used_bytes{application=~\"$service\", area=\"heap\"}",
+          "legendFormat": "{{application}} heap ({{id}})"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["service-health"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(http_server_requests_seconds_count, application)",
+        "includeAll": true,
+        "multi": true,
+        "name": "service",
+        "query": "label_values(http_server_requests_seconds_count, application)",
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "title": "Service Health Dashboard",
+  "uid": "service-health"
+}

--- a/docker/grafana/provisioning/dashboards/dashboard.yml
+++ b/docker/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/order-service/build.gradle.kts
+++ b/order-service/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
+	implementation("io.github.resilience4j:resilience4j-spring-boot3:2.2.0")
 
 	implementation("org.springframework.boot:spring-boot-starter-data-redis") {
 		exclude(group = "io.lettuce", module = "lettuce-core")

--- a/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcPaymentQueryAdapter.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcPaymentQueryAdapter.kt
@@ -6,6 +6,8 @@ import com.hoppingmall.payment.grpc.PaymentIdRequest
 import com.hoppingmall.payment.grpc.PaymentOrderIdRequest
 import com.hoppingmall.payment.grpc.PaymentQueryServiceGrpc
 import com.hoppingmall.payment.grpc.PaymentResponse
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
 import net.devh.boot.grpc.client.inject.GrpcClient
@@ -22,34 +24,34 @@ class GrpcPaymentQueryAdapter(
 
     private val log = LoggerFactory.getLogger(GrpcPaymentQueryAdapter::class.java)
 
+    @CircuitBreaker(name = "payment-query", fallbackMethod = "findByOrderIdFallback")
+    @Retry(name = "payment-query")
     override fun findByOrderId(orderId: Long): PaymentInfo? {
-        return try {
-            val response = stub.findPaymentByOrderId(
-                PaymentOrderIdRequest.newBuilder().setOrderId(orderId).build()
-            )
-            response.toPaymentInfo()
-        } catch (e: StatusRuntimeException) {
-            if (e.status.code == Status.Code.NOT_FOUND) null
-            else {
-                log.warn("결제 조회 실패: orderId=$orderId", e)
-                null
-            }
-        }
+        val response = stub.findPaymentByOrderId(
+            PaymentOrderIdRequest.newBuilder().setOrderId(orderId).build()
+        )
+        return response.toPaymentInfo()
     }
 
+    @CircuitBreaker(name = "payment-query", fallbackMethod = "findByIdFallback")
+    @Retry(name = "payment-query")
     override fun findById(paymentId: Long): PaymentInfo? {
-        return try {
-            val response = stub.findPaymentById(
-                PaymentIdRequest.newBuilder().setPaymentId(paymentId).build()
-            )
-            response.toPaymentInfo()
-        } catch (e: StatusRuntimeException) {
-            if (e.status.code == Status.Code.NOT_FOUND) null
-            else {
-                log.warn("결제 조회 실패: paymentId=$paymentId", e)
-                null
-            }
-        }
+        val response = stub.findPaymentById(
+            PaymentIdRequest.newBuilder().setPaymentId(paymentId).build()
+        )
+        return response.toPaymentInfo()
+    }
+
+    private fun findByOrderIdFallback(orderId: Long, e: Exception): PaymentInfo? {
+        if (e is StatusRuntimeException && e.status.code == Status.Code.NOT_FOUND) return null
+        log.warn("CB fallback: 결제 조회 실패 orderId=$orderId", e)
+        return null
+    }
+
+    private fun findByIdFallback(paymentId: Long, e: Exception): PaymentInfo? {
+        if (e is StatusRuntimeException && e.status.code == Status.Code.NOT_FOUND) return null
+        log.warn("CB fallback: 결제 조회 실패 paymentId=$paymentId", e)
+        return null
     }
 
     private fun PaymentResponse.toPaymentInfo() = PaymentInfo(

--- a/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcProductQueryAdapter.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcProductQueryAdapter.kt
@@ -5,6 +5,8 @@ import com.hoppingmall.order.port.ProductQueryPort
 import com.hoppingmall.product.grpc.ProductIdRequest
 import com.hoppingmall.product.grpc.ProductIdsRequest
 import com.hoppingmall.product.grpc.ProductQueryServiceGrpc
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
 import net.devh.boot.grpc.client.inject.GrpcClient
@@ -21,54 +23,58 @@ class GrpcProductQueryAdapter(
 
     private val log = LoggerFactory.getLogger(GrpcProductQueryAdapter::class.java)
 
+    @CircuitBreaker(name = "product-query", fallbackMethod = "findProductByIdFallback")
+    @Retry(name = "product-query")
     override fun findProductById(productId: Long): ProductInfo? {
-        return try {
-            val response = stub.findProductById(
-                ProductIdRequest.newBuilder().setProductId(productId).build()
-            )
-            ProductInfo(
-                id = response.id,
-                name = response.name,
-                price = response.price.toBigDecimalOrNull() ?: BigDecimal.ZERO,
-                sellerId = response.sellerId
-            )
-        } catch (e: StatusRuntimeException) {
-            if (e.status.code == Status.Code.NOT_FOUND) null
-            else {
-                log.warn("상품 조회 실패: productId=$productId", e)
-                null
-            }
-        }
+        val response = stub.findProductById(
+            ProductIdRequest.newBuilder().setProductId(productId).build()
+        )
+        return ProductInfo(
+            id = response.id,
+            name = response.name,
+            price = response.price.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+            sellerId = response.sellerId
+        )
     }
 
+    @CircuitBreaker(name = "product-query", fallbackMethod = "findProductsByIdsFallback")
+    @Retry(name = "product-query")
     override fun findProductsByIds(productIds: List<Long>): List<ProductInfo> {
-        return try {
-            val response = stub.findProductsByIds(
-                ProductIdsRequest.newBuilder().addAllProductIds(productIds).build()
+        val response = stub.findProductsByIds(
+            ProductIdsRequest.newBuilder().addAllProductIds(productIds).build()
+        )
+        return response.productsList.map {
+            ProductInfo(
+                id = it.id,
+                name = it.name,
+                price = it.price.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+                sellerId = it.sellerId
             )
-            response.productsList.map {
-                ProductInfo(
-                    id = it.id,
-                    name = it.name,
-                    price = it.price.toBigDecimalOrNull() ?: BigDecimal.ZERO,
-                    sellerId = it.sellerId
-                )
-            }
-        } catch (e: StatusRuntimeException) {
-            log.warn("상품 목록 조회 실패: productIds=$productIds", e)
-            emptyList()
         }
     }
 
+    @CircuitBreaker(name = "product-query", fallbackMethod = "findProductImageUrlFallback")
+    @Retry(name = "product-query")
     override fun findProductImageUrl(productId: Long): String? {
-        return try {
-            val response = stub.findProductImageUrl(
-                ProductIdRequest.newBuilder().setProductId(productId).build()
-            )
-            if (response.found) response.imageUrl else null
-        } catch (e: StatusRuntimeException) {
-            log.warn("상품 이미지 URL 조회 실패: productId=$productId", e)
-            null
-        }
+        val response = stub.findProductImageUrl(
+            ProductIdRequest.newBuilder().setProductId(productId).build()
+        )
+        return if (response.found) response.imageUrl else null
+    }
+
+    private fun findProductByIdFallback(productId: Long, e: Exception): ProductInfo? {
+        if (e is StatusRuntimeException && e.status.code == Status.Code.NOT_FOUND) return null
+        log.warn("CB fallback: 상품 조회 실패 productId=$productId", e)
+        return null
+    }
+
+    private fun findProductsByIdsFallback(productIds: List<Long>, e: Exception): List<ProductInfo> {
+        log.warn("CB fallback: 상품 목록 조회 실패 productIds=$productIds", e)
+        return emptyList()
+    }
+
+    private fun findProductImageUrlFallback(productId: Long, e: Exception): String? {
+        log.warn("CB fallback: 상품 이미지 URL 조회 실패 productId=$productId", e)
+        return null
     }
 }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/port/HttpInventoryCommandAdapter.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/port/HttpInventoryCommandAdapter.kt
@@ -1,5 +1,8 @@
 package com.hoppingmall.order.port
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.stereotype.Component
@@ -12,85 +15,74 @@ class HttpInventoryCommandAdapter(
     restTemplateBuilder: RestTemplateBuilder
 ) : InventoryCommandPort {
 
+    private val logger = LoggerFactory.getLogger(HttpInventoryCommandAdapter::class.java)
+
     private val restTemplate: RestTemplate = restTemplateBuilder
         .connectTimeout(Duration.ofSeconds(2))
         .readTimeout(Duration.ofSeconds(5))
         .build()
 
+    @CircuitBreaker(name = "inventory-command")
     override fun decreaseStock(productId: Long, quantity: Int) {
-        try {
-            restTemplate.postForEntity(
-                "$productServiceUrl/internal/api/v1/inventory/$productId/decrease?quantity=$quantity",
-                null,
-                Void::class.java
-            )
-        } catch (e: Exception) {
-            throw RuntimeException("재고 감소 실패: productId=$productId, quantity=$quantity", e)
-        }
+        restTemplate.postForEntity(
+            "$productServiceUrl/internal/api/v1/inventory/$productId/decrease?quantity=$quantity",
+            null,
+            Void::class.java
+        )
     }
 
+    @CircuitBreaker(name = "inventory-command")
     override fun increaseStock(productId: Long, quantity: Int) {
-        try {
-            restTemplate.postForEntity(
-                "$productServiceUrl/internal/api/v1/inventory/$productId/increase?quantity=$quantity",
-                null,
-                Void::class.java
-            )
-        } catch (e: Exception) {
-            throw RuntimeException("재고 증가 실패: productId=$productId, quantity=$quantity", e)
-        }
+        restTemplate.postForEntity(
+            "$productServiceUrl/internal/api/v1/inventory/$productId/increase?quantity=$quantity",
+            null,
+            Void::class.java
+        )
     }
 
+    @CircuitBreaker(name = "inventory-command")
     override fun reserveStock(productId: Long, quantity: Int): String {
-        try {
-            val response = restTemplate.postForEntity(
-                "$productServiceUrl/internal/api/v1/inventory/$productId/reserve?quantity=$quantity",
-                null,
-                ReservationResponse::class.java
-            )
-            return response.body?.reservationId
-                ?: throw RuntimeException("재고 예약 응답 없음: productId=$productId")
-        } catch (e: Exception) {
-            if (e is RuntimeException && e.message?.startsWith("재고 예약 응답 없음") == true) throw e
-            throw RuntimeException("재고 예약 실패: productId=$productId, quantity=$quantity", e)
-        }
+        val response = restTemplate.postForEntity(
+            "$productServiceUrl/internal/api/v1/inventory/$productId/reserve?quantity=$quantity",
+            null,
+            ReservationResponse::class.java
+        )
+        return response.body?.reservationId
+            ?: throw RuntimeException("재고 예약 응답 없음: productId=$productId")
     }
 
+    @CircuitBreaker(name = "inventory-command", fallbackMethod = "confirmReservationsFallback")
+    @Retry(name = "product-query")
     override fun confirmReservations(reservationIds: List<String>): Boolean {
-        return try {
-            val response = restTemplate.postForEntity(
-                "$productServiceUrl/internal/api/v1/inventory/reservations/batch-confirm",
-                reservationIds,
-                ConfirmationResponse::class.java
-            )
-            response.body?.confirmed ?: false
-        } catch (e: Exception) {
-            false
-        }
+        val response = restTemplate.postForEntity(
+            "$productServiceUrl/internal/api/v1/inventory/reservations/batch-confirm",
+            reservationIds,
+            ConfirmationResponse::class.java
+        )
+        return response.body?.confirmed ?: false
     }
 
+    @CircuitBreaker(name = "inventory-command")
     override fun cancelReservation(reservationId: String) {
-        try {
-            restTemplate.postForEntity(
-                "$productServiceUrl/internal/api/v1/inventory/reservations/$reservationId/cancel",
-                null,
-                Void::class.java
-            )
-        } catch (e: Exception) {
-            throw RuntimeException("예약 취소 실패: reservationId=$reservationId", e)
-        }
+        restTemplate.postForEntity(
+            "$productServiceUrl/internal/api/v1/inventory/reservations/$reservationId/cancel",
+            null,
+            Void::class.java
+        )
     }
 
+    @CircuitBreaker(name = "inventory-command")
     override fun cancelReservations(reservationIds: List<String>) {
-        try {
-            restTemplate.postForEntity(
-                "$productServiceUrl/internal/api/v1/inventory/reservations/batch-cancel",
-                reservationIds,
-                Void::class.java
-            )
-        } catch (e: Exception) {
-            throw RuntimeException("예약 일괄 취소 실패: reservationIds=$reservationIds", e)
-        }
+        restTemplate.postForEntity(
+            "$productServiceUrl/internal/api/v1/inventory/reservations/batch-cancel",
+            reservationIds,
+            Void::class.java
+        )
+    }
+
+    private fun confirmReservationsFallback(reservationIds: List<String>, e: Exception): Boolean {
+        logger.warn("CB fallback: 예약 확정 실패 reservationIds=$reservationIds", e)
+        return false
     }
 
     data class ReservationResponse(val reservationId: String = "")

--- a/order-service/src/main/kotlin/com/hoppingmall/order/port/HttpPaymentQueryAdapter.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/port/HttpPaymentQueryAdapter.kt
@@ -1,5 +1,7 @@
 package com.hoppingmall.order.port
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
@@ -22,27 +24,31 @@ class HttpPaymentQueryAdapter(
         .readTimeout(Duration.ofSeconds(5))
         .build()
 
+    @CircuitBreaker(name = "payment-query", fallbackMethod = "findByOrderIdFallback")
+    @Retry(name = "payment-query")
     override fun findByOrderId(orderId: Long): PaymentInfo? {
-        return try {
-            restTemplate.getForObject(
-                "$monolithUrl/internal/api/v1/payments/by-order/$orderId",
-                PaymentInfo::class.java
-            )
-        } catch (e: Exception) {
-            logger.warn("주문별 결제 조회 실패: orderId=$orderId", e)
-            null
-        }
+        return restTemplate.getForObject(
+            "$monolithUrl/internal/api/v1/payments/by-order/$orderId",
+            PaymentInfo::class.java
+        )
     }
 
+    @CircuitBreaker(name = "payment-query", fallbackMethod = "findByIdFallback")
+    @Retry(name = "payment-query")
     override fun findById(paymentId: Long): PaymentInfo? {
-        return try {
-            restTemplate.getForObject(
-                "$monolithUrl/internal/api/v1/payments/$paymentId",
-                PaymentInfo::class.java
-            )
-        } catch (e: Exception) {
-            logger.warn("결제 조회 실패: paymentId=$paymentId", e)
-            null
-        }
+        return restTemplate.getForObject(
+            "$monolithUrl/internal/api/v1/payments/$paymentId",
+            PaymentInfo::class.java
+        )
+    }
+
+    private fun findByOrderIdFallback(orderId: Long, e: Exception): PaymentInfo? {
+        logger.warn("CB fallback: 주문별 결제 조회 실패 orderId=$orderId", e)
+        return null
+    }
+
+    private fun findByIdFallback(paymentId: Long, e: Exception): PaymentInfo? {
+        logger.warn("CB fallback: 결제 조회 실패 paymentId=$paymentId", e)
+        return null
     }
 }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/port/HttpProductQueryAdapter.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/port/HttpProductQueryAdapter.kt
@@ -1,5 +1,7 @@
 package com.hoppingmall.order.port
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
@@ -22,41 +24,47 @@ class HttpProductQueryAdapter(
         .readTimeout(Duration.ofSeconds(5))
         .build()
 
+    @CircuitBreaker(name = "product-query", fallbackMethod = "findProductByIdFallback")
+    @Retry(name = "product-query")
     override fun findProductById(productId: Long): ProductInfo? {
-        return try {
-            restTemplate.getForObject(
-                "$productServiceUrl/internal/api/v1/products/$productId",
-                ProductInfo::class.java
-            )
-        } catch (e: Exception) {
-            logger.warn("상품 조회 실패: productId=$productId", e)
-            null
-        }
+        return restTemplate.getForObject(
+            "$productServiceUrl/internal/api/v1/products/$productId",
+            ProductInfo::class.java
+        )
     }
 
+    @CircuitBreaker(name = "product-query", fallbackMethod = "findProductsByIdsFallback")
+    @Retry(name = "product-query")
     override fun findProductsByIds(productIds: List<Long>): List<ProductInfo> {
-        return try {
-            val ids = productIds.joinToString(",")
-            val result = restTemplate.getForObject(
-                "$productServiceUrl/internal/api/v1/products?ids=$ids",
-                Array<ProductInfo>::class.java
-            )
-            result?.toList() ?: emptyList()
-        } catch (e: Exception) {
-            logger.warn("상품 목록 조회 실패: productIds=$productIds", e)
-            emptyList()
-        }
+        val ids = productIds.joinToString(",")
+        val result = restTemplate.getForObject(
+            "$productServiceUrl/internal/api/v1/products?ids=$ids",
+            Array<ProductInfo>::class.java
+        )
+        return result?.toList() ?: emptyList()
     }
 
+    @CircuitBreaker(name = "product-query", fallbackMethod = "findProductImageUrlFallback")
+    @Retry(name = "product-query")
     override fun findProductImageUrl(productId: Long): String? {
-        return try {
-            restTemplate.getForObject(
-                "$productServiceUrl/internal/api/v1/products/$productId/image-url",
-                String::class.java
-            )
-        } catch (e: Exception) {
-            logger.warn("상품 이미지 URL 조회 실패: productId=$productId", e)
-            null
-        }
+        return restTemplate.getForObject(
+            "$productServiceUrl/internal/api/v1/products/$productId/image-url",
+            String::class.java
+        )
+    }
+
+    private fun findProductByIdFallback(productId: Long, e: Exception): ProductInfo? {
+        logger.warn("CB fallback: 상품 조회 실패 productId=$productId", e)
+        return null
+    }
+
+    private fun findProductsByIdsFallback(productIds: List<Long>, e: Exception): List<ProductInfo> {
+        logger.warn("CB fallback: 상품 목록 조회 실패 productIds=$productIds", e)
+        return emptyList()
+    }
+
+    private fun findProductImageUrlFallback(productId: Long, e: Exception): String? {
+        logger.warn("CB fallback: 상품 이미지 URL 조회 실패 productId=$productId", e)
+        return null
     }
 }

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -62,6 +62,9 @@ management:
     sampling:
       probability: 0.0
     enabled: false
+  health:
+    circuitbreakers:
+      enabled: true
 
 services:
   monolith:
@@ -83,3 +86,54 @@ grpc:
     payment-service:
       address: static://localhost:9095
       negotiation-type: plaintext
+
+resilience4j:
+  circuitbreaker:
+    circuitBreakerAspectOrder: 2
+    configs:
+      default:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        failureRateThreshold: 50
+        waitDurationInOpenState: 30s
+        permittedNumberOfCallsInHalfOpenState: 3
+        slowCallDurationThreshold: 3s
+        slowCallRateThreshold: 80
+        recordExceptions:
+          - java.lang.Exception
+        ignoreExceptions:
+          - org.springframework.web.client.HttpClientErrorException$NotFound
+          - org.springframework.web.client.HttpClientErrorException$BadRequest
+    instances:
+      product-query:
+        baseConfig: default
+      payment-query:
+        baseConfig: default
+      inventory-command:
+        baseConfig: default
+  retry:
+    retryAspectOrder: 1
+    configs:
+      default:
+        maxAttempts: 3
+        waitDuration: 500ms
+        enableExponentialBackoff: true
+        exponentialBackoffMultiplier: 2
+        retryExceptions:
+          - java.io.IOException
+          - java.util.concurrent.TimeoutException
+          - org.springframework.web.client.ResourceAccessException
+      grpc:
+        maxAttempts: 3
+        waitDuration: 500ms
+        enableExponentialBackoff: true
+        exponentialBackoffMultiplier: 2
+        retryExceptions:
+          - io.grpc.StatusRuntimeException
+          - java.io.IOException
+    instances:
+      product-query:
+        baseConfig: default
+      payment-query:
+        baseConfig: default

--- a/order-service/src/test/kotlin/com/hoppingmall/order/port/HttpInventoryCommandAdapterTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/port/HttpInventoryCommandAdapterTest.kt
@@ -76,14 +76,13 @@ class HttpInventoryCommandAdapterTest {
     }
 
     @Test
-    fun 배치_확정_실패_시_false를_반환한다() {
+    fun 배치_확정_실패_시_예외를_발생시킨다() {
         whenever(restTemplate.postForEntity(
             any<String>(), any(), eq(HttpInventoryCommandAdapter.ConfirmationResponse::class.java)
         )).thenThrow(RuntimeException("연결 실패"))
 
-        val result = adapter.confirmReservations(listOf("rsv-1"))
-
-        assertThat(result).isFalse()
+        assertThatThrownBy { adapter.confirmReservations(listOf("rsv-1")) }
+            .isInstanceOf(RuntimeException::class.java)
     }
 
     @Test
@@ -94,7 +93,6 @@ class HttpInventoryCommandAdapterTest {
 
         assertThatThrownBy { adapter.cancelReservation("rsv-1") }
             .isInstanceOf(RuntimeException::class.java)
-            .hasMessageContaining("예약 취소 실패")
     }
 
     @Test
@@ -105,6 +103,5 @@ class HttpInventoryCommandAdapterTest {
 
         assertThatThrownBy { adapter.cancelReservations(listOf("rsv-1", "rsv-2")) }
             .isInstanceOf(RuntimeException::class.java)
-            .hasMessageContaining("예약 일괄 취소 실패")
     }
 }

--- a/order-service/src/test/kotlin/com/hoppingmall/order/port/HttpProductQueryAdapterResilienceTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/port/HttpProductQueryAdapterResilienceTest.kt
@@ -1,0 +1,69 @@
+package com.hoppingmall.order.port
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+
+@DisplayName("Resilience4j CircuitBreaker 설정 검증")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class HttpProductQueryAdapterResilienceTest {
+
+    @Test
+    fun CB_설정이_올바르게_적용된다() {
+        val config = CircuitBreakerConfig.custom()
+            .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+            .slidingWindowSize(10)
+            .minimumNumberOfCalls(5)
+            .failureRateThreshold(50f)
+            .build()
+
+        val registry = CircuitBreakerRegistry.of(config)
+        val cb = registry.circuitBreaker("product-query")
+
+        assertThat(cb.state).isEqualTo(CircuitBreaker.State.CLOSED)
+        assertThat(cb.circuitBreakerConfig.slidingWindowSize).isEqualTo(10)
+        assertThat(cb.circuitBreakerConfig.minimumNumberOfCalls).isEqualTo(5)
+        assertThat(cb.circuitBreakerConfig.failureRateThreshold).isEqualTo(50f)
+    }
+
+    @Test
+    fun 실패율_초과_시_CB가_OPEN_상태로_전환된다() {
+        val config = CircuitBreakerConfig.custom()
+            .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+            .slidingWindowSize(4)
+            .minimumNumberOfCalls(4)
+            .failureRateThreshold(50f)
+            .build()
+
+        val registry = CircuitBreakerRegistry.of(config)
+        val cb = registry.circuitBreaker("product-query")
+
+        repeat(2) { cb.onSuccess(100, java.util.concurrent.TimeUnit.MILLISECONDS) }
+        repeat(3) { cb.onError(100, java.util.concurrent.TimeUnit.MILLISECONDS, RuntimeException("fail")) }
+
+        assertThat(cb.state).isEqualTo(CircuitBreaker.State.OPEN)
+    }
+
+    @Test
+    fun 실패율_미만이면_CB가_CLOSED_유지된다() {
+        val config = CircuitBreakerConfig.custom()
+            .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+            .slidingWindowSize(10)
+            .minimumNumberOfCalls(5)
+            .failureRateThreshold(50f)
+            .build()
+
+        val registry = CircuitBreakerRegistry.of(config)
+        val cb = registry.circuitBreaker("product-query")
+
+        repeat(4) { cb.onSuccess(100, java.util.concurrent.TimeUnit.MILLISECONDS) }
+        repeat(1) { cb.onError(100, java.util.concurrent.TimeUnit.MILLISECONDS, RuntimeException("fail")) }
+
+        assertThat(cb.state).isEqualTo(CircuitBreaker.State.CLOSED)
+    }
+}

--- a/payment-service/build.gradle.kts
+++ b/payment-service/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
+	implementation("io.github.resilience4j:resilience4j-spring-boot3:2.2.0")
 
 	implementation("org.springframework.boot:spring-boot-starter-data-redis") {
 		exclude(group = "io.lettuce", module = "lettuce-core")

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/GrpcMembershipQueryAdapter.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/GrpcMembershipQueryAdapter.kt
@@ -3,6 +3,8 @@ package com.hoppingmall.payment.grpc
 import com.hoppingmall.mall.membership.grpc.MembershipQueryServiceGrpc
 import com.hoppingmall.mall.membership.grpc.UserIdRequest
 import com.hoppingmall.payment.port.MembershipQueryPort
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
 import io.grpc.StatusRuntimeException
 import net.devh.boot.grpc.client.inject.GrpcClient
 import org.slf4j.LoggerFactory
@@ -18,15 +20,17 @@ class GrpcMembershipQueryAdapter(
 
     private val log = LoggerFactory.getLogger(GrpcMembershipQueryAdapter::class.java)
 
+    @CircuitBreaker(name = "membership-query", fallbackMethod = "getPointEarningRateFallback")
+    @Retry(name = "grpc")
     override fun getPointEarningRate(userId: Long): BigDecimal {
-        return try {
-            val response = stub.getPointEarningRate(
-                UserIdRequest.newBuilder().setUserId(userId).build()
-            )
-            response.earningRate.toBigDecimalOrNull() ?: BigDecimal.ZERO
-        } catch (e: StatusRuntimeException) {
-            log.warn("멤버십 적립률 조회 실패: userId=$userId", e)
-            BigDecimal("0.01")
-        }
+        val response = stub.getPointEarningRate(
+            UserIdRequest.newBuilder().setUserId(userId).build()
+        )
+        return response.earningRate.toBigDecimalOrNull() ?: BigDecimal.ZERO
+    }
+
+    private fun getPointEarningRateFallback(userId: Long, e: Exception): BigDecimal {
+        log.warn("CB fallback: 멤버십 적립률 조회 실패 userId=$userId", e)
+        return BigDecimal("0.01")
     }
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/GrpcOrderQueryAdapter.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/GrpcOrderQueryAdapter.kt
@@ -5,6 +5,8 @@ import com.hoppingmall.order.grpc.OrderQueryServiceGrpc
 import com.hoppingmall.payment.port.OrderItemInfo
 import com.hoppingmall.payment.port.OrderQueryPort
 import com.hoppingmall.payment.port.exception.OrderItemQueryFailedException
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
 import io.grpc.StatusRuntimeException
 import net.devh.boot.grpc.client.inject.GrpcClient
 import org.slf4j.LoggerFactory
@@ -20,22 +22,24 @@ class GrpcOrderQueryAdapter(
 
     private val log = LoggerFactory.getLogger(GrpcOrderQueryAdapter::class.java)
 
+    @CircuitBreaker(name = "order-query", fallbackMethod = "findOrderItemsByOrderIdFallback")
+    @Retry(name = "grpc")
     override fun findOrderItemsByOrderId(orderId: Long): List<OrderItemInfo> {
-        return try {
-            val response = stub.findOrderItemsByOrderId(
-                OrderIdRequest.newBuilder().setOrderId(orderId).build()
+        val response = stub.findOrderItemsByOrderId(
+            OrderIdRequest.newBuilder().setOrderId(orderId).build()
+        )
+        return response.itemsList.map {
+            OrderItemInfo(
+                id = it.id,
+                productId = it.productId,
+                quantity = it.quantity,
+                totalPrice = it.totalPrice.toBigDecimalOrNull() ?: BigDecimal.ZERO
             )
-            response.itemsList.map {
-                OrderItemInfo(
-                    id = it.id,
-                    productId = it.productId,
-                    quantity = it.quantity,
-                    totalPrice = it.totalPrice.toBigDecimalOrNull() ?: BigDecimal.ZERO
-                )
-            }
-        } catch (e: StatusRuntimeException) {
-            log.error("주문 상품 조회 실패: orderId=$orderId", e)
-            throw OrderItemQueryFailedException(orderId, e)
         }
+    }
+
+    private fun findOrderItemsByOrderIdFallback(orderId: Long, e: Exception): List<OrderItemInfo> {
+        log.error("CB fallback: 주문 상품 조회 실패 orderId=$orderId", e)
+        throw OrderItemQueryFailedException(orderId, e)
     }
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/port/HttpInventoryCommandAdapter.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/port/HttpInventoryCommandAdapter.kt
@@ -1,7 +1,7 @@
 package com.hoppingmall.payment.port
 
 import com.hoppingmall.payment.port.exception.InventoryRestoreFailedException
-import org.slf4j.LoggerFactory
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
@@ -24,18 +24,12 @@ class HttpInventoryCommandAdapter(
         restTemplateBuilder.connectTimeout(Duration.ofSeconds(2)).readTimeout(Duration.ofSeconds(5)).build()
     )
 
-    private val logger = LoggerFactory.getLogger(HttpInventoryCommandAdapter::class.java)
-
+    @CircuitBreaker(name = "inventory-command")
     override fun increaseStock(productId: Long, quantity: Int) {
-        try {
-            restTemplate.postForEntity(
-                "$productServiceUrl/internal/api/v1/inventory/$productId/increase?quantity=$quantity",
-                null,
-                Void::class.java
-            )
-        } catch (e: Exception) {
-            logger.error("재고 복구 실패: productId=$productId, quantity=$quantity", e)
-            throw InventoryRestoreFailedException(productId, quantity, e)
-        }
+        restTemplate.postForEntity(
+            "$productServiceUrl/internal/api/v1/inventory/$productId/increase?quantity=$quantity",
+            null,
+            Void::class.java
+        )
     }
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/port/HttpMembershipQueryAdapter.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/port/HttpMembershipQueryAdapter.kt
@@ -1,5 +1,7 @@
 package com.hoppingmall.payment.port
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
@@ -23,16 +25,17 @@ class HttpMembershipQueryAdapter(
         .readTimeout(Duration.ofSeconds(5))
         .build()
 
+    @CircuitBreaker(name = "membership-query", fallbackMethod = "getPointEarningRateFallback")
+    @Retry(name = "membership-query")
     override fun getPointEarningRate(userId: Long): BigDecimal {
-        return try {
-            val result = restTemplate.getForObject(
-                "$monolithUrl/internal/api/v1/memberships/by-user/$userId/earning-rate",
-                BigDecimal::class.java
-            )
-            result ?: BigDecimal("0.01")
-        } catch (e: Exception) {
-            logger.warn("멤버십 적립률 조회 실패: userId=$userId", e)
-            BigDecimal("0.01")
-        }
+        return restTemplate.getForObject(
+            "$monolithUrl/internal/api/v1/memberships/by-user/$userId/earning-rate",
+            BigDecimal::class.java
+        ) ?: BigDecimal("0.01")
+    }
+
+    private fun getPointEarningRateFallback(userId: Long, e: Exception): BigDecimal {
+        logger.warn("CB fallback: 멤버십 적립률 조회 실패 userId=$userId", e)
+        return BigDecimal("0.01")
     }
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/port/HttpOrderCommandAdapter.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/port/HttpOrderCommandAdapter.kt
@@ -1,7 +1,6 @@
 package com.hoppingmall.payment.port
 
-import com.hoppingmall.payment.port.exception.OrderCancellationFailedException
-import org.slf4j.LoggerFactory
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
@@ -24,19 +23,13 @@ class HttpOrderCommandAdapter(
         restTemplateBuilder.connectTimeout(Duration.ofSeconds(2)).readTimeout(Duration.ofSeconds(5)).build()
     )
 
-    private val logger = LoggerFactory.getLogger(HttpOrderCommandAdapter::class.java)
-
+    @CircuitBreaker(name = "order-command")
     override fun cancelOrder(orderId: Long): Boolean {
-        return try {
-            restTemplate.postForEntity(
-                "$orderServiceUrl/internal/api/v1/orders/$orderId/cancel",
-                null,
-                Void::class.java
-            )
-            true
-        } catch (e: Exception) {
-            logger.error("주문 취소 실패: orderId=$orderId", e)
-            throw OrderCancellationFailedException(orderId, e)
-        }
+        restTemplate.postForEntity(
+            "$orderServiceUrl/internal/api/v1/orders/$orderId/cancel",
+            null,
+            Void::class.java
+        )
+        return true
     }
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/port/HttpOrderQueryAdapter.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/port/HttpOrderQueryAdapter.kt
@@ -1,6 +1,8 @@
 package com.hoppingmall.payment.port
 
 import com.hoppingmall.payment.port.exception.OrderItemQueryFailedException
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -28,16 +30,18 @@ class HttpOrderQueryAdapter(
 
     private val logger = LoggerFactory.getLogger(HttpOrderQueryAdapter::class.java)
 
+    @CircuitBreaker(name = "order-query", fallbackMethod = "findOrderItemsByOrderIdFallback")
+    @Retry(name = "order-query")
     override fun findOrderItemsByOrderId(orderId: Long): List<OrderItemInfo> {
-        return try {
-            val result = restTemplate.getForObject(
-                "$orderServiceUrl/internal/api/v1/orders/$orderId/items",
-                Array<OrderItemInfo>::class.java
-            )
-            result?.toList() ?: emptyList()
-        } catch (e: Exception) {
-            logger.error("주문 상품 조회 실패: orderId=$orderId", e)
-            throw OrderItemQueryFailedException(orderId, e)
-        }
+        val result = restTemplate.getForObject(
+            "$orderServiceUrl/internal/api/v1/orders/$orderId/items",
+            Array<OrderItemInfo>::class.java
+        )
+        return result?.toList() ?: emptyList()
+    }
+
+    private fun findOrderItemsByOrderIdFallback(orderId: Long, e: Exception): List<OrderItemInfo> {
+        logger.error("CB fallback: 주문 상품 조회 실패 orderId=$orderId", e)
+        throw OrderItemQueryFailedException(orderId, e)
     }
 }

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -57,6 +57,9 @@ management:
     sampling:
       probability: 0.0
     enabled: false
+  health:
+    circuitbreakers:
+      enabled: true
 
 services:
   monolith:
@@ -80,3 +83,56 @@ grpc:
     monolith:
       address: static://localhost:9080
       negotiation-type: plaintext
+
+resilience4j:
+  circuitbreaker:
+    circuitBreakerAspectOrder: 2
+    configs:
+      default:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        failureRateThreshold: 50
+        waitDurationInOpenState: 30s
+        permittedNumberOfCallsInHalfOpenState: 3
+        slowCallDurationThreshold: 3s
+        slowCallRateThreshold: 80
+        recordExceptions:
+          - java.lang.Exception
+        ignoreExceptions:
+          - org.springframework.web.client.HttpClientErrorException$NotFound
+          - org.springframework.web.client.HttpClientErrorException$BadRequest
+    instances:
+      membership-query:
+        baseConfig: default
+      order-command:
+        baseConfig: default
+      order-query:
+        baseConfig: default
+      inventory-command:
+        baseConfig: default
+  retry:
+    retryAspectOrder: 1
+    configs:
+      default:
+        maxAttempts: 3
+        waitDuration: 500ms
+        enableExponentialBackoff: true
+        exponentialBackoffMultiplier: 2
+        retryExceptions:
+          - java.io.IOException
+          - java.util.concurrent.TimeoutException
+          - org.springframework.web.client.ResourceAccessException
+      grpc:
+        maxAttempts: 3
+        waitDuration: 500ms
+        enableExponentialBackoff: true
+        exponentialBackoffMultiplier: 2
+        retryExceptions:
+          - io.grpc.StatusRuntimeException
+          - java.io.IOException
+    instances:
+      membership-query:
+        baseConfig: default
+      order-query:
+        baseConfig: default

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/grpc/GrpcOrderQueryAdapterTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/grpc/GrpcOrderQueryAdapterTest.kt
@@ -48,12 +48,11 @@ class GrpcOrderQueryAdapterTest {
     }
 
     @Test
-    fun gRPC_호출_실패_시_OrderItemQueryFailedException을_던진다() {
+    fun gRPC_호출_실패_시_예외를_전파한다() {
         whenever(stub.findOrderItemsByOrderId(any()))
             .thenThrow(StatusRuntimeException(Status.UNAVAILABLE))
 
         assertThatThrownBy { adapter.findOrderItemsByOrderId(1L) }
-            .isInstanceOf(OrderItemQueryFailedException::class.java)
-            .hasMessageContaining("orderId=1")
+            .isInstanceOf(StatusRuntimeException::class.java)
     }
 }

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/port/HttpInventoryCommandAdapterTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/port/HttpInventoryCommandAdapterTest.kt
@@ -1,6 +1,5 @@
 package com.hoppingmall.payment.port
 
-import com.hoppingmall.payment.port.exception.InventoryRestoreFailedException
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator
@@ -15,6 +14,7 @@ import org.springframework.test.web.client.match.MockRestRequestMatchers.method
 import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
 import org.springframework.test.web.client.response.MockRestResponseCreators.withStatus
 import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.HttpServerErrorException
 import org.springframework.web.client.RestTemplate
 
 @DisplayName("HttpInventoryCommandAdapter")
@@ -36,15 +36,13 @@ class HttpInventoryCommandAdapterTest {
     }
 
     @Test
-    fun 재고_복구_실패_시_InventoryRestoreFailedException을_던진다() {
+    fun 재고_복구_실패_시_예외를_던진다() {
         server.expect(requestTo("http://localhost:8083/internal/api/v1/inventory/10/increase?quantity=5"))
             .andExpect(method(HttpMethod.POST))
             .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR))
 
         assertThatThrownBy { adapter.increaseStock(10L, 5) }
-            .isInstanceOf(InventoryRestoreFailedException::class.java)
-            .hasMessageContaining("productId=10")
-            .hasMessageContaining("quantity=5")
+            .isInstanceOf(HttpServerErrorException::class.java)
 
         server.verify()
     }

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/port/HttpOrderCommandAdapterTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/port/HttpOrderCommandAdapterTest.kt
@@ -1,6 +1,5 @@
 package com.hoppingmall.payment.port
 
-import com.hoppingmall.payment.port.exception.OrderCancellationFailedException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
@@ -15,6 +14,7 @@ import org.springframework.test.web.client.match.MockRestRequestMatchers.method
 import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
 import org.springframework.test.web.client.response.MockRestResponseCreators.withStatus
 import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.HttpServerErrorException
 import org.springframework.web.client.RestTemplate
 
 @DisplayName("HttpOrderCommandAdapter")
@@ -38,14 +38,13 @@ class HttpOrderCommandAdapterTest {
     }
 
     @Test
-    fun 주문_취소_실패_시_OrderCancellationFailedException을_던진다() {
+    fun 주문_취소_실패_시_예외를_던진다() {
         server.expect(requestTo("http://localhost:8084/internal/api/v1/orders/1/cancel"))
             .andExpect(method(HttpMethod.POST))
             .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR))
 
         assertThatThrownBy { adapter.cancelOrder(1L) }
-            .isInstanceOf(OrderCancellationFailedException::class.java)
-            .hasMessageContaining("orderId=1")
+            .isInstanceOf(HttpServerErrorException::class.java)
 
         server.verify()
     }

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/port/HttpOrderQueryAdapterResilienceTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/port/HttpOrderQueryAdapterResilienceTest.kt
@@ -1,0 +1,65 @@
+package com.hoppingmall.payment.port
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+
+@DisplayName("Resilience4j CircuitBreaker 설정 검증")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class HttpOrderQueryAdapterResilienceTest {
+
+    @Test
+    fun CB_설정이_올바르게_적용된다() {
+        val config = CircuitBreakerConfig.custom()
+            .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+            .slidingWindowSize(10)
+            .minimumNumberOfCalls(5)
+            .failureRateThreshold(50f)
+            .build()
+
+        val registry = CircuitBreakerRegistry.of(config)
+        val cb = registry.circuitBreaker("order-query")
+
+        assertThat(cb.state).isEqualTo(CircuitBreaker.State.CLOSED)
+    }
+
+    @Test
+    fun 실패율_초과_시_CB가_OPEN_상태로_전환된다() {
+        val config = CircuitBreakerConfig.custom()
+            .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+            .slidingWindowSize(4)
+            .minimumNumberOfCalls(4)
+            .failureRateThreshold(50f)
+            .build()
+
+        val registry = CircuitBreakerRegistry.of(config)
+        val cb = registry.circuitBreaker("order-query")
+
+        repeat(2) { cb.onSuccess(100, java.util.concurrent.TimeUnit.MILLISECONDS) }
+        repeat(3) { cb.onError(100, java.util.concurrent.TimeUnit.MILLISECONDS, RuntimeException("fail")) }
+
+        assertThat(cb.state).isEqualTo(CircuitBreaker.State.OPEN)
+    }
+
+    @Test
+    fun 최소_호출_미달_시_CB가_CLOSED_유지된다() {
+        val config = CircuitBreakerConfig.custom()
+            .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+            .slidingWindowSize(10)
+            .minimumNumberOfCalls(5)
+            .failureRateThreshold(50f)
+            .build()
+
+        val registry = CircuitBreakerRegistry.of(config)
+        val cb = registry.circuitBreaker("order-query")
+
+        repeat(3) { cb.onError(100, java.util.concurrent.TimeUnit.MILLISECONDS, RuntimeException("fail")) }
+
+        assertThat(cb.state).isEqualTo(CircuitBreaker.State.CLOSED)
+    }
+}

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/port/HttpOrderQueryAdapterTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/port/HttpOrderQueryAdapterTest.kt
@@ -1,6 +1,5 @@
 package com.hoppingmall.payment.port
 
-import com.hoppingmall.payment.port.exception.OrderItemQueryFailedException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
@@ -15,6 +14,7 @@ import org.springframework.test.web.client.match.MockRestRequestMatchers.method
 import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
 import org.springframework.test.web.client.response.MockRestResponseCreators.withStatus
 import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.HttpServerErrorException
 import org.springframework.web.client.RestTemplate
 
 @DisplayName("HttpOrderQueryAdapter")
@@ -41,14 +41,13 @@ class HttpOrderQueryAdapterTest {
     }
 
     @Test
-    fun 주문_상품_조회_실패_시_OrderItemQueryFailedException을_던진다() {
+    fun 주문_상품_조회_실패_시_예외를_던진다() {
         server.expect(requestTo("http://localhost:8084/internal/api/v1/orders/1/items"))
             .andExpect(method(HttpMethod.GET))
             .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR))
 
         assertThatThrownBy { adapter.findOrderItemsByOrderId(1L) }
-            .isInstanceOf(OrderItemQueryFailedException::class.java)
-            .hasMessageContaining("orderId=1")
+            .isInstanceOf(HttpServerErrorException::class.java)
 
         server.verify()
     }

--- a/product-service/build.gradle.kts
+++ b/product-service/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
+	implementation("io.github.resilience4j:resilience4j-spring-boot3:2.2.0")
 
 	implementation("org.springframework.boot:spring-boot-starter-data-redis") {
 		exclude(group = "io.lettuce", module = "lettuce-core")

--- a/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcCartItemQueryAdapter.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcCartItemQueryAdapter.kt
@@ -4,7 +4,8 @@ import com.hoppingmall.order.grpc.CartItemQueryServiceGrpc
 import com.hoppingmall.order.grpc.Empty
 import com.hoppingmall.product.statistics.port.CartAggregation
 import com.hoppingmall.product.statistics.port.CartItemQueryPort
-import io.grpc.StatusRuntimeException
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
 import net.devh.boot.grpc.client.inject.GrpcClient
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
@@ -18,18 +19,20 @@ class GrpcCartItemQueryAdapter(
 
     private val log = LoggerFactory.getLogger(GrpcCartItemQueryAdapter::class.java)
 
+    @CircuitBreaker(name = "cart-query", fallbackMethod = "aggregateCartByProductFallback")
+    @Retry(name = "grpc")
     override fun aggregateCartByProduct(): List<CartAggregation> {
-        return try {
-            val response = stub.aggregateCartByProduct(Empty.getDefaultInstance())
-            response.aggregationsList.map {
-                CartAggregation(
-                    productId = it.productId,
-                    buyerCount = it.buyerCount
-                )
-            }
-        } catch (e: StatusRuntimeException) {
-            log.warn("장바구니 통계 조회 실패", e)
-            emptyList()
+        val response = stub.aggregateCartByProduct(Empty.getDefaultInstance())
+        return response.aggregationsList.map {
+            CartAggregation(
+                productId = it.productId,
+                buyerCount = it.buyerCount
+            )
         }
+    }
+
+    private fun aggregateCartByProductFallback(e: Exception): List<CartAggregation> {
+        log.warn("CB fallback: 장바구니 통계 조회 실패", e)
+        return emptyList()
     }
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcOrderItemQueryAdapter.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcOrderItemQueryAdapter.kt
@@ -4,7 +4,8 @@ import com.hoppingmall.order.grpc.OrderIdRequest
 import com.hoppingmall.order.grpc.OrderQueryServiceGrpc
 import com.hoppingmall.product.statistics.port.OrderItemInfo
 import com.hoppingmall.product.statistics.port.OrderItemQueryPort
-import io.grpc.StatusRuntimeException
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
 import net.devh.boot.grpc.client.inject.GrpcClient
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
@@ -19,23 +20,25 @@ class GrpcOrderItemQueryAdapter(
 
     private val log = LoggerFactory.getLogger(GrpcOrderItemQueryAdapter::class.java)
 
+    @CircuitBreaker(name = "order-item-query", fallbackMethod = "findByOrderIdFallback")
+    @Retry(name = "grpc")
     override fun findByOrderId(orderId: Long): List<OrderItemInfo> {
-        return try {
-            val response = stub.findOrderItemsByOrderId(
-                OrderIdRequest.newBuilder().setOrderId(orderId).build()
+        val response = stub.findOrderItemsByOrderId(
+            OrderIdRequest.newBuilder().setOrderId(orderId).build()
+        )
+        return response.itemsList.map {
+            OrderItemInfo(
+                id = it.id,
+                orderId = it.orderId,
+                productId = it.productId,
+                quantity = it.quantity,
+                totalPrice = it.totalPrice.toBigDecimalOrNull() ?: BigDecimal.ZERO
             )
-            response.itemsList.map {
-                OrderItemInfo(
-                    id = it.id,
-                    orderId = it.orderId,
-                    productId = it.productId,
-                    quantity = it.quantity,
-                    totalPrice = it.totalPrice.toBigDecimalOrNull() ?: BigDecimal.ZERO
-                )
-            }
-        } catch (e: StatusRuntimeException) {
-            log.warn("주문 상품 조회 실패: orderId=$orderId", e)
-            emptyList()
         }
+    }
+
+    private fun findByOrderIdFallback(orderId: Long, e: Exception): List<OrderItemInfo> {
+        log.warn("CB fallback: 주문 상품 조회 실패 orderId=$orderId", e)
+        return emptyList()
     }
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcOrderQueryAdapter.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcOrderQueryAdapter.kt
@@ -3,6 +3,8 @@ package com.hoppingmall.product.grpc
 import com.hoppingmall.order.grpc.*
 import com.hoppingmall.product.review.port.OrderItemInfo
 import com.hoppingmall.product.review.port.OrderQueryPort
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
 import net.devh.boot.grpc.client.inject.GrpcClient
@@ -19,46 +21,50 @@ class GrpcOrderQueryAdapter(
 
     private val log = LoggerFactory.getLogger(GrpcOrderQueryAdapter::class.java)
 
+    @CircuitBreaker(name = "order-query", fallbackMethod = "isDeliveredFallback")
+    @Retry(name = "grpc")
     override fun isDelivered(orderId: Long, buyerId: Long): Boolean {
-        return try {
-            val response = stub.isDelivered(
-                DeliveredCheckRequest.newBuilder()
-                    .setOrderId(orderId)
-                    .setBuyerId(buyerId)
-                    .build()
-            )
-            response.delivered
-        } catch (e: StatusRuntimeException) {
-            log.warn("배송 완료 확인 실패: orderId=$orderId, buyerId=$buyerId", e)
-            false
-        }
+        val response = stub.isDelivered(
+            DeliveredCheckRequest.newBuilder()
+                .setOrderId(orderId)
+                .setBuyerId(buyerId)
+                .build()
+        )
+        return response.delivered
     }
 
+    @CircuitBreaker(name = "order-query", fallbackMethod = "findOrderItemByIdFallback")
+    @Retry(name = "grpc")
     override fun findOrderItemById(orderItemId: Long): OrderItemInfo? {
-        return try {
-            val response = stub.findOrderItemById(
-                OrderItemIdRequest.newBuilder().setOrderItemId(orderItemId).build()
-            )
-            response.toReviewOrderItemInfo()
-        } catch (e: StatusRuntimeException) {
-            if (e.status.code == Status.Code.NOT_FOUND) null
-            else {
-                log.warn("주문 상품 조회 실패: orderItemId=$orderItemId", e)
-                null
-            }
-        }
+        val response = stub.findOrderItemById(
+            OrderItemIdRequest.newBuilder().setOrderItemId(orderItemId).build()
+        )
+        return response.toReviewOrderItemInfo()
     }
 
+    @CircuitBreaker(name = "order-query", fallbackMethod = "findOrderItemsByOrderIdFallback")
+    @Retry(name = "grpc")
     override fun findOrderItemsByOrderId(orderId: Long): List<OrderItemInfo> {
-        return try {
-            val response = stub.findOrderItemsByOrderId(
-                OrderIdRequest.newBuilder().setOrderId(orderId).build()
-            )
-            response.itemsList.map { it.toReviewOrderItemInfo() }
-        } catch (e: StatusRuntimeException) {
-            log.warn("주문 상품 목록 조회 실패: orderId=$orderId", e)
-            emptyList()
-        }
+        val response = stub.findOrderItemsByOrderId(
+            OrderIdRequest.newBuilder().setOrderId(orderId).build()
+        )
+        return response.itemsList.map { it.toReviewOrderItemInfo() }
+    }
+
+    private fun isDeliveredFallback(orderId: Long, buyerId: Long, e: Exception): Boolean {
+        log.warn("CB fallback: 배송 완료 확인 실패 orderId=$orderId, buyerId=$buyerId", e)
+        return false
+    }
+
+    private fun findOrderItemByIdFallback(orderItemId: Long, e: Exception): OrderItemInfo? {
+        if (e is StatusRuntimeException && e.status.code == Status.Code.NOT_FOUND) return null
+        log.warn("CB fallback: 주문 상품 조회 실패 orderItemId=$orderItemId", e)
+        return null
+    }
+
+    private fun findOrderItemsByOrderIdFallback(orderId: Long, e: Exception): List<OrderItemInfo> {
+        log.warn("CB fallback: 주문 상품 목록 조회 실패 orderId=$orderId", e)
+        return emptyList()
     }
 
     private fun OrderItemResponse.toReviewOrderItemInfo() = OrderItemInfo(

--- a/product-service/src/main/kotlin/com/hoppingmall/product/review/port/HttpOrderQueryAdapter.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/review/port/HttpOrderQueryAdapter.kt
@@ -1,5 +1,7 @@
 package com.hoppingmall.product.review.port
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
@@ -22,40 +24,46 @@ class HttpOrderQueryAdapter(
         .readTimeout(Duration.ofSeconds(5))
         .build()
 
+    @CircuitBreaker(name = "order-query", fallbackMethod = "findOrderItemByIdFallback")
+    @Retry(name = "order-query")
     override fun findOrderItemById(orderItemId: Long): OrderItemInfo? {
-        return try {
-            restTemplate.getForObject(
-                "$monolithUrl/internal/api/v1/order-items/$orderItemId",
-                OrderItemInfo::class.java
-            )
-        } catch (e: Exception) {
-            logger.warn("주문 상품 조회 실패: orderItemId=$orderItemId", e)
-            null
-        }
+        return restTemplate.getForObject(
+            "$monolithUrl/internal/api/v1/order-items/$orderItemId",
+            OrderItemInfo::class.java
+        )
     }
 
+    @CircuitBreaker(name = "order-query", fallbackMethod = "isDeliveredFallback")
+    @Retry(name = "order-query")
     override fun isDelivered(orderId: Long, buyerId: Long): Boolean {
-        return try {
-            restTemplate.getForObject(
-                "$monolithUrl/internal/api/v1/orders/$orderId/delivered?buyerId=$buyerId",
-                Boolean::class.java
-            ) ?: false
-        } catch (e: Exception) {
-            logger.warn("배송 완료 여부 조회 실패: orderId=$orderId, buyerId=$buyerId", e)
-            false
-        }
+        return restTemplate.getForObject(
+            "$monolithUrl/internal/api/v1/orders/$orderId/delivered?buyerId=$buyerId",
+            Boolean::class.java
+        ) ?: false
     }
 
+    @CircuitBreaker(name = "order-query", fallbackMethod = "findOrderItemsByOrderIdFallback")
+    @Retry(name = "order-query")
     override fun findOrderItemsByOrderId(orderId: Long): List<OrderItemInfo> {
-        return try {
-            val result = restTemplate.getForObject(
-                "$monolithUrl/internal/api/v1/orders/$orderId/items",
-                Array<OrderItemInfo>::class.java
-            )
-            result?.toList() ?: emptyList()
-        } catch (e: Exception) {
-            logger.warn("주문별 상품 목록 조회 실패: orderId=$orderId", e)
-            emptyList()
-        }
+        val result = restTemplate.getForObject(
+            "$monolithUrl/internal/api/v1/orders/$orderId/items",
+            Array<OrderItemInfo>::class.java
+        )
+        return result?.toList() ?: emptyList()
+    }
+
+    private fun findOrderItemByIdFallback(orderItemId: Long, e: Exception): OrderItemInfo? {
+        logger.warn("CB fallback: 주문 상품 조회 실패 orderItemId=$orderItemId", e)
+        return null
+    }
+
+    private fun isDeliveredFallback(orderId: Long, buyerId: Long, e: Exception): Boolean {
+        logger.warn("CB fallback: 배송 완료 여부 조회 실패 orderId=$orderId, buyerId=$buyerId", e)
+        return false
+    }
+
+    private fun findOrderItemsByOrderIdFallback(orderId: Long, e: Exception): List<OrderItemInfo> {
+        logger.warn("CB fallback: 주문별 상품 목록 조회 실패 orderId=$orderId", e)
+        return emptyList()
     }
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/statistics/port/HttpCartItemQueryAdapter.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/statistics/port/HttpCartItemQueryAdapter.kt
@@ -1,5 +1,7 @@
 package com.hoppingmall.product.statistics.port
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
@@ -22,16 +24,18 @@ class HttpCartItemQueryAdapter(
         .readTimeout(Duration.ofSeconds(5))
         .build()
 
+    @CircuitBreaker(name = "cart-query", fallbackMethod = "aggregateCartByProductFallback")
+    @Retry(name = "cart-query")
     override fun aggregateCartByProduct(): List<CartAggregation> {
-        return try {
-            val result = restTemplate.getForObject(
-                "$orderServiceUrl/internal/api/v1/cart-items/aggregate",
-                Array<CartAggregation>::class.java
-            )
-            result?.toList() ?: emptyList()
-        } catch (e: Exception) {
-            logger.warn("장바구니 집계 조회 실패", e)
-            emptyList()
-        }
+        val result = restTemplate.getForObject(
+            "$orderServiceUrl/internal/api/v1/cart-items/aggregate",
+            Array<CartAggregation>::class.java
+        )
+        return result?.toList() ?: emptyList()
+    }
+
+    private fun aggregateCartByProductFallback(e: Exception): List<CartAggregation> {
+        logger.warn("CB fallback: 장바구니 집계 조회 실패", e)
+        return emptyList()
     }
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/statistics/port/HttpOrderItemQueryAdapter.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/statistics/port/HttpOrderItemQueryAdapter.kt
@@ -1,5 +1,7 @@
 package com.hoppingmall.product.statistics.port
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
@@ -22,16 +24,18 @@ class HttpOrderItemQueryAdapter(
         .readTimeout(Duration.ofSeconds(5))
         .build()
 
+    @CircuitBreaker(name = "order-item-query", fallbackMethod = "findByOrderIdFallback")
+    @Retry(name = "order-item-query")
     override fun findByOrderId(orderId: Long): List<OrderItemInfo> {
-        return try {
-            val result = restTemplate.getForObject(
-                "$orderServiceUrl/internal/api/v1/orders/$orderId/items",
-                Array<OrderItemInfo>::class.java
-            )
-            result?.toList() ?: emptyList()
-        } catch (e: Exception) {
-            logger.warn("주문 상품 조회 실패: orderId=$orderId", e)
-            emptyList()
-        }
+        val result = restTemplate.getForObject(
+            "$orderServiceUrl/internal/api/v1/orders/$orderId/items",
+            Array<OrderItemInfo>::class.java
+        )
+        return result?.toList() ?: emptyList()
+    }
+
+    private fun findByOrderIdFallback(orderId: Long, e: Exception): List<OrderItemInfo> {
+        logger.warn("CB fallback: 주문 상품 조회 실패 orderId=$orderId", e)
+        return emptyList()
     }
 }

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -57,6 +57,9 @@ management:
     sampling:
       probability: 0.0
     enabled: false
+  health:
+    circuitbreakers:
+      enabled: true
 
 services:
   monolith:
@@ -89,3 +92,56 @@ grpc:
     order-service:
       address: static://localhost:9094
       negotiation-type: plaintext
+
+resilience4j:
+  circuitbreaker:
+    circuitBreakerAspectOrder: 2
+    configs:
+      default:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        failureRateThreshold: 50
+        waitDurationInOpenState: 30s
+        permittedNumberOfCallsInHalfOpenState: 3
+        slowCallDurationThreshold: 3s
+        slowCallRateThreshold: 80
+        recordExceptions:
+          - java.lang.Exception
+        ignoreExceptions:
+          - org.springframework.web.client.HttpClientErrorException$NotFound
+          - org.springframework.web.client.HttpClientErrorException$BadRequest
+    instances:
+      order-query:
+        baseConfig: default
+      cart-query:
+        baseConfig: default
+      order-item-query:
+        baseConfig: default
+  retry:
+    retryAspectOrder: 1
+    configs:
+      default:
+        maxAttempts: 3
+        waitDuration: 500ms
+        enableExponentialBackoff: true
+        exponentialBackoffMultiplier: 2
+        retryExceptions:
+          - java.io.IOException
+          - java.util.concurrent.TimeoutException
+          - org.springframework.web.client.ResourceAccessException
+      grpc:
+        maxAttempts: 3
+        waitDuration: 500ms
+        enableExponentialBackoff: true
+        exponentialBackoffMultiplier: 2
+        retryExceptions:
+          - io.grpc.StatusRuntimeException
+          - java.io.IOException
+    instances:
+      order-query:
+        baseConfig: default
+      cart-query:
+        baseConfig: default
+      order-item-query:
+        baseConfig: default

--- a/product-service/src/test/kotlin/com/hoppingmall/product/review/port/HttpOrderQueryAdapterResilienceTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/review/port/HttpOrderQueryAdapterResilienceTest.kt
@@ -1,0 +1,49 @@
+package com.hoppingmall.product.review.port
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+
+@DisplayName("Resilience4j CircuitBreaker 설정 검증")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class HttpOrderQueryAdapterResilienceTest {
+
+    @Test
+    fun CB_설정이_올바르게_적용된다() {
+        val config = CircuitBreakerConfig.custom()
+            .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+            .slidingWindowSize(10)
+            .minimumNumberOfCalls(5)
+            .failureRateThreshold(50f)
+            .build()
+
+        val registry = CircuitBreakerRegistry.of(config)
+        val cb = registry.circuitBreaker("order-query")
+
+        assertThat(cb.state).isEqualTo(CircuitBreaker.State.CLOSED)
+        assertThat(cb.circuitBreakerConfig.slidingWindowSize).isEqualTo(10)
+    }
+
+    @Test
+    fun 실패율_초과_시_CB가_OPEN_상태로_전환된다() {
+        val config = CircuitBreakerConfig.custom()
+            .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+            .slidingWindowSize(4)
+            .minimumNumberOfCalls(4)
+            .failureRateThreshold(50f)
+            .build()
+
+        val registry = CircuitBreakerRegistry.of(config)
+        val cb = registry.circuitBreaker("order-query")
+
+        repeat(2) { cb.onSuccess(100, java.util.concurrent.TimeUnit.MILLISECONDS) }
+        repeat(3) { cb.onError(100, java.util.concurrent.TimeUnit.MILLISECONDS, RuntimeException("fail")) }
+
+        assertThat(cb.state).isEqualTo(CircuitBreaker.State.OPEN)
+    }
+}

--- a/settlement-service/build.gradle.kts
+++ b/settlement-service/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
+	implementation("io.github.resilience4j:resilience4j-spring-boot3:2.2.0")
 
 	runtimeOnly("com.mysql:mysql-connector-j")
 	runtimeOnly("com.h2database:h2")

--- a/settlement-service/src/main/kotlin/com/hoppingmall/settlement/port/HttpOrderItemQueryAdapter.kt
+++ b/settlement-service/src/main/kotlin/com/hoppingmall/settlement/port/HttpOrderItemQueryAdapter.kt
@@ -1,6 +1,9 @@
 package com.hoppingmall.settlement.port
 
 import com.hoppingmall.settlement.exception.ServiceCommunicationException
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.core.ParameterizedTypeReference
@@ -17,27 +20,37 @@ class HttpOrderItemQueryAdapter(
     restTemplateBuilder: RestTemplateBuilder
 ) : OrderItemQueryPort {
 
+    private val logger = LoggerFactory.getLogger(HttpOrderItemQueryAdapter::class.java)
+
     private val restTemplate: RestTemplate = restTemplateBuilder
         .connectTimeout(Duration.ofSeconds(5))
         .readTimeout(Duration.ofSeconds(10))
         .build()
 
+    @CircuitBreaker(name = "order-item-query", fallbackMethod = "findDeliveredItemsBySellerAndPeriodFallback")
+    @Retry(name = "order-item-query")
     override fun findDeliveredItemsBySellerAndPeriod(
         sellerId: Long,
         startDate: LocalDateTime,
         endDate: LocalDateTime
     ): List<OrderItemInfo> {
-        try {
-            val url = "$orderServiceUrl/internal/api/v1/order-items/delivered?sellerId=$sellerId&startDate=${startDate.format(DateTimeFormatter.ISO_DATE_TIME)}&endDate=${endDate.format(DateTimeFormatter.ISO_DATE_TIME)}"
-            val response = restTemplate.exchange(
-                url,
-                HttpMethod.GET,
-                null,
-                object : ParameterizedTypeReference<List<OrderItemInfo>>() {}
-            )
-            return response.body ?: emptyList()
-        } catch (e: Exception) {
-            throw ServiceCommunicationException("order-service 배송완료 주문상품 조회 실패: ${e.message}")
-        }
+        val url = "$orderServiceUrl/internal/api/v1/order-items/delivered?sellerId=$sellerId&startDate=${startDate.format(DateTimeFormatter.ISO_DATE_TIME)}&endDate=${endDate.format(DateTimeFormatter.ISO_DATE_TIME)}"
+        val response = restTemplate.exchange(
+            url,
+            HttpMethod.GET,
+            null,
+            object : ParameterizedTypeReference<List<OrderItemInfo>>() {}
+        )
+        return response.body ?: emptyList()
+    }
+
+    private fun findDeliveredItemsBySellerAndPeriodFallback(
+        sellerId: Long,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime,
+        e: Exception
+    ): List<OrderItemInfo> {
+        logger.error("CB fallback: order-service 배송완료 주문상품 조회 실패 sellerId=$sellerId", e)
+        throw ServiceCommunicationException("order-service 배송완료 주문상품 조회 실패: ${e.message}")
     }
 }

--- a/settlement-service/src/main/kotlin/com/hoppingmall/settlement/port/HttpRefundQueryAdapter.kt
+++ b/settlement-service/src/main/kotlin/com/hoppingmall/settlement/port/HttpRefundQueryAdapter.kt
@@ -1,6 +1,9 @@
 package com.hoppingmall.settlement.port
 
 import com.hoppingmall.settlement.exception.ServiceCommunicationException
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.core.ParameterizedTypeReference
@@ -17,27 +20,37 @@ class HttpRefundQueryAdapter(
     restTemplateBuilder: RestTemplateBuilder
 ) : RefundQueryPort {
 
+    private val logger = LoggerFactory.getLogger(HttpRefundQueryAdapter::class.java)
+
     private val restTemplate: RestTemplate = restTemplateBuilder
         .connectTimeout(Duration.ofSeconds(5))
         .readTimeout(Duration.ofSeconds(10))
         .build()
 
+    @CircuitBreaker(name = "refund-query", fallbackMethod = "findCompletedBySellerAndPeriodFallback")
+    @Retry(name = "refund-query")
     override fun findCompletedBySellerAndPeriod(
         sellerId: Long,
         startDate: LocalDateTime,
         endDate: LocalDateTime
     ): List<RefundInfo> {
-        try {
-            val url = "$orderServiceUrl/internal/api/v1/refunds/completed?sellerId=$sellerId&startDate=${startDate.format(DateTimeFormatter.ISO_DATE_TIME)}&endDate=${endDate.format(DateTimeFormatter.ISO_DATE_TIME)}"
-            val response = restTemplate.exchange(
-                url,
-                HttpMethod.GET,
-                null,
-                object : ParameterizedTypeReference<List<RefundInfo>>() {}
-            )
-            return response.body ?: emptyList()
-        } catch (e: Exception) {
-            throw ServiceCommunicationException("order-service 완료 환불 조회 실패: ${e.message}")
-        }
+        val url = "$orderServiceUrl/internal/api/v1/refunds/completed?sellerId=$sellerId&startDate=${startDate.format(DateTimeFormatter.ISO_DATE_TIME)}&endDate=${endDate.format(DateTimeFormatter.ISO_DATE_TIME)}"
+        val response = restTemplate.exchange(
+            url,
+            HttpMethod.GET,
+            null,
+            object : ParameterizedTypeReference<List<RefundInfo>>() {}
+        )
+        return response.body ?: emptyList()
+    }
+
+    private fun findCompletedBySellerAndPeriodFallback(
+        sellerId: Long,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime,
+        e: Exception
+    ): List<RefundInfo> {
+        logger.error("CB fallback: order-service 완료 환불 조회 실패 sellerId=$sellerId", e)
+        throw ServiceCommunicationException("order-service 완료 환불 조회 실패: ${e.message}")
     }
 }

--- a/settlement-service/src/main/kotlin/com/hoppingmall/settlement/port/HttpSellerQueryAdapter.kt
+++ b/settlement-service/src/main/kotlin/com/hoppingmall/settlement/port/HttpSellerQueryAdapter.kt
@@ -1,6 +1,9 @@
 package com.hoppingmall.settlement.port
 
 import com.hoppingmall.settlement.exception.ServiceCommunicationException
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.stereotype.Component
@@ -13,22 +16,27 @@ class HttpSellerQueryAdapter(
     restTemplateBuilder: RestTemplateBuilder
 ) : SellerQueryPort {
 
+    private val logger = LoggerFactory.getLogger(HttpSellerQueryAdapter::class.java)
+
     private val restTemplate: RestTemplate = restTemplateBuilder
         .connectTimeout(Duration.ofSeconds(5))
         .readTimeout(Duration.ofSeconds(10))
         .build()
 
+    @CircuitBreaker(name = "seller-query", fallbackMethod = "findByUserIdFallback")
+    @Retry(name = "seller-query")
     override fun findByUserId(userId: Long): SellerInfo? {
-        try {
-            val response = restTemplate.getForEntity(
-                "$userServiceUrl/internal/api/v1/sellers/by-user/$userId",
-                SellerResponse::class.java
-            )
-            val body = response.body ?: return null
-            return SellerInfo(id = body.id, userId = body.userId)
-        } catch (e: Exception) {
-            throw ServiceCommunicationException("user-service 판매자 조회 실패: ${e.message}")
-        }
+        val response = restTemplate.getForEntity(
+            "$userServiceUrl/internal/api/v1/sellers/by-user/$userId",
+            SellerResponse::class.java
+        )
+        val body = response.body ?: return null
+        return SellerInfo(id = body.id, userId = body.userId)
+    }
+
+    private fun findByUserIdFallback(userId: Long, e: Exception): SellerInfo? {
+        logger.error("CB fallback: user-service 판매자 조회 실패 userId=$userId", e)
+        throw ServiceCommunicationException("user-service 판매자 조회 실패: ${e.message}")
     }
 
     data class SellerResponse(

--- a/settlement-service/src/main/resources/application.yml
+++ b/settlement-service/src/main/resources/application.yml
@@ -29,6 +29,9 @@ management:
     web:
       exposure:
         include: health,metrics,prometheus
+  health:
+    circuitbreakers:
+      enabled: true
   metrics:
     tags:
       application: settlement-service
@@ -55,3 +58,62 @@ springdoc:
     path: /v3/api-docs
   swagger-ui:
     path: /swagger-ui.html
+
+resilience4j:
+  circuitbreaker:
+    circuitBreakerAspectOrder: 2
+    configs:
+      default:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        failureRateThreshold: 50
+        waitDurationInOpenState: 30s
+        permittedNumberOfCallsInHalfOpenState: 3
+        slowCallDurationThreshold: 3s
+        slowCallRateThreshold: 80
+        recordExceptions:
+          - java.lang.Exception
+        ignoreExceptions:
+          - org.springframework.web.client.HttpClientErrorException$NotFound
+          - org.springframework.web.client.HttpClientErrorException$BadRequest
+      settlement:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 5
+        minimumNumberOfCalls: 3
+        failureRateThreshold: 50
+        waitDurationInOpenState: 60s
+        permittedNumberOfCallsInHalfOpenState: 2
+        slowCallDurationThreshold: 8s
+        slowCallRateThreshold: 80
+        recordExceptions:
+          - java.lang.Exception
+        ignoreExceptions:
+          - org.springframework.web.client.HttpClientErrorException$NotFound
+          - org.springframework.web.client.HttpClientErrorException$BadRequest
+    instances:
+      order-item-query:
+        baseConfig: settlement
+      refund-query:
+        baseConfig: settlement
+      seller-query:
+        baseConfig: settlement
+  retry:
+    retryAspectOrder: 1
+    configs:
+      settlement:
+        maxAttempts: 3
+        waitDuration: 1s
+        enableExponentialBackoff: true
+        exponentialBackoffMultiplier: 2
+        retryExceptions:
+          - java.io.IOException
+          - java.util.concurrent.TimeoutException
+          - org.springframework.web.client.ResourceAccessException
+    instances:
+      order-item-query:
+        baseConfig: settlement
+      refund-query:
+        baseConfig: settlement
+      seller-query:
+        baseConfig: settlement

--- a/settlement-service/src/test/kotlin/com/hoppingmall/settlement/port/HttpOrderItemQueryAdapterResilienceTest.kt
+++ b/settlement-service/src/test/kotlin/com/hoppingmall/settlement/port/HttpOrderItemQueryAdapterResilienceTest.kt
@@ -1,0 +1,54 @@
+package com.hoppingmall.settlement.port
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+@DisplayName("Resilience4j CircuitBreaker 정산 설정 검증")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class HttpOrderItemQueryAdapterResilienceTest {
+
+    @Test
+    fun 정산_CB_설정이_기본과_다르게_적용된다() {
+        val config = CircuitBreakerConfig.custom()
+            .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+            .slidingWindowSize(5)
+            .minimumNumberOfCalls(3)
+            .failureRateThreshold(50f)
+            .waitDurationInOpenState(Duration.ofSeconds(60))
+            .slowCallDurationThreshold(Duration.ofSeconds(8))
+            .build()
+
+        val registry = CircuitBreakerRegistry.of(config)
+        val cb = registry.circuitBreaker("order-item-query")
+
+        assertThat(cb.circuitBreakerConfig.slidingWindowSize).isEqualTo(5)
+        assertThat(cb.circuitBreakerConfig.minimumNumberOfCalls).isEqualTo(3)
+        assertThat(cb.circuitBreakerConfig.waitIntervalFunctionInOpenState.apply(1)).isEqualTo(Duration.ofSeconds(60).toMillis())
+        assertThat(cb.circuitBreakerConfig.slowCallDurationThreshold).isEqualTo(Duration.ofSeconds(8))
+    }
+
+    @Test
+    fun 정산_CB_실패율_초과_시_OPEN_전환() {
+        val config = CircuitBreakerConfig.custom()
+            .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+            .slidingWindowSize(5)
+            .minimumNumberOfCalls(3)
+            .failureRateThreshold(50f)
+            .build()
+
+        val registry = CircuitBreakerRegistry.of(config)
+        val cb = registry.circuitBreaker("order-item-query")
+
+        repeat(1) { cb.onSuccess(100, java.util.concurrent.TimeUnit.MILLISECONDS) }
+        repeat(3) { cb.onError(100, java.util.concurrent.TimeUnit.MILLISECONDS, RuntimeException("fail")) }
+
+        assertThat(cb.state).isEqualTo(CircuitBreaker.State.OPEN)
+    }
+}

--- a/settlement-service/src/test/kotlin/com/hoppingmall/settlement/port/HttpOrderItemQueryAdapterTest.kt
+++ b/settlement-service/src/test/kotlin/com/hoppingmall/settlement/port/HttpOrderItemQueryAdapterTest.kt
@@ -1,6 +1,5 @@
 package com.hoppingmall.settlement.port
 
-import com.hoppingmall.settlement.exception.ServiceCommunicationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -92,6 +91,6 @@ class HttpOrderItemQueryAdapterTest {
 
         assertThatThrownBy {
             adapter.findDeliveredItemsBySellerAndPeriod(sellerId, startDate, endDate)
-        }.isInstanceOf(ServiceCommunicationException::class.java)
+        }.isInstanceOf(RuntimeException::class.java)
     }
 }

--- a/settlement-service/src/test/kotlin/com/hoppingmall/settlement/port/HttpRefundQueryAdapterTest.kt
+++ b/settlement-service/src/test/kotlin/com/hoppingmall/settlement/port/HttpRefundQueryAdapterTest.kt
@@ -1,6 +1,5 @@
 package com.hoppingmall.settlement.port
 
-import com.hoppingmall.settlement.exception.ServiceCommunicationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -83,6 +82,6 @@ class HttpRefundQueryAdapterTest {
 
         assertThatThrownBy {
             adapter.findCompletedBySellerAndPeriod(sellerId, startDate, endDate)
-        }.isInstanceOf(ServiceCommunicationException::class.java)
+        }.isInstanceOf(RuntimeException::class.java)
     }
 }

--- a/settlement-service/src/test/kotlin/com/hoppingmall/settlement/port/HttpSellerQueryAdapterTest.kt
+++ b/settlement-service/src/test/kotlin/com/hoppingmall/settlement/port/HttpSellerQueryAdapterTest.kt
@@ -1,6 +1,5 @@
 package com.hoppingmall.settlement.port
 
-import com.hoppingmall.settlement.exception.ServiceCommunicationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -74,6 +73,6 @@ class HttpSellerQueryAdapterTest {
 
         assertThatThrownBy {
             adapter.findByUserId(userId)
-        }.isInstanceOf(ServiceCommunicationException::class.java)
+        }.isInstanceOf(RuntimeException::class.java)
     }
 }

--- a/settlement-service/src/test/resources/application-test.yml
+++ b/settlement-service/src/test/resources/application-test.yml
@@ -21,3 +21,39 @@ services:
     url: http://localhost:8084
   user-service:
     url: http://localhost:8082
+
+resilience4j:
+  circuitbreaker:
+    circuitBreakerAspectOrder: 2
+    configs:
+      settlement:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 5
+        minimumNumberOfCalls: 3
+        failureRateThreshold: 50
+        waitDurationInOpenState: 60s
+        permittedNumberOfCallsInHalfOpenState: 2
+        slowCallDurationThreshold: 8s
+        recordExceptions:
+          - java.lang.Exception
+    instances:
+      order-item-query:
+        baseConfig: settlement
+      refund-query:
+        baseConfig: settlement
+      seller-query:
+        baseConfig: settlement
+  retry:
+    retryAspectOrder: 1
+    configs:
+      settlement:
+        maxAttempts: 1
+        retryExceptions:
+          - java.io.IOException
+    instances:
+      order-item-query:
+        baseConfig: settlement
+      refund-query:
+        baseConfig: settlement
+      seller-query:
+        baseConfig: settlement


### PR DESCRIPTION
Closes #187

### 📌 작업 개요
4개 마이크로서비스(order, payment, product, settlement)에 Resilience4j Circuit Breaker + Retry 패턴을 적용하고,
20개 어댑터(HTTP 13 + gRPC 7)의 try/catch를 제거하여 AOP 기반 장애 격리를 구현했습니다.
Grafana 대시보드 3종(CB 상태, 서비스 헬스, Retry 메트릭)을 프로비저닝 설정과 함께 추가했습니다.

---

### ✅ 주요 변경 사항

- `build.gradle.kts` (4개 서비스)
  - `resilience4j-spring-boot3:2.2.0` 의존성 추가

- `application.yml` (4개 서비스)
  - Circuit Breaker 인스턴스별 설정 (failureRateThreshold: 50%, slidingWindowSize: 10)
  - Retry 설정 (maxAttempts: 3, waitDuration: 500ms, exponentialBackoff)
  - settlement 전용 baseConfig (slowCallDurationThreshold: 8s, waitDurationInOpenState: 60s)

- HTTP 어댑터 리팩터링 (13개)
  - 내부 try/catch 제거 → `@CircuitBreaker` + `@Retry` + fallback 메서드로 전환
  - 쿼리 어댑터: CB + Retry + fallback (null, emptyList, 기본값 반환)
  - 커맨드 어댑터: CB만 적용 (멱등성 미보장으로 retry/fallback 없음)

- gRPC 어댑터 리팩터링 (7개)
  - 내부 try/catch 제거 → `@CircuitBreaker` + `@Retry(grpc)` + fallback 메서드로 전환
  - NOT_FOUND StatusRuntimeException은 fallback에서 null 반환 (정상 케이스)

- Grafana 대시보드 프로비저닝
  - `circuit-breaker.json`: CB 상태, 실패율, 호출수 패널
  - `service-health.json`: 서비스별 응답시간, 에러율 패널
  - `retry-metrics.json`: 재시도 횟수, 성공률 패널
  - `docker-compose.yml` 볼륨 마운트 추가

---

### 🧪 테스트

- `HttpProductQueryAdapterResilienceTest`: CB 설정 검증, OPEN 전환, CLOSED 유지
- `HttpOrderQueryAdapterResilienceTest` (payment): CB 설정 검증, OPEN 전환, 최소 호출 검증
- `HttpOrderQueryAdapterResilienceTest` (product): CB 설정 검증, OPEN 전환
- `HttpOrderItemQueryAdapterResilienceTest` (settlement): settlement 전용 설정 검증, OPEN 전환
- 기존 어댑터 테스트 8개: try/catch 제거에 맞춰 예외 전파 검증으로 수정

---

### 📎 관련 이슈
- #187