### PR TITLE
feat: gRPC OTel 계측 + 인터셉터 BusinessContext 리네임

### DIFF
--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/config/KafkaConsumerConfig.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/config/KafkaConsumerConfig.kt
@@ -1,6 +1,6 @@
 package com.hoppingmall.notification.config
 
-import com.hoppingmall.notification.config.kafka.TracingConsumerInterceptor
+import com.hoppingmall.notification.config.kafka.BusinessContextConsumerInterceptor
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.springframework.beans.factory.annotation.Value
@@ -38,7 +38,7 @@ class KafkaConsumerConfig(
     fun kafkaListenerContainerFactory(): ConcurrentKafkaListenerContainerFactory<String, Any> {
         val factory = ConcurrentKafkaListenerContainerFactory<String, Any>()
         factory.consumerFactory = consumerFactory()
-        factory.setRecordInterceptor(TracingConsumerInterceptor())
+        factory.setRecordInterceptor(BusinessContextConsumerInterceptor())
         return factory
     }
 }

--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/config/kafka/BusinessContextConsumerInterceptor.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/config/kafka/BusinessContextConsumerInterceptor.kt
@@ -6,19 +6,16 @@ import org.slf4j.MDC
 import org.springframework.kafka.listener.RecordInterceptor
 import java.util.UUID
 
