### PR TITLE
feat: Brave/Zipkin → OpenTelemetry/Tempo 마이그레이션

### DIFF
--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -45,8 +45,9 @@ dependencies {
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
 	implementation("io.micrometer:micrometer-registry-prometheus")
-	implementation("io.micrometer:micrometer-tracing-bridge-brave")
-	implementation("io.zipkin.reporter2:zipkin-reporter-brave")
+	implementation("io.micrometer:micrometer-tracing-bridge-otel")
+	implementation("io.opentelemetry:opentelemetry-exporter-otlp")
+	implementation("io.micrometer:context-propagation")
 
 	implementation("net.logstash.logback:logstash-logback-encoder:8.0")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,11 +203,17 @@ services:
       host.docker.internal:7006
       --cluster-replicas 1 --cluster-yes"
 
-  zipkin:
-    image: openzipkin/zipkin:latest
-    container_name: zipkin
+  tempo:
+    image: grafana/tempo:2.3.1
+    container_name: tempo
+    command: ["-config.file=/etc/tempo/tempo.yml"]
     ports:
-      - "9411:9411"
+      - "3200:3200"
+      - "4317:4317"
+      - "4318:4318"
+    volumes:
+      - ./docker/tempo.yml:/etc/tempo/tempo.yml
+      - tempo-data:/tmp/tempo
 
   prometheus:
     image: prom/prometheus:latest
@@ -253,7 +259,7 @@ services:
     depends_on:
       - prometheus
       - loki
-      - zipkin
+      - tempo
 
   notification-service:
     build:
@@ -394,3 +400,4 @@ volumes:
   mysql-data:
   prometheus-data:
   grafana-data:
+  tempo-data:

--- a/docker/grafana-datasources.yml
+++ b/docker/grafana-datasources.yml
@@ -14,8 +14,17 @@ datasources:
     url: http://loki:3100
     editable: true
 
-  - name: Zipkin
-    type: zipkin
+  - name: Tempo
+    type: tempo
     access: proxy
-    url: http://zipkin:9411
+    url: http://tempo:3200
     editable: true
+    jsonData:
+      tracesToLogsV2:
+        datasourceUid: loki
+        filterByTraceID: true
+        filterBySpanID: false
+      nodeGraph:
+        enabled: true
+      serviceMap:
+        datasourceUid: prometheus

--- a/docker/tempo.yml
+++ b/docker/tempo.yml
@@ -1,0 +1,19 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/blocks
+    wal:
+      path: /tmp/tempo/wal

--- a/hoppingmall-common/build.gradle.kts
+++ b/hoppingmall-common/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 	kotlin("plugin.spring") version "1.9.25"
 	kotlin("plugin.jpa") version "1.9.25"
 	id("io.spring.dependency-management") version "1.1.7"
+	`java-library`
 }
 
 group = "com.hoppingmall"
@@ -30,4 +31,6 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("net.logstash.logback:logstash-logback-encoder:8.0")
+	api("io.micrometer:micrometer-tracing-bridge-otel")
+	api("io.opentelemetry:opentelemetry-exporter-otlp")
 }

