### PR TITLE
config: ArgoCD + Istio Canary 배포 로컬 CD 파이프라인 구축

### DIFF
--- a/k8s-cd/argocd/api-gateway-app.yaml
+++ b/k8s-cd/argocd/api-gateway-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: api-gateway
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/perArdua/hoppingmall.git
+    targetRevision: develop
+    path: k8s-cd/overlays/local/api-gateway
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hoppingmall
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s-cd/argocd/product-service-app.yaml
+++ b/k8s-cd/argocd/product-service-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: product-service
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/perArdua/hoppingmall.git
+    targetRevision: develop
+    path: k8s-cd/overlays/local/product-service
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hoppingmall
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s-cd/argocd/user-service-app.yaml
+++ b/k8s-cd/argocd/user-service-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: user-service
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/perArdua/hoppingmall.git
+    targetRevision: develop
+    path: k8s-cd/overlays/local/user-service
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hoppingmall
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s-cd/base/api-gateway/destination-rule.yaml
+++ b/k8s-cd/base/api-gateway/destination-rule.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: api-gateway-destrule
+  namespace: hoppingmall
+spec:
+  host: api-gateway
+  subsets:
+    - name: stable
+      labels:
+        app: api-gateway
+    - name: canary
+      labels:
+        app: api-gateway

--- a/k8s-cd/base/api-gateway/kustomization.yaml
+++ b/k8s-cd/base/api-gateway/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rollout.yaml
+  - service.yaml
+  - destination-rule.yaml
+  - virtualservice.yaml

--- a/k8s-cd/base/api-gateway/rollout.yaml
+++ b/k8s-cd/base/api-gateway/rollout.yaml
@@ -1,0 +1,76 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: api-gateway
+  namespace: hoppingmall
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: api-gateway
+  strategy:
+    canary:
+      canaryService: api-gateway-canary
+      stableService: api-gateway
+      trafficRouting:
+        istio:
+          virtualServices:
+            - name: api-gateway-vsvc
+              routes:
+                - primary
+          destinationRule:
+            name: api-gateway-destrule
+            canarySubsetName: canary
+            stableSubsetName: stable
+      steps:
+        - setWeight: 20
+        - pause: {}
+        - setWeight: 50
+        - pause: {}
+        - setWeight: 100
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+      annotations:
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+        - name: api-gateway
+          image: api-gateway:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "k8s"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=75.0 -XX:+UseSerialGC"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: JWT_SECRET
+          envFrom:
+            - configMapRef:
+                name: hoppingmall-config
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8000
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          resources:
+            requests:
+              memory: "384Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/k8s-cd/base/api-gateway/service.yaml
+++ b/k8s-cd/base/api-gateway/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway
+  namespace: hoppingmall
+spec:
+  selector:
+    app: api-gateway
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway-canary
+  namespace: hoppingmall
+spec:
+  selector:
+    app: api-gateway
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000

--- a/k8s-cd/base/api-gateway/virtualservice.yaml
+++ b/k8s-cd/base/api-gateway/virtualservice.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: api-gateway-vsvc
+  namespace: hoppingmall
+spec:
+  hosts:
+    - api-gateway
+  http:
+    - name: primary
+      route:
+        - destination:
+            host: api-gateway
+            subset: stable
+          weight: 100
+        - destination:
+            host: api-gateway
+            subset: canary
+          weight: 0

--- a/k8s-cd/base/product-service/destination-rule.yaml
+++ b/k8s-cd/base/product-service/destination-rule.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: product-service-destrule
+  namespace: hoppingmall
+spec:
+  host: product-service
+  subsets:
+    - name: stable
+      labels:
+        app: product-service
+    - name: canary
+      labels:
+        app: product-service

--- a/k8s-cd/base/product-service/kustomization.yaml
+++ b/k8s-cd/base/product-service/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rollout.yaml
+  - service.yaml
+  - destination-rule.yaml
+  - virtualservice.yaml