-class TracingConsumerInterceptor : RecordInterceptor<String, Any> {
+class BusinessContextConsumerInterceptor : RecordInterceptor<String, Any> {
 
     override fun intercept(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>): ConsumerRecord<String, Any> {
-        val traceId = extractHeader(record, TRACE_ID_HEADER)
             ?: UUID.randomUUID().toString().replace("-", "").take(16)
-        MDC.put(TRACE_ID_KEY, traceId)
         extractHeader(record, USER_ID_HEADER)?.let { MDC.put(USER_ID_KEY, it) }
         extractHeader(record, SERVICE_HEADER)?.let { MDC.put(SERVICE_KEY, it) }
         return record
     }
 
     override fun afterRecord(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>) {
-        MDC.remove(TRACE_ID_KEY)
         MDC.remove(USER_ID_KEY)
         MDC.remove(SERVICE_KEY)
     }
@@ -29,8 +26,6 @@ class TracingConsumerInterceptor : RecordInterceptor<String, Any> {
     }
 
     companion object {
-        const val TRACE_ID_KEY = "traceId"
-        const val TRACE_ID_HEADER = "X-Trace-Id"
         const val USER_ID_KEY = "userId"
         const val USER_ID_HEADER = "X-User-Id"
         const val SERVICE_KEY = "service"

--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/config/kafka/BusinessContextConsumerInterceptor.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/config/kafka/BusinessContextConsumerInterceptor.kt
@@ -4,12 +4,9 @@ import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.MDC
 import org.springframework.kafka.listener.RecordInterceptor
-import java.util.UUID
-
 class BusinessContextConsumerInterceptor : RecordInterceptor<String, Any> {
 
     override fun intercept(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>): ConsumerRecord<String, Any> {
-            ?: UUID.randomUUID().toString().replace("-", "").take(16)
         extractHeader(record, USER_ID_HEADER)?.let { MDC.put(USER_ID_KEY, it) }
         extractHeader(record, SERVICE_HEADER)?.let { MDC.put(SERVICE_KEY, it) }
         return record

--- a/order-service/build.gradle.kts
+++ b/order-service/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
 	implementation("io.grpc:grpc-kotlin-stub:$grpcKotlinVersion")
 	implementation("com.google.protobuf:protobuf-kotlin:$protobufVersion")
 	implementation("net.devh:grpc-spring-boot-starter:3.1.0.RELEASE")
+	implementation("io.opentelemetry.instrumentation:opentelemetry-grpc-1.6:2.12.0-alpha")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
 }
 

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/KafkaConfig.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/KafkaConfig.kt
@@ -1,7 +1,7 @@
 package com.hoppingmall.order.config
 
-import com.hoppingmall.order.config.kafka.TracingConsumerInterceptor
-import com.hoppingmall.order.config.kafka.TracingProducerInterceptor
+import com.hoppingmall.order.config.kafka.BusinessContextConsumerInterceptor
+import com.hoppingmall.order.config.kafka.BusinessContextProducerInterceptor
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.errors.SerializationException
@@ -58,7 +58,7 @@ class KafkaConfig {
         configProps[ProducerConfig.LINGER_MS_CONFIG] = 10
         configProps[ProducerConfig.COMPRESSION_TYPE_CONFIG] = "lz4"
 
-        configProps[ProducerConfig.INTERCEPTOR_CLASSES_CONFIG] = listOf(TracingProducerInterceptor::class.java.name)
+        configProps[ProducerConfig.INTERCEPTOR_CLASSES_CONFIG] = listOf(BusinessContextProducerInterceptor::class.java.name)
 
         val producerFactory = DefaultKafkaProducerFactory<String, Any>(configProps)
         producerFactory.setTransactionIdPrefix("order-tx-$instanceId-")
@@ -102,7 +102,7 @@ class KafkaConfig {
         val factory = ConcurrentKafkaListenerContainerFactory<String, Any>()
         factory.consumerFactory = consumerFactory()
         factory.setConcurrency(4)
-        factory.setRecordInterceptor(TracingConsumerInterceptor())
+        factory.setRecordInterceptor(BusinessContextConsumerInterceptor())
 
         val errorHandler = DefaultErrorHandler(
             { record, exception ->

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/kafka/BusinessContextConsumerInterceptor.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/kafka/BusinessContextConsumerInterceptor.kt
@@ -1,4 +1,4 @@
-package com.hoppingmall.payment.config.kafka
+package com.hoppingmall.order.config.kafka
 
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -6,19 +6,16 @@ import org.slf4j.MDC
 import org.springframework.kafka.listener.RecordInterceptor
 import java.util.UUID
 
-class TracingConsumerInterceptor : RecordInterceptor<String, Any> {
+class BusinessContextConsumerInterceptor : RecordInterceptor<String, Any> {
 
     override fun intercept(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>): ConsumerRecord<String, Any> {
-        val traceId = extractHeader(record, TRACE_ID_HEADER)
             ?: UUID.randomUUID().toString().replace("-", "").take(16)
-        MDC.put(TRACE_ID_KEY, traceId)
         extractHeader(record, USER_ID_HEADER)?.let { MDC.put(USER_ID_KEY, it) }
         extractHeader(record, SERVICE_HEADER)?.let { MDC.put(SERVICE_KEY, it) }
         return record
     }
 
     override fun afterRecord(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>) {
-        MDC.remove(TRACE_ID_KEY)
         MDC.remove(USER_ID_KEY)
         MDC.remove(SERVICE_KEY)
     }
@@ -29,8 +26,6 @@ class TracingConsumerInterceptor : RecordInterceptor<String, Any> {
     }
 
     companion object {
-        const val TRACE_ID_KEY = "traceId"
-        const val TRACE_ID_HEADER = "X-Trace-Id"
         const val USER_ID_KEY = "userId"
         const val USER_ID_HEADER = "X-User-Id"
         const val SERVICE_KEY = "service"

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/kafka/BusinessContextConsumerInterceptor.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/kafka/BusinessContextConsumerInterceptor.kt
@@ -4,12 +4,9 @@ import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.MDC
 import org.springframework.kafka.listener.RecordInterceptor
-import java.util.UUID
-
 class BusinessContextConsumerInterceptor : RecordInterceptor<String, Any> {
 
     override fun intercept(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>): ConsumerRecord<String, Any> {
-            ?: UUID.randomUUID().toString().replace("-", "").take(16)
         extractHeader(record, USER_ID_HEADER)?.let { MDC.put(USER_ID_KEY, it) }
         extractHeader(record, SERVICE_HEADER)?.let { MDC.put(SERVICE_KEY, it) }
         return record

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/kafka/BusinessContextProducerInterceptor.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/kafka/BusinessContextProducerInterceptor.kt
@@ -5,10 +5,9 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.slf4j.MDC
 
-class TracingProducerInterceptor : ProducerInterceptor<String, Any> {
+class BusinessContextProducerInterceptor : ProducerInterceptor<String, Any> {
 
     override fun onSend(record: ProducerRecord<String, Any>): ProducerRecord<String, Any> {
-        addHeaderFromMdc(record, TRACE_ID_KEY, TRACE_ID_HEADER)
         addHeaderFromMdc(record, USER_ID_KEY, USER_ID_HEADER)
         addHeaderFromMdc(record, SERVICE_KEY, SERVICE_HEADER)
         return record
@@ -28,8 +27,6 @@ class TracingProducerInterceptor : ProducerInterceptor<String, Any> {
     override fun configure(configs: MutableMap<String, *>?) {}
 
     companion object {
-        const val TRACE_ID_KEY = "traceId"
-        const val TRACE_ID_HEADER = "X-Trace-Id"
         const val USER_ID_KEY = "userId"
         const val USER_ID_HEADER = "X-User-Id"
         const val SERVICE_KEY = "service"

--- a/order-service/src/main/kotlin/com/hoppingmall/order/grpc/BusinessContextClientInterceptor.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/grpc/BusinessContextClientInterceptor.kt
@@ -5,11 +5,9 @@ import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor
 import org.slf4j.MDC
 
 @GrpcGlobalClientInterceptor
-class TracingClientInterceptor : ClientInterceptor {
+class BusinessContextClientInterceptor : ClientInterceptor {
 
     companion object {
-        val TRACE_ID_KEY: Metadata.Key<String> =
-            Metadata.Key.of("x-trace-id", Metadata.ASCII_STRING_MARSHALLER)
         val USER_ID_KEY: Metadata.Key<String> =
             Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER)
     }
@@ -23,7 +21,6 @@ class TracingClientInterceptor : ClientInterceptor {
             next.newCall(method, callOptions)
         ) {
             override fun start(responseListener: Listener<RespT>, headers: Metadata) {
-                MDC.get("traceId")?.let { headers.put(TRACE_ID_KEY, it) }
                 MDC.get("userId")?.let { headers.put(USER_ID_KEY, it) }
                 super.start(responseListener, headers)
             }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/grpc/BusinessContextServerInterceptor.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/grpc/BusinessContextServerInterceptor.kt
@@ -9,11 +9,9 @@ import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor
 import org.slf4j.MDC
 
 @GrpcGlobalServerInterceptor
-class TracingServerInterceptor : ServerInterceptor {
+class BusinessContextServerInterceptor : ServerInterceptor {
 
     companion object {
-        val TRACE_ID_KEY: Metadata.Key<String> =
-            Metadata.Key.of("x-trace-id", Metadata.ASCII_STRING_MARSHALLER)
         val USER_ID_KEY: Metadata.Key<String> =
             Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER)
     }
@@ -23,7 +21,7 @@ class TracingServerInterceptor : ServerInterceptor {
         headers: Metadata,
         next: ServerCallHandler<ReqT, RespT>
     ): ServerCall.Listener<ReqT> {
-        headers.get(TRACE_ID_KEY)?.let { MDC.put("traceId", it) }
+        
         headers.get(USER_ID_KEY)?.let { MDC.put("userId", it) }
 
         return object : ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(
@@ -33,7 +31,6 @@ class TracingServerInterceptor : ServerInterceptor {
                 try {
                     super.onComplete()
                 } finally {
-                    MDC.remove("traceId")
                     MDC.remove("userId")
                 }
             }
@@ -42,7 +39,6 @@ class TracingServerInterceptor : ServerInterceptor {
                 try {
                     super.onCancel()
                 } finally {
-                    MDC.remove("traceId")
                     MDC.remove("userId")
                 }
             }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcTelemetryConfig.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcTelemetryConfig.kt
@@ -1,0 +1,24 @@
+package com.hoppingmall.order.grpc
+
+import io.grpc.ClientInterceptor
+import io.grpc.ServerInterceptor
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class GrpcTelemetryConfig(private val openTelemetry: OpenTelemetry) {
+
+    private val grpcTelemetry = GrpcTelemetry.create(openTelemetry)
+
+    @Bean
+    @GrpcGlobalServerInterceptor
+    fun otelGrpcServerInterceptor(): ServerInterceptor = grpcTelemetry.newServerInterceptor()
+
+    @Bean
+    @GrpcGlobalClientInterceptor
+    fun otelGrpcClientInterceptor(): ClientInterceptor = grpcTelemetry.newClientInterceptor()
+}

--- a/payment-service/build.gradle.kts
+++ b/payment-service/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
 	implementation("io.grpc:grpc-kotlin-stub:$grpcKotlinVersion")
 	implementation("com.google.protobuf:protobuf-kotlin:$protobufVersion")
 	implementation("net.devh:grpc-spring-boot-starter:3.1.0.RELEASE")
+	implementation("io.opentelemetry.instrumentation:opentelemetry-grpc-1.6:2.12.0-alpha")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
 }
 

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/KafkaConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/KafkaConfig.kt
@@ -1,7 +1,7 @@
 package com.hoppingmall.payment.config
 
-import com.hoppingmall.payment.config.kafka.TracingConsumerInterceptor
-import com.hoppingmall.payment.config.kafka.TracingProducerInterceptor
+import com.hoppingmall.payment.config.kafka.BusinessContextConsumerInterceptor
+import com.hoppingmall.payment.config.kafka.BusinessContextProducerInterceptor
 import com.hoppingmall.payment.dlq.domain.DeadLetterMessage
 import com.hoppingmall.payment.dlq.service.DLQCommandService
 import org.apache.kafka.clients.consumer.ConsumerConfig
@@ -58,7 +58,7 @@ class KafkaConfig(
         configProps[ProducerConfig.BATCH_SIZE_CONFIG] = 16384
         configProps[ProducerConfig.LINGER_MS_CONFIG] = 10
         configProps[ProducerConfig.COMPRESSION_TYPE_CONFIG] = "lz4"
-        configProps[ProducerConfig.INTERCEPTOR_CLASSES_CONFIG] = listOf(TracingProducerInterceptor::class.java.name)
+        configProps[ProducerConfig.INTERCEPTOR_CLASSES_CONFIG] = listOf(BusinessContextProducerInterceptor::class.java.name)
 
         val producerFactory = DefaultKafkaProducerFactory<String, Any>(configProps)
         producerFactory.setTransactionIdPrefix("payment-tx-$instanceId-")
@@ -126,7 +126,7 @@ class KafkaConfig(
             MessageConversionException::class.java
         )
         factory.setCommonErrorHandler(errorHandler)
-        factory.setRecordInterceptor(TracingConsumerInterceptor())
+        factory.setRecordInterceptor(BusinessContextConsumerInterceptor())
 
         return factory
     }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/kafka/BusinessContextConsumerInterceptor.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/kafka/BusinessContextConsumerInterceptor.kt
@@ -4,12 +4,9 @@ import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.MDC
 import org.springframework.kafka.listener.RecordInterceptor
-import java.util.UUID
-
 class BusinessContextConsumerInterceptor : RecordInterceptor<String, Any> {
 
     override fun intercept(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>): ConsumerRecord<String, Any> {
-            ?: UUID.randomUUID().toString().replace("-", "").take(16)
         extractHeader(record, USER_ID_HEADER)?.let { MDC.put(USER_ID_KEY, it) }
         extractHeader(record, SERVICE_HEADER)?.let { MDC.put(SERVICE_KEY, it) }
         return record

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/kafka/BusinessContextConsumerInterceptor.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/kafka/BusinessContextConsumerInterceptor.kt
@@ -1,4 +1,4 @@
-package com.hoppingmall.order.config.kafka
+package com.hoppingmall.payment.config.kafka
 
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -6,19 +6,16 @@ import org.slf4j.MDC
 import org.springframework.kafka.listener.RecordInterceptor
 import java.util.UUID
 
-class TracingConsumerInterceptor : RecordInterceptor<String, Any> {
+class BusinessContextConsumerInterceptor : RecordInterceptor<String, Any> {
 
     override fun intercept(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>): ConsumerRecord<String, Any> {
-        val traceId = extractHeader(record, TRACE_ID_HEADER)
             ?: UUID.randomUUID().toString().replace("-", "").take(16)
-        MDC.put(TRACE_ID_KEY, traceId)
         extractHeader(record, USER_ID_HEADER)?.let { MDC.put(USER_ID_KEY, it) }
         extractHeader(record, SERVICE_HEADER)?.let { MDC.put(SERVICE_KEY, it) }
         return record
     }
 
     override fun afterRecord(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>) {
-        MDC.remove(TRACE_ID_KEY)
         MDC.remove(USER_ID_KEY)
         MDC.remove(SERVICE_KEY)
     }
@@ -29,8 +26,6 @@ class TracingConsumerInterceptor : RecordInterceptor<String, Any> {
     }
 
     companion object {
-        const val TRACE_ID_KEY = "traceId"
-        const val TRACE_ID_HEADER = "X-Trace-Id"
         const val USER_ID_KEY = "userId"
         const val USER_ID_HEADER = "X-User-Id"
         const val SERVICE_KEY = "service"

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/kafka/BusinessContextProducerInterceptor.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/kafka/BusinessContextProducerInterceptor.kt
@@ -5,10 +5,9 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.slf4j.MDC
 
-class TracingProducerInterceptor : ProducerInterceptor<String, Any> {
+class BusinessContextProducerInterceptor : ProducerInterceptor<String, Any> {
 
     override fun onSend(record: ProducerRecord<String, Any>): ProducerRecord<String, Any> {
-        addHeaderFromMdc(record, TRACE_ID_KEY, TRACE_ID_HEADER)
         addHeaderFromMdc(record, USER_ID_KEY, USER_ID_HEADER)
         addHeaderFromMdc(record, SERVICE_KEY, SERVICE_HEADER)
         return record
@@ -28,8 +27,6 @@ class TracingProducerInterceptor : ProducerInterceptor<String, Any> {
     override fun configure(configs: MutableMap<String, *>?) {}
 
     companion object {
-        const val TRACE_ID_KEY = "traceId"
-        const val TRACE_ID_HEADER = "X-Trace-Id"
         const val USER_ID_KEY = "userId"
         const val USER_ID_HEADER = "X-User-Id"
         const val SERVICE_KEY = "service"

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/BusinessContextClientInterceptor.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/BusinessContextClientInterceptor.kt
@@ -1,15 +1,13 @@
-package com.hoppingmall.product.grpc
+package com.hoppingmall.payment.grpc
 
 import io.grpc.*
 import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor
 import org.slf4j.MDC
 
 @GrpcGlobalClientInterceptor
-class TracingClientInterceptor : ClientInterceptor {
+class BusinessContextClientInterceptor : ClientInterceptor {
 
     companion object {
-        val TRACE_ID_KEY: Metadata.Key<String> =
-            Metadata.Key.of("x-trace-id", Metadata.ASCII_STRING_MARSHALLER)
         val USER_ID_KEY: Metadata.Key<String> =
             Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER)
     }
@@ -23,7 +21,6 @@ class TracingClientInterceptor : ClientInterceptor {
             next.newCall(method, callOptions)
         ) {
             override fun start(responseListener: Listener<RespT>, headers: Metadata) {
-                MDC.get("traceId")?.let { headers.put(TRACE_ID_KEY, it) }
                 MDC.get("userId")?.let { headers.put(USER_ID_KEY, it) }
                 super.start(responseListener, headers)
             }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/BusinessContextServerInterceptor.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/BusinessContextServerInterceptor.kt
@@ -1,4 +1,4 @@
-package com.hoppingmall.product.grpc
+package com.hoppingmall.payment.grpc
 
 import io.grpc.ForwardingServerCallListener
 import io.grpc.Metadata
@@ -9,11 +9,9 @@ import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor
 import org.slf4j.MDC
 
 @GrpcGlobalServerInterceptor
-class TracingServerInterceptor : ServerInterceptor {
+class BusinessContextServerInterceptor : ServerInterceptor {
 
     companion object {
-        val TRACE_ID_KEY: Metadata.Key<String> =
-            Metadata.Key.of("x-trace-id", Metadata.ASCII_STRING_MARSHALLER)
         val USER_ID_KEY: Metadata.Key<String> =
             Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER)
     }
@@ -23,7 +21,7 @@ class TracingServerInterceptor : ServerInterceptor {
         headers: Metadata,
         next: ServerCallHandler<ReqT, RespT>
     ): ServerCall.Listener<ReqT> {
-        headers.get(TRACE_ID_KEY)?.let { MDC.put("traceId", it) }
+        
         headers.get(USER_ID_KEY)?.let { MDC.put("userId", it) }
 
         return object : ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(
@@ -33,7 +31,6 @@ class TracingServerInterceptor : ServerInterceptor {
                 try {
                     super.onComplete()
                 } finally {
-                    MDC.remove("traceId")
                     MDC.remove("userId")
                 }
             }
@@ -42,7 +39,6 @@ class TracingServerInterceptor : ServerInterceptor {
                 try {
                     super.onCancel()
                 } finally {
-                    MDC.remove("traceId")
                     MDC.remove("userId")
                 }
             }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/GrpcTelemetryConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/GrpcTelemetryConfig.kt
@@ -1,0 +1,24 @@
+package com.hoppingmall.payment.grpc
+
+import io.grpc.ClientInterceptor
+import io.grpc.ServerInterceptor
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class GrpcTelemetryConfig(private val openTelemetry: OpenTelemetry) {
+
+    private val grpcTelemetry = GrpcTelemetry.create(openTelemetry)
+
+    @Bean
+    @GrpcGlobalServerInterceptor
+    fun otelGrpcServerInterceptor(): ServerInterceptor = grpcTelemetry.newServerInterceptor()
+
+    @Bean
+    @GrpcGlobalClientInterceptor
+    fun otelGrpcClientInterceptor(): ClientInterceptor = grpcTelemetry.newClientInterceptor()
+}

--- a/product-service/build.gradle.kts
+++ b/product-service/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
 	implementation("io.grpc:grpc-kotlin-stub:$grpcKotlinVersion")
 	implementation("com.google.protobuf:protobuf-kotlin:$protobufVersion")
 	implementation("net.devh:grpc-spring-boot-starter:3.1.0.RELEASE")
+	implementation("io.opentelemetry.instrumentation:opentelemetry-grpc-1.6:2.12.0-alpha")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
 }
 

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/KafkaConsumerConfig.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/KafkaConsumerConfig.kt
@@ -1,6 +1,6 @@
 package com.hoppingmall.product.config
 
-import com.hoppingmall.product.config.kafka.TracingConsumerInterceptor
+import com.hoppingmall.product.config.kafka.BusinessContextConsumerInterceptor
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.errors.SerializationException
 import org.apache.kafka.common.serialization.StringDeserializer
@@ -56,7 +56,7 @@ class KafkaConsumerConfig {
     fun kafkaListenerContainerFactory(): ConcurrentKafkaListenerContainerFactory<String, Any> {
         val factory = ConcurrentKafkaListenerContainerFactory<String, Any>()
         factory.consumerFactory = consumerFactory()
-        factory.setRecordInterceptor(TracingConsumerInterceptor())
+        factory.setRecordInterceptor(BusinessContextConsumerInterceptor())
 
         val errorHandler = DefaultErrorHandler(
             { record, exception ->

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/kafka/BusinessContextConsumerInterceptor.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/kafka/BusinessContextConsumerInterceptor.kt
@@ -4,12 +4,9 @@ import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.MDC
 import org.springframework.kafka.listener.RecordInterceptor
-import java.util.UUID
-
 class BusinessContextConsumerInterceptor : RecordInterceptor<String, Any> {
 
     override fun intercept(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>): ConsumerRecord<String, Any> {
-            ?: UUID.randomUUID().toString().replace("-", "").take(16)
         extractHeader(record, USER_ID_HEADER)?.let { MDC.put(USER_ID_KEY, it) }
         extractHeader(record, SERVICE_HEADER)?.let { MDC.put(SERVICE_KEY, it) }
         return record

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/kafka/BusinessContextConsumerInterceptor.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/kafka/BusinessContextConsumerInterceptor.kt
@@ -1,4 +1,4 @@
-package com.hoppingmall.user.config.kafka
+package com.hoppingmall.product.config.kafka
 
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -6,19 +6,16 @@ import org.slf4j.MDC
 import org.springframework.kafka.listener.RecordInterceptor
 import java.util.UUID
 
-class TracingConsumerInterceptor : RecordInterceptor<String, Any> {
+class BusinessContextConsumerInterceptor : RecordInterceptor<String, Any> {
 
     override fun intercept(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>): ConsumerRecord<String, Any> {
-        val traceId = extractHeader(record, TRACE_ID_HEADER)
             ?: UUID.randomUUID().toString().replace("-", "").take(16)
-        MDC.put(TRACE_ID_KEY, traceId)
         extractHeader(record, USER_ID_HEADER)?.let { MDC.put(USER_ID_KEY, it) }
         extractHeader(record, SERVICE_HEADER)?.let { MDC.put(SERVICE_KEY, it) }
         return record
     }
 
     override fun afterRecord(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>) {
-        MDC.remove(TRACE_ID_KEY)
         MDC.remove(USER_ID_KEY)
         MDC.remove(SERVICE_KEY)
     }
@@ -29,8 +26,6 @@ class TracingConsumerInterceptor : RecordInterceptor<String, Any> {
     }
 
     companion object {
-        const val TRACE_ID_KEY = "traceId"
-        const val TRACE_ID_HEADER = "X-Trace-Id"
         const val USER_ID_KEY = "userId"
         const val USER_ID_HEADER = "X-User-Id"
         const val SERVICE_KEY = "service"

--- a/product-service/src/main/kotlin/com/hoppingmall/product/grpc/BusinessContextClientInterceptor.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/grpc/BusinessContextClientInterceptor.kt
@@ -1,15 +1,13 @@
-package com.hoppingmall.payment.grpc
+package com.hoppingmall.product.grpc
 
 import io.grpc.*
 import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor
 import org.slf4j.MDC
 
 @GrpcGlobalClientInterceptor
-class TracingClientInterceptor : ClientInterceptor {
+class BusinessContextClientInterceptor : ClientInterceptor {
 
     companion object {
-        val TRACE_ID_KEY: Metadata.Key<String> =
-            Metadata.Key.of("x-trace-id", Metadata.ASCII_STRING_MARSHALLER)
         val USER_ID_KEY: Metadata.Key<String> =
             Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER)
     }
@@ -23,7 +21,6 @@ class TracingClientInterceptor : ClientInterceptor {
             next.newCall(method, callOptions)
         ) {
             override fun start(responseListener: Listener<RespT>, headers: Metadata) {
-                MDC.get("traceId")?.let { headers.put(TRACE_ID_KEY, it) }
                 MDC.get("userId")?.let { headers.put(USER_ID_KEY, it) }
                 super.start(responseListener, headers)
             }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/grpc/BusinessContextServerInterceptor.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/grpc/BusinessContextServerInterceptor.kt
@@ -1,4 +1,4 @@
-package com.hoppingmall.payment.grpc
+package com.hoppingmall.product.grpc
 
 import io.grpc.ForwardingServerCallListener
 import io.grpc.Metadata
@@ -9,11 +9,9 @@ import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor
 import org.slf4j.MDC
 
 @GrpcGlobalServerInterceptor
-class TracingServerInterceptor : ServerInterceptor {
+class BusinessContextServerInterceptor : ServerInterceptor {
 
     companion object {
-        val TRACE_ID_KEY: Metadata.Key<String> =
-            Metadata.Key.of("x-trace-id", Metadata.ASCII_STRING_MARSHALLER)
         val USER_ID_KEY: Metadata.Key<String> =
             Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER)
     }
@@ -23,7 +21,7 @@ class TracingServerInterceptor : ServerInterceptor {
         headers: Metadata,
         next: ServerCallHandler<ReqT, RespT>
     ): ServerCall.Listener<ReqT> {
-        headers.get(TRACE_ID_KEY)?.let { MDC.put("traceId", it) }
+        
         headers.get(USER_ID_KEY)?.let { MDC.put("userId", it) }
 
         return object : ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(
@@ -33,7 +31,6 @@ class TracingServerInterceptor : ServerInterceptor {
                 try {
                     super.onComplete()
                 } finally {
-                    MDC.remove("traceId")
                     MDC.remove("userId")
                 }
             }
@@ -42,7 +39,6 @@ class TracingServerInterceptor : ServerInterceptor {
                 try {
                     super.onCancel()
                 } finally {
-                    MDC.remove("traceId")
                     MDC.remove("userId")
                 }
             }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcTelemetryConfig.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/grpc/GrpcTelemetryConfig.kt
@@ -1,0 +1,24 @@
+package com.hoppingmall.product.grpc
+
+import io.grpc.ClientInterceptor
+import io.grpc.ServerInterceptor
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class GrpcTelemetryConfig(private val openTelemetry: OpenTelemetry) {
+
+    private val grpcTelemetry = GrpcTelemetry.create(openTelemetry)
+
+    @Bean
+    @GrpcGlobalServerInterceptor
+    fun otelGrpcServerInterceptor(): ServerInterceptor = grpcTelemetry.newServerInterceptor()
+
+    @Bean
+    @GrpcGlobalClientInterceptor
+    fun otelGrpcClientInterceptor(): ClientInterceptor = grpcTelemetry.newClientInterceptor()
+}

--- a/user-service/build.gradle.kts
+++ b/user-service/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
 	implementation("io.grpc:grpc-kotlin-stub:$grpcKotlinVersion")
 	implementation("com.google.protobuf:protobuf-kotlin:$protobufVersion")
 	implementation("net.devh:grpc-spring-boot-starter:3.1.0.RELEASE")
+	implementation("io.opentelemetry.instrumentation:opentelemetry-grpc-1.6:2.12.0-alpha")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
 }
 

--- a/user-service/src/main/kotlin/com/hoppingmall/user/config/KafkaConsumerConfig.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/config/KafkaConsumerConfig.kt
@@ -1,6 +1,6 @@
 package com.hoppingmall.user.config
 
-import com.hoppingmall.user.config.kafka.TracingConsumerInterceptor
+import com.hoppingmall.user.config.kafka.BusinessContextConsumerInterceptor
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.springframework.beans.factory.annotation.Value
@@ -38,7 +38,7 @@ class KafkaConsumerConfig(
     fun kafkaListenerContainerFactory(): ConcurrentKafkaListenerContainerFactory<String, Any> {
         val factory = ConcurrentKafkaListenerContainerFactory<String, Any>()
         factory.consumerFactory = consumerFactory()
-        factory.setRecordInterceptor(TracingConsumerInterceptor())
+        factory.setRecordInterceptor(BusinessContextConsumerInterceptor())
         return factory
     }
 }

--- a/user-service/src/main/kotlin/com/hoppingmall/user/config/kafka/BusinessContextConsumerInterceptor.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/config/kafka/BusinessContextConsumerInterceptor.kt
@@ -4,12 +4,9 @@ import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.MDC
 import org.springframework.kafka.listener.RecordInterceptor
-import java.util.UUID
-
 class BusinessContextConsumerInterceptor : RecordInterceptor<String, Any> {
 
     override fun intercept(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>): ConsumerRecord<String, Any> {
-            ?: UUID.randomUUID().toString().replace("-", "").take(16)
         extractHeader(record, USER_ID_HEADER)?.let { MDC.put(USER_ID_KEY, it) }
         extractHeader(record, SERVICE_HEADER)?.let { MDC.put(SERVICE_KEY, it) }
         return record

--- a/user-service/src/main/kotlin/com/hoppingmall/user/config/kafka/BusinessContextConsumerInterceptor.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/config/kafka/BusinessContextConsumerInterceptor.kt
@@ -1,4 +1,4 @@
-package com.hoppingmall.product.config.kafka
+package com.hoppingmall.user.config.kafka
 
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -6,19 +6,16 @@ import org.slf4j.MDC
 import org.springframework.kafka.listener.RecordInterceptor
 import java.util.UUID
 
-class TracingConsumerInterceptor : RecordInterceptor<String, Any> {
+class BusinessContextConsumerInterceptor : RecordInterceptor<String, Any> {
 
     override fun intercept(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>): ConsumerRecord<String, Any> {
-        val traceId = extractHeader(record, TRACE_ID_HEADER)
             ?: UUID.randomUUID().toString().replace("-", "").take(16)
-        MDC.put(TRACE_ID_KEY, traceId)
         extractHeader(record, USER_ID_HEADER)?.let { MDC.put(USER_ID_KEY, it) }
         extractHeader(record, SERVICE_HEADER)?.let { MDC.put(SERVICE_KEY, it) }
         return record
     }
 
     override fun afterRecord(record: ConsumerRecord<String, Any>, consumer: Consumer<String, Any>) {
-        MDC.remove(TRACE_ID_KEY)
         MDC.remove(USER_ID_KEY)
         MDC.remove(SERVICE_KEY)
     }
@@ -29,8 +26,6 @@ class TracingConsumerInterceptor : RecordInterceptor<String, Any> {
     }
 
     companion object {
-        const val TRACE_ID_KEY = "traceId"
-        const val TRACE_ID_HEADER = "X-Trace-Id"
         const val USER_ID_KEY = "userId"
         const val USER_ID_HEADER = "X-User-Id"
         const val SERVICE_KEY = "service"

--- a/user-service/src/main/kotlin/com/hoppingmall/user/grpc/BusinessContextServerInterceptor.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/grpc/BusinessContextServerInterceptor.kt
@@ -9,11 +9,9 @@ import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor
 import org.slf4j.MDC
 
 @GrpcGlobalServerInterceptor
-class TracingServerInterceptor : ServerInterceptor {
+class BusinessContextServerInterceptor : ServerInterceptor {
 
     companion object {
-        val TRACE_ID_KEY: Metadata.Key<String> =
-            Metadata.Key.of("x-trace-id", Metadata.ASCII_STRING_MARSHALLER)
         val USER_ID_KEY: Metadata.Key<String> =
             Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER)
     }
@@ -23,7 +21,7 @@ class TracingServerInterceptor : ServerInterceptor {
         headers: Metadata,
         next: ServerCallHandler<ReqT, RespT>
     ): ServerCall.Listener<ReqT> {
-        headers.get(TRACE_ID_KEY)?.let { MDC.put("traceId", it) }
+        
         headers.get(USER_ID_KEY)?.let { MDC.put("userId", it) }
 
         return object : ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(
@@ -33,7 +31,6 @@ class TracingServerInterceptor : ServerInterceptor {
                 try {
                     super.onComplete()
                 } finally {
-                    MDC.remove("traceId")
                     MDC.remove("userId")
                 }
             }
@@ -42,7 +39,6 @@ class TracingServerInterceptor : ServerInterceptor {
                 try {
                     super.onCancel()
                 } finally {
-                    MDC.remove("traceId")
                     MDC.remove("userId")
                 }
             }

--- a/user-service/src/main/kotlin/com/hoppingmall/user/grpc/GrpcTelemetryConfig.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/grpc/GrpcTelemetryConfig.kt
@@ -1,0 +1,24 @@
+package com.hoppingmall.user.grpc
+
+import io.grpc.ClientInterceptor
+import io.grpc.ServerInterceptor
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class GrpcTelemetryConfig(private val openTelemetry: OpenTelemetry) {
+
+    private val grpcTelemetry = GrpcTelemetry.create(openTelemetry)
+
+    @Bean
+    @GrpcGlobalServerInterceptor
+    fun otelGrpcServerInterceptor(): ServerInterceptor = grpcTelemetry.newServerInterceptor()
+
+    @Bean
+    @GrpcGlobalClientInterceptor
+    fun otelGrpcClientInterceptor(): ClientInterceptor = grpcTelemetry.newClientInterceptor()
+}


### PR DESCRIPTION
Closes #252

### 📌 작업 개요
4개 gRPC 서비스에 OpenTelemetry gRPC 계측을 추가하고, 14개 커스텀 인터셉터를 트레이싱 역할에서 비즈니스 컨텍스트 전파 역할로 리네임했습니다.

---

### ✅ 주요 변경 사항

- `build.gradle.kts` (order, payment, product, user)
  - `opentelemetry-grpc-1.6:2.12.0-alpha` 의존성 추가

- `GrpcTelemetryConfig` (4개 서비스 신규)
  - OTel gRPC server/client 인터셉터 빈 등록

- gRPC 인터셉터 리네임 (7개 파일)
  - `TracingServerInterceptor` → `BusinessContextServerInterceptor` (4개 서비스)
  - `TracingClientInterceptor` → `BusinessContextClientInterceptor` (3개 서비스)
  - traceId 전파 제거, userId 전파만 유지

- Kafka 인터셉터 리네임 (7개 파일)
  - `TracingProducerInterceptor` → `BusinessContextProducerInterceptor` (2개 서비스)
  - `TracingConsumerInterceptor` → `BusinessContextConsumerInterceptor` (5개 서비스)
  - traceId 전파 제거, userId/service 전파만 유지

- KafkaConfig 참조 업데이트 (5개 파일)

---

### 🧪 테스트

- order, payment, product, user, notification 서비스 전체 `./gradlew test` 통과

---

### 📎 관련 이슈
- #252
