### PR TITLE
fix: SseEmitter 스레드 안전성 + Gateway 헤더 보안

### DIFF
--- a/api-gateway/src/main/kotlin/com/hoppingmall/gateway/filter/JwtValidationGatewayFilterFactory.kt
+++ b/api-gateway/src/main/kotlin/com/hoppingmall/gateway/filter/JwtValidationGatewayFilterFactory.kt
@@ -39,6 +39,7 @@ class JwtValidationGatewayFilterFactory(
                 val role = claims["role"] as? String ?: "BUYER"
 
                 val modifiedRequest = request.mutate()
+                    .headers { it.remove("x-user-id"); it.remove("x-user-role") }
                     .header("x-user-id", userId)
                     .header("x-user-role", role)
                     .build()

--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/service/SseEmitterRepository.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/service/SseEmitterRepository.kt
@@ -3,14 +3,15 @@ package com.hoppingmall.notification.service
 import org.springframework.stereotype.Repository
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
 
 @Repository
 class SseEmitterRepository {
 
-    private val emitters = ConcurrentHashMap<Long, MutableList<SseEmitter>>()
+    private val emitters = ConcurrentHashMap<Long, CopyOnWriteArrayList<SseEmitter>>()
 
     fun save(userId: Long, emitter: SseEmitter): SseEmitter {
-        emitters.computeIfAbsent(userId) { mutableListOf() }.add(emitter)
+        emitters.computeIfAbsent(userId) { CopyOnWriteArrayList() }.add(emitter)
         return emitter
     }
 
@@ -19,9 +20,8 @@ class SseEmitterRepository {
     }
 
     fun remove(userId: Long, emitter: SseEmitter) {
-        emitters[userId]?.remove(emitter)
-        if (emitters[userId]?.isEmpty() == true) {
-            emitters.remove(userId)
+        emitters.compute(userId) { _, list ->
+            list?.apply { remove(emitter) }?.ifEmpty { null }
         }
     }
 }


### PR DESCRIPTION
Closes #239
### 📌 작업 개요
SseEmitterRepository 스레드 안전성 확보 및 Gateway 헤더 injection 방지.
### ✅ 주요 변경 사항
- SseEmitterRepository: CopyOnWriteArrayList + atomic compute
- JwtValidationGatewayFilter: headers.remove() 후 header() 추가
### 📎 관련 이슈
- #239