### PR TITLE
perf: 환불 목록 조회 N+1 쿼리 제거

### DIFF
--- a/order-service/src/main/kotlin/com/hoppingmall/order/refund/domain/repository/RefundItemRepository.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/refund/domain/repository/RefundItemRepository.kt
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository
 @Repository
 interface RefundItemRepository : JpaRepository<RefundItem, Long> {
     fun findByRefundId(refundId: Long): List<RefundItem>
+    fun findByRefundIdIn(refundIds: List<Long>): List<RefundItem>
 
     @Query(
         value = """

--- a/order-service/src/main/kotlin/com/hoppingmall/order/refund/service/RefundQueryServiceImpl.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/refund/service/RefundQueryServiceImpl.kt
@@ -28,16 +28,24 @@ class RefundQueryServiceImpl(
     }
 
     override fun getMyRefunds(buyerId: Long, pageable: Pageable): Page<RefundResponse> {
-        return refundRepository.findByBuyerId(buyerId, pageable).map { refund ->
-            val items = refundItemRepository.findByRefundId(refund.id!!)
-            RefundResponse.from(refund, items)
+        val refundPage = refundRepository.findByBuyerId(buyerId, pageable)
+        val refundIds = refundPage.content.mapNotNull { it.id }
+        val itemsByRefundId = if (refundIds.isNotEmpty()) {
+            refundItemRepository.findByRefundIdIn(refundIds).groupBy { it.refundId }
+        } else emptyMap()
+        return refundPage.map { refund ->
+            RefundResponse.from(refund, itemsByRefundId[refund.id] ?: emptyList())
         }
     }
 
     override fun getSellerRefunds(sellerId: Long, pageable: Pageable): Page<RefundResponse> {
-        return refundRepository.findBySellerId(sellerId, pageable).map { refund ->
-            val items = refundItemRepository.findByRefundId(refund.id!!)
-            RefundResponse.from(refund, items)
+        val refundPage = refundRepository.findBySellerId(sellerId, pageable)
+        val refundIds = refundPage.content.mapNotNull { it.id }
+        val itemsByRefundId = if (refundIds.isNotEmpty()) {
+            refundItemRepository.findByRefundIdIn(refundIds).groupBy { it.refundId }
+        } else emptyMap()
+        return refundPage.map { refund ->
+            RefundResponse.from(refund, itemsByRefundId[refund.id] ?: emptyList())
         }
     }
 }


### PR DESCRIPTION
Closes #203

### 📌 작업 개요
RefundQueryServiceImpl의 환불 목록 조회에서 N+1 쿼리 패턴을 배치 조회로 개선했습니다.

---

### ✅ 주요 변경 사항

- `refund.domain.repository`
  - `RefundItemRepository`: findByRefundIdIn(refundIds) 배치 조회 메서드 추가

- `refund.service`
  - `RefundQueryServiceImpl`: getMyRefunds/getSellerRefunds에서 배치 조회 + groupBy 패턴 적용

---

### 🧪 테스트

- order-service `./gradlew build` 성공

---

### 📎 관련 이슈
- #203