### PR TITLE
fix: 데드락 방지를 위한 락 순서 정렬 + Lost Update 수정

### DIFF
--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/RefundPointsService.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/RefundPointsService.kt
@@ -18,7 +18,7 @@ class RefundPointsService(
         val earnHistory = pointHistoryRepository.findByPaymentIdAndType(paymentId, PointType.EARN)
             ?: return
 
-        val point = pointRepository.findByUserId(userId) ?: return
+        val point = pointRepository.findByUserIdForUpdate(userId) ?: return
 
         point.usePoints(earnHistory.amount)
         pointRepository.save(point)

--- a/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImpl.kt
@@ -102,13 +102,13 @@ class InventoryCommandServiceImpl(
                     targetStatus = ReservationStatus.CANCELLED,
                     updatedAt = LocalDateTime.now()
                 )
-                reservationIds.forEach { rsvId ->
-                    val reservation = inventoryReservationRepository.findByReservationId(rsvId) ?: return@forEach
-                    if (reservation.status == ReservationStatus.CANCELLED) {
+                reservationIds.mapNotNull { rsvId -> inventoryReservationRepository.findByReservationId(rsvId) }
+                    .filter { it.status == ReservationStatus.CANCELLED }
+                    .sortedBy { it.productId }
+                    .forEach { reservation ->
                         val inventory = inventoryRepository.findByProductIdForUpdate(reservation.productId) ?: return@forEach
                         inventory.increaseStock(reservation.quantity)
                     }
-                }
             }
             throw ReservationConfirmFailedException()
         }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/ReservationExpiryScheduler.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/ReservationExpiryScheduler.kt
@@ -32,7 +32,7 @@ class ReservationExpiryScheduler(
 
         logger.info("만료 예약 처리 시작: ${expiredReservations.size}건")
 
-        expiredReservations.forEach { reservation ->
+        expiredReservations.sortedBy { it.productId }.forEach { reservation ->
             val updated = inventoryReservationRepository.updateStatusByCas(
                 reservationId = reservation.reservationId,
                 expectedStatus = ReservationStatus.RESERVED,


### PR DESCRIPTION
Closes #219

### 📌 작업 개요
inventory 락 획득 순서를 productId 기준으로 정렬하여 데드락 가능성을 제거하고, RefundPointsService의 Lost Update 버그를 수정했습니다.

---

### ✅ 주요 변경 사항

- `product-service`
  - `InventoryCommandServiceImpl`: confirmReservations 롤백 시 productId 정렬 후 락 획득
  - `ReservationExpiryScheduler`: 만료 예약 처리 시 productId 정렬 후 락 획득

- `payment-service`
  - `RefundPointsService`: findByUserId → findByUserIdForUpdate (비관적 락으로 동시 잔액 수정 방지)

---

### 📎 관련 이슈
- #219