### PR TITLE
perf: CartItem HTTP 병합 + Scheduler N+1 제거

### DIFF
--- a/order-service/src/main/kotlin/com/hoppingmall/order/cartItem/service/CartItemCommandServiceImpl.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/cartItem/service/CartItemCommandServiceImpl.kt
@@ -24,13 +24,12 @@ class CartItemCommandServiceImpl(
         val product = productQueryPort.findProductById(request.productId)
             ?: throw CartItemProductNotFoundException()
 
-        val productImageUrl = productQueryPort.findProductImageUrl(request.productId)
         val existingCartItem = cartItemRepository.findByBuyerIdAndProductId(buyerId, request.productId)
 
         val cartItem = if (existingCartItem != null) {
             updateExistingCartItem(existingCartItem, request.quantity)
         } else {
-            createNewCartItem(buyerId, product, productImageUrl, request.quantity)
+            createNewCartItem(buyerId, product, product.imageUrl, request.quantity)
         }
 
         return CartItemResponse.from(cartItem)

--- a/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcProductQueryAdapter.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcProductQueryAdapter.kt
@@ -33,7 +33,8 @@ class GrpcProductQueryAdapter(
             id = response.id,
             name = response.name,
             price = response.price.toBigDecimalOrNull() ?: BigDecimal.ZERO,
-            sellerId = response.sellerId
+            sellerId = response.sellerId,
+            imageUrl = response.imageUrl.takeIf { it.isNotBlank() }
         )
     }
 
@@ -53,15 +54,6 @@ class GrpcProductQueryAdapter(
         }
     }
 
