### PR TITLE
perf: 배치 재고 예약 엔드포인트 추가

### DIFF
--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImpl.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImpl.kt
@@ -50,18 +50,8 @@ class OrderCommandServiceImpl(
             if (!productMap.containsKey(productId)) throw OrderProductNotFoundException()
         }
 
-        val reservationMap = mutableMapOf<Long, String>()
-        try {
-            cartItems.sortedBy { it.productId }.forEach { cartItem ->
-                val reservationId = inventoryCommandPort.reserveStock(cartItem.productId, cartItem.quantity)
-                reservationMap[cartItem.productId] = reservationId
-            }
-        } catch (e: Exception) {
-            if (reservationMap.isNotEmpty()) {
-                inventoryCommandPort.cancelReservations(reservationMap.values.toList())
-            }
-            throw e
-        }
+        val items = cartItems.map { it.productId to it.quantity }
+        val reservationMap = inventoryCommandPort.batchReserveStock(items)
 
         val totalAmount = cartItems.fold(BigDecimal.ZERO) { acc, it -> acc.add(it.productPrice.multiply(BigDecimal(it.quantity))) }
 

--- a/order-service/src/main/kotlin/com/hoppingmall/order/port/HttpInventoryCommandAdapter.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/port/HttpInventoryCommandAdapter.kt
@@ -51,7 +51,7 @@ class HttpInventoryCommandAdapter(
             ?: throw RuntimeException("재고 예약 응답 없음: productId=$productId")
     }
 
