### PR TITLE
fix: 장바구니 수정 시 고아 row 생성 버그 수정

### DIFF
--- a/order-service/src/main/kotlin/com/hoppingmall/order/cartItem/domain/CartItem.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/cartItem/domain/CartItem.kt
@@ -34,11 +34,16 @@ class CartItem private constructor(
     val productImageUrl: String?,
 
     @Column
-    val quantity: Int,
+    var quantity: Int,
 
     @Column(precision = 10, scale = 2)
-    val totalPrice: BigDecimal,
+    var totalPrice: BigDecimal,
 ): BaseEntity() {
+
+    fun updateQuantity(newQuantity: Int) {
+        this.quantity = newQuantity
+        this.totalPrice = productPrice.multiply(BigDecimal(newQuantity))
+    }
     companion object {
         fun create(
             buyerId: Long,

--- a/order-service/src/main/kotlin/com/hoppingmall/order/cartItem/service/CartItemCommandServiceImpl.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/cartItem/service/CartItemCommandServiceImpl.kt
@@ -37,16 +37,8 @@ class CartItemCommandServiceImpl(
     }
 
     private fun updateExistingCartItem(existingCartItem: CartItem, additionalQuantity: Int): CartItem {
-        val updatedQuantity = existingCartItem.quantity + additionalQuantity
-        val updatedCartItem = CartItem.create(
-            buyerId = existingCartItem.buyerId,
-            productId = existingCartItem.productId,
-            productName = existingCartItem.productName,
-            productPrice = existingCartItem.productPrice,
-            productImageUrl = existingCartItem.productImageUrl,
-            quantity = updatedQuantity
-        )
-        return cartItemRepository.save(updatedCartItem)
+        existingCartItem.updateQuantity(existingCartItem.quantity + additionalQuantity)
+        return existingCartItem
     }
 
     private fun createNewCartItem(
@@ -74,17 +66,9 @@ class CartItemCommandServiceImpl(
             throw CartItemAccessDeniedException()
         }
 
-        val updatedCartItem = CartItem.create(
-            buyerId = cartItem.buyerId,
-            productId = cartItem.productId,
-            productName = cartItem.productName,
-            productPrice = cartItem.productPrice,
-            productImageUrl = cartItem.productImageUrl,
-            quantity = request.quantity
-        )
-        val savedCartItem = cartItemRepository.save(updatedCartItem)
+        cartItem.updateQuantity(request.quantity)
 
-        return CartItemResponse.from(savedCartItem)
+        return CartItemResponse.from(cartItem)
     }
 
     override fun removeCartItem(buyerId: Long, cartItemId: Long) {


### PR DESCRIPTION
Closes #209

### 📌 작업 개요
CartItem 수정 시 기존 row를 업데이트하지 않고 새 row를 INSERT하는 정합성 버그를 수정했습니다.

---

### ✅ 주요 변경 사항
- `cartItem.domain.CartItem`: quantity, totalPrice를 var로 변경, updateQuantity() 추가
- `cartItem.service.CartItemCommandServiceImpl`: 새 엔티티 생성 → 기존 엔티티 필드 수정 (JPA dirty checking)

---

### 📎 관련 이슈
- #209