### PR TITLE
perf: ProductStatistics 인덱스 추가

### DIFF
--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/ProductStatistics.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/ProductStatistics.kt
@@ -3,13 +3,20 @@ package com.hoppingmall.product.product.domain
 import com.hoppingmall.product.common.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.Index
 import jakarta.persistence.Table
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDateTime
 
 @Entity
-@Table(name = "product_statistics")
+@Table(
+    name = "product_statistics",
+    indexes = [
+        Index(name = "idx_product_statistics_seller_id", columnList = "sellerId"),
+        Index(name = "idx_product_statistics_category_id", columnList = "categoryId")
+    ]
+)
 class ProductStatistics private constructor(
     @Column(unique = true, nullable = false)
     val productId: Long,


### PR DESCRIPTION
Closes #207

### 📌 작업 개요
ProductStatistics 테이블에 sellerId, categoryId 인덱스를 추가하여 판매자 대시보드 및 카테고리별 조회 성능을 개선했습니다.

---

### ✅ 주요 변경 사항
- `product.domain.ProductStatistics`: @Table indexes에 sellerId, categoryId 추가

---

### 📎 관련 이슈
- #207