-    @CircuitBreaker(name = "product-query", fallbackMethod = "findProductImageUrlFallback")
-    @Retry(name = "product-query")
-    override fun findProductImageUrl(productId: Long): String? {
-        val response = stub.findProductImageUrl(
-            ProductIdRequest.newBuilder().setProductId(productId).build()
-        )
-        return if (response.found) response.imageUrl else null
-    }
-
     private fun findProductByIdFallback(productId: Long, e: Exception): ProductInfo? {
         if (e is StatusRuntimeException && e.status.code == Status.Code.NOT_FOUND) return null
         log.warn("CB fallback: 상품 조회 실패 productId=$productId", e)
@@ -71,10 +63,5 @@ class GrpcProductQueryAdapter(
     private fun findProductsByIdsFallback(productIds: List<Long>, e: Exception): List<ProductInfo> {
         log.warn("CB fallback: 상품 목록 조회 실패 productIds=$productIds", e)
         return emptyList()
-    }
-
-    private fun findProductImageUrlFallback(productId: Long, e: Exception): String? {
-        log.warn("CB fallback: 상품 이미지 URL 조회 실패 productId=$productId", e)
-        return null
     }
 }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/port/HttpProductQueryAdapter.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/port/HttpProductQueryAdapter.kt
@@ -44,15 +44,6 @@ class HttpProductQueryAdapter(
         return result?.toList() ?: emptyList()
     }
 
-    @CircuitBreaker(name = "product-query", fallbackMethod = "findProductImageUrlFallback")
-    @Retry(name = "product-query")
-    override fun findProductImageUrl(productId: Long): String? {
-        return restTemplate.getForObject(
-            "$productServiceUrl/internal/api/v1/products/$productId/image-url",
-            String::class.java
-        )
-    }
-
     private fun findProductByIdFallback(productId: Long, e: Exception): ProductInfo? {
         logger.warn("CB fallback: 상품 조회 실패 productId=$productId", e)
         return null
@@ -61,10 +52,5 @@ class HttpProductQueryAdapter(
     private fun findProductsByIdsFallback(productIds: List<Long>, e: Exception): List<ProductInfo> {
         logger.warn("CB fallback: 상품 목록 조회 실패 productIds=$productIds", e)
         return emptyList()
-    }
-
-    private fun findProductImageUrlFallback(productId: Long, e: Exception): String? {
-        logger.warn("CB fallback: 상품 이미지 URL 조회 실패 productId=$productId", e)
-        return null
     }
 }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/port/ProductQueryPort.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/port/ProductQueryPort.kt
@@ -5,12 +5,12 @@ import java.math.BigDecimal
 interface ProductQueryPort {
     fun findProductById(productId: Long): ProductInfo?
     fun findProductsByIds(productIds: List<Long>): List<ProductInfo>
-    fun findProductImageUrl(productId: Long): String?
 }
 
 data class ProductInfo(
     val id: Long,
     val name: String,
     val price: BigDecimal,
-    val sellerId: Long
+    val sellerId: Long,
+    val imageUrl: String? = null
 )

--- a/order-service/src/main/proto/product_query.proto
+++ b/order-service/src/main/proto/product_query.proto
@@ -16,6 +16,7 @@ message ProductResponse {
   string name = 2;
   string price = 3;
   int64 seller_id = 4;
+  string image_url = 5;
 }
 message ProductListResponse { repeated ProductResponse products = 1; }
 message ImageUrlResponse {

--- a/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcProductQueryService.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcProductQueryService.kt
@@ -15,11 +15,14 @@ class GrpcProductQueryService(
     override suspend fun findProductById(request: ProductIdRequest): ProductResponse {
         val product = productRepository.findNullableById(request.productId)
             ?: throw StatusException(Status.NOT_FOUND)
+        val firstImageUrl = productImageRepository.findByProductIdOrderBySortOrder(request.productId)
+            .firstOrNull()?.imageUrl ?: ""
         return productResponse {
             id = product.id!!
             name = product.name
             price = product.price.toPlainString()
             sellerId = product.sellerId
+            imageUrl = firstImageUrl
         }
     }
 

--- a/product-service/src/main/kotlin/com/hoppingmall/product/internal/InternalProductController.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/internal/InternalProductController.kt
@@ -17,12 +17,15 @@ class InternalProductController(
     fun getProduct(@PathVariable id: Long): ResponseEntity<ProductInfo> {
         val product = productRepository.findNullableById(id)
             ?: return ResponseEntity.notFound().build()
+        val firstImageUrl = productImageRepository.findByProductIdOrderBySortOrder(id)
+            .firstOrNull()?.imageUrl
         return ResponseEntity.ok(
             ProductInfo(
                 id = product.id!!,
                 name = product.name,
                 price = product.price,
-                sellerId = product.sellerId
+                sellerId = product.sellerId,
+                imageUrl = firstImageUrl
             )
         )
     }
@@ -52,6 +55,7 @@ class InternalProductController(
         val id: Long,
         val name: String,
         val price: BigDecimal,
-        val sellerId: Long
+        val sellerId: Long,
+        val imageUrl: String? = null
     )
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/ReservationExpiryScheduler.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/ReservationExpiryScheduler.kt
@@ -32,22 +32,28 @@ class ReservationExpiryScheduler(
 
         logger.info("만료 예약 처리 시작: ${expiredReservations.size}건")
 
-        expiredReservations.sortedBy { it.productId }.forEach { reservation ->
-            val updated = inventoryReservationRepository.updateStatusByCas(
-                reservationId = reservation.reservationId,
-                expectedStatus = ReservationStatus.RESERVED,
-                targetStatus = ReservationStatus.EXPIRED,
-                updatedAt = LocalDateTime.now()
-            )
-
-            if (updated > 0) {
-                val inventory = inventoryRepository.findByProductIdForUpdate(reservation.productId)
-                if (inventory != null) {
-                    inventory.increaseStock(reservation.quantity)
-                    logger.info("예약 만료 처리: reservationId=${reservation.reservationId}, " +
-                        "productId=${reservation.productId}, quantity=${reservation.quantity}")
+        expiredReservations.sortedBy { it.productId }
+            .groupBy { it.productId }
+            .forEach { (productId, reservations) ->
+                val expiredQuantity = reservations.sumOf { reservation ->
+                    val updated = inventoryReservationRepository.updateStatusByCas(
+                        reservationId = reservation.reservationId,
+                        expectedStatus = ReservationStatus.RESERVED,
+                        targetStatus = ReservationStatus.EXPIRED,
+                        updatedAt = LocalDateTime.now()
+                    )
+                    if (updated > 0) {
+                        logger.info("예약 만료 처리: reservationId=${reservation.reservationId}, " +
+                            "productId=${reservation.productId}, quantity=${reservation.quantity}")
+                        reservation.quantity
+                    } else {
+                        0
+                    }
+                }
+                if (expiredQuantity > 0) {
+                    val inventory = inventoryRepository.findByProductIdForUpdate(productId)
+                    inventory?.increaseStock(expiredQuantity)
                 }
             }
-        }
     }
 }

--- a/product-service/src/main/proto/product_query.proto
+++ b/product-service/src/main/proto/product_query.proto
@@ -16,6 +16,7 @@ message ProductResponse {
   string name = 2;
   string price = 3;
   int64 seller_id = 4;
+  string image_url = 5;
 }
 message ProductListResponse { repeated ProductResponse products = 1; }
 message ImageUrlResponse {


### PR DESCRIPTION
Closes #227

### 📌 작업 개요
CartItem 추가 시 HTTP 호출을 2→1로 줄이고, ReservationExpiryScheduler의 N+1 인벤토리 락을 제거했습니다.

### ✅ 주요 변경 사항
- ProductInfo에 imageUrl 필드 추가, findProductImageUrl 제거
- product_query.proto: ProductResponse에 image_url 추가
- ReservationExpiryScheduler: productId 그룹핑으로 인벤토리 락 1회/product

### 📎 관련 이슈
- #227