### PR TITLE
config: K8s 배포 매니페스트 + CI 검증 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,11 +107,16 @@ jobs:
         with:
           version: 'v1.29.0'
 
+      - name: kubeconform 설치
+        run: |
+          curl -sSL https://github.com/yannh/kubeconform/releases/download/v0.6.4/kubeconform-linux-amd64.tar.gz | tar xz
+          sudo mv kubeconform /usr/local/bin/
+
       - name: K8s 매니페스트 검증
         run: |
           find k8s -name '*.yml' -o -name '*.yaml' | while read f; do
             echo "Validating $f..."
-            kubectl apply --dry-run=client -f "$f" 2>&1 || exit 1
+            kubeconform -strict -summary "$f" || exit 1
           done
 
   final-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,25 @@ jobs:
       - name: Docker 빌드 검증
         run: docker build -t ${{ matrix.service }}:ci-test ./${{ matrix.service }}
 
+  k8s-validate:
+    name: K8s 매니페스트 검증
+    runs-on: ubuntu-latest
+    steps:
+      - name: 소스 체크아웃
+        uses: actions/checkout@v3
+
+      - name: kubectl 설치
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'v1.29.0'
+
+      - name: K8s 매니페스트 검증
+        run: |
+          find k8s -name '*.yml' -o -name '*.yaml' | while read f; do
+            echo "Validating $f..."
+            kubectl apply --dry-run=client -f "$f" 2>&1 || exit 1
+          done
+
   final-check:
     name: CI 최종 검증
     runs-on: ubuntu-latest
@@ -102,6 +121,7 @@ jobs:
       - monolith-test
       - services-test
       - services-docker-build
+      - k8s-validate
     if: always()
     steps:
       - name: 모든 선행 job 결과 확인
@@ -109,6 +129,7 @@ jobs:
           echo "monolith-test=${{ needs.monolith-test.result }}"
           echo "services-test=${{ needs.services-test.result }}"
           echo "services-docker-build=${{ needs.services-docker-build.result }}"
+          echo "k8s-validate=${{ needs.k8s-validate.result }}"
 
           if [ "${{ needs.monolith-test.result }}" != "success" ]; then
             exit 1
@@ -119,5 +140,9 @@ jobs:
           fi
 
           if [ "${{ needs.services-docker-build.result }}" != "success" ]; then
+            exit 1
+          fi
+
+          if [ "${{ needs.k8s-validate.result }}" != "success" ]; then
             exit 1
           fi