--- a/k8s-cd/base/product-service/rollout.yaml
+++ b/k8s-cd/base/product-service/rollout.yaml
@@ -1,0 +1,87 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: product-service
+  namespace: hoppingmall
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: product-service
+  strategy:
+    canary:
+      canaryService: product-service-canary
+      stableService: product-service
+      trafficRouting:
+        istio:
+          virtualServices:
+            - name: product-service-vsvc
+              routes:
+                - primary
+          destinationRule:
+            name: product-service-destrule
+            canarySubsetName: canary
+            stableSubsetName: stable
+      steps:
+        - setWeight: 20
+        - pause: {}
+        - setWeight: 50
+        - pause: {}
+        - setWeight: 100
+  template:
+    metadata:
+      labels:
+        app: product-service
+      annotations:
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+        - name: product-service
+          image: product-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8083
+            - containerPort: 9093
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "k8s,grpc"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=75.0 -XX:+UseSerialGC"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: JWT_SECRET
+            - name: INTERNAL_SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: INTERNAL_SERVICE_TOKEN
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: MYSQL_ROOT_PASSWORD
+          envFrom:
+            - configMapRef:
+                name: hoppingmall-config
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8083
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8083
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          resources:
+            requests:
+              memory: "384Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/k8s-cd/base/product-service/service.yaml
+++ b/k8s-cd/base/product-service/service.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-service
+  namespace: hoppingmall
+spec:
+  selector:
+    app: product-service
+  ports:
+    - name: http
+      port: 8083
+      targetPort: 8083
+    - name: grpc
+      port: 9093
+      targetPort: 9093
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-service-canary
+  namespace: hoppingmall
+spec:
+  selector:
+    app: product-service
+  ports:
+    - name: http
+      port: 8083
+      targetPort: 8083
+    - name: grpc
+      port: 9093
+      targetPort: 9093

--- a/k8s-cd/base/product-service/virtualservice.yaml
+++ b/k8s-cd/base/product-service/virtualservice.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: product-service-vsvc
+  namespace: hoppingmall
+spec:
+  hosts:
+    - product-service
+  http:
+    - name: primary
+      route:
+        - destination:
+            host: product-service
+            subset: stable
+          weight: 100
+        - destination:
+            host: product-service
+            subset: canary
+          weight: 0
+    - name: grpc
+      match:
+        - port: 9093
+      route:
+        - destination:
+            host: product-service
+            subset: stable
+          weight: 100
+        - destination:
+            host: product-service
+            subset: canary
+          weight: 0

--- a/k8s-cd/base/user-service/destination-rule.yaml
+++ b/k8s-cd/base/user-service/destination-rule.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: user-service-destrule
+  namespace: hoppingmall
+spec:
+  host: user-service
+  subsets:
+    - name: stable
+      labels:
+        app: user-service
+    - name: canary
+      labels:
+        app: user-service

--- a/k8s-cd/base/user-service/kustomization.yaml
+++ b/k8s-cd/base/user-service/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rollout.yaml
+  - service.yaml
+  - destination-rule.yaml
+  - virtualservice.yaml

--- a/k8s-cd/base/user-service/rollout.yaml
+++ b/k8s-cd/base/user-service/rollout.yaml
@@ -1,0 +1,87 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: user-service
+  namespace: hoppingmall
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: user-service
+  strategy:
+    canary:
+      canaryService: user-service-canary
+      stableService: user-service
+      trafficRouting:
+        istio:
+          virtualServices:
+            - name: user-service-vsvc
+              routes:
+                - primary
+          destinationRule:
+            name: user-service-destrule
+            canarySubsetName: canary
+            stableSubsetName: stable
+      steps:
+        - setWeight: 20
+        - pause: {}
+        - setWeight: 50
+        - pause: {}
+        - setWeight: 100
+  template:
+    metadata:
+      labels:
+        app: user-service
+      annotations:
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+        - name: user-service
+          image: user-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8082
+            - containerPort: 9082
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "k8s,grpc"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=75.0 -XX:+UseSerialGC"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: JWT_SECRET
+            - name: INTERNAL_SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: INTERNAL_SERVICE_TOKEN
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hoppingmall-secret
+                  key: MYSQL_ROOT_PASSWORD
+          envFrom:
+            - configMapRef:
+                name: hoppingmall-config
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8082
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8082
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          resources:
+            requests:
+              memory: "384Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/k8s-cd/base/user-service/service.yaml
+++ b/k8s-cd/base/user-service/service.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-service
+  namespace: hoppingmall
+spec:
+  selector:
+    app: user-service
+  ports:
+    - name: http
+      port: 8082
+      targetPort: 8082
+    - name: grpc
+      port: 9082
+      targetPort: 9082
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-service-canary
+  namespace: hoppingmall
+spec:
+  selector:
+    app: user-service
+  ports:
+    - name: http
+      port: 8082
+      targetPort: 8082
+    - name: grpc
+      port: 9082
+      targetPort: 9082

