### PR TITLE
config: 나머지 4개 서비스 Canary 배포 매니페스트 추가

### DIFF
--- a/k8s-cd/argocd/notification-service-app.yaml
+++ b/k8s-cd/argocd/notification-service-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: notification-service
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/perArdua/hoppingmall.git
+    targetRevision: develop
+    path: k8s-cd/overlays/local/notification-service
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hoppingmall
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s-cd/argocd/order-service-app.yaml
+++ b/k8s-cd/argocd/order-service-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: order-service
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/perArdua/hoppingmall.git
+    targetRevision: develop
+    path: k8s-cd/overlays/local/order-service
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hoppingmall
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s-cd/argocd/payment-service-app.yaml
+++ b/k8s-cd/argocd/payment-service-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: payment-service
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/perArdua/hoppingmall.git
+    targetRevision: develop
+    path: k8s-cd/overlays/local/payment-service
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hoppingmall
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s-cd/argocd/settlement-service-app.yaml
+++ b/k8s-cd/argocd/settlement-service-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: settlement-service
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/perArdua/hoppingmall.git
+    targetRevision: develop
+    path: k8s-cd/overlays/local/settlement-service
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hoppingmall
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s-cd/base/notification-service/destination-rule.yaml
+++ b/k8s-cd/base/notification-service/destination-rule.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: notification-service-destrule
+  namespace: hoppingmall
+spec:
+  host: notification-service
+  subsets:
+    - name: stable
+      labels:
+        app: notification-service
+    - name: canary
+      labels:
+        app: notification-service

--- a/k8s-cd/base/notification-service/kustomization.yaml
+++ b/k8s-cd/base/notification-service/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rollout.yaml
+  - service.yaml
+  - destination-rule.yaml
+  - virtualservice.yaml

--- a/k8s-cd/base/notification-service/rollout.yaml
+++ b/k8s-cd/base/notification-service/rollout.yaml
@@ -1,26 +1,26 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
-  name: product-service
+  name: notification-service
   namespace: hoppingmall
 spec:
   replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: product-service
+      app: notification-service
   strategy:
     canary:
-      canaryService: product-service-canary
-      stableService: product-service
+      canaryService: notification-service-canary
+      stableService: notification-service
       trafficRouting:
         istio:
           virtualServices:
-            - name: product-service-vsvc
+            - name: notification-service-vsvc
               routes:
                 - primary
           destinationRule:
-            name: product-service-destrule
+            name: notification-service-destrule
             canarySubsetName: canary
             stableSubsetName: stable
       steps:
@@ -32,20 +32,19 @@ spec:
   template:
     metadata:
       labels:
-        app: product-service
+        app: notification-service
       annotations:
         sidecar.istio.io/inject: "true"
     spec:
       containers:
-        - name: product-service
-          image: product-service:latest
+        - name: notification-service
+          image: notification-service:latest
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 8083
-            - containerPort: 9093
+            - containerPort: 8081
           env:
             - name: SPRING_PROFILES_ACTIVE
-              value: "k8s,grpc"
+              value: "k8s"
             - name: JAVA_TOOL_OPTIONS
               value: "-XX:MaxRAMPercentage=75.0 -XX:+UseSerialGC"
             - name: JWT_SECRET
@@ -53,11 +52,6 @@ spec:
                 secretKeyRef:
                   name: hoppingmall-secret
                   key: JWT_SECRET
-            - name: INTERNAL_SERVICE_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: hoppingmall-secret
-                  key: INTERNAL_SERVICE_TOKEN
             - name: MYSQL_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -69,13 +63,13 @@ spec:
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
-              port: 8083
+              port: 8081
             initialDelaySeconds: 30
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
-              port: 8083
+              port: 8081
             initialDelaySeconds: 60
             periodSeconds: 15
           volumeMounts:

