### PR TITLE
perf: ProductStatisticsScheduler 배치 처리로 OOM 방지

### DIFF
--- a/product-service/src/main/kotlin/com/hoppingmall/product/inventory/domain/repository/InventoryRepository.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/inventory/domain/repository/InventoryRepository.kt
@@ -17,4 +17,6 @@ interface InventoryRepository : JpaRepository<Inventory, Long> {
     fun findByProductIdForUpdate(@Param("productId") productId: Long): Inventory?
 
     fun existsByProductId(productId: Long): Boolean
+
+    fun findAllByProductIdIn(productIds: List<Long>): List<Inventory>
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/statistics/service/ProductStatisticsScheduler.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/statistics/service/ProductStatisticsScheduler.kt
@@ -6,9 +6,10 @@ import com.hoppingmall.product.product.service.ProductStatisticsCommandService
 import com.hoppingmall.product.statistics.port.CartItemQueryPort
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
+import org.springframework.data.domain.PageRequest
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 
 @Component
 @Profile("!test")
@@ -16,40 +17,43 @@ class ProductStatisticsScheduler(
     private val productStatisticsRepository: ProductStatisticsRepository,
     private val cartItemQueryPort: CartItemQueryPort,
     private val inventoryRepository: InventoryRepository,
-    private val productStatisticsCommandService: ProductStatisticsCommandService
+    private val productStatisticsCommandService: ProductStatisticsCommandService,
+    private val transactionTemplate: TransactionTemplate
 ) {
     private val logger = LoggerFactory.getLogger(ProductStatisticsScheduler::class.java)
 
-    @Scheduled(cron = "0 0 * * * *")
-    @Transactional
+    @Scheduled(fixedDelay = 3600000)
     fun syncCartAndInventory() {
         logger.info("장바구니/재고 동기화 시작")
-
-        val allStats = productStatisticsRepository.findAll()
-        if (allStats.isEmpty()) {
-            logger.info("동기화할 통계가 없습니다")
-            return
-        }
 
         val cartMap = cartItemQueryPort
             .aggregateCartByProduct()
             .associateBy { it.productId }
 
-        val inventoryMap = inventoryRepository.findAll()
-            .associateBy { it.productId }
-
+        var page = 0
         var updatedCount = 0
+        var hasNext: Boolean
 
-        for (stats in allStats) {
-            val cart = cartMap[stats.productId]
-            val inventory = inventoryMap[stats.productId]
+        do {
+            val currentPage = page
+            val batchUpdated = transactionTemplate.execute {
+                val statsPage = productStatisticsRepository.findAll(PageRequest.of(currentPage, 500))
+                val productIds = statsPage.content.map { it.productId }
+                val inventoryMap = inventoryRepository.findAllByProductIdIn(productIds).associateBy { it.productId }
 
-            val cartCount = cart?.buyerCount ?: 0L
-            val stock = inventory?.stockQuantity ?: 0
+                for (stats in statsPage.content) {
+                    val cart = cartMap[stats.productId]
+                    val inventory = inventoryMap[stats.productId]
+                    stats.updateCartAndInventory(cart?.buyerCount ?: 0L, inventory?.stockQuantity ?: 0)
+                }
 
-            stats.updateCartAndInventory(cartCount, stock)
-            updatedCount++
-        }
+                statsPage.hasNext() to statsPage.content.size
+            }!!
+
+            hasNext = batchUpdated.first
+            updatedCount += batchUpdated.second
+            page++
+        } while (hasNext)
 
         logger.info("장바구니/재고 동기화 완료: ${updatedCount}건")
 


### PR DESCRIPTION
Closes #213

### 📌 작업 개요
ProductStatisticsScheduler의 findAll() 전체 테이블 로드를 2-phase 배치 처리로 변경하여 OOM 위험을 제거했습니다.

---

### ✅ 주요 변경 사항
- `statistics.service.ProductStatisticsScheduler`: 2-phase 설계 (Phase 1: 원격 호출 TX 밖, Phase 2: TransactionTemplate per batch)
- `inventory.domain.repository.InventoryRepository`: findAllByProductIdIn 추가

---

### 📎 관련 이슈
- #213