--- a/k8s-cd/base/user-service/virtualservice.yaml
+++ b/k8s-cd/base/user-service/virtualservice.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: user-service-vsvc
+  namespace: hoppingmall
+spec:
+  hosts:
+    - user-service
+  http:
+    - name: primary
+      route:
+        - destination:
+            host: user-service
+            subset: stable
+          weight: 100
+        - destination:
+            host: user-service
+            subset: canary
+          weight: 0
+    - name: grpc
+      match:
+        - port: 9082
+      route:
+        - destination:
+            host: user-service
+            subset: stable
+          weight: 100
+        - destination:
+            host: user-service
+            subset: canary
+          weight: 0

--- a/k8s-cd/overlays/local/api-gateway/kustomization.yaml
+++ b/k8s-cd/overlays/local/api-gateway/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base/api-gateway
+images:
+  - name: api-gateway
+    newName: localhost:5001/api-gateway
+    newTag: latest

--- a/k8s-cd/overlays/local/product-service/kustomization.yaml
+++ b/k8s-cd/overlays/local/product-service/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base/product-service
+images:
+  - name: product-service
+    newName: localhost:5001/product-service
+    newTag: latest

--- a/k8s-cd/overlays/local/user-service/kustomization.yaml
+++ b/k8s-cd/overlays/local/user-service/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base/user-service
+images:
+  - name: user-service
+    newName: localhost:5001/user-service
+    newTag: latest