--- a/k8s-cd/base/notification-service/service.yaml
+++ b/k8s-cd/base/notification-service/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: notification-service
+  namespace: hoppingmall
+spec:
+  selector:
+    app: notification-service
+  ports:
+    - name: http
+      port: 8081
+      targetPort: 8081
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: notification-service-canary
+  namespace: hoppingmall
+spec:
+  selector:
+    app: notification-service
+  ports:
+    - name: http
+      port: 8081
+      targetPort: 8081

--- a/k8s-cd/base/notification-service/virtualservice.yaml
+++ b/k8s-cd/base/notification-service/virtualservice.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: notification-service-vsvc
+  namespace: hoppingmall
+spec:
+  hosts:
+    - notification-service
+  http:
+    - name: primary
+      route:
+        - destination:
+            host: notification-service
+            subset: stable
+          weight: 100
+        - destination:
+            host: notification-service
+            subset: canary
+          weight: 0

--- a/k8s-cd/base/order-service/destination-rule.yaml
+++ b/k8s-cd/base/order-service/destination-rule.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: order-service-destrule
+  namespace: hoppingmall
+spec:
+  host: order-service
+  subsets:
+    - name: stable
+      labels:
+        app: order-service
+    - name: canary
+      labels:
+        app: order-service

--- a/k8s-cd/base/order-service/kustomization.yaml
+++ b/k8s-cd/base/order-service/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rollout.yaml
+  - service.yaml
+  - destination-rule.yaml
+  - virtualservice.yaml

--- a/k8s-cd/base/order-service/rollout.yaml
+++ b/k8s-cd/base/order-service/rollout.yaml
@@ -1,26 +1,26 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
-  name: product-service
+  name: order-service
   namespace: hoppingmall
 spec:
   replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: product-service
+      app: order-service
   strategy:
     canary:
-      canaryService: product-service-canary
-      stableService: product-service
+      canaryService: order-service-canary
+      stableService: order-service
       trafficRouting:
         istio:
           virtualServices:
-            - name: product-service-vsvc
+            - name: order-service-vsvc
               routes:
                 - primary
           destinationRule:
-            name: product-service-destrule
+            name: order-service-destrule
             canarySubsetName: canary
             stableSubsetName: stable
       steps:
@@ -32,17 +32,17 @@ spec:
   template:
     metadata:
       labels:
-        app: product-service
+        app: order-service
       annotations:
         sidecar.istio.io/inject: "true"
     spec:
       containers:
-        - name: product-service
-          image: product-service:latest
+        - name: order-service
+          image: order-service:latest
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 8083
-            - containerPort: 9093
+            - containerPort: 8084
+            - containerPort: 9094
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "k8s,grpc"
@@ -69,13 +69,13 @@ spec:
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
-              port: 8083
+              port: 8084
             initialDelaySeconds: 30
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
-              port: 8083
+              port: 8084
             initialDelaySeconds: 60
             periodSeconds: 15
           volumeMounts:

--- a/k8s-cd/base/order-service/service.yaml
+++ b/k8s-cd/base/order-service/service.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: order-service
+  namespace: hoppingmall
+spec:
+  selector:
+    app: order-service
+  ports:
+    - name: http
+      port: 8084
+      targetPort: 8084
+    - name: grpc
+      port: 9094
+      targetPort: 9094
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: order-service-canary
+  namespace: hoppingmall
+spec:
+  selector:
+    app: order-service
+  ports:
+    - name: http
+      port: 8084
+      targetPort: 8084
+    - name: grpc
+      port: 9094
+      targetPort: 9094

--- a/k8s-cd/base/order-service/virtualservice.yaml
+++ b/k8s-cd/base/order-service/virtualservice.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: order-service-vsvc
+  namespace: hoppingmall
+spec:
+  hosts:
+    - order-service
+  http:
+    - name: primary
+      route:
+        - destination:
+            host: order-service
+            subset: stable
+          weight: 100
+        - destination:
+            host: order-service
+            subset: canary
+          weight: 0
+    - name: grpc
+      match:
+        - port: 9094
+      route:
+        - destination:
+            host: order-service
+            subset: stable
+          weight: 100
+        - destination:
+            host: order-service
+            subset: canary
+          weight: 0

