### PR TITLE
perf: Cache per-cache 튜닝 + raw 커넥션 제거

### DIFF
--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/CacheConfig.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/CacheConfig.kt
@@ -3,7 +3,8 @@ package com.hoppingmall.product.config
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
-import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.cache.caffeine.CaffeineCache
+import org.springframework.cache.support.SimpleCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.util.concurrent.TimeUnit
@@ -14,12 +15,29 @@ class CacheConfig {
 
     @Bean
     fun cacheManager(): CacheManager {
-        val cacheManager = CaffeineCacheManager()
-        cacheManager.setCaffeine(
+        val productCache = CaffeineCache(
+            "product",
             Caffeine.newBuilder()
-                .maximumSize(1000)
+                .maximumSize(500)
                 .expireAfterWrite(10, TimeUnit.MINUTES)
+                .build()
         )
-        return cacheManager
+        val inventoryCache = CaffeineCache(
+            "inventory",
+            Caffeine.newBuilder()
+                .maximumSize(500)
+                .expireAfterWrite(5, TimeUnit.MINUTES)
+                .build()
+        )
+        val categoryCache = CaffeineCache(
+            "category",
+            Caffeine.newBuilder()
+                .maximumSize(200)
+                .expireAfterWrite(60, TimeUnit.MINUTES)
+                .build()
+        )
+        return SimpleCacheManager().apply {
+            setCaches(listOf(productCache, inventoryCache, categoryCache))
+        }
     }
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductSearchRepositoryImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductSearchRepositoryImpl.kt
@@ -3,21 +3,19 @@ package com.hoppingmall.product.product.domain.repository
 import com.hoppingmall.product.common.enums.ProductStatus
 import com.hoppingmall.product.product.domain.Product
 import jakarta.persistence.EntityManager
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.domain.SliceImpl
-import javax.sql.DataSource
 import java.math.BigDecimal
 
 class ProductSearchRepositoryImpl(
     private val entityManager: EntityManager,
-    private val dataSource: DataSource
+    @Value("\${spring.datasource.url:}")
+    private val datasourceUrl: String
 ) : ProductSearchRepository {
 
-    private val useFullText: Boolean by lazy {
-        val url = dataSource.connection.use { it.metaData.url }
-        url.contains("mysql", ignoreCase = true)
-    }
+    private val useFullText: Boolean = datasourceUrl.contains("mysql", ignoreCase = true)
 
     override fun searchProducts(
         keyword: String?,


### PR DESCRIPTION
Closes #225

### 📌 작업 개요
product-service Cache를 per-cache TTL로 튜닝하고 ProductSearchRepositoryImpl의 raw JDBC 커넥션을 제거했습니다.

### ✅ 주요 변경 사항
- `config.CacheConfig`: SimpleCacheManager (product 10min, inventory 5min, category 60min)
- `ProductSearchRepositoryImpl`: dataSource.connection → @Value 프로퍼티

### 📎 관련 이슈
- #225