--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REGISTRY="localhost:5001"
+TAG=$(git rev-parse --short HEAD)
+SERVICES=("api-gateway" "user-service" "product-service")
+
+if [[ $# -gt 0 ]]; then
+  SERVICES=("$@")
+fi
+
+echo "==> Building with tag: ${TAG}"
+
+FAILED=()
+for svc in "${SERVICES[@]}"; do
+  echo "==> Building ${svc}..."
+  if docker build -t "${REGISTRY}/${svc}:${TAG}" "./${svc}/"; then
+    docker push "${REGISTRY}/${svc}:${TAG}"
+    echo "    ${svc}:${TAG} pushed"
+  else
+    echo "    FAILED: ${svc}"
+    FAILED+=("$svc")
+  fi
+done
+
+echo ""
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  echo "=== Build failures: ${FAILED[*]} ==="
+  exit 1
+else
+  echo "=== All builds successful (tag: ${TAG}) ==="
+fi

--- a/scripts/canary-demo.sh
+++ b/scripts/canary-demo.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE="${1:-api-gateway}"
+NAMESPACE="hoppingmall"
+
+echo "=== Canary Demo: ${SERVICE} ==="
+echo ""
+
+echo "==> Current rollout status"
+kubectl argo rollouts get rollout "${SERVICE}" -n "${NAMESPACE}" 2>/dev/null || {
+  echo "Rollout '${SERVICE}' not found. Deploy first with: ./scripts/deploy-all.sh"
+  exit 1
+}
+
+echo ""
+echo "==> To trigger a canary update, build a new image and update the tag:"
+echo "    ./scripts/build-push.sh ${SERVICE}"
+echo "    cd k8s-cd/overlays/local/${SERVICE}"
+echo "    kustomize edit set image ${SERVICE}=localhost:5001/${SERVICE}:\$(git rev-parse --short HEAD)"
+echo "    git add . && git commit -m 'chore: update ${SERVICE} image' && git push"
+echo ""
+echo "==> ArgoCD will detect the change and start canary rollout"
+echo ""
+echo "==> At each pause step, use these commands:"
+echo "    Promote:  kubectl argo rollouts promote ${SERVICE} -n ${NAMESPACE}"
+echo "    Abort:    kubectl argo rollouts abort ${SERVICE} -n ${NAMESPACE}"
+echo "    Status:   kubectl argo rollouts get rollout ${SERVICE} -n ${NAMESPACE} --watch"
+echo ""
+
+read -p "Watch rollout status now? (y/N) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  kubectl argo rollouts get rollout "${SERVICE}" -n "${NAMESPACE}" --watch
+fi

--- a/scripts/deploy-all.sh
+++ b/scripts/deploy-all.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TAG=$(git rev-parse --short HEAD)
+SERVICES=("api-gateway" "user-service" "product-service")
+
+echo "==> Updating image tags to ${TAG}"
+for svc in "${SERVICES[@]}"; do
+  KUSTOMIZATION="k8s-cd/overlays/local/${svc}/kustomization.yaml"
+  sed -i "s|newTag:.*|newTag: ${TAG}|" "$KUSTOMIZATION"
+  echo "    ${svc}: tag updated to ${TAG}"
+done
+
+echo "==> Applying ArgoCD Applications"
+kubectl apply -f k8s-cd/argocd/
+
+echo "==> Waiting for sync..."
+sleep 5
+
+for svc in "${SERVICES[@]}"; do
+  echo ""
+  echo "--- ${svc} ---"
+  kubectl argo rollouts status "${svc}" -n hoppingmall --timeout 60s 2>/dev/null || echo "  Rollout not yet available"
+done
+
+echo ""
+echo "=== Deployment initiated ==="
+echo "Monitor: kubectl argo rollouts dashboard -n hoppingmall"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER_NAME="hoppingmall"
+REGISTRY_NAME="kind-registry"
+REGISTRY_PORT="5001"
+
+total_ram_kb=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}' || echo "0")
+total_ram_gb=$((total_ram_kb / 1024 / 1024))
+if [[ "$total_ram_gb" -lt 8 && "$total_ram_gb" -gt 0 ]]; then
+  echo "WARNING: System RAM is ${total_ram_gb}GB. Minimum 8GB recommended."
+  read -p "Continue? (y/N) " -n 1 -r
+  echo
+  [[ $REPLY =~ ^[Yy]$ ]] || exit 1
+fi
+
+if ! kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+  echo "==> Creating Kind cluster: ${CLUSTER_NAME}"
+
+  if ! docker inspect "${REGISTRY_NAME}" &>/dev/null; then
+    docker run -d --restart=always -p "${REGISTRY_PORT}:5000" --network bridge --name "${REGISTRY_NAME}" registry:2
+  fi
+
+  cat <<EOF | kind create cluster --name "${CLUSTER_NAME}" --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${REGISTRY_PORT}"]
+      endpoint = ["http://${REGISTRY_NAME}:5000"]
+EOF
+
+  if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${REGISTRY_NAME}")" = 'null' ]; then
+    docker network connect "kind" "${REGISTRY_NAME}"
+  fi
+else
+  echo "==> Kind cluster '${CLUSTER_NAME}' already exists"
+fi
+
+echo "==> Installing Istio"
+if ! kubectl get namespace istio-system &>/dev/null; then
+  istioctl install --set profile=demo -y
+else
+  echo "    Istio already installed"
+fi
+
+echo "==> Creating hoppingmall namespace"
+kubectl apply -f k8s/namespace.yml
+kubectl label namespace hoppingmall istio-injection=enabled --overwrite
+
+echo "==> Disabling Istio sidecar for infra pods"
+for manifest in k8s/infra/*.yml; do
+  kubectl apply -f "$manifest"
+done
+for deploy in mysql kafka zookeeper redis zipkin prometheus loki grafana; do
+  kubectl patch statefulset "$deploy" -n hoppingmall --type=merge -p '{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject":"false"}}}}}' 2>/dev/null || true
+  kubectl patch deployment "$deploy" -n hoppingmall --type=merge -p '{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject":"false"}}}}}' 2>/dev/null || true
+done
+kubectl patch daemonset promtail -n hoppingmall --type=merge -p '{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject":"false"}}}}}' 2>/dev/null || true
+
+echo "==> Installing Argo Rollouts"
+if ! kubectl get namespace argo-rollouts &>/dev/null; then
+  kubectl create namespace argo-rollouts
+  kubectl apply -n argo-rollouts -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
+else
+  echo "    Argo Rollouts already installed"
+fi
+
+echo "==> Installing ArgoCD"
+if ! kubectl get namespace argocd &>/dev/null; then
+  kubectl create namespace argocd
+  kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+else
+  echo "    ArgoCD already installed"
+fi
+
+echo "==> Applying base config"
+kubectl apply -f k8s/configmap.yml -f k8s/secret.yml
+
+echo ""
+echo "=== Setup Complete ==="
+echo "ArgoCD admin password: kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d"
+echo "ArgoCD port-forward:  kubectl port-forward svc/argocd-server -n argocd 8443:443"
+echo "Argo Rollouts dashboard: kubectl argo rollouts dashboard -n hoppingmall"

--- a/scripts/validate-manifests.sh
+++ b/scripts/validate-manifests.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICES=("api-gateway" "user-service" "product-service")
+SKIP_KINDS="Rollout,AnalysisTemplate,VirtualService,DestinationRule,Application"
+FAILED=0
+
+echo "==> Validating k8s-cd manifests"
+
+for svc in "${SERVICES[@]}"; do
+  echo ""
+  echo "--- ${svc} (base) ---"
+  if kubectl kustomize "k8s-cd/base/${svc}/" > /dev/null 2>&1; then
+    echo "    kubectl kustomize: OK"
+  else
+    echo "    kubectl kustomize: FAILED"
+    FAILED=1
+  fi
+
+  echo "--- ${svc} (overlay/local) ---"
+  OUTPUT=$(kubectl kustomize "k8s-cd/overlays/local/${svc}/" 2>&1)
+  if [[ $? -eq 0 ]]; then
+    echo "    kubectl kustomize: OK"
+    if echo "$OUTPUT" | grep -q "localhost:5001/${svc}"; then
+      echo "    image reference: OK (localhost:5001/${svc})"
+    else
+      echo "    image reference: MISSING localhost:5001/${svc}"
+      FAILED=1
+    fi
+  else
+    echo "    kubectl kustomize: FAILED"
+    FAILED=1
+  fi
+done
+
+echo ""
+echo "--- kubeconform ---"
+for svc in "${SERVICES[@]}"; do
+  BUILT=$(kubectl kustomize "k8s-cd/overlays/local/${svc}/" 2>/dev/null)
+  if echo "$BUILT" | kubeconform -skip "${SKIP_KINDS}" -strict -summary 2>/dev/null; then
+    echo "    ${svc}: kubeconform OK"
+  else
+    echo "    ${svc}: kubeconform issues (CRD types skipped)"
+  fi
+done
+
+echo ""
+echo "--- File extension check ---"
+YML_COUNT=$(find k8s-cd -name "*.yml" 2>/dev/null | wc -l)
+if [[ "$YML_COUNT" -eq 0 ]]; then
+  echo "    No .yml files in k8s-cd/: OK"
+else
+  echo "    WARNING: Found ${YML_COUNT} .yml files in k8s-cd/"
+  FAILED=1
+fi
+
+echo ""
+if [[ "$FAILED" -eq 0 ]]; then
+  echo "=== All validations passed ==="
+  exit 0
+else
+  echo "=== Some validations failed ==="
+  exit 1
+fi


### PR DESCRIPTION
Closes #197

### 📌 작업 개요
ArgoCD + Istio + Argo Rollouts를 활용한 로컬 Canary 배포 CD 파이프라인을 구축했습니다.
3개 서비스(api-gateway, user-service, product-service)에 대해 Kustomize base/overlay 구조로 구성하고,
Kind 클러스터 기반 로컬 환경에서 Canary 배포를 실행할 수 있는 운영 스크립트를 제공합니다.

---

### ✅ 주요 변경 사항

- `k8s-cd/base/{service}`
  - `rollout.yaml`: Deployment → Argo Rollout 전환 (Canary 20% → 50% → 100%)
  - `service.yaml`: stable + canary Service 분리
  - `destination-rule.yaml`: Istio DestinationRule (stable/canary subset)
  - `virtualservice.yaml`: Istio VirtualService (HTTP + gRPC 이중 라우트)
  - `kustomization.yaml`: Kustomize 리소스 참조

- `k8s-cd/overlays/local/{service}`
  - `kustomization.yaml`: localhost:5001 레지스트리 이미지 패치

- `k8s-cd/argocd/{service}-app.yaml`
  - ArgoCD Application (GitOps auto-sync, prune, selfHeal)

- `scripts/`
  - `setup.sh`: Kind + Istio + Argo Rollouts + ArgoCD 설치
  - `build-push.sh`: Docker 빌드 + 로컬 레지스트리 push (git SHA 태그)
  - `deploy-all.sh`: ArgoCD Application 배포
  - `canary-demo.sh`: Canary promote/abort 데모
  - `validate-manifests.sh`: kustomize build + kubeconform 검증

---

### 🧪 테스트

- `scripts/validate-manifests.sh` 실행: 3개 서비스 base/overlay kustomize build 성공
- 이미지 참조 검증: localhost:5001/{service} 확인
- .yml 파일 부재 확인: k8s-cd/ 내 0건

---

### 📎 관련 이슈
- #197