### PR TITLE
fix: OrderSagaConsumer 분산 데드락 제거 + Saga 재설계

### DIFF
--- a/order-service/src/main/kotlin/com/hoppingmall/order/internal/InternalOrderController.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/internal/InternalOrderController.kt
@@ -8,6 +8,7 @@ import com.hoppingmall.order.shipping.domain.repository.ShippingRepository
 import com.hoppingmall.order.shipping.enum.ShippingStatus
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.*
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -55,6 +56,7 @@ class InternalOrderController(
     }
 
     @PostMapping("/orders/{orderId}/cancel")
+    @Transactional
     fun cancelOrder(@PathVariable orderId: Long): ResponseEntity<Void> {
         val order = orderRepository.findById(orderId).orElse(null)
             ?: return ResponseEntity.notFound().build()

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/SagaEventLog.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/SagaEventLog.kt
@@ -21,9 +21,27 @@ class SagaEventLog(
     val orderId: Long,
 
     @Column(nullable = false)
-    val createdAt: LocalDateTime = LocalDateTime.now()
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "saga_event_log_steps", joinColumns = [JoinColumn(name = "saga_event_log_id")])
+    @Column(name = "step")
+    val completedSteps: MutableSet<String> = mutableSetOf()
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
+
+    fun markStepCompleted(step: String) {
+        completedSteps.add(step)
+    }
+
+    fun isStepCompleted(step: String): Boolean = step in completedSteps
+
+    fun isFullyCompleted(): Boolean = completedSteps.containsAll(setOf(LOCAL_COMPLETED, REMOTE_COMPLETED))
+
+    companion object {
+        const val LOCAL_COMPLETED = "LOCAL_COMPLETED"
+        const val REMOTE_COMPLETED = "REMOTE_COMPLETED"
+    }
 }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/repository/SagaEventLogRepository.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/repository/SagaEventLogRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface SagaEventLogRepository : JpaRepository<SagaEventLog, Long> {
     fun existsByEventId(eventId: String): Boolean
+    fun findByEventId(eventId: String): SagaEventLog?
 }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderSagaConsumer.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderSagaConsumer.kt
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 
 @Service
 class OrderSagaConsumer(
@@ -21,102 +22,181 @@ class OrderSagaConsumer(
     private val orderItemRepository: OrderItemRepository,
     private val inventoryCommandPort: InventoryCommandPort,
     private val transactionalEventPublisherPort: TransactionalEventPublisherPort,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val transactionTemplate: TransactionTemplate
 ) {
     private val logger = LoggerFactory.getLogger(OrderSagaConsumer::class.java)
 
     @KafkaListener(topics = ["payment"], groupId = "order-saga-service")
-    @Transactional
     fun handlePaymentCompleted(message: String) {
         val event = objectMapper.readValue(message, PaymentCompletedEvent::class.java)
         val eventId = "payment-completed-${event.transactionId}"
 
-        if (sagaEventLogRepository.existsByEventId(eventId)) {
+        val existingLog = sagaEventLogRepository.findByEventId(eventId)
+        if (existingLog != null && existingLog.isFullyCompleted()) {
             logger.info("이미 처리된 결제 완료 이벤트: $eventId")
             return
         }
 
-        val order = orderRepository.findById(event.orderId).orElse(null)
-        if (order == null) {
-            logger.error("주문을 찾을 수 없음: orderId=${event.orderId}")
-            return
-        }
-
-        if (order.status != OrderStatus.CREATED) {
-            logger.warn("주문 상태가 CREATED가 아님: orderId=${event.orderId}, status=${order.status}")
-            sagaEventLogRepository.save(SagaEventLog(eventId = eventId, eventType = "PAYMENT_COMPLETED", orderId = event.orderId))
-            return
-        }
-
-        val orderItems = orderItemRepository.findByOrderId(event.orderId)
-        val reservationIds = orderItems.mapNotNull { it.reservationId }
-
-        val allConfirmed = if (reservationIds.isNotEmpty()) {
-            inventoryCommandPort.confirmReservations(reservationIds)
+        val reservationIds = if (existingLog == null || !existingLog.isStepCompleted(SagaEventLog.LOCAL_COMPLETED)) {
+            executeLocalPhase(event, eventId)
         } else {
-            true
+            reconstructReservationIds(event.orderId)
         }
 
-        if (allConfirmed) {
+        if (reservationIds == null) return
+
+        executeRemotePhase(eventId, event, reservationIds)
+    }
+
+    private fun executeLocalPhase(event: PaymentCompletedEvent, eventId: String): List<String>? {
+        return transactionTemplate.execute {
+            val order = orderRepository.findById(event.orderId).orElse(null)
+            if (order == null) {
+                logger.error("주문을 찾을 수 없음: orderId=${event.orderId}")
+                return@execute null
+            }
+
+            if (order.status != OrderStatus.CREATED) {
+                logger.warn("주문 상태가 CREATED가 아님: orderId=${event.orderId}, status=${order.status}")
+                val log = sagaEventLogRepository.findByEventId(eventId)
+                    ?: SagaEventLog(eventId = eventId, eventType = "PAYMENT_COMPLETED", orderId = event.orderId)
+                log.markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
+                log.markStepCompleted(SagaEventLog.REMOTE_COMPLETED)
+                sagaEventLogRepository.save(log)
+                return@execute null
+            }
+
             order.updateStatus(OrderStatus.PAID)
             orderRepository.save(order)
-            logger.info("주문 결제 확정: orderId=${event.orderId}")
-        } else {
+
+            val log = SagaEventLog(eventId = eventId, eventType = "PAYMENT_COMPLETED", orderId = event.orderId)
+            log.markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
+            sagaEventLogRepository.save(log)
+
+            orderItemRepository.findByOrderId(event.orderId).mapNotNull { it.reservationId }
+        }
+    }
+
+    private fun executeRemotePhase(eventId: String, event: PaymentCompletedEvent, reservationIds: List<String>) {
+        try {
+            val confirmed = if (reservationIds.isNotEmpty()) {
+                inventoryCommandPort.confirmReservations(reservationIds)
+            } else {
+                true
+            }
+
+            if (confirmed) {
+                transactionTemplate.execute {
+                    val log = sagaEventLogRepository.findByEventId(eventId)!!
+                    log.markStepCompleted(SagaEventLog.REMOTE_COMPLETED)
+                    sagaEventLogRepository.save(log)
+                }
+                logger.info("주문 결제 확정: orderId=${event.orderId}")
+            } else {
+                compensateFailedConfirmation(eventId, event)
+            }
+        } catch (e: Exception) {
+            logger.error("재고 확정 실패, 보상 처리: orderId=${event.orderId}", e)
+            compensateFailedConfirmation(eventId, event)
+        }
+    }
+
+    @Transactional
+    fun compensateFailedConfirmation(eventId: String, event: PaymentCompletedEvent) {
+        val order = orderRepository.findById(event.orderId).orElse(null) ?: return
+        if (order.status == OrderStatus.PAID && order.isCancellable()) {
             order.updateStatus(OrderStatus.CANCELLED)
             orderRepository.save(order)
-
-            reservationIds.forEach { inventoryCommandPort.cancelReservation(it) }
-
-            transactionalEventPublisherPort.publishEvent(
-                aggregateType = "Order",
-                aggregateId = event.orderId.toString(),
-                eventType = "PaymentReversalRequested",
-                eventData = mapOf(
-                    "eventType" to "PaymentReversalRequested",
-                    "eventId" to "reversal-${event.transactionId}",
-                    "orderId" to event.orderId,
-                    "paymentId" to event.paymentId,
-                    "userId" to event.userId,
-                    "reason" to "RESERVATION_EXPIRED"
-                ),
-                topic = "payment-reversal",
-                partitionKey = event.orderId.toString()
-            )
-            logger.warn("예약 만료로 주문 취소 + 결제 역보상 요청: orderId=${event.orderId}")
         }
 
-        sagaEventLogRepository.save(SagaEventLog(eventId = eventId, eventType = "PAYMENT_COMPLETED", orderId = event.orderId))
+        transactionalEventPublisherPort.publishEvent(
+            aggregateType = "Order",
+            aggregateId = event.orderId.toString(),
+            eventType = "PaymentReversalRequested",
+            eventData = mapOf(
+                "eventType" to "PaymentReversalRequested",
+                "eventId" to "reversal-${event.transactionId}",
+                "orderId" to event.orderId,
+                "paymentId" to event.paymentId,
+                "userId" to event.userId,
+                "reason" to "RESERVATION_EXPIRED"
+            ),
+            topic = "payment-reversal",
+            partitionKey = event.orderId.toString()
+        )
+
+        val log = sagaEventLogRepository.findByEventId(eventId)
+        log?.markStepCompleted(SagaEventLog.REMOTE_COMPLETED)
+        log?.let { sagaEventLogRepository.save(it) }
+
+        logger.warn("예약 만료로 주문 취소 + 결제 역보상 요청: orderId=${event.orderId}")
+    }
+
+    private fun reconstructReservationIds(orderId: Long): List<String>? {
+        val orderItems = orderItemRepository.findByOrderId(orderId)
+        if (orderItems.isEmpty()) return null
+        return orderItems.mapNotNull { it.reservationId }
     }
 
     @KafkaListener(topics = ["payment-compensation"], groupId = "order-saga-service")
-    @Transactional
     fun handlePaymentCompensation(message: String) {
         val node = objectMapper.readTree(message)
         val eventId = node.get("eventId")?.asText() ?: return
 
-        if (sagaEventLogRepository.existsByEventId(eventId)) {
+        val existingLog = sagaEventLogRepository.findByEventId(eventId)
+        if (existingLog != null && existingLog.isFullyCompleted()) {
             logger.info("이미 처리된 보상 이벤트: $eventId")
             return
         }
 
         val orderId = node.get("orderId")?.asLong() ?: return
 
-        val order = orderRepository.findById(orderId).orElse(null)
-        if (order == null) {
-            logger.error("주문을 찾을 수 없음: orderId=$orderId")
-            return
+        val reservationIds = if (existingLog == null || !existingLog.isStepCompleted(SagaEventLog.LOCAL_COMPLETED)) {
+            executeCompensationLocalPhase(eventId, orderId)
+        } else {
+            reconstructReservationIds(orderId)
         }
 
-        if (order.isCancellable()) {
-            order.updateStatus(OrderStatus.CANCELLED)
-            orderRepository.save(order)
+        if (reservationIds == null) return
+
+        executeCompensationRemotePhase(eventId, orderId, reservationIds)
+    }
+
+    private fun executeCompensationLocalPhase(eventId: String, orderId: Long): List<String>? {
+        return transactionTemplate.execute {
+            val order = orderRepository.findById(orderId).orElse(null)
+            if (order == null) {
+                logger.error("주문을 찾을 수 없음: orderId=$orderId")
+                return@execute null
+            }
+
+            if (order.isCancellable()) {
+                order.updateStatus(OrderStatus.CANCELLED)
+                orderRepository.save(order)
+            }
+
+            val log = SagaEventLog(eventId = eventId, eventType = "PAYMENT_COMPENSATION", orderId = orderId)
+            log.markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
+            sagaEventLogRepository.save(log)
+
+            orderItemRepository.findByOrderId(orderId).mapNotNull { it.reservationId }
+        }
+    }
+
+    private fun executeCompensationRemotePhase(eventId: String, orderId: Long, reservationIds: List<String>) {
+        try {
+            reservationIds.forEach { inventoryCommandPort.cancelReservation(it) }
+        } catch (e: Exception) {
+            logger.error("보상 예약 취소 실패: orderId=$orderId", e)
         }
 
-        val orderItems = orderItemRepository.findByOrderId(orderId)
-        val reservationIds = orderItems.mapNotNull { it.reservationId }
-        reservationIds.forEach { inventoryCommandPort.cancelReservation(it) }
+        transactionTemplate.execute {
+            val log = sagaEventLogRepository.findByEventId(eventId)!!
+            log.markStepCompleted(SagaEventLog.REMOTE_COMPLETED)
+            sagaEventLogRepository.save(log)
+        }
 
-        sagaEventLogRepository.save(SagaEventLog(eventId = eventId, eventType = "PAYMENT_COMPENSATION", orderId = orderId))
         logger.info("결제 보상 처리 완료 (예약 취소 + 주문 CANCELLED): orderId=$orderId")
     }
 }

--- a/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderSagaConsumerTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderSagaConsumerTest.kt
@@ -14,20 +14,23 @@ import com.hoppingmall.order.order.enum.OrderStatus
 import com.hoppingmall.order.port.InventoryCommandPort
 import com.hoppingmall.order.port.TransactionalEventPublisherPort
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
 import java.math.BigDecimal
 import java.util.Optional
 
@@ -54,8 +57,28 @@ class OrderSagaConsumerTest {
     @Mock
     private lateinit var objectMapper: ObjectMapper
 
-    @InjectMocks
+    @Mock
+    private lateinit var transactionTemplate: TransactionTemplate
+
     private lateinit var consumer: OrderSagaConsumer
+
+    @BeforeEach
+    fun setUp() {
+        Mockito.lenient().`when`(transactionTemplate.execute(any<TransactionCallback<Any>>())).thenAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            val callback = invocation.arguments[0] as TransactionCallback<Any?>
+            callback.doInTransaction(mock())
+        }
+        consumer = OrderSagaConsumer(
+            sagaEventLogRepository,
+            orderRepository,
+            orderItemRepository,
+            inventoryCommandPort,
+            transactionalEventPublisherPort,
+            objectMapper,
+            transactionTemplate
+        )
+    }
 
     private val paymentCompletedEvent = PaymentCompletedEvent(
         paymentId = 100L,
@@ -74,30 +97,48 @@ class OrderSagaConsumerTest {
             productName = "상품A", productPrice = BigDecimal("50000"),
             quantity = 1, reservationId = "rsv-1"
         )
+        val sagaLog = SagaEventLog(
+            eventId = "payment-completed-txn-123",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 1L
+        ).apply { markStepCompleted(SagaEventLog.LOCAL_COMPLETED) }
 
         whenever(objectMapper.readValue(any<String>(), eq(PaymentCompletedEvent::class.java)))
             .thenReturn(paymentCompletedEvent)
-        whenever(sagaEventLogRepository.existsByEventId("payment-completed-txn-123")).thenReturn(false)
+        whenever(sagaEventLogRepository.findByEventId("payment-completed-txn-123"))
+            .thenReturn(null)
+            .thenReturn(sagaLog)
         whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
         whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(orderItem))
         whenever(inventoryCommandPort.confirmReservations(listOf("rsv-1"))).thenReturn(true)
+        whenever(sagaEventLogRepository.save(any<SagaEventLog>())).thenAnswer { it.arguments[0] }
 
         consumer.handlePaymentCompleted("{}")
 
         assertThat(order.status).isEqualTo(OrderStatus.PAID)
         verify(orderRepository).save(order)
-        verify(sagaEventLogRepository).save(any<SagaEventLog>())
     }
 
     @Test
     fun 이미_처리된_결제_완료_이벤트는_무시한다() {
+        val fullyCompleted = SagaEventLog(
+            eventId = "payment-completed-txn-123",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 1L
+        ).apply {
+            markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
+            markStepCompleted(SagaEventLog.REMOTE_COMPLETED)
+        }
+
         whenever(objectMapper.readValue(any<String>(), eq(PaymentCompletedEvent::class.java)))
             .thenReturn(paymentCompletedEvent)
-        whenever(sagaEventLogRepository.existsByEventId("payment-completed-txn-123")).thenReturn(true)
+        whenever(sagaEventLogRepository.findByEventId("payment-completed-txn-123"))
+            .thenReturn(fullyCompleted)
 
         consumer.handlePaymentCompleted("{}")
 
         verify(orderRepository, never()).findById(any())
+        verify(inventoryCommandPort, never()).confirmReservations(any())
     }
 
     @Test
@@ -108,18 +149,25 @@ class OrderSagaConsumerTest {
             productName = "상품A", productPrice = BigDecimal("50000"),
             quantity = 1, reservationId = "rsv-1"
         )
+        val sagaLog = SagaEventLog(
+            eventId = "payment-completed-txn-123",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 1L
+        ).apply { markStepCompleted(SagaEventLog.LOCAL_COMPLETED) }
 
         whenever(objectMapper.readValue(any<String>(), eq(PaymentCompletedEvent::class.java)))
             .thenReturn(paymentCompletedEvent)
-        whenever(sagaEventLogRepository.existsByEventId("payment-completed-txn-123")).thenReturn(false)
+        whenever(sagaEventLogRepository.findByEventId("payment-completed-txn-123"))
+            .thenReturn(null)
+            .thenReturn(sagaLog)
         whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
         whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(orderItem))
         whenever(inventoryCommandPort.confirmReservations(listOf("rsv-1"))).thenReturn(false)
+        whenever(sagaEventLogRepository.save(any<SagaEventLog>())).thenAnswer { it.arguments[0] }
 
         consumer.handlePaymentCompleted("{}")
 
         assertThat(order.status).isEqualTo(OrderStatus.CANCELLED)
-        verify(inventoryCommandPort).cancelReservation("rsv-1")
         verify(transactionalEventPublisherPort).publishEvent(
             aggregateType = eq("Order"),
             aggregateId = eq("1"),
@@ -138,12 +186,20 @@ class OrderSagaConsumerTest {
             productName = "상품A", productPrice = BigDecimal("50000"),
             quantity = 1
         )
+        val sagaLog = SagaEventLog(
+            eventId = "payment-completed-txn-123",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 1L
+        ).apply { markStepCompleted(SagaEventLog.LOCAL_COMPLETED) }
 
         whenever(objectMapper.readValue(any<String>(), eq(PaymentCompletedEvent::class.java)))
             .thenReturn(paymentCompletedEvent)
-        whenever(sagaEventLogRepository.existsByEventId("payment-completed-txn-123")).thenReturn(false)
+        whenever(sagaEventLogRepository.findByEventId("payment-completed-txn-123"))
+            .thenReturn(null)
+            .thenReturn(sagaLog)
         whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
         whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(orderItem))
+        whenever(sagaEventLogRepository.save(any<SagaEventLog>())).thenAnswer { it.arguments[0] }
 
         consumer.handlePaymentCompleted("{}")
 
@@ -158,8 +214,9 @@ class OrderSagaConsumerTest {
 
         whenever(objectMapper.readValue(any<String>(), eq(PaymentCompletedEvent::class.java)))
             .thenReturn(paymentCompletedEvent)
-        whenever(sagaEventLogRepository.existsByEventId("payment-completed-txn-123")).thenReturn(false)
+        whenever(sagaEventLogRepository.findByEventId("payment-completed-txn-123")).thenReturn(null)
         whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+        whenever(sagaEventLogRepository.save(any<SagaEventLog>())).thenAnswer { it.arguments[0] }
 
         consumer.handlePaymentCompleted("{}")
 
@@ -176,28 +233,44 @@ class OrderSagaConsumerTest {
             productName = "상품A", productPrice = BigDecimal("50000"),
             quantity = 1, reservationId = "rsv-1"
         )
+        val sagaLog = SagaEventLog(
+            eventId = "evt-comp-1",
+            eventType = "PAYMENT_COMPENSATION",
+            orderId = 1L
+        ).apply { markStepCompleted(SagaEventLog.LOCAL_COMPLETED) }
 
         val node = mock<com.fasterxml.jackson.databind.JsonNode>()
         whenever(objectMapper.readTree(any<String>())).thenReturn(node)
         whenever(node.get("eventId")).thenReturn(TextNode("evt-comp-1"))
         whenever(node.get("orderId")).thenReturn(LongNode(1L))
-        whenever(sagaEventLogRepository.existsByEventId("evt-comp-1")).thenReturn(false)
+        whenever(sagaEventLogRepository.findByEventId("evt-comp-1"))
+            .thenReturn(null)
+            .thenReturn(sagaLog)
         whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
         whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(orderItem))
+        whenever(sagaEventLogRepository.save(any<SagaEventLog>())).thenAnswer { it.arguments[0] }
 
         consumer.handlePaymentCompensation("{}")
 
         assertThat(order.status).isEqualTo(OrderStatus.CANCELLED)
         verify(inventoryCommandPort).cancelReservation("rsv-1")
-        verify(sagaEventLogRepository).save(any<SagaEventLog>())
     }
 
     @Test
     fun 이미_처리된_보상_이벤트는_무시한다() {
+        val fullyCompleted = SagaEventLog(
+            eventId = "evt-comp-1",
+            eventType = "PAYMENT_COMPENSATION",
+            orderId = 1L
+        ).apply {
+            markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
+            markStepCompleted(SagaEventLog.REMOTE_COMPLETED)
+        }
+
         val node = mock<com.fasterxml.jackson.databind.JsonNode>()
         whenever(objectMapper.readTree(any<String>())).thenReturn(node)
         whenever(node.get("eventId")).thenReturn(TextNode("evt-comp-1"))
-        whenever(sagaEventLogRepository.existsByEventId("evt-comp-1")).thenReturn(true)
+        whenever(sagaEventLogRepository.findByEventId("evt-comp-1")).thenReturn(fullyCompleted)
 
         consumer.handlePaymentCompensation("{}")
 

--- a/product-service/src/main/kotlin/com/hoppingmall/product/inventory/domain/repository/InventoryReservationRepository.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/inventory/domain/repository/InventoryReservationRepository.kt
@@ -13,6 +13,8 @@ interface InventoryReservationRepository : JpaRepository<InventoryReservation, L
 
     fun findByReservationId(reservationId: String): InventoryReservation?
 
+    fun findByReservationIdIn(reservationIds: List<String>): List<InventoryReservation>
+
     @Modifying(clearAutomatically = true)
     @Query("""
         UPDATE InventoryReservation r

--- a/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImpl.kt
@@ -95,6 +95,13 @@ class InventoryCommandServiceImpl(
         )
 
         if (updatedCount != reservationIds.size) {
+            val reservations = inventoryReservationRepository.findByReservationIdIn(reservationIds)
+            val allConfirmed = reservations.size == reservationIds.size &&
+                reservations.all { it.status == ReservationStatus.CONFIRMED }
+            if (allConfirmed) {
+                return true
+            }
+
             if (updatedCount > 0) {
                 inventoryReservationRepository.batchUpdateStatusByCas(
                     reservationIds = reservationIds,


### PR DESCRIPTION
Closes #221

### 📌 작업 개요
OrderSagaConsumer의 @Transactional 내 HTTP 호출로 인한 분산 데드락을 제거하고, 2-phase saga 패턴으로 재설계했습니다.

---

### ✅ 주요 변경 사항

- `order-service`
  - `SagaEventLog`: completedSteps(@ElementCollection) 추가, LOCAL/REMOTE_COMPLETED 단계 추적
  - `SagaEventLogRepository`: findByEventId 추가
  - `OrderSagaConsumer`: Phase 1(local TX via TransactionTemplate) + Phase 2(no TX, HTTP) 분리
  - `InternalOrderController`: cancelOrder에 @Transactional 추가

- `product-service`
  - `InventoryCommandServiceImpl`: confirmReservations 멱등성 수정 (CONFIRMED = 성공)
  - `InventoryReservationRepository`: findByReservationIdIn 추가

---

### 🧪 테스트

- order-service `./gradlew build` 성공 (40 tests passed)
- product-service `./gradlew build` 성공

---

### 📎 관련 이슈
- #221