-    @CircuitBreaker(name = "inventory-command", fallbackMethod = "confirmReservationsFallback")
+    @CircuitBreaker(name = "inventory-command")
     @Retry(name = "product-query")
     override fun confirmReservations(reservationIds: List<String>): Boolean {
         val response = restTemplate.postForEntity(
@@ -80,11 +80,20 @@ class HttpInventoryCommandAdapter(
         )
     }
 
-    private fun confirmReservationsFallback(reservationIds: List<String>, e: Exception): Boolean {
-        logger.warn("CB fallback: 예약 확정 실패 reservationIds=$reservationIds", e)
-        return false
+    @CircuitBreaker(name = "inventory-command")
+    override fun batchReserveStock(items: List<Pair<Long, Int>>): Map<Long, String> {
+        val requestBody = items.map { BatchReserveRequest(it.first, it.second) }
+        val responseType = object : org.springframework.core.ParameterizedTypeReference<Map<Long, String>>() {}
+        val response = restTemplate.exchange(
+            "$productServiceUrl/internal/api/v1/inventory/batch-reserve",
+            org.springframework.http.HttpMethod.POST,
+            org.springframework.http.HttpEntity(requestBody),
+            responseType
+        )
+        return response.body ?: throw RuntimeException("배치 재고 예약 응답 없음")
     }
 
     data class ReservationResponse(val reservationId: String = "")
     data class ConfirmationResponse(val confirmed: Boolean = false)
+    data class BatchReserveRequest(val productId: Long, val quantity: Int)
 }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/port/InventoryCommandPort.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/port/InventoryCommandPort.kt
@@ -7,4 +7,5 @@ interface InventoryCommandPort {
     fun confirmReservations(reservationIds: List<String>): Boolean
     fun cancelReservation(reservationId: String)
     fun cancelReservations(reservationIds: List<String>)
+    fun batchReserveStock(items: List<Pair<Long, Int>>): Map<Long, String>
 }

--- a/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImplTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImplTest.kt
@@ -63,7 +63,7 @@ class OrderCommandServiceImplTest {
 
         whenever(cartItemRepository.findAllById(listOf(1L))).thenReturn(listOf(cartItem))
         whenever(productQueryPort.findProductsByIds(listOf(100L))).thenReturn(listOf(productInfo))
-        whenever(inventoryCommandPort.reserveStock(100L, 2)).thenReturn("rsv-1")
+        whenever(inventoryCommandPort.batchReserveStock(listOf(100L to 2))).thenReturn(mapOf(100L to "rsv-1"))
         whenever(orderRepository.save(any<Order>())).thenAnswer {
             val order = it.arguments[0] as Order
             setEntityId(order, 1L)
@@ -78,7 +78,7 @@ class OrderCommandServiceImplTest {
 
         val result = service.createOrder(10L, OrderCreateRequest(cartItemIds = listOf(1L)))
 
-        verify(inventoryCommandPort).reserveStock(100L, 2)
+        verify(inventoryCommandPort).batchReserveStock(listOf(100L to 2))
         assertThat(result).isNotNull
     }
 
@@ -91,13 +91,10 @@ class OrderCommandServiceImplTest {
 
         whenever(cartItemRepository.findAllById(listOf(1L, 2L))).thenReturn(listOf(cartItem1, cartItem2))
         whenever(productQueryPort.findProductsByIds(any())).thenReturn(listOf(productInfo1, productInfo2))
-        whenever(inventoryCommandPort.reserveStock(100L, 1)).thenReturn("rsv-1")
-        whenever(inventoryCommandPort.reserveStock(200L, 1)).thenThrow(RuntimeException("재고 부족"))
+        whenever(inventoryCommandPort.batchReserveStock(any())).thenThrow(RuntimeException("재고 부족"))
 
         assertThatThrownBy { service.createOrder(10L, OrderCreateRequest(cartItemIds = listOf(1L, 2L))) }
             .isInstanceOf(RuntimeException::class.java)
-
-        verify(inventoryCommandPort).cancelReservations(listOf("rsv-1"))
     }
 
     @Test

--- a/product-service/src/main/kotlin/com/hoppingmall/product/internal/InternalInventoryController.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/internal/InternalInventoryController.kt
@@ -56,6 +56,14 @@ class InternalInventoryController(
         return ResponseEntity.ok().build()
     }
 
+    @PostMapping("/batch-reserve")
+    fun batchReserveStock(@RequestBody items: List<ReserveRequest>): ResponseEntity<Map<Long, String>> {
+        val pairs = items.map { it.productId to it.quantity }
+        val result = inventoryCommandService.batchReserveStock(pairs)
+        return ResponseEntity.ok(result)
+    }
+
+    data class ReserveRequest(val productId: Long, val quantity: Int)
     data class ReservationResponse(val reservationId: String)
     data class ConfirmationResponse(val confirmed: Boolean)
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandService.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandService.kt
@@ -13,4 +13,5 @@ interface InventoryCommandService {
     fun confirmReservations(reservationIds: List<String>): Boolean
     fun cancelReservation(reservationId: String)
     fun cancelReservations(reservationIds: List<String>)
+    fun batchReserveStock(items: List<Pair<Long, Int>>): Map<Long, String>
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImpl.kt
@@ -140,4 +140,19 @@ class InventoryCommandServiceImpl(
     override fun cancelReservations(reservationIds: List<String>) {
         reservationIds.forEach { cancelReservation(it) }
     }
+
+    override fun batchReserveStock(items: List<Pair<Long, Int>>): Map<Long, String> {
+        val sorted = items.sortedBy { it.first }
+        val reservationMap = mutableMapOf<Long, String>()
+        try {
+            sorted.forEach { (productId, quantity) ->
+                val reservationId = reserveStock(productId, quantity)
+                reservationMap[productId] = reservationId
+            }
+        } catch (e: Exception) {
+            reservationMap.values.forEach { cancelReservation(it) }
+            throw e
+        }
+        return reservationMap
+    }
 }


### PR DESCRIPTION
Closes #217

### 📌 작업 개요
주문 생성 시 N번 순차 HTTP 호출을 1번 배치 호출로 변경하고, confirmReservationsFallback(silent false 반환)을 제거했습니다.

---

### ✅ 주요 변경 사항
- product-service: InventoryCommandService.batchReserveStock + InternalInventoryController POST /batch-reserve
- order-service: InventoryCommandPort.batchReserveStock + HttpInventoryCommandAdapter 배치 호출
- order-service: OrderCommandServiceImpl 순차 루프 → 단일 batchReserveStock
- order-service: confirmReservationsFallback 삭제 (CB open 시 예외 전파)

---

### 📎 관련 이슈
- #217