### PR TITLE
fix: Outbox @Async + RefundConsumer TX + AsyncConfig 수정

### DIFF
--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/PaymentServiceApplication.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/PaymentServiceApplication.kt
@@ -2,11 +2,9 @@ package com.hoppingmall.payment
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
-@EnableAsync
 @EnableScheduling
 class PaymentServiceApplication
 

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/AsyncConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/AsyncConfig.kt
@@ -1,0 +1,23 @@
+package com.hoppingmall.payment.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+@Configuration
+@EnableAsync
+class AsyncConfig {
+
+    @Bean("paymentAsyncExecutor")
+    fun paymentAsyncExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 2
+        executor.maxPoolSize = 5
+        executor.queueCapacity = 50
+        executor.setThreadNamePrefix("payment-async-")
+        executor.initialize()
+        return executor
+    }
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/outbox/service/OutboxEventService.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/outbox/service/OutboxEventService.kt
@@ -7,7 +7,6 @@ import com.hoppingmall.payment.outbox.repository.OutboxEventRepository
 import org.slf4j.LoggerFactory
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.support.SendResult
-import org.springframework.scheduling.annotation.Async
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -91,7 +90,6 @@ class OutboxEventService(
         }
     }
 
-    @Async
     @Transactional
     fun publishEvent(eventId: Long) {
         var event: OutboxEvent? = null

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/refund/service/RefundCompletionConsumer.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/refund/service/RefundCompletionConsumer.kt
@@ -1,10 +1,6 @@
 package com.hoppingmall.payment.refund.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.hoppingmall.payment.coupon.service.CouponCommandService
-import com.hoppingmall.payment.payment.domain.repository.PaymentRepository
-import com.hoppingmall.payment.payment.enum.PaymentStatus
-import com.hoppingmall.payment.point.service.PointCommandService
 import com.hoppingmall.payment.port.InventoryCommandPort
 import com.hoppingmall.payment.port.OrderCommandPort
 import com.hoppingmall.payment.port.ProductStatisticsPort
@@ -16,15 +12,12 @@ import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 
 @Service
 class RefundCompletionConsumer(
     private val refundEventLogRepository: RefundEventLogRepository,
-    private val paymentRepository: PaymentRepository,
-    private val pointCommandService: PointCommandService,
-    private val couponCommandService: CouponCommandService,
+    private val refundLocalOperationService: RefundLocalOperationService,
     private val inventoryCommandPort: InventoryCommandPort,
     private val orderCommandPort: OrderCommandPort,
     private val productStatisticsPort: ProductStatisticsPort,
@@ -81,7 +74,7 @@ class RefundCompletionConsumer(
 
             val eventLog = existingLog ?: createEventLog(event)
 
-            executeLocalOperations(event, eventLog)
+            refundLocalOperationService.execute(event, eventLog)
             executeInventoryOperations(event, eventLog)
             executeOrderOperations(event, eventLog)
 
@@ -106,40 +99,6 @@ class RefundCompletionConsumer(
             refundEventLogRepository.findByEventId(event.eventId)
                 ?: throw e
         }
-    }
-
-    @Transactional
-    fun executeLocalOperations(event: RefundCompletedEvent, eventLog: RefundEventLog) {
-        if (event.isFullRefund) {
-            if (!eventLog.isStepCompleted(RefundEventLog.PAYMENT_UPDATED)) {
-                val payment = paymentRepository.findById(event.paymentId).orElse(null)
-                if (payment != null) {
-                    payment.updateStatus(PaymentStatus.REFUNDED)
-                    paymentRepository.save(payment)
-                }
-                eventLog.markStepCompleted(RefundEventLog.PAYMENT_UPDATED)
-            }
-
-            if (!eventLog.isStepCompleted(RefundEventLog.COUPON_RESTORED) && event.couponId != null) {
-                couponCommandService.restoreCouponByOrder(event.orderId)
-                eventLog.markStepCompleted(RefundEventLog.COUPON_RESTORED)
-            }
-        } else {
-            eventLog.markStepCompleted(RefundEventLog.PAYMENT_UPDATED)
-            eventLog.markStepCompleted(RefundEventLog.COUPON_RESTORED)
-        }
-
-        if (!eventLog.isStepCompleted(RefundEventLog.POINTS_REFUNDED)) {
-            pointCommandService.refundPoints(
-                userId = event.buyerId,
-                amount = event.pointRefundAmount,
-                paymentId = event.paymentId,
-                orderId = event.orderId
-            )
-            eventLog.markStepCompleted(RefundEventLog.POINTS_REFUNDED)
-        }
-
-        refundEventLogRepository.save(eventLog)
     }
 
     fun executeInventoryOperations(event: RefundCompletedEvent, eventLog: RefundEventLog) {

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/refund/service/RefundLocalOperationService.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/refund/service/RefundLocalOperationService.kt
@@ -1,0 +1,54 @@
+package com.hoppingmall.payment.refund.service
+
+import com.hoppingmall.payment.coupon.service.CouponCommandService
+import com.hoppingmall.payment.payment.domain.repository.PaymentRepository
+import com.hoppingmall.payment.payment.enum.PaymentStatus
+import com.hoppingmall.payment.point.service.PointCommandService
+import com.hoppingmall.payment.refund.domain.RefundEventLog
+import com.hoppingmall.payment.refund.domain.repository.RefundEventLogRepository
+import com.hoppingmall.payment.refund.dto.event.RefundCompletedEvent
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class RefundLocalOperationService(
+    private val paymentRepository: PaymentRepository,
+    private val pointCommandService: PointCommandService,
+    private val couponCommandService: CouponCommandService,
+    private val refundEventLogRepository: RefundEventLogRepository
+) {
+
+    @Transactional
+    fun execute(event: RefundCompletedEvent, eventLog: RefundEventLog) {
+        if (event.isFullRefund) {
+            if (!eventLog.isStepCompleted(RefundEventLog.PAYMENT_UPDATED)) {
+                val payment = paymentRepository.findById(event.paymentId).orElse(null)
+                if (payment != null) {
+                    payment.updateStatus(PaymentStatus.REFUNDED)
+                    paymentRepository.save(payment)
+                }
+                eventLog.markStepCompleted(RefundEventLog.PAYMENT_UPDATED)
+            }
+
+            if (!eventLog.isStepCompleted(RefundEventLog.COUPON_RESTORED) && event.couponId != null) {
+                couponCommandService.restoreCouponByOrder(event.orderId)
+                eventLog.markStepCompleted(RefundEventLog.COUPON_RESTORED)
+            }
+        } else {
+            eventLog.markStepCompleted(RefundEventLog.PAYMENT_UPDATED)
+            eventLog.markStepCompleted(RefundEventLog.COUPON_RESTORED)
+        }
+
+        if (!eventLog.isStepCompleted(RefundEventLog.POINTS_REFUNDED)) {
+            pointCommandService.refundPoints(
+                userId = event.buyerId,
+                amount = event.pointRefundAmount,
+                paymentId = event.paymentId,
+                orderId = event.orderId
+            )
+            eventLog.markStepCompleted(RefundEventLog.POINTS_REFUNDED)
+        }
+
+        refundEventLogRepository.save(eventLog)
+    }
+}

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/refund/service/RefundCompletionConsumerTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/refund/service/RefundCompletionConsumerTest.kt
@@ -1,12 +1,6 @@
 package com.hoppingmall.payment.refund.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.hoppingmall.payment.coupon.service.CouponCommandService
-import com.hoppingmall.payment.payment.domain.Payment
-import com.hoppingmall.payment.payment.domain.repository.PaymentRepository
-import com.hoppingmall.payment.payment.enum.PaymentMethod
-import com.hoppingmall.payment.payment.enum.PaymentStatus
-import com.hoppingmall.payment.point.service.PointCommandService
 import com.hoppingmall.payment.port.InventoryCommandPort
 import com.hoppingmall.payment.port.OrderCommandPort
 import com.hoppingmall.payment.port.ProductStatisticsPort
@@ -24,7 +18,6 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.*
 import java.math.BigDecimal
-import java.util.*
 
 @DisplayName("RefundCompletionConsumer")
 @DisplayNameGeneration(ReplaceUnderscores::class)
@@ -35,13 +28,7 @@ class RefundCompletionConsumerTest {
     private lateinit var refundEventLogRepository: RefundEventLogRepository
 
     @Mock
-    private lateinit var paymentRepository: PaymentRepository
-
-    @Mock
-    private lateinit var pointCommandService: PointCommandService
-
-    @Mock
-    private lateinit var couponCommandService: CouponCommandService
+    private lateinit var refundLocalOperationService: RefundLocalOperationService
 
     @Mock
     private lateinit var inventoryCommandPort: InventoryCommandPort
@@ -119,35 +106,19 @@ class RefundCompletionConsumerTest {
     fun 전체_환불_완료_처리_성공() {
         val event = fullRefundEvent()
         val eventLog = newEventLog()
-        val payment = Payment.create(
-            orderId = 100L,
-            userId = 300L,
-            amount = BigDecimal("50000"),
-            method = PaymentMethod.CREDIT_CARD
-        )
 
         whenever(refundEventLogRepository.findByEventId(event.eventId)).thenReturn(null)
         whenever(refundEventLogRepository.save(any<RefundEventLog>())).thenReturn(eventLog)
-        whenever(paymentRepository.findById(event.paymentId)).thenReturn(Optional.of(payment))
         whenever(orderCommandPort.cancelOrder(event.orderId)).thenReturn(true)
 
         consumer.processRefundCompletion(event)
 
-        verify(paymentRepository).findById(event.paymentId)
-        verify(paymentRepository).save(payment)
-        verify(couponCommandService).restoreCouponByOrder(event.orderId)
-        verify(pointCommandService).refundPoints(
-            userId = event.buyerId,
-            amount = event.pointRefundAmount,
-            paymentId = event.paymentId,
-            orderId = event.orderId
-        )
+        verify(refundLocalOperationService).execute(eq(event), any())
         verify(inventoryCommandPort).increaseStock(1L, 2)
         verify(inventoryCommandPort).increaseStock(2L, 1)
         verify(productStatisticsPort).incrementRefundStats(1L, 2L, BigDecimal("25000"))
         verify(productStatisticsPort).incrementRefundStats(2L, 1L, BigDecimal("25000"))
         verify(orderCommandPort).cancelOrder(event.orderId)
-        verify(refundEventLogRepository, times(4)).save(any<RefundEventLog>())
     }
 
     @Test
@@ -160,14 +131,7 @@ class RefundCompletionConsumerTest {
 
         consumer.processRefundCompletion(event)
 
-        verify(paymentRepository, never()).findById(any())
-        verify(couponCommandService, never()).restoreCouponByOrder(any())
-        verify(pointCommandService).refundPoints(
-            userId = event.buyerId,
-            amount = event.pointRefundAmount,
-            paymentId = event.paymentId,
-            orderId = event.orderId
-        )
+        verify(refundLocalOperationService).execute(eq(event), any())
         verify(inventoryCommandPort).increaseStock(1L, 1)
         verify(productStatisticsPort).incrementRefundStats(1L, 1L, BigDecimal("25000"))
         verify(orderCommandPort, never()).cancelOrder(any())
@@ -183,8 +147,7 @@ class RefundCompletionConsumerTest {
         consumer.processRefundCompletion(event)
 
         verify(refundEventLogRepository, never()).save(any<RefundEventLog>())
-        verify(paymentRepository, never()).findById(any())
-        verify(pointCommandService, never()).refundPoints(any(), any(), any(), any())
+        verify(refundLocalOperationService, never()).execute(any(), any())
         verify(inventoryCommandPort, never()).increaseStock(any(), any())
         verify(orderCommandPort, never()).cancelOrder(any())
     }
@@ -202,9 +165,7 @@ class RefundCompletionConsumerTest {
 
         consumer.processRefundCompletion(event)
 
-        verify(paymentRepository, never()).findById(any())
-        verify(couponCommandService, never()).restoreCouponByOrder(any())
-        verify(pointCommandService, never()).refundPoints(any(), any(), any(), any())
+        verify(refundLocalOperationService).execute(eq(event), any())
         verify(inventoryCommandPort).increaseStock(1L, 2)
         verify(inventoryCommandPort).increaseStock(2L, 1)
         verify(productStatisticsPort).incrementRefundStats(1L, 2L, BigDecimal("25000"))

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/refund/service/RefundLocalOperationServiceTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/refund/service/RefundLocalOperationServiceTest.kt
@@ -1,0 +1,148 @@
+package com.hoppingmall.payment.refund.service
+
+import com.hoppingmall.payment.coupon.service.CouponCommandService
+import com.hoppingmall.payment.payment.domain.Payment
+import com.hoppingmall.payment.payment.domain.repository.PaymentRepository
+import com.hoppingmall.payment.payment.enum.PaymentMethod
+import com.hoppingmall.payment.payment.enum.PaymentStatus
+import com.hoppingmall.payment.point.service.PointCommandService
+import com.hoppingmall.payment.refund.domain.RefundEventLog
+import com.hoppingmall.payment.refund.domain.repository.RefundEventLogRepository
+import com.hoppingmall.payment.refund.dto.event.RefundCompletedEvent
+import com.hoppingmall.payment.refund.dto.event.RefundItemEvent
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.*
+import java.math.BigDecimal
+import java.util.*
+
+@DisplayName("RefundLocalOperationService")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class RefundLocalOperationServiceTest {
+
+    @Mock
+    private lateinit var paymentRepository: PaymentRepository
+
+    @Mock
+    private lateinit var pointCommandService: PointCommandService
+
+    @Mock
+    private lateinit var couponCommandService: CouponCommandService
+
+    @Mock
+    private lateinit var refundEventLogRepository: RefundEventLogRepository
+
+    @InjectMocks
+    private lateinit var service: RefundLocalOperationService
+
+    private fun fullRefundEvent(couponId: Long? = 10L) = RefundCompletedEvent(
+        eventId = "evt-1",
+        refundId = 1L,
+        orderId = 100L,
+        paymentId = 200L,
+        buyerId = 300L,
+        refundAmount = BigDecimal("50000"),
+        pointRefundAmount = BigDecimal("1000"),
+        isFullRefund = true,
+        couponId = couponId,
+        items = listOf(RefundItemEvent(productId = 1L, quantity = 2, refundPrice = BigDecimal("25000")))
+    )
+
+    private fun partialRefundEvent() = RefundCompletedEvent(
+        eventId = "evt-2",
+        refundId = 2L,
+        orderId = 100L,
+        paymentId = 200L,
+        buyerId = 300L,
+        refundAmount = BigDecimal("25000"),
+        pointRefundAmount = BigDecimal("500"),
+        isFullRefund = false,
+        couponId = null,
+        items = listOf(RefundItemEvent(productId = 1L, quantity = 1, refundPrice = BigDecimal("25000")))
+    )
+
+    private fun newEventLog() = RefundEventLog(
+        eventId = "evt-1",
+        eventType = "REFUND_COMPLETED",
+        refundId = 1L,
+        orderId = 100L
+    )
+
+    @Test
+    fun 전체_환불_시_결제상태_쿠폰_포인트_처리() {
+        val event = fullRefundEvent()
+        val eventLog = newEventLog()
+        val payment = Payment.create(
+            orderId = 100L,
+            userId = 300L,
+            amount = BigDecimal("50000"),
+            method = PaymentMethod.CREDIT_CARD
+        )
+
+        whenever(paymentRepository.findById(event.paymentId)).thenReturn(Optional.of(payment))
+        whenever(refundEventLogRepository.save(any<RefundEventLog>())).thenReturn(eventLog)
+
+        service.execute(event, eventLog)
+
+        verify(paymentRepository).findById(event.paymentId)
+        verify(paymentRepository).save(payment)
+        verify(couponCommandService).restoreCouponByOrder(event.orderId)
+        verify(pointCommandService).refundPoints(
+            userId = event.buyerId,
+            amount = event.pointRefundAmount,
+            paymentId = event.paymentId,
+            orderId = event.orderId
+        )
+        verify(refundEventLogRepository).save(eventLog)
+    }
+
+    @Test
+    fun 부분_환불_시_결제상태와_쿠폰은_처리하지_않음() {
+        val event = partialRefundEvent()
+        val eventLog = RefundEventLog(
+            eventId = "evt-2",
+            eventType = "REFUND_COMPLETED",
+            refundId = 2L,
+            orderId = 100L
+        )
+
+        whenever(refundEventLogRepository.save(any<RefundEventLog>())).thenReturn(eventLog)
+
+        service.execute(event, eventLog)
+
+        verify(paymentRepository, never()).findById(any())
+        verify(couponCommandService, never()).restoreCouponByOrder(any())
+        verify(pointCommandService).refundPoints(
+            userId = event.buyerId,
+            amount = event.pointRefundAmount,
+            paymentId = event.paymentId,
+            orderId = event.orderId
+        )
+        verify(refundEventLogRepository).save(eventLog)
+    }
+
+    @Test
+    fun 이미_완료된_스텝은_재처리하지_않음() {
+        val event = fullRefundEvent()
+        val eventLog = newEventLog()
+        eventLog.markStepCompleted(RefundEventLog.PAYMENT_UPDATED)
+        eventLog.markStepCompleted(RefundEventLog.COUPON_RESTORED)
+        eventLog.markStepCompleted(RefundEventLog.POINTS_REFUNDED)
+
+        whenever(refundEventLogRepository.save(any<RefundEventLog>())).thenReturn(eventLog)
+
+        service.execute(event, eventLog)
+
+        verify(paymentRepository, never()).findById(any())
+        verify(couponCommandService, never()).restoreCouponByOrder(any())
+        verify(pointCommandService, never()).refundPoints(any(), any(), any(), any())
+        verify(refundEventLogRepository).save(eventLog)
+    }
+}


### PR DESCRIPTION
Closes #233
### 📌 작업 개요
payment-service의 @Async self-call, @Transactional self-call, 무제한 스레드 생성 문제를 수정했습니다.
### ✅ 주요 변경 사항
- OutboxEventService: @Async 제거
- RefundLocalOperationService 추출 (TX 정상 동작)
- AsyncConfig 추가 (bounded thread pool)
### 📎 관련 이슈
- #233