### PR TITLE
fix: 포인트 잔액 동시 차감 Race Condition 수정

### DIFF
--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointCommandServiceImpl.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointCommandServiceImpl.kt
@@ -73,13 +73,13 @@ class PointCommandServiceImpl(
 
     private fun findOrCreatePoint(userId: Long): Point {
         return try {
-            pointRepository.findByUserId(userId)
+            pointRepository.findByUserIdForUpdate(userId)
                 ?: run {
                     val newPoint = Point(userId = userId)
                     pointRepository.save(newPoint)
                 }
         } catch (e: org.springframework.dao.DataIntegrityViolationException) {
-            pointRepository.findByUserId(userId)
+            pointRepository.findByUserIdForUpdate(userId)
                 ?: throw IllegalStateException("포인트 생성 실패: 사용자 $userId")
         }
     }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointEventConsumer.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointEventConsumer.kt
@@ -84,13 +84,13 @@ class PointEventConsumer(
 
     private fun findOrCreatePoint(userId: Long): Point {
         return try {
-            pointRepository.findByUserId(userId)
+            pointRepository.findByUserIdForUpdate(userId)
                 ?: run {
                     val newPoint = Point(userId = userId)
                     pointRepository.save(newPoint)
                 }
         } catch (e: DataIntegrityViolationException) {
-            pointRepository.findByUserId(userId)
+            pointRepository.findByUserIdForUpdate(userId)
                 ?: throw IllegalStateException("포인트 생성/조회 실패: 사용자 $userId")
         }
     }


### PR DESCRIPTION
Closes #201

### 📌 작업 개요
PointCommandServiceImpl과 PointEventConsumer에서 포인트 잔액 조회 시 비관적 락(PESSIMISTIC_WRITE)을 적용하여 동시 차감/적립 Race Condition을 수정했습니다.

---

### ✅ 주요 변경 사항

- `point.service`
  - `PointCommandServiceImpl`: findOrCreatePoint()에서 findByUserId → findByUserIdForUpdate 교체 (happy path + catch)
  - `PointEventConsumer`: 동일하게 findByUserIdForUpdate 적용

---

### 🧪 테스트

- payment-service `./gradlew build` 성공

---

### 📎 관련 이슈
- #201