--- a/notification-service/build.gradle.kts
+++ b/notification-service/build.gradle.kts
@@ -52,8 +52,8 @@ dependencies {
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
 	implementation("io.micrometer:micrometer-registry-prometheus")
-	implementation("io.micrometer:micrometer-tracing-bridge-brave")
-	implementation("io.zipkin.reporter2:zipkin-reporter-brave")
+	implementation("io.micrometer:micrometer-tracing-bridge-otel")
+	implementation("io.opentelemetry:opentelemetry-exporter-otlp")
 
 	implementation("net.logstash.logback:logstash-logback-encoder:8.0")
 

--- a/order-service/build.gradle.kts
+++ b/order-service/build.gradle.kts
@@ -56,8 +56,8 @@ dependencies {
 	runtimeOnly("com.h2database:h2")
 
 	implementation("io.micrometer:micrometer-registry-prometheus")
-	implementation("io.micrometer:micrometer-tracing-bridge-brave")
-	implementation("io.zipkin.reporter2:zipkin-reporter-brave")
+	implementation("io.micrometer:micrometer-tracing-bridge-otel")
+	implementation("io.opentelemetry:opentelemetry-exporter-otlp")
 
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
 

--- a/payment-service/build.gradle.kts
+++ b/payment-service/build.gradle.kts
@@ -56,8 +56,8 @@ dependencies {
 	runtimeOnly("com.h2database:h2")
 
 	implementation("io.micrometer:micrometer-registry-prometheus")
-	implementation("io.micrometer:micrometer-tracing-bridge-brave")
-	implementation("io.zipkin.reporter2:zipkin-reporter-brave")
+	implementation("io.micrometer:micrometer-tracing-bridge-otel")
+	implementation("io.opentelemetry:opentelemetry-exporter-otlp")
 
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
 

--- a/product-service/build.gradle.kts
+++ b/product-service/build.gradle.kts
@@ -56,8 +56,8 @@ dependencies {
 	implementation("org.apache.commons:commons-csv:1.12.0")
 
 	implementation("io.micrometer:micrometer-registry-prometheus")
-	implementation("io.micrometer:micrometer-tracing-bridge-brave")
-	implementation("io.zipkin.reporter2:zipkin-reporter-brave")
+	implementation("io.micrometer:micrometer-tracing-bridge-otel")
+	implementation("io.opentelemetry:opentelemetry-exporter-otlp")
 
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
 

--- a/settlement-service/build.gradle.kts
+++ b/settlement-service/build.gradle.kts
@@ -46,8 +46,8 @@ dependencies {
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
 	implementation("io.micrometer:micrometer-registry-prometheus")
-	implementation("io.micrometer:micrometer-tracing-bridge-brave")
-	implementation("io.zipkin.reporter2:zipkin-reporter-brave")
+	implementation("io.micrometer:micrometer-tracing-bridge-otel")
+	implementation("io.opentelemetry:opentelemetry-exporter-otlp")
 
 	implementation("net.logstash.logback:logstash-logback-encoder:8.0")
 

--- a/user-service/build.gradle.kts
+++ b/user-service/build.gradle.kts
@@ -58,8 +58,8 @@ dependencies {
 	implementation("com.bucket4j:bucket4j-redis:8.10.1")
 
 	implementation("io.micrometer:micrometer-registry-prometheus")
-	implementation("io.micrometer:micrometer-tracing-bridge-brave")
-	implementation("io.zipkin.reporter2:zipkin-reporter-brave")
+	implementation("io.micrometer:micrometer-tracing-bridge-otel")
+	implementation("io.opentelemetry:opentelemetry-exporter-otlp")
 
 	implementation("net.logstash.logback:logstash-logback-encoder:8.0")
 


### PR DESCRIPTION
Closes #248

### 📌 작업 개요
7개 마이크로서비스의 트레이싱 스택을 Brave/Zipkin에서 OpenTelemetry/Tempo로 전환했습니다.

---

### ✅ 주요 변경 사항

- `build.gradle.kts` (7개 서비스)
  - `micrometer-tracing-bridge-brave` → `micrometer-tracing-bridge-otel`
  - `zipkin-reporter-brave` → `opentelemetry-exporter-otlp`

- `hoppingmall-common/build.gradle.kts`
  - `java-library` 플러그인 추가
  - OTel 의존성을 `api` scope로 추가 (6개 servlet 서비스에 전이)

- `api-gateway/build.gradle.kts`
  - `context-propagation` 라이브러리 추가 (WebFlux reactive tracing 지원)

- `docker-compose.yml`
  - Zipkin 컨테이너 → Tempo 2.3.1 (OTLP gRPC 4317 / HTTP 4318)

- `docker/grafana-datasources.yml`
  - Zipkin datasource → Tempo (trace-to-log, service map 연결)

- `docker/tempo.yml` (신규)
  - Tempo 서버 설정 (OTLP receiver + local storage)

---

### 🧪 테스트

- 7개 서비스 전체 `./gradlew test` 통과 확인

---

### 📎 관련 이슈
- #248
