### PR TITLE
fix: Kafka consumer 실패 메시지 DLQ 저장

### DIFF
--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/KafkaConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/KafkaConfig.kt
@@ -2,6 +2,8 @@ package com.hoppingmall.payment.config
 
 import com.hoppingmall.payment.config.kafka.TracingConsumerInterceptor
 import com.hoppingmall.payment.config.kafka.TracingProducerInterceptor
+import com.hoppingmall.payment.dlq.domain.DeadLetterMessage
+import com.hoppingmall.payment.dlq.service.DLQService
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization.StringDeserializer
@@ -23,7 +25,9 @@ import java.util.UUID
 
 @Configuration
 @Profile("!test")
-class KafkaConfig {
+class KafkaConfig(
+    private val dlqService: DLQService
+) {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -103,6 +107,16 @@ class KafkaConfig {
             { record, exception ->
                 log.error("Kafka 메시지 처리 실패 (DLQ): topic={}, offset={}, error={}",
                     record.topic(), record.offset(), exception.message)
+                val deadLetterMessage = DeadLetterMessage(
+                    originalTopic = record.topic(),
+                    originalPartition = record.partition(),
+                    originalOffset = record.offset(),
+                    originalKey = record.key()?.toString(),
+                    originalValue = record.value()?.toString(),
+                    exception = exception.message,
+                    timestamp = System.currentTimeMillis()
+                )
+                dlqService.saveDLQMessage(deadLetterMessage)
             },
             FixedBackOff(1000L, 3)
         )


### PR DESCRIPTION
Closes #235
### 📌 작업 개요
Kafka consumer 3회 재시도 실패 시 로그만 남기던 것을 DB DLQ에 저장하도록 변경했습니다.
### ✅ 주요 변경 사항
- KafkaConfig: recovery callback에서 DLQService.saveDLQMessage() 호출
### 📎 관련 이슈
- #235