--- a/k8s-cd/base/payment-service/destination-rule.yaml
+++ b/k8s-cd/base/payment-service/destination-rule.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: payment-service-destrule
+  namespace: hoppingmall
+spec:
+  host: payment-service
+  subsets:
+    - name: stable
+      labels:
+        app: payment-service
+    - name: canary
+      labels:
+        app: payment-service

--- a/k8s-cd/base/payment-service/kustomization.yaml
+++ b/k8s-cd/base/payment-service/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rollout.yaml
+  - service.yaml
+  - destination-rule.yaml
+  - virtualservice.yaml

--- a/k8s-cd/base/payment-service/rollout.yaml
+++ b/k8s-cd/base/payment-service/rollout.yaml
@@ -1,26 +1,26 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
-  name: product-service
+  name: payment-service
   namespace: hoppingmall
 spec:
   replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: product-service
+      app: payment-service
   strategy:
     canary:
-      canaryService: product-service-canary
-      stableService: product-service
+      canaryService: payment-service-canary
+      stableService: payment-service
       trafficRouting:
         istio:
           virtualServices:
-            - name: product-service-vsvc
+            - name: payment-service-vsvc
               routes:
                 - primary
           destinationRule:
-            name: product-service-destrule
+            name: payment-service-destrule
             canarySubsetName: canary
             stableSubsetName: stable
       steps:
@@ -32,17 +32,17 @@ spec:
   template:
     metadata:
       labels:
-        app: product-service
+        app: payment-service
       annotations:
         sidecar.istio.io/inject: "true"
     spec:
       containers:
-        - name: product-service
-          image: product-service:latest
+        - name: payment-service
+          image: payment-service:latest
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 8083
-            - containerPort: 9093
+            - containerPort: 8085
+            - containerPort: 9095
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "k8s,grpc"
@@ -69,14 +69,14 @@ spec:
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
-              port: 8083
+              port: 8085
             initialDelaySeconds: 30
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
-              port: 8083
-            initialDelaySeconds: 60
+              port: 8085
+            initialDelaySeconds: 180
             periodSeconds: 15
           volumeMounts:
             - name: redisson-config
@@ -84,10 +84,10 @@ spec:
               readOnly: true
           resources:
             requests:
-              memory: "384Mi"
+              memory: "512Mi"
               cpu: "250m"
             limits:
-              memory: "512Mi"
+              memory: "768Mi"
               cpu: "500m"
       volumes:
         - name: redisson-config

--- a/k8s-cd/base/payment-service/service.yaml
+++ b/k8s-cd/base/payment-service/service.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-service
+  namespace: hoppingmall
+spec:
+  selector:
+    app: payment-service
+  ports:
+    - name: http
+      port: 8085
+      targetPort: 8085
+    - name: grpc
+      port: 9095
+      targetPort: 9095
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-service-canary
+  namespace: hoppingmall
+spec:
+  selector:
+    app: payment-service
+  ports:
+    - name: http
+      port: 8085
+      targetPort: 8085
+    - name: grpc
+      port: 9095
+      targetPort: 9095

--- a/k8s-cd/base/payment-service/virtualservice.yaml
+++ b/k8s-cd/base/payment-service/virtualservice.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: payment-service-vsvc
+  namespace: hoppingmall
+spec:
+  hosts:
+    - payment-service
+  http:
+    - name: primary
+      route:
+        - destination:
+            host: payment-service
+            subset: stable
+          weight: 100
+        - destination:
+            host: payment-service
+            subset: canary
+          weight: 0
+    - name: grpc
+      match:
+        - port: 9095
+      route:
+        - destination:
+            host: payment-service
+            subset: stable
+          weight: 100
+        - destination:
+            host: payment-service
+            subset: canary
+          weight: 0

--- a/k8s-cd/base/settlement-service/destination-rule.yaml
+++ b/k8s-cd/base/settlement-service/destination-rule.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: settlement-service-destrule
+  namespace: hoppingmall
+spec:
+  host: settlement-service
+  subsets:
+    - name: stable
+      labels:
+        app: settlement-service
+    - name: canary
+      labels:
+        app: settlement-service

