### PR TITLE
perf: Page → Slice 전환으로 COUNT 쿼리 제거

### DIFF
--- a/order-service/src/main/kotlin/com/hoppingmall/order/refund/controller/RefundController.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/refund/controller/RefundController.kt
@@ -8,8 +8,8 @@ import com.hoppingmall.order.refund.dto.response.RefundResponse
 import com.hoppingmall.order.refund.service.RefundCommandService
 import com.hoppingmall.order.refund.service.RefundQueryService
 import jakarta.validation.Valid
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -49,7 +49,7 @@ class RefundController(
         @AuthenticationPrincipal principal: UserPrincipal,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int
-    ): ResponseEntity<Page<RefundResponse>> {
+    ): ResponseEntity<Slice<RefundResponse>> {
         val buyerId = principal.getUserId()
         val pageable = PageRequest.of(page, size)
         val refunds = refundQueryService.getMyRefunds(buyerId, pageable)
@@ -61,7 +61,7 @@ class RefundController(
         @AuthenticationPrincipal principal: UserPrincipal,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int
-    ): ResponseEntity<Page<RefundResponse>> {
+    ): ResponseEntity<Slice<RefundResponse>> {
         val sellerId = principal.getUserId()
         val pageable = PageRequest.of(page, size)
         val refunds = refundQueryService.getSellerRefunds(sellerId, pageable)

--- a/order-service/src/main/kotlin/com/hoppingmall/order/refund/domain/repository/RefundRepository.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/refund/domain/repository/RefundRepository.kt
@@ -2,8 +2,8 @@ package com.hoppingmall.order.refund.domain.repository
 
 import com.hoppingmall.order.refund.domain.Refund
 import com.hoppingmall.order.refund.enum.RefundStatus
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
@@ -11,8 +11,8 @@ import java.time.LocalDateTime
 @Repository
 interface RefundRepository : JpaRepository<Refund, Long> {
     fun findByOrderIdAndStatusNot(orderId: Long, status: RefundStatus): List<Refund>
-    fun findByBuyerId(buyerId: Long, pageable: Pageable): Page<Refund>
-    fun findBySellerId(sellerId: Long, pageable: Pageable): Page<Refund>
+    fun findByBuyerId(buyerId: Long, pageable: Pageable): Slice<Refund>
+    fun findBySellerId(sellerId: Long, pageable: Pageable): Slice<Refund>
     fun findBySellerIdAndStatusAndCompletedAtBetween(
         sellerId: Long, status: RefundStatus, startDate: LocalDateTime, endDate: LocalDateTime
     ): List<Refund>

--- a/order-service/src/main/kotlin/com/hoppingmall/order/refund/service/RefundQueryService.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/refund/service/RefundQueryService.kt
@@ -1,11 +1,11 @@
 package com.hoppingmall.order.refund.service
 
 import com.hoppingmall.order.refund.dto.response.RefundResponse
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 
 interface RefundQueryService {
     fun getRefund(refundId: Long, userId: Long): RefundResponse
-    fun getMyRefunds(buyerId: Long, pageable: Pageable): Page<RefundResponse>
-    fun getSellerRefunds(sellerId: Long, pageable: Pageable): Page<RefundResponse>
+    fun getMyRefunds(buyerId: Long, pageable: Pageable): Slice<RefundResponse>
+    fun getSellerRefunds(sellerId: Long, pageable: Pageable): Slice<RefundResponse>
 }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/refund/service/RefundQueryServiceImpl.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/refund/service/RefundQueryServiceImpl.kt
@@ -5,8 +5,8 @@ import com.hoppingmall.order.refund.domain.repository.RefundRepository
 import com.hoppingmall.order.refund.dto.response.RefundResponse
 import com.hoppingmall.order.refund.exception.RefundAccessDeniedException
 import com.hoppingmall.order.refund.exception.RefundNotFoundException
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -27,7 +27,7 @@ class RefundQueryServiceImpl(
         return RefundResponse.from(refund, items)
     }
 
-    override fun getMyRefunds(buyerId: Long, pageable: Pageable): Page<RefundResponse> {
+    override fun getMyRefunds(buyerId: Long, pageable: Pageable): Slice<RefundResponse> {
         val refundPage = refundRepository.findByBuyerId(buyerId, pageable)
         val refundIds = refundPage.content.mapNotNull { it.id }
         val itemsByRefundId = if (refundIds.isNotEmpty()) {
@@ -38,7 +38,7 @@ class RefundQueryServiceImpl(
         }
     }
 
-    override fun getSellerRefunds(sellerId: Long, pageable: Pageable): Page<RefundResponse> {
+    override fun getSellerRefunds(sellerId: Long, pageable: Pageable): Slice<RefundResponse> {
         val refundPage = refundRepository.findBySellerId(sellerId, pageable)
         val refundIds = refundPage.content.mapNotNull { it.id }
         val itemsByRefundId = if (refundIds.isNotEmpty()) {

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/controller/PaymentController.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/controller/PaymentController.kt
@@ -5,8 +5,8 @@ import com.hoppingmall.payment.payment.dto.response.PaymentResponse
 import com.hoppingmall.payment.payment.service.PaymentCommandService
 import com.hoppingmall.payment.payment.service.PaymentQueryService
 import jakarta.validation.Valid
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
 import org.springframework.http.ResponseEntity
 import com.hoppingmall.payment.common.UserPrincipal
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -46,7 +46,7 @@ class PaymentController(
         @AuthenticationPrincipal principal: UserPrincipal,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int
-    ): ResponseEntity<Page<PaymentResponse>> {
+    ): ResponseEntity<Slice<PaymentResponse>> {
         val userId = principal.getUserId()
         val pageable = PageRequest.of(page, size)
         val payments = paymentQueryService.getPaymentsByUserId(userId, pageable)

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/domain/repository/PaymentRepository.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/domain/repository/PaymentRepository.kt
@@ -1,8 +1,8 @@
 package com.hoppingmall.payment.payment.domain.repository
 
 import com.hoppingmall.payment.payment.domain.Payment
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
@@ -13,7 +13,7 @@ interface PaymentRepository : JpaRepository<Payment, Long> {
 
     fun findByUserId(userId: Long): List<Payment>
 
-    fun findByUserId(userId: Long, pageable: Pageable): Page<Payment>
+    fun findByUserId(userId: Long, pageable: Pageable): Slice<Payment>
 
     fun findByTransactionId(transactionId: String): Payment?
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/PaymentQueryService.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/PaymentQueryService.kt
@@ -1,13 +1,13 @@
 package com.hoppingmall.payment.payment.service
 
 import com.hoppingmall.payment.payment.dto.response.PaymentResponse
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 
 interface PaymentQueryService {
     fun getPaymentById(paymentId: Long, userId: Long): PaymentResponse
 
-    fun getPaymentsByUserId(userId: Long, pageable: Pageable): Page<PaymentResponse>
+    fun getPaymentsByUserId(userId: Long, pageable: Pageable): Slice<PaymentResponse>
 
     fun getPaymentsByOrderId(orderId: Long, userId: Long): List<PaymentResponse>
 

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/PaymentQueryServiceImpl.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/PaymentQueryServiceImpl.kt
@@ -4,8 +4,8 @@ import com.hoppingmall.payment.payment.domain.repository.PaymentRepository
 import com.hoppingmall.payment.payment.dto.response.PaymentResponse
 import com.hoppingmall.payment.payment.exception.PaymentAccessDeniedException
 import com.hoppingmall.payment.payment.exception.PaymentNotFoundException
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -24,7 +24,7 @@ class PaymentQueryServiceImpl(
         return PaymentResponse.from(payment)
     }
 
-    override fun getPaymentsByUserId(userId: Long, pageable: Pageable): Page<PaymentResponse> {
+    override fun getPaymentsByUserId(userId: Long, pageable: Pageable): Slice<PaymentResponse> {
         return paymentRepository.findByUserId(userId, pageable)
             .map { PaymentResponse.from(it) }
     }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/controller/PointController.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/controller/PointController.kt
@@ -7,8 +7,8 @@ import com.hoppingmall.payment.point.dto.response.PointUseResponse
 import com.hoppingmall.payment.point.service.PointCommandService
 import com.hoppingmall.payment.point.service.PointQueryService
 import jakarta.validation.Valid
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
 import org.springframework.http.ResponseEntity
 import com.hoppingmall.payment.common.UserPrincipal
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -37,7 +37,7 @@ class PointController(
         @AuthenticationPrincipal principal: UserPrincipal,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int
-    ): ResponseEntity<Page<PointHistoryResponse>> {
+    ): ResponseEntity<Slice<PointHistoryResponse>> {
         val userId = principal.getUserId()
         val pageable = PageRequest.of(page, size)
         val history = pointQueryService.getPointHistory(userId, pageable)

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/domain/PointHistoryRepository.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/domain/PointHistoryRepository.kt
@@ -1,8 +1,8 @@
 package com.hoppingmall.payment.point.domain
 
 import com.hoppingmall.payment.point.enum.PointType
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
@@ -12,7 +12,7 @@ interface PointHistoryRepository : JpaRepository<PointHistory, Long> {
 
     fun findByUserIdOrderByCreatedAtDesc(userId: Long): List<PointHistory>
 
-    fun findByUserId(userId: Long, pageable: Pageable): Page<PointHistory>
+    fun findByUserId(userId: Long, pageable: Pageable): Slice<PointHistory>
 
     fun findByPaymentIdAndType(paymentId: Long, type: PointType): PointHistory?
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointQueryService.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointQueryService.kt
@@ -2,11 +2,11 @@ package com.hoppingmall.payment.point.service
 
 import com.hoppingmall.payment.point.dto.response.PointBalanceResponse
 import com.hoppingmall.payment.point.dto.response.PointHistoryResponse
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 
 interface PointQueryService {
     fun getPointBalance(userId: Long): PointBalanceResponse
 
-    fun getPointHistory(userId: Long, pageable: Pageable): Page<PointHistoryResponse>
+    fun getPointHistory(userId: Long, pageable: Pageable): Slice<PointHistoryResponse>
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointQueryServiceImpl.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointQueryServiceImpl.kt
@@ -4,8 +4,9 @@ import com.hoppingmall.payment.point.domain.PointRepository
 import com.hoppingmall.payment.point.domain.PointHistoryRepository
 import com.hoppingmall.payment.point.dto.response.PointBalanceResponse
 import com.hoppingmall.payment.point.dto.response.PointHistoryResponse
-import org.springframework.data.domain.Page
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -17,13 +18,14 @@ class PointQueryServiceImpl(
     private val pointHistoryRepository: PointHistoryRepository
 ) : PointQueryService {
 
+    @Cacheable(cacheNames = ["point-balance"], key = "#userId")
     override fun getPointBalance(userId: Long): PointBalanceResponse {
         val point = pointRepository.findByUserId(userId)
         val balance = point?.balance ?: BigDecimal.ZERO
         return PointBalanceResponse(balance = balance)
     }
 
-    override fun getPointHistory(userId: Long, pageable: Pageable): Page<PointHistoryResponse> {
+    override fun getPointHistory(userId: Long, pageable: Pageable): Slice<PointHistoryResponse> {
         return pointHistoryRepository.findByUserId(userId, pageable)
             .map { history ->
                 PointHistoryResponse(

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/controller/ProductStatisticsController.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/controller/ProductStatisticsController.kt
@@ -5,6 +5,7 @@ import com.hoppingmall.product.product.dto.response.*
 import com.hoppingmall.product.product.service.ProductStatisticsQueryService
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.format.annotation.DateTimeFormat
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
@@ -30,7 +31,7 @@ class ProductStatisticsController(
     fun getBySellerId(
         @PathVariable sellerId: Long,
         pageable: Pageable
-    ): ApiResponse<Page<ProductStatisticsResponse>> {
+    ): ApiResponse<Slice<ProductStatisticsResponse>> {
         return ApiResponse.success(productStatisticsQueryService.getBySellerId(sellerId, pageable))
     }
 
@@ -38,7 +39,7 @@ class ProductStatisticsController(
     fun getByCategoryId(
         @PathVariable categoryId: Long,
         pageable: Pageable
-    ): ApiResponse<Page<ProductStatisticsResponse>> {
+    ): ApiResponse<Slice<ProductStatisticsResponse>> {
         return ApiResponse.success(productStatisticsQueryService.getByCategoryId(categoryId, pageable))
     }
 

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/controller/SellerDashboardController.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/controller/SellerDashboardController.kt
@@ -7,8 +7,8 @@ import com.hoppingmall.product.product.dto.response.ProductHourlyStatisticsRespo
 import com.hoppingmall.product.product.dto.response.ProductStatisticsResponse
 import com.hoppingmall.product.product.dto.response.SellerTodaySummaryResponse
 import com.hoppingmall.product.product.service.SellerDashboardService
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
@@ -30,7 +30,7 @@ class SellerDashboardController(
     fun getOverview(
         @AuthenticationPrincipal principal: UserPrincipal,
         pageable: Pageable
-    ): ApiResponse<Page<ProductStatisticsResponse>> {
+    ): ApiResponse<Slice<ProductStatisticsResponse>> {
         return ApiResponse.success(sellerDashboardService.getOverview(principal.getUserId(), pageable))
     }
 

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductStatisticsRepository.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductStatisticsRepository.kt
@@ -2,8 +2,8 @@ package com.hoppingmall.product.product.domain.repository
 
 import com.hoppingmall.product.product.domain.ProductStatistics
 import jakarta.persistence.LockModeType
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
@@ -14,8 +14,8 @@ import java.math.BigDecimal
 @Repository
 interface ProductStatisticsRepository : JpaRepository<ProductStatistics, Long> {
     fun findByProductId(productId: Long): ProductStatistics?
-    fun findBySellerId(sellerId: Long, pageable: Pageable): Page<ProductStatistics>
-    fun findByCategoryId(categoryId: Long, pageable: Pageable): Page<ProductStatistics>
+    fun findBySellerId(sellerId: Long, pageable: Pageable): Slice<ProductStatistics>
+    fun findByCategoryId(categoryId: Long, pageable: Pageable): Slice<ProductStatistics>
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT ps FROM ProductStatistics ps WHERE ps.productId = :productId")

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductStatisticsQueryService.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductStatisticsQueryService.kt
@@ -3,13 +3,14 @@ package com.hoppingmall.product.product.service
 import com.hoppingmall.product.product.dto.response.*
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import java.time.LocalDate
 
 interface ProductStatisticsQueryService {
     fun getAll(pageable: Pageable): Page<ProductStatisticsResponse>
     fun getByProductId(productId: Long): ProductStatisticsResponse
-    fun getBySellerId(sellerId: Long, pageable: Pageable): Page<ProductStatisticsResponse>
-    fun getByCategoryId(categoryId: Long, pageable: Pageable): Page<ProductStatisticsResponse>
+    fun getBySellerId(sellerId: Long, pageable: Pageable): Slice<ProductStatisticsResponse>
+    fun getByCategoryId(categoryId: Long, pageable: Pageable): Slice<ProductStatisticsResponse>
     fun getSummary(): ProductStatisticsSummaryResponse
     fun getTodaySummary(): TodaySummaryResponse
     fun getDailyStatistics(productId: Long, startDate: LocalDate, endDate: LocalDate): List<ProductDailyStatisticsResponse>

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductStatisticsQueryServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductStatisticsQueryServiceImpl.kt
@@ -7,6 +7,7 @@ import com.hoppingmall.product.product.dto.response.*
 import com.hoppingmall.product.product.exception.ProductStatisticsNotFoundException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -30,12 +31,12 @@ class ProductStatisticsQueryServiceImpl(
         return ProductStatisticsResponse.from(statistics)
     }
 
-    override fun getBySellerId(sellerId: Long, pageable: Pageable): Page<ProductStatisticsResponse> {
+    override fun getBySellerId(sellerId: Long, pageable: Pageable): Slice<ProductStatisticsResponse> {
         return productStatisticsRepository.findBySellerId(sellerId, pageable)
             .map { ProductStatisticsResponse.from(it) }
     }
 
-    override fun getByCategoryId(categoryId: Long, pageable: Pageable): Page<ProductStatisticsResponse> {
+    override fun getByCategoryId(categoryId: Long, pageable: Pageable): Slice<ProductStatisticsResponse> {
         return productStatisticsRepository.findByCategoryId(categoryId, pageable)
             .map { ProductStatisticsResponse.from(it) }
     }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/SellerDashboardService.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/SellerDashboardService.kt
@@ -4,12 +4,12 @@ import com.hoppingmall.product.product.dto.response.ProductDailyStatisticsRespon
 import com.hoppingmall.product.product.dto.response.ProductHourlyStatisticsResponse
 import com.hoppingmall.product.product.dto.response.ProductStatisticsResponse
 import com.hoppingmall.product.product.dto.response.SellerTodaySummaryResponse
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import java.time.LocalDate
 
 interface SellerDashboardService {
-    fun getOverview(sellerId: Long, pageable: Pageable): Page<ProductStatisticsResponse>
+    fun getOverview(sellerId: Long, pageable: Pageable): Slice<ProductStatisticsResponse>
     fun getProductStatistics(sellerId: Long, productId: Long): ProductStatisticsResponse
     fun getTodaySummary(sellerId: Long): SellerTodaySummaryResponse
     fun getDailyStatistics(sellerId: Long, productId: Long, startDate: LocalDate, endDate: LocalDate): List<ProductDailyStatisticsResponse>

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/SellerDashboardServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/SellerDashboardServiceImpl.kt
@@ -10,8 +10,8 @@ import com.hoppingmall.product.product.dto.response.SellerTodaySummaryResponse
 import com.hoppingmall.product.product.exception.ProductException
 import com.hoppingmall.product.product.exception.ProductStatisticsNotFoundException
 import com.hoppingmall.product.product.exception.code.ProductErrorCode
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -24,7 +24,7 @@ class SellerDashboardServiceImpl(
     private val productHourlyStatisticsRepository: ProductHourlyStatisticsRepository
 ) : SellerDashboardService {
 
-    override fun getOverview(sellerId: Long, pageable: Pageable): Page<ProductStatisticsResponse> {
+    override fun getOverview(sellerId: Long, pageable: Pageable): Slice<ProductStatisticsResponse> {
         return productStatisticsRepository.findBySellerId(sellerId, pageable)
             .map { ProductStatisticsResponse.from(it) }
     }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/review/controller/ReviewController.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/review/controller/ReviewController.kt
@@ -9,8 +9,8 @@ import com.hoppingmall.product.review.dto.response.ReviewResponse
 import com.hoppingmall.product.review.service.ReviewCommandService
 import com.hoppingmall.product.review.service.ReviewQueryService
 import jakarta.validation.Valid
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -49,7 +49,7 @@ class ReviewController(
     fun getProductReviews(
         @PathVariable productId: Long,
         @PageableDefault(size = 10) pageable: Pageable
-    ): ResponseEntity<ApiResponse<Page<ReviewResponse>>> {
+    ): ResponseEntity<ApiResponse<Slice<ReviewResponse>>> {
         val response = reviewQueryService.getReviewsByProductId(productId, pageable)
         return ResponseEntity.ok(ApiResponse.success(response))
     }
@@ -58,7 +58,7 @@ class ReviewController(
     fun getMyReviews(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
         @PageableDefault(size = 10) pageable: Pageable
-    ): ResponseEntity<ApiResponse<Page<ReviewResponse>>> {
+    ): ResponseEntity<ApiResponse<Slice<ReviewResponse>>> {
         val response = reviewQueryService.getMyReviews(userPrincipal.getUserId(), pageable)
         return ResponseEntity.ok(ApiResponse.success(response))
     }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/review/domain/repository/ReviewRepository.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/review/domain/repository/ReviewRepository.kt
@@ -1,8 +1,8 @@
 package com.hoppingmall.product.review.domain.repository
 
 import com.hoppingmall.product.review.domain.Review
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface ReviewRepository : JpaRepository<Review, Long> {
-    fun findByProductId(productId: Long, pageable: Pageable): Page<Review>
-    fun findByBuyerId(buyerId: Long, pageable: Pageable): Page<Review>
+    fun findByProductId(productId: Long, pageable: Pageable): Slice<Review>
+    fun findByBuyerId(buyerId: Long, pageable: Pageable): Slice<Review>
     fun existsByOrderItemId(orderItemId: Long): Boolean
     fun findNullableById(id: Long): Review?
 

--- a/product-service/src/main/kotlin/com/hoppingmall/product/review/service/ReviewQueryService.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/review/service/ReviewQueryService.kt
@@ -1,11 +1,11 @@
 package com.hoppingmall.product.review.service
 
 import com.hoppingmall.product.review.dto.response.ReviewResponse
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 
 interface ReviewQueryService {
     fun getReview(reviewId: Long): ReviewResponse
-    fun getReviewsByProductId(productId: Long, pageable: Pageable): Page<ReviewResponse>
-    fun getMyReviews(buyerId: Long, pageable: Pageable): Page<ReviewResponse>
+    fun getReviewsByProductId(productId: Long, pageable: Pageable): Slice<ReviewResponse>
+    fun getMyReviews(buyerId: Long, pageable: Pageable): Slice<ReviewResponse>
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/review/service/ReviewQueryServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/review/service/ReviewQueryServiceImpl.kt
@@ -3,8 +3,8 @@ package com.hoppingmall.product.review.service
 import com.hoppingmall.product.review.domain.repository.ReviewRepository
 import com.hoppingmall.product.review.dto.response.ReviewResponse
 import com.hoppingmall.product.review.exception.ReviewNotFoundException
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -20,12 +20,12 @@ class ReviewQueryServiceImpl(
         return ReviewResponse.from(review)
     }
 
-    override fun getReviewsByProductId(productId: Long, pageable: Pageable): Page<ReviewResponse> {
+    override fun getReviewsByProductId(productId: Long, pageable: Pageable): Slice<ReviewResponse> {
         return reviewRepository.findByProductId(productId, pageable)
             .map { ReviewResponse.from(it) }
     }
 
-    override fun getMyReviews(buyerId: Long, pageable: Pageable): Page<ReviewResponse> {
+    override fun getMyReviews(buyerId: Long, pageable: Pageable): Slice<ReviewResponse> {
         return reviewRepository.findByBuyerId(buyerId, pageable)
             .map { ReviewResponse.from(it) }
     }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/controller/WishlistController.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/controller/WishlistController.kt
@@ -8,8 +8,8 @@ import com.hoppingmall.product.wishlist.dto.response.WishlistResponse
 import com.hoppingmall.product.wishlist.service.WishlistCommandService
 import com.hoppingmall.product.wishlist.service.WishlistQueryService
 import jakarta.validation.Valid
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -50,7 +50,7 @@ class WishlistController(
     fun getWishlists(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
         @PageableDefault(size = 20) pageable: Pageable
-    ): ResponseEntity<ApiResponse<Page<WishlistResponse>>> {
+    ): ResponseEntity<ApiResponse<Slice<WishlistResponse>>> {
         val wishlists = wishlistQueryService.getWishlists(userPrincipal.getUserId(), pageable)
         return ResponseEntity.ok(ApiResponse.success(wishlists))
     }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/domain/repository/WishlistRepository.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/domain/repository/WishlistRepository.kt
@@ -1,13 +1,13 @@
 package com.hoppingmall.product.wishlist.domain.repository
 
 import com.hoppingmall.product.wishlist.domain.Wishlist
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface WishlistRepository : JpaRepository<Wishlist, Long> {
-    fun findByBuyerId(buyerId: Long, pageable: Pageable): Page<Wishlist>
+    fun findByBuyerId(buyerId: Long, pageable: Pageable): Slice<Wishlist>
     fun existsByBuyerIdAndProductId(buyerId: Long, productId: Long): Boolean
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/service/WishlistQueryService.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/service/WishlistQueryService.kt
@@ -1,10 +1,10 @@
 package com.hoppingmall.product.wishlist.service
 
 import com.hoppingmall.product.wishlist.dto.response.WishlistResponse
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 
 interface WishlistQueryService {
-    fun getWishlists(buyerId: Long, pageable: Pageable): Page<WishlistResponse>
+    fun getWishlists(buyerId: Long, pageable: Pageable): Slice<WishlistResponse>
     fun isWishlisted(buyerId: Long, productId: Long): Boolean
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/service/WishlistQueryServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/service/WishlistQueryServiceImpl.kt
@@ -2,8 +2,8 @@ package com.hoppingmall.product.wishlist.service
 
 import com.hoppingmall.product.wishlist.domain.repository.WishlistRepository
 import com.hoppingmall.product.wishlist.dto.response.WishlistResponse
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -13,7 +13,7 @@ class WishlistQueryServiceImpl(
     private val wishlistRepository: WishlistRepository
 ) : WishlistQueryService {
 
-    override fun getWishlists(buyerId: Long, pageable: Pageable): Page<WishlistResponse> {
+    override fun getWishlists(buyerId: Long, pageable: Pageable): Slice<WishlistResponse> {
         return wishlistRepository.findByBuyerId(buyerId, pageable)
             .map { WishlistResponse.from(it) }
     }


### PR DESCRIPTION
Closes #211

### 📌 작업 개요
6개 레포지토리의 페이징 조회에서 Page → Slice로 전환하여 불필요한 COUNT 쿼리를 제거했습니다.

---

### ✅ 주요 변경 사항
- product-service: ReviewRepository, WishlistRepository, ProductStatisticsRepository
- order-service: RefundRepository
- payment-service: PaymentRepository, PointHistoryRepository
- 각 서비스 인터페이스, 구현체, 컨트롤러 반환 타입 Slice로 동기화

---

### 📎 관련 이슈
- #211