### PR TITLE
perf: Notification unread count + Point 잔액 캐싱 추가

### DIFF
--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/config/CacheConfig.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/config/CacheConfig.kt
@@ -1,0 +1,25 @@
+package com.hoppingmall.notification.config
+
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class CacheConfig {
+
+    @Bean
+    fun cacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
+        val unreadCountConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofSeconds(300))
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+            .withCacheConfiguration("unread-count", unreadCountConfig)
+            .build()
+    }
+}

--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/consumer/NotificationEventConsumer.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/consumer/NotificationEventConsumer.kt
@@ -8,6 +8,7 @@ import com.hoppingmall.notification.enums.NotificationType
 import com.hoppingmall.notification.service.NotificationSseService
 import com.hoppingmall.notification.service.SseNotificationMessage
 import org.slf4j.LoggerFactory
+import org.springframework.cache.CacheManager
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.kafka.annotation.KafkaListener
@@ -20,7 +21,8 @@ import org.springframework.transaction.annotation.Transactional
 class NotificationEventConsumer(
     private val notificationRepository: NotificationRepository,
     private val redisTemplate: RedisTemplate<String, String>,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val cacheManager: CacheManager
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -66,6 +68,7 @@ class NotificationEventConsumer(
                 return
             }
 
+            cacheManager.getCache("unread-count")?.evict(userId)
             publishSseEvent(saved)
             log.info("알림 처리 완료: userId={}, type={}, title={}", userId, type, title)
         } catch (e: Exception) {

--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/service/NotificationCommandServiceImpl.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/service/NotificationCommandServiceImpl.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.notification.service
 import com.hoppingmall.notification.domain.NotificationRepository
 import com.hoppingmall.notification.exception.NotificationAccessDeniedException
 import com.hoppingmall.notification.exception.NotificationNotFoundException
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -12,6 +13,7 @@ class NotificationCommandServiceImpl(
     private val notificationRepository: NotificationRepository
 ) : NotificationCommandService {
 
+    @CacheEvict(cacheNames = ["unread-count"], key = "#userId")
     override fun markAsRead(notificationId: Long, userId: Long) {
         val notification = notificationRepository.findById(notificationId)
             .orElseThrow { NotificationNotFoundException() }
@@ -23,6 +25,7 @@ class NotificationCommandServiceImpl(
         notification.markAsRead()
     }
 
+    @CacheEvict(cacheNames = ["unread-count"], key = "#userId")
     override fun markAllAsRead(userId: Long) {
         notificationRepository.markAllAsRead(userId)
     }

--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/service/NotificationQueryServiceImpl.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/service/NotificationQueryServiceImpl.kt
@@ -4,6 +4,7 @@ import com.hoppingmall.notification.domain.NotificationRepository
 import com.hoppingmall.notification.dto.response.NotificationResponse
 import com.hoppingmall.notification.dto.response.UnreadCountResponse
 import com.hoppingmall.notification.enums.NotificationType
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
@@ -28,6 +29,7 @@ class NotificationQueryServiceImpl(
         return notifications.map { NotificationResponse.from(it) }
     }
 
+    @Cacheable(cacheNames = ["unread-count"], key = "#userId")
     override fun getUnreadCount(userId: Long): UnreadCountResponse {
         val count = notificationRepository.countByUserIdAndIsRead(userId, false)
         return UnreadCountResponse(count)

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/CacheConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/CacheConfig.kt
@@ -3,7 +3,8 @@ package com.hoppingmall.payment.config
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
-import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.cache.caffeine.CaffeineCache
+import org.springframework.cache.support.SimpleCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.util.concurrent.TimeUnit
@@ -14,12 +15,15 @@ class CacheConfig {
 
     @Bean
     fun cacheManager(): CacheManager {
-        val cacheManager = CaffeineCacheManager()
-        cacheManager.setCaffeine(
+        val pointBalanceCache = CaffeineCache(
+            "point-balance",
             Caffeine.newBuilder()
                 .maximumSize(1000)
-                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .expireAfterWrite(30, TimeUnit.SECONDS)
+                .build()
         )
-        return cacheManager
+        return SimpleCacheManager().apply {
+            setCaches(listOf(pointBalanceCache))
+        }
     }
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointCommandServiceImpl.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointCommandServiceImpl.kt
@@ -8,6 +8,7 @@ import com.hoppingmall.payment.point.dto.request.PointUseRequest
 import com.hoppingmall.payment.point.dto.response.PointUseResponse
 import com.hoppingmall.payment.point.enum.PointType
 import com.hoppingmall.payment.point.exception.PointInsufficientBalanceException
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -19,6 +20,7 @@ class PointCommandServiceImpl(
     private val pointHistoryRepository: PointHistoryRepository
 ) : PointCommandService {
 
+    @CacheEvict(cacheNames = ["point-balance"], key = "#userId")
     override fun usePoint(userId: Long, request: PointUseRequest): PointUseResponse {
         val point = findOrCreatePoint(userId)
         validateSufficientBalance(point, request.amount)
@@ -43,6 +45,7 @@ class PointCommandServiceImpl(
         )
     }
 
+    @CacheEvict(cacheNames = ["point-balance"], key = "#userId")
     override fun refundPoints(userId: Long, amount: BigDecimal, paymentId: Long, orderId: Long) {
         if (amount <= BigDecimal.ZERO) return
 

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointEventConsumer.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointEventConsumer.kt
@@ -10,6 +10,7 @@ import com.hoppingmall.payment.point.domain.PointHistoryRepository
 import com.hoppingmall.payment.point.domain.PointRepository
 import com.hoppingmall.payment.point.enum.PointType
 import org.slf4j.LoggerFactory
+import org.springframework.cache.CacheManager
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Service
@@ -21,7 +22,8 @@ class PointEventConsumer(
     private val pointRepository: PointRepository,
     private val pointHistoryRepository: PointHistoryRepository,
     private val transactionalEventPublisher: TransactionalEventPublisher,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val cacheManager: CacheManager
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -38,6 +40,7 @@ class PointEventConsumer(
             val point = findOrCreatePoint(event.userId)
             point.balance += event.earnAmount
             val savedPoint = pointRepository.save(point)
+            cacheManager.getCache("point-balance")?.evict(event.userId)
 
             pointHistoryRepository.save(
                 PointHistory(


### PR DESCRIPTION
Closes #215

### 📌 작업 개요
Notification unread count에 Redis 캐시, Point 잔액에 Caffeine 캐시(30s TTL)를 추가하여 DB 조회 빈도를 줄였습니다.

---

### ✅ 주요 변경 사항
- notification-service: CacheConfig(Redis), @Cacheable/@CacheEvict, 프로그래밍 방식 eviction
- payment-service: CacheConfig 업데이트(30s TTL), @Cacheable/@CacheEvict, 프로그래밍 방식 eviction

---

### 📎 관련 이슈
- #215