--- a/api-gateway/src/main/resources/application-k8s.yml
+++ b/api-gateway/src/main/resources/application-k8s.yml
@@ -1,0 +1,178 @@
+spring:
+  data:
+    redis:
+      host: redis.hoppingmall.svc.cluster.local
+      port: 6379
+
+  cloud:
+    gateway:
+      routes:
+        - id: user-service-public
+          uri: http://user-service.hoppingmall.svc.cluster.local:8082
+          predicates:
+            - Path=/api/v1/users/signup,/api/v1/users/login,/api/v1/auth/refresh
+
+        - id: product-service-statistics
+          uri: http://product-service.hoppingmall.svc.cluster.local:8083
+          predicates:
+            - Path=/api/v1/admin/product-statistics/**
+          filters:
+            - name: JwtValidation
+
+        - id: payment-service-admin-coupons
+          uri: http://payment-service.hoppingmall.svc.cluster.local:8085
+          predicates:
+            - Path=/api/v1/admin/coupons/**
+          filters:
+            - name: JwtValidation
+
+        - id: settlement-service-admin-settlements
+          uri: http://settlement-service.hoppingmall.svc.cluster.local:8086
+          predicates:
+            - Path=/api/v1/admin/settlements/**
+          filters:
+            - JwtValidation
+
+        - id: monolith-admin-dlq
+          uri: http://monolith.hoppingmall.svc.cluster.local:8080
+          predicates:
+            - Path=/api/v1/admin/dlq/**
+          filters:
+            - JwtValidation
+
+        - id: user-service
+          uri: http://user-service.hoppingmall.svc.cluster.local:8082
+          predicates:
+            - Path=/api/v1/users/**,/api/v1/auth/**,/api/v1/sellers/**,/api/v1/admin/sellers/**,/api/v1/memberships/**
+          filters:
+            - JwtValidation
+
+        - id: notification-service
+          uri: http://notification-service.hoppingmall.svc.cluster.local:8081
+          predicates:
+            - Path=/api/v1/notifications/**
+          filters:
+            - JwtValidation
+
+        - id: product-service-products
+          uri: http://product-service.hoppingmall.svc.cluster.local:8083
+          predicates:
+            - Path=/api/v1/products/**
+          filters:
+            - name: JwtValidation
+
+        - id: product-service-categories
+          uri: http://product-service.hoppingmall.svc.cluster.local:8083
+          predicates:
+            - Path=/api/v1/categories/**
+          filters:
+            - name: JwtValidation
+
+        - id: product-service-inventories
+          uri: http://product-service.hoppingmall.svc.cluster.local:8083
+          predicates:
+            - Path=/api/v1/inventories/**
+          filters:
+            - name: JwtValidation
+
+        - id: product-service-reviews
+          uri: http://product-service.hoppingmall.svc.cluster.local:8083
+          predicates:
+            - Path=/api/v1/reviews/**
+          filters:
+            - name: JwtValidation
+
+        - id: product-service-wishlists
+          uri: http://product-service.hoppingmall.svc.cluster.local:8083
+          predicates:
+            - Path=/api/v1/wishlists/**
+          filters:
+            - name: JwtValidation
+
+        - id: product-service-dashboard
+          uri: http://product-service.hoppingmall.svc.cluster.local:8083
+          predicates:
+            - Path=/api/v1/seller/dashboard/**
+          filters:
+            - name: JwtValidation
+
+        - id: settlement-service-seller-settlements
+          uri: http://settlement-service.hoppingmall.svc.cluster.local:8086
+          predicates:
+            - Path=/api/v1/seller/settlements/**
+          filters:
+            - JwtValidation
+
+        - id: order-service-orders
+          uri: http://order-service.hoppingmall.svc.cluster.local:8084
+          predicates:
+            - Path=/api/v1/orders/**
+          filters:
+            - name: JwtValidation
+
+        - id: order-service-cart-items
+          uri: http://order-service.hoppingmall.svc.cluster.local:8084
+          predicates:
+            - Path=/api/v1/cart-items/**
+          filters:
+            - name: JwtValidation
+
+        - id: order-service-shipping
+          uri: http://order-service.hoppingmall.svc.cluster.local:8084
+          predicates:
+            - Path=/api/v1/shipping/**
+          filters:
+            - name: JwtValidation
+
+        - id: order-service-refunds
+          uri: http://order-service.hoppingmall.svc.cluster.local:8084
+          predicates:
+            - Path=/api/v1/refunds/**
+          filters:
+            - name: JwtValidation
+
+        - id: payment-service-payments
+          uri: http://payment-service.hoppingmall.svc.cluster.local:8085
+          predicates:
+            - Path=/api/v1/payments/**
+          filters:
+            - name: JwtValidation
+
+        - id: payment-service-points
+          uri: http://payment-service.hoppingmall.svc.cluster.local:8085
+          predicates:
+            - Path=/api/v1/points/**
+          filters:
+            - name: JwtValidation
+
+        - id: payment-service-point-policies
+          uri: http://payment-service.hoppingmall.svc.cluster.local:8085
+          predicates:
+            - Path=/api/v1/point-policies/**
+          filters:
+            - name: JwtValidation
+
+        - id: payment-service-coupons
+          uri: http://payment-service.hoppingmall.svc.cluster.local:8085
+          predicates:
+            - Path=/api/v1/coupons/**
+          filters:
+            - name: JwtValidation
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://zipkin.hoppingmall.svc.cluster.local:9411/api/v2/spans
+
+logging:
+  level:
+    root: INFO
+    com.hoppingmall: INFO
+    org.springframework.cloud.gateway: INFO

--- a/app/src/main/resources/application-k8s.yml
+++ b/app/src/main/resources/application-k8s.yml
@@ -1,0 +1,61 @@
+spring:
+  datasource:
+    url: jdbc:mysql://mysql.hoppingmall.svc.cluster.local:3306/monolith_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: ${MYSQL_ROOT_PASSWORD}
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+
+  data:
+    redis:
+      redisson:
+        config: |
+          singleServerConfig:
+            address: "redis://redis.hoppingmall.svc.cluster.local:6379"
+
+  kafka:
+    bootstrap-servers: kafka.hoppingmall.svc.cluster.local:29092
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://zipkin.hoppingmall.svc.cluster.local:9411/api/v2/spans
+
+logging:
+  level:
+    root: INFO
+    com.hoppingmall: INFO
+    org.hibernate.SQL: WARN
+
+file:
+  upload:
+    base-upload-dir: /app/uploads
+    max-file-size: 5242880
+    allowed-extensions:
+      - jpg
+      - jpeg
+      - png
+      - gif
+      - webp
+    allowed-domains:
+      - product
+    sub-directory: images
+
+internal:
+  service:
+    token: ${INTERNAL_SERVICE_TOKEN}

--- a/k8s/configmap.yml
+++ b/k8s/configmap.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hoppingmall-config
+  namespace: hoppingmall
+data:
+  MYSQL_HOST: mysql.hoppingmall.svc.cluster.local
+  MYSQL_PORT: "3306"
+  KAFKA_BOOTSTRAP_SERVERS: kafka.hoppingmall.svc.cluster.local:29092
+  REDIS_HOST: redis.hoppingmall.svc.cluster.local
+  REDIS_PORT: "6379"
+  ZIPKIN_ENDPOINT: http://zipkin.hoppingmall.svc.cluster.local:9411/api/v2/spans
+  MONOLITH_URL: http://monolith.hoppingmall.svc.cluster.local:8080
+  USER_SERVICE_URL: http://user-service.hoppingmall.svc.cluster.local:8082
+  PRODUCT_SERVICE_URL: http://product-service.hoppingmall.svc.cluster.local:8083
+  ORDER_SERVICE_URL: http://order-service.hoppingmall.svc.cluster.local:8084
+  PAYMENT_SERVICE_URL: http://payment-service.hoppingmall.svc.cluster.local:8085
+  SETTLEMENT_SERVICE_URL: http://settlement-service.hoppingmall.svc.cluster.local:8086
+  NOTIFICATION_SERVICE_URL: http://notification-service.hoppingmall.svc.cluster.local:8081

--- a/k8s/infra/grafana-deployment.yml
+++ b/k8s/infra/grafana-deployment.yml
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: hoppingmall
+data:
+  datasources.yml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus.hoppingmall.svc.cluster.local:9090
+        isDefault: true
+        editable: true
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://loki.hoppingmall.svc.cluster.local:3100
+        editable: true
+      - name: Zipkin
+        type: zipkin
+        access: proxy
+        url: http://zipkin.hoppingmall.svc.cluster.local:9411
+        editable: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-provisioning
+  namespace: hoppingmall
+data:
+  dashboards.yml: |
+    apiVersion: 1
+    providers:
+      - name: 'HoppingMall'
+        orgId: 1
+        folder: 'HoppingMall'
+        type: file
+        disableDeletion: false
+        updateIntervalSeconds: 30
+        options:
+          path: /var/lib/grafana/dashboards
+          foldersFromFilesStructure: false
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: hoppingmall
+spec:
+  selector:
+    app: grafana
+  ports:
+    - port: 3000
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: hoppingmall
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              value: "admin"
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              value: "admin"
+          volumeMounts:
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+            - name: dashboard-provisioning
+              mountPath: /etc/grafana/provisioning/dashboards
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "250m"
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 15
+      volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources
+        - name: dashboard-provisioning
+          configMap:
+            name: grafana-dashboard-provisioning

--- a/k8s/infra/kafka-statefulset.yml
+++ b/k8s/infra/kafka-statefulset.yml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  namespace: hoppingmall
+spec:
+  clusterIP: None
+  selector:
+    app: kafka
+  ports:
+    - name: internal
+      port: 29092
+      targetPort: 29092
+    - name: external
+      port: 9092
+      targetPort: 9092
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka
+  namespace: hoppingmall
+spec:
+  serviceName: kafka
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+        - name: kafka
+          image: confluentinc/cp-kafka:7.6.0
+          ports:
+            - containerPort: 29092
+            - containerPort: 9092
+          env:
+            - name: KAFKA_BROKER_ID
+              value: "1"
+            - name: KAFKA_ZOOKEEPER_CONNECT
+              value: "zookeeper.hoppingmall.svc.cluster.local:2181"
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT"
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: "PLAINTEXT://kafka.hoppingmall.svc.cluster.local:29092,PLAINTEXT_HOST://localhost:9092"
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+              value: "true"
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+          readinessProbe:
+            tcpSocket:
+              port: 29092
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 29092
+            initialDelaySeconds: 30
+            periodSeconds: 15

--- a/k8s/infra/loki-deployment.yml
+++ b/k8s/infra/loki-deployment.yml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: hoppingmall
+data:
+  loki.yml: |
+    auth_enabled: false
+
+    server:
+      http_listen_port: 3100
+
+    common:
+      path_prefix: /loki
+      storage:
+        filesystem:
+          chunks_directory: /loki/chunks
+          rules_directory: /loki/rules
+      replication_factor: 1
+      ring:
+        kvstore:
+          store: inmemory
+
+    schema_config:
+      configs:
+        - from: 2020-10-24
+          store: tsdb
+          object_store: filesystem
+          schema: v13
+          index:
+            prefix: index_
+            period: 24h
+
+    limits_config:
+      reject_old_samples: true
+      reject_old_samples_max_age: 168h
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: hoppingmall
+spec:
+  selector:
+    app: loki
+  ports:
+    - port: 3100
+      targetPort: 3100
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki
+  namespace: hoppingmall
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      containers:
+        - name: loki
+          image: grafana/loki:2.9.0
+          ports:
+            - containerPort: 3100
+          args:
+            - "-config.file=/etc/loki/loki.yml"
+          volumeMounts:
+            - name: loki-config
+              mountPath: /etc/loki
+            - name: loki-data
+              mountPath: /loki
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "250m"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 3100
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 3100
+            initialDelaySeconds: 15
+            periodSeconds: 15
+      volumes:
+        - name: loki-config
+          configMap:
+            name: loki-config
+        - name: loki-data
+          emptyDir: {}

--- a/k8s/infra/mysql-statefulset.yml
+++ b/k8s/infra/mysql-statefulset.yml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql-init-db
+  namespace: hoppingmall
+data:
+  init-db.sql: |
+    CREATE DATABASE IF NOT EXISTS monolith_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    CREATE DATABASE IF NOT EXISTS notification_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    CREATE DATABASE IF NOT EXISTS user_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    CREATE DATABASE IF NOT EXISTS product_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    CREATE DATABASE IF NOT EXISTS order_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    CREATE DATABASE IF NOT EXISTS payment_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    CREATE DATABASE IF NOT EXISTS settlement_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  namespace: hoppingmall
+spec:
+  clusterIP: None
+  selector:
+    app: mysql
+  ports:
+    - port: 3306
+      targetPort: 3306
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  namespace: hoppingmall
+spec:
+  serviceName: mysql
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:8.0
+          ports:
+            - containerPort: 3306
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: MYSQL_ROOT_PASSWORD
+          volumeMounts:
+            - name: mysql-data
+              mountPath: /var/lib/mysql
+            - name: init-db
+              mountPath: /docker-entrypoint-initdb.d
+          readinessProbe:
+            exec:
+              command: ["mysqladmin", "ping", "-h", "localhost"]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["mysqladmin", "ping", "-h", "localhost"]
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+      volumes:
+        - name: init-db
+          configMap:
+            name: mysql-init-db
+  volumeClaimTemplates:
+    - metadata:
+        name: mysql-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi

--- a/k8s/infra/prometheus-deployment.yml
+++ b/k8s/infra/prometheus-deployment.yml
@@ -1,0 +1,131 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: hoppingmall
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+
+    scrape_configs:
+      - job_name: 'monolith'
+        metrics_path: '/actuator/prometheus'
+        static_configs:
+          - targets: ['monolith.hoppingmall.svc.cluster.local:8080']
+            labels:
+              service: 'monolith'
+
+      - job_name: 'notification-service'
+        metrics_path: '/actuator/prometheus'
+        static_configs:
+          - targets: ['notification-service.hoppingmall.svc.cluster.local:8081']
+            labels:
+              service: 'notification-service'
+
+      - job_name: 'user-service'
+        metrics_path: '/actuator/prometheus'
+        static_configs:
+          - targets: ['user-service.hoppingmall.svc.cluster.local:8082']
+            labels:
+              service: 'user-service'
+
+      - job_name: 'product-service'
+        metrics_path: '/actuator/prometheus'
+        static_configs:
+          - targets: ['product-service.hoppingmall.svc.cluster.local:8083']
+            labels:
+              service: 'product-service'
+
+      - job_name: 'order-service'
+        metrics_path: '/actuator/prometheus'
+        static_configs:
+          - targets: ['order-service.hoppingmall.svc.cluster.local:8084']
+            labels:
+              service: 'order-service'
+
+      - job_name: 'payment-service'
+        metrics_path: '/actuator/prometheus'
+        static_configs:
+          - targets: ['payment-service.hoppingmall.svc.cluster.local:8085']
+            labels:
+              service: 'payment-service'
+
+      - job_name: 'settlement-service'
+        metrics_path: '/actuator/prometheus'
+        static_configs:
+          - targets: ['settlement-service.hoppingmall.svc.cluster.local:8086']
+            labels:
+              service: 'settlement-service'
+
+      - job_name: 'api-gateway'
+        metrics_path: '/actuator/prometheus'
+        static_configs:
+          - targets: ['api-gateway.hoppingmall.svc.cluster.local:8000']
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: hoppingmall
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - port: 9090
+      targetPort: 9090
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: hoppingmall
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:latest
+          ports:
+            - containerPort: 9090
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus"
+          volumeMounts:
+            - name: prometheus-config
+              mountPath: /etc/prometheus
+            - name: prometheus-data
+              mountPath: /prometheus
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "250m"
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9090
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9090
+            initialDelaySeconds: 15
+            periodSeconds: 15
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config
+        - name: prometheus-data
+          emptyDir: {}

--- a/k8s/infra/promtail-daemonset.yml
+++ b/k8s/infra/promtail-daemonset.yml
@@ -1,0 +1,112 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+  namespace: hoppingmall
+data:
+  promtail.yml: |
+    server:
+      http_listen_port: 9080
+      grpc_listen_port: 0
+
+    positions:
+      filename: /tmp/positions.yaml
+
+    clients:
+      - url: http://loki.hoppingmall.svc.cluster.local:3100/loki/api/v1/push
+
+    scrape_configs:
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+                - hoppingmall
+        relabel_configs:
+          - source_labels: ['__meta_kubernetes_pod_name']
+            target_label: 'pod'
+          - source_labels: ['__meta_kubernetes_pod_container_name']
+            target_label: 'container'
+          - source_labels: ['__meta_kubernetes_namespace']
+            target_label: 'namespace'
+          - source_labels: ['__meta_kubernetes_pod_uid', '__meta_kubernetes_pod_container_name']
+            target_label: '__path__'
+            separator: '/'
+            replacement: '/var/log/pods/*$1/$2/*.log'
+        pipeline_stages:
+          - cri: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: promtail
+  namespace: hoppingmall
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: promtail
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/proxy", "services", "endpoints", "pods"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: promtail
+subjects:
+  - kind: ServiceAccount
+    name: promtail
+    namespace: hoppingmall
+roleRef:
+  kind: ClusterRole
+  name: promtail
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail
+  namespace: hoppingmall
+spec:
+  selector:
+    matchLabels:
+      app: promtail
+  template:
+    metadata:
+      labels:
+        app: promtail
+    spec:
+      serviceAccountName: promtail
+      containers:
+        - name: promtail
+          image: grafana/promtail:2.9.0
+          args:
+            - "-config.file=/etc/promtail/promtail.yml"
+          volumeMounts:
+            - name: promtail-config
+              mountPath: /etc/promtail
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+      volumes:
+        - name: promtail-config
+          configMap:
+            name: promtail-config
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: containers
+          hostPath:
+            path: /var/lib/docker/containers

--- a/k8s/infra/redis-deployment.yml
+++ b/k8s/infra/redis-deployment.yml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: hoppingmall
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: hoppingmall
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.2-alpine
+          ports:
+            - containerPort: 6379
+          command: ["redis-server", "--appendonly", "yes"]
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 10
+            periodSeconds: 15

--- a/k8s/infra/zipkin-deployment.yml
+++ b/k8s/infra/zipkin-deployment.yml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: zipkin
+  namespace: hoppingmall
+spec:
+  selector:
+    app: zipkin
+  ports:
+    - port: 9411
+      targetPort: 9411
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zipkin
+  namespace: hoppingmall
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zipkin
+  template:
+    metadata:
+      labels:
+        app: zipkin
+    spec:
+      containers:
+        - name: zipkin
+          image: openzipkin/zipkin:latest
+          ports:
+            - containerPort: 9411
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "250m"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 9411
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 9411
+            initialDelaySeconds: 15
+            periodSeconds: 15

--- a/k8s/infra/zookeeper-statefulset.yml
+++ b/k8s/infra/zookeeper-statefulset.yml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper
+  namespace: hoppingmall
+spec:
+  clusterIP: None
+  selector:
+    app: zookeeper
+  ports:
+    - port: 2181
+      targetPort: 2181
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: zookeeper
+  namespace: hoppingmall
+spec:
+  serviceName: zookeeper
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zookeeper
+  template:
+    metadata:
+      labels:
+        app: zookeeper
+    spec:
+      containers:
+        - name: zookeeper
+          image: confluentinc/cp-zookeeper:7.6.0
+          ports:
+            - containerPort: 2181
+          env:
+            - name: ZOOKEEPER_CLIENT_PORT
+              value: "2181"
+            - name: ZOOKEEPER_TICK_TIME
+              value: "2000"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "250m"
+          readinessProbe:
+            tcpSocket:
+              port: 2181
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 2181
+            initialDelaySeconds: 15
+            periodSeconds: 15

--- a/k8s/namespace.yml
+++ b/k8s/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hoppingmall

--- a/k8s/secret.yml
+++ b/k8s/secret.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hoppingmall-secret
+  namespace: hoppingmall
+type: Opaque
+data:
+  JWT_SECRET: ZGVmYXVsdC1rOHMtc2VjcmV0LWtleS1mb3ItZGV2ZWxvcG1lbnQtb25seS0zMmNoYXJzIQ==
+  INTERNAL_SERVICE_TOKEN: azhzLWludGVybmFsLXRva2VuLTIwMjY=
+  MYSQL_ROOT_PASSWORD: cm9vdA==

--- a/k8s/services/api-gateway.yml
+++ b/k8s/services/api-gateway.yml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway
+  namespace: hoppingmall
+spec:
+  selector:
+    app: api-gateway
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  namespace: hoppingmall
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-gateway
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+    spec:
+      containers:
+        - name: api-gateway
+          image: api-gateway:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "k8s"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=75.0 -XX:+UseSerialGC"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: JWT_SECRET
+          envFrom:
+            - configMapRef:
+                name: hoppingmall-config
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8000
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          resources:
+            requests:
+              memory: "384Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/k8s/services/monolith.yml
+++ b/k8s/services/monolith.yml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: monolith
+  namespace: hoppingmall
+spec:
+  selector:
+    app: monolith
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+    - name: grpc
+      port: 9080
+      targetPort: 9080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monolith
+  namespace: hoppingmall
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: monolith
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: monolith
+    spec:
+      containers:
+        - name: monolith
+          image: monolith:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+            - containerPort: 9080
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "k8s,grpc"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=75.0 -XX:+UseSerialGC"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: JWT_SECRET
+            - name: INTERNAL_SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: INTERNAL_SERVICE_TOKEN
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: MYSQL_ROOT_PASSWORD
+          envFrom:
+            - configMapRef:
+                name: hoppingmall-config
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          resources:
+            requests:
+              memory: "384Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/k8s/services/notification-service.yml
+++ b/k8s/services/notification-service.yml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: notification-service
+  namespace: hoppingmall
+spec:
+  selector:
+    app: notification-service
+  ports:
+    - name: http
+      port: 8081
+      targetPort: 8081
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notification-service
+  namespace: hoppingmall
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: notification-service
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: notification-service
+    spec:
+      containers:
+        - name: notification-service
+          image: notification-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8081
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "k8s"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=75.0 -XX:+UseSerialGC"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: JWT_SECRET
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: MYSQL_ROOT_PASSWORD
+          envFrom:
+            - configMapRef:
+                name: hoppingmall-config
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8081
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8081
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          resources:
+            requests:
+              memory: "384Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/k8s/services/order-service.yml
+++ b/k8s/services/order-service.yml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: order-service
+  namespace: hoppingmall
+spec:
+  selector:
+    app: order-service
+  ports:
+    - name: http
+      port: 8084
+      targetPort: 8084
+    - name: grpc
+      port: 9094
+      targetPort: 9094
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: order-service
+  namespace: hoppingmall
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: order-service
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: order-service
+    spec:
+      containers:
+        - name: order-service
+          image: order-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8084
+            - containerPort: 9094
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "k8s,grpc"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=75.0 -XX:+UseSerialGC"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: JWT_SECRET
+            - name: INTERNAL_SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: INTERNAL_SERVICE_TOKEN
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: MYSQL_ROOT_PASSWORD
+          envFrom:
+            - configMapRef:
+                name: hoppingmall-config
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8084
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8084
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          resources:
+            requests:
+              memory: "384Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/k8s/services/payment-service.yml
+++ b/k8s/services/payment-service.yml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-service
+  namespace: hoppingmall
+spec:
+  selector:
+    app: payment-service
+  ports:
+    - name: http
+      port: 8085
+      targetPort: 8085
+    - name: grpc
+      port: 9095
+      targetPort: 9095
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-service
+  namespace: hoppingmall
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: payment-service
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: payment-service
+    spec:
+      containers:
+        - name: payment-service
+          image: payment-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8085
+            - containerPort: 9095
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "k8s,grpc"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=75.0 -XX:+UseSerialGC"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: JWT_SECRET
+            - name: INTERNAL_SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: INTERNAL_SERVICE_TOKEN
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: MYSQL_ROOT_PASSWORD
+          envFrom:
+            - configMapRef:
+                name: hoppingmall-config
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8085
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8085
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          resources:
+            requests:
+              memory: "384Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/k8s/services/product-service.yml
+++ b/k8s/services/product-service.yml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-service
+  namespace: hoppingmall
+spec:
+  selector:
+    app: product-service
+  ports:
+    - name: http
+      port: 8083
+      targetPort: 8083
+    - name: grpc
+      port: 9093
+      targetPort: 9093
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-service
+  namespace: hoppingmall
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: product-service
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: product-service
+    spec:
+      containers:
+        - name: product-service
+          image: product-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8083
+            - containerPort: 9093
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "k8s,grpc"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=75.0 -XX:+UseSerialGC"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: JWT_SECRET
+            - name: INTERNAL_SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: INTERNAL_SERVICE_TOKEN
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: MYSQL_ROOT_PASSWORD
+          envFrom:
+            - configMapRef:
+                name: hoppingmall-config
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8083
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8083
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          resources:
+            requests:
+              memory: "384Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/k8s/services/settlement-service.yml
+++ b/k8s/services/settlement-service.yml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: settlement-service
+  namespace: hoppingmall
+spec:
+  selector:
+    app: settlement-service
+  ports:
+    - name: http
+      port: 8086
+      targetPort: 8086
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: settlement-service
+  namespace: hoppingmall
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: settlement-service
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: settlement-service
+    spec:
+      containers:
+        - name: settlement-service
+          image: settlement-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8086
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "k8s"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=75.0 -XX:+UseSerialGC"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: JWT_SECRET
+            - name: INTERNAL_SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: INTERNAL_SERVICE_TOKEN
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: MYSQL_ROOT_PASSWORD
+          envFrom:
+            - configMapRef:
+                name: hoppingmall-config
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8086
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8086
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          resources:
+            requests:
+              memory: "384Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/k8s/services/user-service.yml
+++ b/k8s/services/user-service.yml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-service
+  namespace: hoppingmall
+spec:
+  selector:
+    app: user-service
+  ports:
+    - name: http
+      port: 8082
+      targetPort: 8082
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: user-service
+  namespace: hoppingmall
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: user-service
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: user-service
+    spec:
+      containers:
+        - name: user-service
+          image: user-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8082
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "k8s"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=75.0 -XX:+UseSerialGC"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: JWT_SECRET
+            - name: INTERNAL_SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: INTERNAL_SERVICE_TOKEN
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: MYSQL_ROOT_PASSWORD
+          envFrom:
+            - configMapRef:
+                name: hoppingmall-config
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8082
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8082
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          resources:
+            requests:
+              memory: "384Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/notification-service/src/main/resources/application-k8s.yml
+++ b/notification-service/src/main/resources/application-k8s.yml
@@ -1,0 +1,35 @@
+spring:
+  datasource:
+    url: jdbc:mysql://mysql.hoppingmall.svc.cluster.local:3306/notification_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: ${MYSQL_ROOT_PASSWORD}
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: update
+  data:
+    redis:
+      redisson:
+        config: |
+          singleServerConfig:
+            address: "redis://redis.hoppingmall.svc.cluster.local:6379"
+  kafka:
+    bootstrap-servers: kafka.hoppingmall.svc.cluster.local:29092
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://zipkin.hoppingmall.svc.cluster.local:9411/api/v2/spans
+
+logging:
+  level:
+    root: INFO
+    com.hoppingmall: INFO

--- a/order-service/src/main/resources/application-k8s.yml
+++ b/order-service/src/main/resources/application-k8s.yml
@@ -1,0 +1,54 @@
+spring:
+  datasource:
+    url: jdbc:mysql://mysql.hoppingmall.svc.cluster.local:3306/order_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: ${MYSQL_ROOT_PASSWORD}
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+
+  data:
+    redis:
+      redisson:
+        config: |
+          singleServerConfig:
+            address: "redis://redis.hoppingmall.svc.cluster.local:6379"
+
+  kafka:
+    consumer:
+      bootstrap-servers: kafka.hoppingmall.svc.cluster.local:29092
+    producer:
+      bootstrap-servers: kafka.hoppingmall.svc.cluster.local:29092
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+    enabled: true
+  zipkin:
+    tracing:
+      endpoint: http://zipkin.hoppingmall.svc.cluster.local:9411/api/v2/spans
+
+services:
+  monolith:
+    url: http://monolith.hoppingmall.svc.cluster.local:8080
+  product-service:
+    url: http://product-service.hoppingmall.svc.cluster.local:8083
+
+internal:
+  service:
+    token: ${INTERNAL_SERVICE_TOKEN}
+
+grpc:
+  client:
+    product-service:
+      address: static://product-service.hoppingmall.svc.cluster.local:9093
+      negotiation-type: plaintext
+    payment-service:
+      address: static://payment-service.hoppingmall.svc.cluster.local:9095
+      negotiation-type: plaintext

--- a/payment-service/src/main/resources/application-k8s.yml
+++ b/payment-service/src/main/resources/application-k8s.yml
@@ -1,0 +1,56 @@
+spring:
+  datasource:
+    url: jdbc:mysql://mysql.hoppingmall.svc.cluster.local:3306/payment_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: ${MYSQL_ROOT_PASSWORD}
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+
+  data:
+    redis:
+      redisson:
+        config: |
+          singleServerConfig:
+            address: "redis://redis.hoppingmall.svc.cluster.local:6379"
+
+  kafka:
+    consumer:
+      bootstrap-servers: kafka.hoppingmall.svc.cluster.local:29092
+    producer:
+      bootstrap-servers: kafka.hoppingmall.svc.cluster.local:29092
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+    enabled: true
+  zipkin:
+    tracing:
+      endpoint: http://zipkin.hoppingmall.svc.cluster.local:9411/api/v2/spans
+
+services:
+  monolith:
+    url: http://monolith.hoppingmall.svc.cluster.local:8080
+  order-service:
+    url: http://order-service.hoppingmall.svc.cluster.local:8084
+  product-service:
+    url: http://product-service.hoppingmall.svc.cluster.local:8083
+
+internal:
+  service:
+    token: ${INTERNAL_SERVICE_TOKEN}
+
+grpc:
+  client:
+    order-service:
+      address: static://order-service.hoppingmall.svc.cluster.local:9094
+      negotiation-type: plaintext
+    monolith:
+      address: static://monolith.hoppingmall.svc.cluster.local:9080
+      negotiation-type: plaintext

--- a/product-service/src/main/resources/application-k8s.yml
+++ b/product-service/src/main/resources/application-k8s.yml
@@ -1,0 +1,51 @@
+spring:
+  datasource:
+    url: jdbc:mysql://mysql.hoppingmall.svc.cluster.local:3306/product_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: ${MYSQL_ROOT_PASSWORD}
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+
+  data:
+    redis:
+      redisson:
+        config: |
+          singleServerConfig:
+            address: "redis://redis.hoppingmall.svc.cluster.local:6379"
+
+  kafka:
+    consumer:
+      bootstrap-servers: kafka.hoppingmall.svc.cluster.local:29092
+    producer:
+      bootstrap-servers: kafka.hoppingmall.svc.cluster.local:29092
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+    enabled: true
+  zipkin:
+    tracing:
+      endpoint: http://zipkin.hoppingmall.svc.cluster.local:9411/api/v2/spans
+
+services:
+  monolith:
+    url: http://monolith.hoppingmall.svc.cluster.local:8080
+  order-service:
+    url: http://order-service.hoppingmall.svc.cluster.local:8084
+
+internal:
+  service:
+    token: ${INTERNAL_SERVICE_TOKEN}
+
+grpc:
+  client:
+    order-service:
+      address: static://order-service.hoppingmall.svc.cluster.local:9094
+      negotiation-type: plaintext

--- a/settlement-service/src/main/resources/application-k8s.yml
+++ b/settlement-service/src/main/resources/application-k8s.yml
@@ -1,0 +1,33 @@
+spring:
+  datasource:
+    url: jdbc:mysql://mysql.hoppingmall.svc.cluster.local:3306/settlement_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: ${MYSQL_ROOT_PASSWORD}
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: update
+
+services:
+  order-service:
+    url: http://order-service.hoppingmall.svc.cluster.local:8084
+  user-service:
+    url: http://user-service.hoppingmall.svc.cluster.local:8082
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://zipkin.hoppingmall.svc.cluster.local:9411/api/v2/spans
+
+logging:
+  level:
+    root: INFO
+    com.hoppingmall: INFO

--- a/user-service/src/main/resources/application-k8s.yml
+++ b/user-service/src/main/resources/application-k8s.yml
@@ -1,0 +1,47 @@
+spring:
+  kafka:
+    bootstrap-servers: kafka.hoppingmall.svc.cluster.local:29092
+    consumer:
+      group-id: membership-service
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "*"
+
+  datasource:
+    url: jdbc:mysql://mysql.hoppingmall.svc.cluster.local:3306/user_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: ${MYSQL_ROOT_PASSWORD}
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: update
+  data:
+    redis:
+      redisson:
+        config: |
+          singleServerConfig:
+            address: "redis://redis.hoppingmall.svc.cluster.local:6379"
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://zipkin.hoppingmall.svc.cluster.local:9411/api/v2/spans
+
+internal:
+  service:
+    token: ${INTERNAL_SERVICE_TOKEN}
+
+logging:
+  level:
+    root: INFO
+    com.hoppingmall: INFO


### PR DESCRIPTION
Closes #189

### 📌 작업 개요
Docker Compose 기반 인프라를 Kind/Minikube에서 동작할 수 있도록 K8s 매니페스트를 작성하고,
8개 서비스에 application-k8s.yml 프로파일을 추가했습니다.
CI에 kubectl dry-run 기반 매니페스트 검증 job을 추가했습니다.

---

### ✅ 주요 변경 사항

- `k8s/` (20개 매니페스트 파일)
  - `namespace.yml`, `configmap.yml`, `secret.yml`: 기본 리소스 정의
  - `infra/`: MySQL StatefulSet + PVC, Zookeeper/Kafka StatefulSet, Redis standalone, Zipkin, Prometheus, Loki, Promtail DaemonSet, Grafana
  - `services/`: 8개 서비스 Deployment + Service (health probes, resource limits, JVM 튜닝)

- `application-k8s.yml` (8개 파일)
  - K8s DNS 기반 서비스 디스커버리 (*.hoppingmall.svc.cluster.local)
  - Redis: Redisson singleServerConfig (6개), Spring Data Redis host/port (api-gateway), 없음 (settlement)
  - gRPC 클라이언트 주소 K8s DNS로 전환
  - management.endpoint.health.probes.enabled: true

- `.github/workflows/ci.yml`
  - `k8s-validate` job 추가 (kubectl --dry-run=client)
  - `final-check`에 k8s-validate 의존성 추가

---

### 🧪 테스트

- K8s 매니페스트 YAML 문법 검증 완료
- application-k8s.yml Redis 설정 패턴 검증: singleServerConfig (6), host/port (1), 없음 (1)
- MYSQL_ROOT_PASSWORD secretKeyRef 모든 DB 사용 서비스에 주입 확인
- CI k8s-validate job이 final-check에 연결됨 확인

---

### 📎 관련 이슈
- #189