--- a/k8s-cd/base/settlement-service/kustomization.yaml
+++ b/k8s-cd/base/settlement-service/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rollout.yaml
+  - service.yaml
+  - destination-rule.yaml
+  - virtualservice.yaml

--- a/k8s-cd/base/settlement-service/rollout.yaml
+++ b/k8s-cd/base/settlement-service/rollout.yaml
@@ -1,26 +1,26 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
-  name: product-service
+  name: settlement-service
   namespace: hoppingmall
 spec:
   replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: product-service
+      app: settlement-service
   strategy:
     canary:
-      canaryService: product-service-canary
-      stableService: product-service
+      canaryService: settlement-service-canary
+      stableService: settlement-service
       trafficRouting:
         istio:
           virtualServices:
-            - name: product-service-vsvc
+            - name: settlement-service-vsvc
               routes:
                 - primary
           destinationRule:
-            name: product-service-destrule
+            name: settlement-service-destrule
             canarySubsetName: canary
             stableSubsetName: stable
       steps:
@@ -32,20 +32,19 @@ spec:
   template:
     metadata:
       labels:
-        app: product-service
+        app: settlement-service
       annotations:
         sidecar.istio.io/inject: "true"
     spec:
       containers:
-        - name: product-service
-          image: product-service:latest
+        - name: settlement-service
+          image: settlement-service:latest
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 8083
-            - containerPort: 9093
+            - containerPort: 8086
           env:
             - name: SPRING_PROFILES_ACTIVE
-              value: "k8s,grpc"
+              value: "k8s"
             - name: JAVA_TOOL_OPTIONS
               value: "-XX:MaxRAMPercentage=75.0 -XX:+UseSerialGC"
             - name: JWT_SECRET
@@ -69,19 +68,15 @@ spec:
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
-              port: 8083
+              port: 8086
             initialDelaySeconds: 30
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
-              port: 8083
+              port: 8086
             initialDelaySeconds: 60
             periodSeconds: 15
-          volumeMounts:
-            - name: redisson-config
-              mountPath: /config
-              readOnly: true
           resources:
             requests:
               memory: "384Mi"
@@ -89,7 +84,3 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "500m"
-      volumes:
-        - name: redisson-config
-          configMap:
-            name: redisson-config

--- a/k8s-cd/base/settlement-service/service.yaml
+++ b/k8s-cd/base/settlement-service/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: settlement-service
+  namespace: hoppingmall
+spec:
+  selector:
+    app: settlement-service
+  ports:
+    - name: http
+      port: 8086
+      targetPort: 8086
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: settlement-service-canary
+  namespace: hoppingmall
+spec:
+  selector:
+    app: settlement-service
+  ports:
+    - name: http
+      port: 8086
+      targetPort: 8086

--- a/k8s-cd/base/settlement-service/virtualservice.yaml
+++ b/k8s-cd/base/settlement-service/virtualservice.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: settlement-service-vsvc
+  namespace: hoppingmall
+spec:
+  hosts:
+    - settlement-service
+  http:
+    - name: primary
+      route:
+        - destination:
+            host: settlement-service
+            subset: stable
+          weight: 100
+        - destination:
+            host: settlement-service
+            subset: canary
+          weight: 0

--- a/k8s-cd/base/user-service/rollout.yaml
+++ b/k8s-cd/base/user-service/rollout.yaml
@@ -78,6 +78,10 @@ spec:
               port: 8082
             initialDelaySeconds: 60
             periodSeconds: 15
+          volumeMounts:
+            - name: redisson-config
+              mountPath: /config
+              readOnly: true
           resources:
             requests:
               memory: "384Mi"
@@ -85,3 +89,7 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "500m"
+      volumes:
+        - name: redisson-config
+          configMap:
+            name: redisson-config

--- a/k8s-cd/overlays/local/api-gateway/kustomization.yaml
+++ b/k8s-cd/overlays/local/api-gateway/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
   - name: api-gateway
     newName: localhost:5001/api-gateway
