### PR TITLE
feat: 비즈니스 메트릭 + Grafana 대시보드 추가

### DIFF
--- a/docker/grafana/dashboards/kafka-pipeline.json
+++ b/docker/grafana/dashboards/kafka-pipeline.json
@@ -1,0 +1,124 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Outbox Event Publish Rate (per min)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(outbox_event_published_count_total[1m]) * 60",
+          "legendFormat": "{{application}} published"
+        },
+        {
+          "expr": "rate(outbox_event_failed_count_total[1m]) * 60",
+          "legendFormat": "{{application}} failed"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqpm" }, "overrides": [] }
+    },
+    {
+      "title": "Outbox Publish by Topic (per min)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(outbox_event_published_by_topic_total[1m]) * 60",
+          "legendFormat": "{{application}} {{topic}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqpm" }, "overrides": [] }
+    },
+    {
+      "title": "Order Created / Cancelled (per min)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "expr": "rate(order_created_count_total{application=\"order-service\"}[1m]) * 60",
+          "legendFormat": "created"
+        },
+        {
+          "expr": "rate(order_cancelled_count_total{application=\"order-service\"}[1m]) * 60",
+          "legendFormat": "cancelled"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqpm" }, "overrides": [] }
+    },
+    {
+      "title": "Order Amount Over Time",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "expr": "rate(order_amount_total_total{application=\"order-service\"}[5m]) * 300",
+          "legendFormat": "amount (5m window)"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "currencyKRW" }, "overrides": [] }
+    },
+    {
+      "title": "DLQ Trend",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "expr": "rate(dlq_message_saved_count_total[1m]) * 60",
+          "legendFormat": "new DLQ messages/min"
+        },
+        {
+          "expr": "rate(dlq_retry_success_count_total[1m]) * 60",
+          "legendFormat": "retry success/min"
+        },
+        {
+          "expr": "rate(dlq_retry_failed_count_total[1m]) * 60",
+          "legendFormat": "retry failed/min"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqpm" }, "overrides": [] }
+    },
+    {
+      "title": "Outbox Failure Rate (%)",
+      "type": "gauge",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "targets": [
+        {
+          "expr": "outbox_event_failed_count_total / (outbox_event_published_count_total + outbox_event_failed_count_total) * 100",
+          "legendFormat": "{{application}} failure rate"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["kafka", "outbox", "observability"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "title": "Kafka Event Pipeline",
+  "uid": "kafka-pipeline"
+}

--- a/docker/grafana/dashboards/payment-flow.json
+++ b/docker/grafana/dashboards/payment-flow.json
@@ -1,0 +1,119 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Payment Success / Failure Rate (per min)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(payment_completed_count_total{application=\"payment-service\"}[1m]) * 60",
+          "legendFormat": "completed"
+        },
+        {
+          "expr": "rate(payment_failed_count_total{application=\"payment-service\"}[1m]) * 60",
+          "legendFormat": "failed"
+        },
+        {
+          "expr": "rate(payment_cancelled_count_total{application=\"payment-service\"}[1m]) * 60",
+          "legendFormat": "cancelled"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqpm" }, "overrides": [] }
+    },
+    {
+      "title": "Payment Amount Over Time",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(payment_amount_total_total{application=\"payment-service\"}[5m]) * 300",
+          "legendFormat": "amount (5m window)"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "currencyKRW" }, "overrides": [] }
+    },
+    {
+      "title": "Payment Processing Duration (p50 / p95 / p99)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(payment_processing_duration_seconds_bucket{application=\"payment-service\"}[5m]))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(payment_processing_duration_seconds_bucket{application=\"payment-service\"}[5m]))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(payment_processing_duration_seconds_bucket{application=\"payment-service\"}[5m]))",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] }
+    },
+    {
+      "title": "Payment Success Rate (%)",
+      "type": "gauge",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "expr": "payment_completed_count_total / (payment_completed_count_total + payment_failed_count_total + payment_cancelled_count_total) * 100",
+          "legendFormat": "success rate"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "steps": [
+              { "color": "red", "value": 0 },
+              { "color": "yellow", "value": 90 },
+              { "color": "green", "value": 98 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "DLQ Messages",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+      "targets": [
+        {
+          "expr": "dlq_message_saved_count_total{application=\"payment-service\"}",
+          "legendFormat": "saved"
+        },
+        {
+          "expr": "dlq_retry_success_count_total{application=\"payment-service\"}",
+          "legendFormat": "retry success"
+        },
+        {
+          "expr": "dlq_retry_failed_count_total{application=\"payment-service\"}",
+          "legendFormat": "retry failed"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["payment", "observability"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "title": "Payment Flow",
+  "uid": "payment-flow"
+}

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/OrderMetrics.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/OrderMetrics.kt
@@ -1,0 +1,31 @@
+package com.hoppingmall.order.config
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+
+@Component
+class OrderMetrics(private val registry: MeterRegistry) {
+
+    private val createdCounter = Counter.builder("order.created.count")
+        .description("Total number of created orders")
+        .register(registry)
+
+    private val cancelledCounter = Counter.builder("order.cancelled.count")
+        .description("Total number of cancelled orders")
+        .register(registry)
+
+    private val amountCounter = Counter.builder("order.amount.total")
+        .description("Total order amount")
+        .register(registry)
+
+    fun recordOrderCreated(amount: BigDecimal) {
+        createdCounter.increment()
+        amountCounter.increment(amount.toDouble())
+    }
+
+    fun recordOrderCancelled() {
+        cancelledCounter.increment()
+    }
+}

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/OutboxMetrics.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/OutboxMetrics.kt
@@ -1,0 +1,33 @@
+package com.hoppingmall.order.config
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.stereotype.Component
+
+@Component
+class OutboxMetrics(private val registry: MeterRegistry) {
+
+    private val publishedCounter = Counter.builder("outbox.event.published.count")
+        .description("Total number of outbox events published")
+        .register(registry)
+
+    private val failedCounter = Counter.builder("outbox.event.failed.count")
+        .description("Total number of outbox event publish failures")
+        .register(registry)
+
+    fun recordOutboxPublished(topic: String) {
+        publishedCounter.increment()
+        Counter.builder("outbox.event.published.by_topic")
+            .tag("topic", topic)
+            .register(registry)
+            .increment()
+    }
+
+    fun recordOutboxFailed(topic: String) {
+        failedCounter.increment()
+        Counter.builder("outbox.event.failed.by_topic")
+            .tag("topic", topic)
+            .register(registry)
+            .increment()
+    }
+}

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImpl.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImpl.kt
@@ -13,6 +13,7 @@ import com.hoppingmall.order.order.exception.OrderAccessDeniedException
 import com.hoppingmall.order.order.exception.OrderEmptyItemsException
 import com.hoppingmall.order.order.exception.OrderNotFoundException
 import com.hoppingmall.order.order.exception.OrderProductNotFoundException
+import com.hoppingmall.order.config.OrderMetrics
 import com.hoppingmall.order.port.InventoryCommandPort
 import com.hoppingmall.order.port.ProductQueryPort
 import org.slf4j.LoggerFactory
@@ -27,7 +28,8 @@ class OrderCommandServiceImpl(
     private val orderItemRepository: OrderItemRepository,
     private val cartItemRepository: CartItemRepository,
     private val productQueryPort: ProductQueryPort,
-    private val inventoryCommandPort: InventoryCommandPort
+    private val inventoryCommandPort: InventoryCommandPort,
+    private val orderMetrics: OrderMetrics
 ) : OrderCommandService {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -72,6 +74,7 @@ class OrderCommandServiceImpl(
 
         cartItemRepository.deleteAllById(request.cartItemIds)
 
+        orderMetrics.recordOrderCreated(totalAmount)
         log.info("주문 생성: orderId={}, buyerId={}, totalAmount={}, itemCount={}", order.id, buyerId, totalAmount, orderItems.size)
         return OrderResponse.from(order, savedOrderItems)
     }
@@ -100,6 +103,7 @@ class OrderCommandServiceImpl(
             }
         }
 
+        orderMetrics.recordOrderCancelled()
         log.info("주문 취소: orderId={}, buyerId={}", orderId, buyerId)
         return OrderResponse.from(order, orderItems)
     }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/outbox/service/OutboxEventPublisher.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/outbox/service/OutboxEventPublisher.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.order.outbox.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.order.config.OutboxMetrics
 import com.hoppingmall.order.outbox.domain.OutboxEvent
 import com.hoppingmall.order.outbox.domain.OutboxStatus
 import com.hoppingmall.order.outbox.repository.OutboxEventRepository
@@ -17,7 +18,8 @@ import java.time.LocalDateTime
 class OutboxEventPublisher(
     private val outboxEventRepository: OutboxEventRepository,
     private val kafkaTemplate: KafkaTemplate<String, Any>,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val outboxMetrics: OutboxMetrics
 ) {
 
     private val logger = LoggerFactory.getLogger(OutboxEventPublisher::class.java)
@@ -91,6 +93,7 @@ class OutboxEventPublisher(
     private fun handlePublishSuccess(event: OutboxEvent, result: SendResult<String, Any>) {
         event.markAsProcessed()
         outboxEventRepository.save(event)
+        outboxMetrics.recordOutboxPublished(event.topic)
 
         logger.info("Outbox event published successfully: " +
             "eventId=${event.id}, topic=${event.topic}, " +
@@ -110,6 +113,7 @@ class OutboxEventPublisher(
                 "retryCount=${event.retryCount}, error=$errorMessage")
         }
 
+        outboxMetrics.recordOutboxFailed(event.topic)
         outboxEventRepository.save(event)
     }
 }

--- a/order-service/src/test/kotlin/com/hoppingmall/order/config/OrderMetricsTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/config/OrderMetricsTest.kt
@@ -1,0 +1,48 @@
+package com.hoppingmall.order.config
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("OrderMetrics 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class OrderMetricsTest {
+
+    private lateinit var registry: SimpleMeterRegistry
+    private lateinit var orderMetrics: OrderMetrics
+
+    @BeforeEach
+    fun setUp() {
+        registry = SimpleMeterRegistry()
+        orderMetrics = OrderMetrics(registry)
+    }
+
+    @Test
+    fun 주문_생성_시_카운터와_금액이_증가한다() {
+        orderMetrics.recordOrderCreated(BigDecimal("100000"))
+
+        assertThat(registry.counter("order.created.count").count()).isEqualTo(1.0)
+        assertThat(registry.counter("order.amount.total").count()).isEqualTo(100000.0)
+    }
+
+    @Test
+    fun 주문_취소_시_카운터가_증가한다() {
+        orderMetrics.recordOrderCancelled()
+
+        assertThat(registry.counter("order.cancelled.count").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun 여러_주문_생성_시_누적_카운터가_정확하다() {
+        orderMetrics.recordOrderCreated(BigDecimal("50000"))
+        orderMetrics.recordOrderCreated(BigDecimal("30000"))
+
+        assertThat(registry.counter("order.created.count").count()).isEqualTo(2.0)
+        assertThat(registry.counter("order.amount.total").count()).isEqualTo(80000.0)
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/config/OutboxMetricsTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/config/OutboxMetricsTest.kt
@@ -1,0 +1,37 @@
+package com.hoppingmall.order.config
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("OutboxMetrics 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class OutboxMetricsTest {
+
+    private lateinit var registry: SimpleMeterRegistry
+    private lateinit var outboxMetrics: OutboxMetrics
+
+    @BeforeEach
+    fun setUp() {
+        registry = SimpleMeterRegistry()
+        outboxMetrics = OutboxMetrics(registry)
+    }
+
+    @Test
+    fun Outbox_발행_성공_시_카운터가_증가한다() {
+        outboxMetrics.recordOutboxPublished("order-saga")
+
+        assertThat(registry.counter("outbox.event.published.count").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun Outbox_발행_실패_시_카운터가_증가한다() {
+        outboxMetrics.recordOutboxFailed("order-saga")
+
+        assertThat(registry.counter("outbox.event.failed.count").count()).isEqualTo(1.0)
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImplTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImplTest.kt
@@ -11,6 +11,7 @@ import com.hoppingmall.order.order.enum.OrderStatus
 import com.hoppingmall.order.order.exception.OrderAccessDeniedException
 import com.hoppingmall.order.order.exception.OrderEmptyItemsException
 import com.hoppingmall.order.order.exception.OrderNotFoundException
+import com.hoppingmall.order.config.OrderMetrics
 import com.hoppingmall.order.port.InventoryCommandPort
 import com.hoppingmall.order.port.ProductInfo
 import com.hoppingmall.order.port.ProductQueryPort
@@ -52,6 +53,9 @@ class OrderCommandServiceImplTest {
 
     @Mock
     private lateinit var inventoryCommandPort: InventoryCommandPort
+
+    @Mock
+    private lateinit var orderMetrics: OrderMetrics
 
     @InjectMocks
     private lateinit var service: OrderCommandServiceImpl

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/OutboxMetrics.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/OutboxMetrics.kt
@@ -1,0 +1,61 @@
+package com.hoppingmall.payment.config
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.stereotype.Component
+
+@Component
+class OutboxMetrics(private val registry: MeterRegistry) {
+
+    private val publishedCounter = Counter.builder("outbox.event.published.count")
+        .description("Total number of outbox events published")
+        .register(registry)
+
+    private val failedCounter = Counter.builder("outbox.event.failed.count")
+        .description("Total number of outbox event publish failures")
+        .register(registry)
+
+    private val dlqSavedCounter = Counter.builder("dlq.message.saved.count")
+        .description("Total number of messages saved to DLQ")
+        .register(registry)
+
+    private val dlqRetrySuccessCounter = Counter.builder("dlq.retry.success.count")
+        .description("Total number of successful DLQ retries")
+        .register(registry)
+
+    private val dlqRetryFailedCounter = Counter.builder("dlq.retry.failed.count")
+        .description("Total number of failed DLQ retries")
+        .register(registry)
+
+    fun recordOutboxPublished(topic: String) {
+        publishedCounter.increment()
+        Counter.builder("outbox.event.published.by_topic")
+            .tag("topic", topic)
+            .register(registry)
+            .increment()
+    }
+
+    fun recordOutboxFailed(topic: String) {
+        failedCounter.increment()
+        Counter.builder("outbox.event.failed.by_topic")
+            .tag("topic", topic)
+            .register(registry)
+            .increment()
+    }
+
+    fun recordDlqSaved(topic: String) {
+        dlqSavedCounter.increment()
+        Counter.builder("dlq.message.saved.by_topic")
+            .tag("topic", topic)
+            .register(registry)
+            .increment()
+    }
+
+    fun recordDlqRetrySuccess() {
+        dlqRetrySuccessCounter.increment()
+    }
+
+    fun recordDlqRetryFailed() {
+        dlqRetryFailedCounter.increment()
+    }
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/PaymentMetrics.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/PaymentMetrics.kt
@@ -1,0 +1,52 @@
+package com.hoppingmall.payment.config
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+
+@Component
+class PaymentMetrics(private val registry: MeterRegistry) {
+
+    private val completedCounter = Counter.builder("payment.completed.count")
+        .description("Total number of successful payments")
+        .register(registry)
+
+    private val failedCounter = Counter.builder("payment.failed.count")
+        .description("Total number of failed payments")
+        .register(registry)
+
+    private val cancelledCounter = Counter.builder("payment.cancelled.count")
+        .description("Total number of cancelled payments")
+        .register(registry)
+
+    private val amountCounter = Counter.builder("payment.amount.total")
+        .description("Total payment amount processed")
+        .register(registry)
+
+    private val processingTimer = Timer.builder("payment.processing.duration")
+        .description("Payment processing duration")
+        .register(registry)
+
+    fun recordPaymentCompleted(amount: BigDecimal, method: String) {
+        completedCounter.increment()
+        amountCounter.increment(amount.toDouble())
+        Counter.builder("payment.completed.count.by_method")
+            .tag("method", method)
+            .register(registry)
+            .increment()
+    }
+
+    fun recordPaymentFailed() {
+        failedCounter.increment()
+    }
+
+    fun recordPaymentCancelled() {
+        cancelledCounter.increment()
+    }
+
+    fun <T> recordProcessingTime(block: () -> T): T {
+        return processingTimer.recordCallable(block)!!
+    }
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/dlq/service/DLQCommandService.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/dlq/service/DLQCommandService.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.payment.dlq.service
 
+import com.hoppingmall.payment.config.OutboxMetrics
 import com.hoppingmall.payment.dlq.domain.DLQMessage
 import com.hoppingmall.payment.dlq.domain.DLQStatus
 import com.hoppingmall.payment.dlq.domain.DeadLetterMessage
@@ -15,7 +16,8 @@ import java.util.concurrent.ConcurrentHashMap
 @Transactional
 class DLQCommandService(
     private val dlqMessageRepository: DLQMessageRepository,
-    private val kafkaTemplate: KafkaTemplate<String, Any>
+    private val kafkaTemplate: KafkaTemplate<String, Any>,
+    private val outboxMetrics: OutboxMetrics
 ) {
 
     private val logger = LoggerFactory.getLogger(DLQCommandService::class.java)
@@ -60,6 +62,7 @@ class DLQCommandService(
 
             dlqMessage.nextRetryAt = DLQMessage.calculateNextRetryAt(0)
             dlqMessageRepository.save(dlqMessage)
+            outboxMetrics.recordDlqSaved(deadLetterMessage.originalTopic)
             logger.info("DLQ 메시지 저장 완료: topic={}, partition={}, offset={}",
                 deadLetterMessage.originalTopic, deadLetterMessage.originalPartition, deadLetterMessage.originalOffset)
 
@@ -107,11 +110,13 @@ class DLQCommandService(
             dlqMessage.markAsProcessed("수동 재처리 성공")
             dlqMessageRepository.save(dlqMessage)
 
+            outboxMetrics.recordDlqRetrySuccess()
             logger.info("DLQ 메시지 재처리 성공: id={}, topic={}", dlqMessageId, dlqMessage.originalTopic)
             true
 
         } catch (e: Exception) {
             logger.error("DLQ 메시지 재처리 실패: id={}, error={}", dlqMessageId, e.message, e)
+            outboxMetrics.recordDlqRetryFailed()
 
             try {
                 val dlqMessage = dlqMessageRepository.findById(dlqMessageId).orElse(null)

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/outbox/service/OutboxEventPublisher.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/outbox/service/OutboxEventPublisher.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.payment.outbox.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.payment.config.OutboxMetrics
 import com.hoppingmall.payment.outbox.domain.OutboxEvent
 import com.hoppingmall.payment.outbox.domain.OutboxStatus
 import com.hoppingmall.payment.outbox.repository.OutboxEventRepository
@@ -17,7 +18,8 @@ import java.util.concurrent.CompletableFuture
 class OutboxEventPublisher(
     private val outboxEventRepository: OutboxEventRepository,
     private val kafkaTemplate: KafkaTemplate<String, Any>,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val outboxMetrics: OutboxMetrics
 ) {
 
     private val logger = LoggerFactory.getLogger(OutboxEventPublisher::class.java)
@@ -96,6 +98,7 @@ class OutboxEventPublisher(
     private fun handlePublishSuccess(event: OutboxEvent, result: SendResult<String, Any>) {
         event.markAsProcessed()
         outboxEventRepository.save(event)
+        outboxMetrics.recordOutboxPublished(event.topic)
 
         logger.info("Outbox event published successfully: " +
             "eventId=${event.id}, topic=${event.topic}, " +
@@ -114,6 +117,7 @@ class OutboxEventPublisher(
             logger.warn("Outbox event failed, will retry: eventId=${event.id}, " +
                 "retryCount=${event.retryCount}, error=$errorMessage")
         }
+        outboxMetrics.recordOutboxFailed(event.topic)
 
         outboxEventRepository.save(event)
     }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/PaymentCommandServiceImpl.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/PaymentCommandServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.payment.payment.service
 
+import com.hoppingmall.payment.config.PaymentMetrics
 import com.hoppingmall.payment.coupon.service.CouponCommandService
 import com.hoppingmall.payment.payment.domain.Payment
 import com.hoppingmall.payment.payment.domain.repository.PaymentRepository
@@ -24,6 +25,7 @@ class PaymentCommandServiceImpl(
     private val paymentEventService: PaymentEventService,
     private val paymentNotificationService: PaymentNotificationService,
     private val couponCommandService: CouponCommandService,
+    private val paymentMetrics: PaymentMetrics,
     transactionManager: PlatformTransactionManager
 ) : PaymentCommandService {
 
@@ -31,7 +33,7 @@ class PaymentCommandServiceImpl(
 
     private val log = LoggerFactory.getLogger(javaClass)
 
-    override fun processPayment(paymentRequest: PaymentRequest, userId: Long): PaymentResponse {
+    override fun processPayment(paymentRequest: PaymentRequest, userId: Long): PaymentResponse = paymentMetrics.recordProcessingTime {
         var couponDiscountAmount = BigDecimal.ZERO
         var couponId: Long? = null
 
@@ -67,11 +69,13 @@ class PaymentCommandServiceImpl(
 
             if (saved.status == PaymentStatus.SUCCESS) {
                 log.info("결제 성공: paymentId={}, orderId={}, userId={}, amount={}", saved.id, saved.orderId, userId, saved.amount)
+                paymentMetrics.recordPaymentCompleted(saved.amount, saved.method.name)
                 publishPaymentEvents(saved)
             }
 
             if (saved.status == PaymentStatus.FAILED) {
                 log.warn("결제 실패: paymentId={}, orderId={}, userId={}, error={}", saved.id, saved.orderId, userId, saved.errorMessage)
+                paymentMetrics.recordPaymentFailed()
                 if (couponId != null) {
                     couponCommandService.restoreCouponByPayment(couponId!!, userId)
                 }
@@ -82,7 +86,7 @@ class PaymentCommandServiceImpl(
             saved
         }!!
 
-        return PaymentResponse.from(finalPayment)
+        PaymentResponse.from(finalPayment)
     }
 
     @Transactional
@@ -101,6 +105,7 @@ class PaymentCommandServiceImpl(
         payment.status = PaymentStatus.CANCELLED
         val cancelledPayment = paymentRepository.save(payment)
 
+        paymentMetrics.recordPaymentCancelled()
         paymentEventService.publishPaymentCancelledEvent(cancelledPayment)
         paymentNotificationService.publishPaymentCancelledNotification(cancelledPayment)
 

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/config/OutboxMetricsTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/config/OutboxMetricsTest.kt
@@ -1,0 +1,66 @@
+package com.hoppingmall.payment.config
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("OutboxMetrics 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class OutboxMetricsTest {
+
+    private lateinit var registry: SimpleMeterRegistry
+    private lateinit var outboxMetrics: OutboxMetrics
+
+    @BeforeEach
+    fun setUp() {
+        registry = SimpleMeterRegistry()
+        outboxMetrics = OutboxMetrics(registry)
+    }
+
+    @Test
+    fun Outbox_발행_성공_시_카운터가_증가한다() {
+        outboxMetrics.recordOutboxPublished("payment-completed")
+
+        assertThat(registry.counter("outbox.event.published.count").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun Outbox_발행_실패_시_카운터가_증가한다() {
+        outboxMetrics.recordOutboxFailed("payment-completed")
+
+        assertThat(registry.counter("outbox.event.failed.count").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun DLQ_저장_시_카운터가_증가한다() {
+        outboxMetrics.recordDlqSaved("payment-completed")
+
+        assertThat(registry.counter("dlq.message.saved.count").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun DLQ_재시도_성공_시_카운터가_증가한다() {
+        outboxMetrics.recordDlqRetrySuccess()
+
+        assertThat(registry.counter("dlq.retry.success.count").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun DLQ_재시도_실패_시_카운터가_증가한다() {
+        outboxMetrics.recordDlqRetryFailed()
+
+        assertThat(registry.counter("dlq.retry.failed.count").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun 토픽별_카운터가_태그와_함께_증가한다() {
+        outboxMetrics.recordOutboxPublished("payment-completed")
+        outboxMetrics.recordOutboxPublished("point-earn-request")
+
+        assertThat(registry.counter("outbox.event.published.count").count()).isEqualTo(2.0)
+    }
+}

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/config/PaymentMetricsTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/config/PaymentMetricsTest.kt
@@ -1,0 +1,63 @@
+package com.hoppingmall.payment.config
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("PaymentMetrics 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class PaymentMetricsTest {
+
+    private lateinit var registry: SimpleMeterRegistry
+    private lateinit var paymentMetrics: PaymentMetrics
+
+    @BeforeEach
+    fun setUp() {
+        registry = SimpleMeterRegistry()
+        paymentMetrics = PaymentMetrics(registry)
+    }
+
+    @Test
+    fun 결제_성공_시_카운터가_증가한다() {
+        paymentMetrics.recordPaymentCompleted(BigDecimal("50000"), "CREDIT_CARD")
+
+        assertThat(registry.counter("payment.completed.count").count()).isEqualTo(1.0)
+        assertThat(registry.counter("payment.amount.total").count()).isEqualTo(50000.0)
+    }
+
+    @Test
+    fun 결제_실패_시_카운터가_증가한다() {
+        paymentMetrics.recordPaymentFailed()
+
+        assertThat(registry.counter("payment.failed.count").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun 결제_취소_시_카운터가_증가한다() {
+        paymentMetrics.recordPaymentCancelled()
+
+        assertThat(registry.counter("payment.cancelled.count").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun 결제_처리_시간을_기록한다() {
+        val result = paymentMetrics.recordProcessingTime { "done" }
+
+        assertThat(result).isEqualTo("done")
+        assertThat(registry.timer("payment.processing.duration").count()).isEqualTo(1)
+    }
+
+    @Test
+    fun 결제_수단별_카운터가_태그와_함께_증가한다() {
+        paymentMetrics.recordPaymentCompleted(BigDecimal("10000"), "CREDIT_CARD")
+        paymentMetrics.recordPaymentCompleted(BigDecimal("20000"), "BANK_TRANSFER")
+
+        assertThat(registry.counter("payment.completed.count").count()).isEqualTo(2.0)
+        assertThat(registry.counter("payment.amount.total").count()).isEqualTo(30000.0)
+    }
+}

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/dlq/service/DLQServiceTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/dlq/service/DLQServiceTest.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.payment.dlq.service
 
+import com.hoppingmall.payment.config.OutboxMetrics
 import com.hoppingmall.payment.dlq.domain.DLQMessage
 import com.hoppingmall.payment.dlq.domain.DLQStatus
 import com.hoppingmall.payment.dlq.domain.DeadLetterMessage
@@ -27,6 +28,9 @@ class DLQServiceTest {
 
     @Mock
     private lateinit var kafkaTemplate: KafkaTemplate<String, Any>
+
+    @Mock
+    private lateinit var outboxMetrics: OutboxMetrics
 
     @InjectMocks
     private lateinit var dlqCommandService: DLQCommandService


### PR DESCRIPTION
Closes #246

### 📌 작업 개요
Observability Phase 1: 기존 Brave/Zipkin 트레이싱 스택 변경 없이, Payment/Order/Outbox/DLQ 도메인에 Micrometer 커스텀 비즈니스 메트릭을 추가하고 Grafana 대시보드를 구성했습니다.

---

### ✅ 주요 변경 사항

- `payment-service/config`
  - `PaymentMetrics`: 결제 성공/실패/취소 카운터, 금액 누적, 처리시간 타이머
  - `OutboxMetrics`: Outbox 발행/실패, DLQ 저장/재시도 성공/실패 카운터

- `order-service/config`
  - `OrderMetrics`: 주문 생성/취소 카운터, 주문금액 누적
  - `OutboxMetrics`: Outbox 발행/실패 카운터

- `payment-service/service`
  - `PaymentCommandServiceImpl`: 결제 성공/실패/취소 메트릭 + 처리시간 타이머 연동
  - `OutboxEventPublisher`: 발행 성공/실패 메트릭 연동
  - `DLQCommandService`: DLQ 저장/재시도 메트릭 연동

- `order-service/service`
  - `OrderCommandServiceImpl`: 주문 생성/취소 메트릭 연동
  - `OutboxEventPublisher`: 발행 성공/실패 메트릭 연동

- `docker/grafana/dashboards`
  - `payment-flow.json`: 결제 성공/실패율, 금액 추이, 처리시간 p50/p95/p99, 성공률 게이지, DLQ 현황
  - `kafka-pipeline.json`: Outbox 발행률, 토픽별 발행, 주문 추이, DLQ 트렌드, Outbox 실패율 게이지

---

### 🧪 테스트

- `PaymentMetricsTest`: 결제 성공/실패/취소/처리시간/수단별 카운터 검증 (5건)
- `OutboxMetricsTest` (payment): Outbox 발행/실패, DLQ 저장/재시도 검증 (6건)
- `OrderMetricsTest`: 주문 생성/취소/누적 카운터 검증 (3건)
- `OutboxMetricsTest` (order): Outbox 발행/실패 검증 (2건)
- 기존 테스트 Mock 의존성 추가 (OrderCommandServiceImplTest, DLQServiceTest)

---

### 📎 관련 이슈
- #246