-    newTag: latest
+    newTag: f31869c

--- a/k8s-cd/overlays/local/notification-service/kustomization.yaml
+++ b/k8s-cd/overlays/local/notification-service/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base/notification-service
+images:
+  - name: notification-service
+    newName: localhost:5001/notification-service
+    newTag: fix5

--- a/k8s-cd/overlays/local/order-service/kustomization.yaml
+++ b/k8s-cd/overlays/local/order-service/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base/order-service
+images:
+  - name: order-service
+    newName: localhost:5001/order-service
+    newTag: fix5

--- a/k8s-cd/overlays/local/payment-service/kustomization.yaml
+++ b/k8s-cd/overlays/local/payment-service/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base/payment-service
+images:
+  - name: payment-service
+    newName: localhost:5001/payment-service
+    newTag: fix5

--- a/k8s-cd/overlays/local/product-service/kustomization.yaml
+++ b/k8s-cd/overlays/local/product-service/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
   - name: product-service
     newName: localhost:5001/product-service
-    newTag: latest
+    newTag: fix4

--- a/k8s-cd/overlays/local/settlement-service/kustomization.yaml
+++ b/k8s-cd/overlays/local/settlement-service/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base/settlement-service
+images:
+  - name: settlement-service
+    newName: localhost:5001/settlement-service
+    newTag: f31869c

--- a/k8s-cd/overlays/local/user-service/kustomization.yaml
+++ b/k8s-cd/overlays/local/user-service/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
   - name: user-service
     newName: localhost:5001/user-service
-    newTag: latest
+    newTag: fix4

--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 REGISTRY="localhost:5001"
 TAG=$(git rev-parse --short HEAD)
-SERVICES=("api-gateway" "user-service" "product-service")
+SERVICES=("api-gateway" "user-service" "product-service" "order-service" "payment-service" "notification-service" "settlement-service")
 
 if [[ $# -gt 0 ]]; then
   SERVICES=("$@")

--- a/scripts/deploy-all.sh
+++ b/scripts/deploy-all.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 TAG=$(git rev-parse --short HEAD)
-SERVICES=("api-gateway" "user-service" "product-service")
+SERVICES=("api-gateway" "user-service" "product-service" "order-service" "payment-service" "notification-service" "settlement-service")
 
 echo "==> Updating image tags to ${TAG}"
 for svc in "${SERVICES[@]}"; do

--- a/scripts/validate-manifests.sh
+++ b/scripts/validate-manifests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SERVICES=("api-gateway" "user-service" "product-service")
+SERVICES=("api-gateway" "user-service" "product-service" "order-service" "payment-service" "notification-service" "settlement-service")
 SKIP_KINDS="Rollout,AnalysisTemplate,VirtualService,DestinationRule,Application"
 FAILED=0
 


### PR DESCRIPTION
Closes #199

### 📌 작업 개요
기존 3개 서비스(api-gateway, user-service, product-service)에 이어 나머지 4개 서비스에 대한 Argo Rollouts + Istio Canary 배포 매니페스트를 추가했습니다.

---

### ✅ 주요 변경 사항

- `k8s-cd/base/{order,payment,notification,settlement}-service`
  - Rollout (Canary 20% → 50% → 100%), Service (stable/canary), DestinationRule, VirtualService, kustomization

- `k8s-cd/overlays/local/{4서비스}`
  - localhost:5001 레지스트리 이미지 패치

- `k8s-cd/argocd/{4서비스}-app.yaml`
  - ArgoCD Application (auto-sync)

- `scripts/build-push.sh, deploy-all.sh, validate-manifests.sh`
  - SERVICES 배열 7개 서비스로 확장

- `order-service/gradlew, settlement-service/gradlew`
  - CRLF → LF 수정 (Alpine Docker 빌드 호환)

---

### 🧪 테스트

- `scripts/validate-manifests.sh` 실행: 7개 서비스 전부 kustomize build 성공
- Kind 클러스터에서 7개 서비스 전부 2/2 Running 확인 완료

---

### 📎 관련 이슈
- #199