### PR TITLE
feat: Confluent Schema Registry + Avro 이벤트 스키마 관리

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,18 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
 
+  schema-registry:
+    image: confluentinc/cp-schema-registry:7.6.0
+    container_name: schema-registry
+    ports:
+      - "8081:8081"
+    depends_on:
+      - kafka
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'kafka:29092'
+      SCHEMA_REGISTRY_LISTENERS: 'http://0.0.0.0:8081'
+
   redis-node-1:
     image: redis:7.2-alpine
     container_name: redis-node-1

--- a/hoppingmall-common/build.gradle.kts
+++ b/hoppingmall-common/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 	kotlin("plugin.spring") version "1.9.25"
 	kotlin("plugin.jpa") version "1.9.25"
 	id("io.spring.dependency-management") version "1.1.7"
+	id("com.github.davidmc24.gradle.plugin.avro") version "1.9.1"
 	`java-library`
 }
 
@@ -17,6 +18,7 @@ java {
 
 repositories {
 	mavenCentral()
+	maven { url = uri("https://packages.confluent.io/maven/") }
 }
 
 dependencyManagement {
@@ -33,4 +35,6 @@ dependencies {
 	implementation("net.logstash.logback:logstash-logback-encoder:8.0")
 	api("io.micrometer:micrometer-tracing-bridge-otel")
 	api("io.opentelemetry:opentelemetry-exporter-otlp")
+	api("org.apache.avro:avro:1.11.3")
+	api("io.confluent:kafka-avro-serializer:7.6.0")
 }

--- a/hoppingmall-common/src/main/avro/MembershipUpdateRequestEvent.avsc
+++ b/hoppingmall-common/src/main/avro/MembershipUpdateRequestEvent.avsc
@@ -1,0 +1,12 @@
+{
+  "type": "record",
+  "name": "MembershipUpdateRequestEvent",
+  "namespace": "com.hoppingmall.common.event",
+  "fields": [
+    {"name": "eventId", "type": "string"},
+    {"name": "userId", "type": "long"},
+    {"name": "orderId", "type": "long"},
+    {"name": "paymentId", "type": "long"},
+    {"name": "amount", "type": "string"}
+  ]
+}

--- a/hoppingmall-common/src/main/avro/NotificationEvent.avsc
+++ b/hoppingmall-common/src/main/avro/NotificationEvent.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "NotificationEvent",
+  "namespace": "com.hoppingmall.common.event",
+  "fields": [
+    {"name": "eventId", "type": "string"},
+    {"name": "userId", "type": "long"},
+    {"name": "type", "type": {"type": "enum", "name": "NotificationType", "symbols": [
+      "PAYMENT_COMPLETED", "PAYMENT_FAILED", "PAYMENT_CANCELLED",
+      "POINT_EARNED", "ORDER_STATUS_CHANGED", "REFUND_COMPLETED"
+    ]}},
+    {"name": "title", "type": "string"},
+    {"name": "content", "type": "string"},
+    {"name": "metadata", "type": ["null", "string"], "default": null}
+  ]
+}

--- a/hoppingmall-common/src/main/avro/PaymentCancelledEvent.avsc
+++ b/hoppingmall-common/src/main/avro/PaymentCancelledEvent.avsc
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "PaymentCancelledEvent",
+  "namespace": "com.hoppingmall.common.event",
+  "fields": [
+    {"name": "eventId", "type": "string"},
+    {"name": "paymentId", "type": "long"},
+    {"name": "orderId", "type": "long"},
+    {"name": "userId", "type": "long"},
+    {"name": "amount", "type": "string"},
+    {"name": "transactionId", "type": "string", "default": ""}
+  ]
+}

--- a/hoppingmall-common/src/main/avro/PaymentCompletedEvent.avsc
+++ b/hoppingmall-common/src/main/avro/PaymentCompletedEvent.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "PaymentCompletedEvent",
+  "namespace": "com.hoppingmall.common.event",
+  "fields": [
+    {"name": "paymentId", "type": "long"},
+    {"name": "orderId", "type": "long"},
+    {"name": "userId", "type": "long"},
+    {"name": "amount", "type": "string"},
+    {"name": "pointAmount", "type": "string", "default": "0"},
+    {"name": "method", "type": {"type": "enum", "name": "PaymentMethod", "symbols": ["CREDIT_CARD", "BANK_TRANSFER"]}},
+    {"name": "status", "type": {"type": "enum", "name": "PaymentStatus", "symbols": ["PENDING", "SUCCESS", "FAILED", "CANCELLED"]}},
+    {"name": "transactionId", "type": "string"},
+    {"name": "completedAt", "type": "string"}
+  ]
+}

--- a/hoppingmall-common/src/main/avro/PaymentFailedEvent.avsc
+++ b/hoppingmall-common/src/main/avro/PaymentFailedEvent.avsc
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "PaymentFailedEvent",
+  "namespace": "com.hoppingmall.common.event",
+  "fields": [
+    {"name": "eventId", "type": "string"},
+    {"name": "paymentId", "type": "long"},
+    {"name": "orderId", "type": "long"},
+    {"name": "userId", "type": "long"},
+    {"name": "amount", "type": "string"},
+    {"name": "reason", "type": "string", "default": ""}
+  ]
+}

--- a/hoppingmall-common/src/main/avro/PointEarnRequestEvent.avsc
+++ b/hoppingmall-common/src/main/avro/PointEarnRequestEvent.avsc
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "PointEarnRequestEvent",
+  "namespace": "com.hoppingmall.common.event",
+  "fields": [
+    {"name": "eventId", "type": "string"},
+    {"name": "userId", "type": "long"},
+    {"name": "orderId", "type": "long"},
+    {"name": "paymentId", "type": "long"},
+    {"name": "earnAmount", "type": "string"},
+    {"name": "reason", "type": "string", "default": "결제 완료"}
+  ]
+}

--- a/hoppingmall-common/src/main/avro/RefundCompletedEvent.avsc
+++ b/hoppingmall-common/src/main/avro/RefundCompletedEvent.avsc
@@ -1,0 +1,25 @@
+{
+  "type": "record",
+  "name": "RefundCompletedEvent",
+  "namespace": "com.hoppingmall.common.event",
+  "fields": [
+    {"name": "eventId", "type": "string"},
+    {"name": "refundId", "type": "long"},
+    {"name": "orderId", "type": "long"},
+    {"name": "paymentId", "type": "long"},
+    {"name": "buyerId", "type": "long"},
+    {"name": "refundAmount", "type": "string"},
+    {"name": "pointRefundAmount", "type": "string", "default": "0"},
+    {"name": "isFullRefund", "type": "boolean", "default": false},
+    {"name": "couponId", "type": ["null", "long"], "default": null},
+    {"name": "items", "type": {"type": "array", "items": {
+      "type": "record",
+      "name": "RefundItemEvent",
+      "fields": [
+        {"name": "productId", "type": "long"},
+        {"name": "quantity", "type": "int"},
+        {"name": "refundPrice", "type": "string"}
+      ]
+    }}, "default": []}
+  ]
+}

--- a/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/event/AvroEventConverter.kt
+++ b/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/event/AvroEventConverter.kt
@@ -1,0 +1,68 @@
+package com.hoppingmall.common.event
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericData
+import org.apache.avro.generic.GenericRecord
+import org.springframework.stereotype.Component
+
+@Component
+class AvroEventConverter(private val objectMapper: ObjectMapper) {
+
+    private val schemaMap: Map<String, Schema> = mapOf(
+        "PaymentCompletedEvent" to PaymentCompletedEvent.getClassSchema(),
+        "PaymentFailedEvent" to PaymentFailedEvent.getClassSchema(),
+        "PaymentCancelledEvent" to PaymentCancelledEvent.getClassSchema(),
+        "PointEarnRequestEvent" to PointEarnRequestEvent.getClassSchema(),
+        "MembershipUpdateRequestEvent" to MembershipUpdateRequestEvent.getClassSchema(),
+        "NotificationEvent" to NotificationEvent.getClassSchema(),
+        "RefundCompletedEvent" to RefundCompletedEvent.getClassSchema()
+    )
+
+    fun convertJsonToAvro(eventType: String, jsonData: String): GenericRecord {
+        val schema = schemaMap[eventType]
+            ?: throw IllegalArgumentException("Unknown event type: $eventType")
+        val jsonMap = objectMapper.readValue(jsonData, Map::class.java)
+        return buildGenericRecord(schema, jsonMap)
+    }
+
+    private fun buildGenericRecord(schema: Schema, map: Map<*, *>): GenericRecord {
+        val record = GenericData.Record(schema)
+        for (field in schema.fields) {
+            val value = map[field.name()]
+            record.put(field.name(), convertValue(field.schema(), value))
+        }
+        return record
+    }
+
+    private fun convertValue(schema: Schema, value: Any?): Any? {
+        return when (schema.type) {
+            Schema.Type.UNION -> {
+                if (value == null) return null
+                val nonNullSchema = schema.types.first { it.type != Schema.Type.NULL }
+                convertValue(nonNullSchema, value)
+            }
+            Schema.Type.ENUM -> GenericData.EnumSymbol(schema, value.toString())
+            Schema.Type.LONG -> (value as? Number)?.toLong() ?: 0L
+            Schema.Type.INT -> (value as? Number)?.toInt() ?: 0
+            Schema.Type.BOOLEAN -> value as? Boolean ?: false
+            Schema.Type.STRING -> value?.toString() ?: ""
+            Schema.Type.ARRAY -> {
+                val elementSchema = schema.elementType
+                val list = value as? List<*> ?: emptyList<Any>()
+                list.map { item ->
+                    if (elementSchema.type == Schema.Type.RECORD && item is Map<*, *>) {
+                        buildGenericRecord(elementSchema, item)
+                    } else {
+                        convertValue(elementSchema, item)
+                    }
+                }
+            }
+            Schema.Type.RECORD -> {
+                if (value is Map<*, *>) buildGenericRecord(schema, value)
+                else GenericData.Record(schema)
+            }
+            else -> value
+        }
+    }
+}

--- a/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/event/AvroJsonDeserializer.kt
+++ b/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/event/AvroJsonDeserializer.kt
@@ -1,0 +1,53 @@
+package com.hoppingmall.common.event
+
+import io.confluent.kafka.serializers.KafkaAvroDeserializer
+import org.apache.avro.generic.GenericRecord
+import org.apache.kafka.common.serialization.Deserializer
+
+class AvroJsonDeserializer : Deserializer<String> {
+
+    private val avroDeserializer = KafkaAvroDeserializer()
+
+    override fun configure(configs: Map<String, *>, isKey: Boolean) {
+        avroDeserializer.configure(configs, isKey)
+    }
+
+    override fun deserialize(topic: String, data: ByteArray?): String? {
+        if (data == null) return null
+        val record = avroDeserializer.deserialize(topic, data) ?: return null
+        if (record is GenericRecord) {
+            return genericRecordToJson(record)
+        }
+        return record.toString()
+    }
+
+    override fun close() {
+        avroDeserializer.close()
+    }
+
+    private fun genericRecordToJson(record: GenericRecord): String {
+        val map = mutableMapOf<String, Any?>()
+        for (field in record.schema.fields) {
+            val value = record.get(field.name())
+            map[field.name()] = convertAvroValue(value)
+        }
+        return com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(map)
+    }
+
+    private fun convertAvroValue(value: Any?): Any? {
+        return when (value) {
+            null -> null
+            is org.apache.avro.util.Utf8 -> value.toString()
+            is GenericRecord -> {
+                val map = mutableMapOf<String, Any?>()
+                for (field in value.schema.fields) {
+                    map[field.name()] = convertAvroValue(value.get(field.name()))
+                }
+                map
+            }
+            is org.apache.avro.generic.GenericData.EnumSymbol -> value.toString()
+            is List<*> -> value.map { convertAvroValue(it) }
+            else -> value
+        }
+    }
+}

--- a/notification-service/build.gradle.kts
+++ b/notification-service/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
 
 repositories {
 	mavenCentral()
-tmaven { url = uri("https://packages.confluent.io/maven/") }
+	maven { url = uri("https://packages.confluent.io/maven/") }
 }
 
 dependencies {

--- a/notification-service/build.gradle.kts
+++ b/notification-service/build.gradle.kts
@@ -23,6 +23,7 @@ kotlin {
 
 repositories {
 	mavenCentral()
+tmaven { url = uri("https://packages.confluent.io/maven/") }
 }
 
 dependencies {

--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/config/KafkaConsumerConfig.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/config/KafkaConsumerConfig.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.notification.config
 
+import com.hoppingmall.common.event.AvroJsonDeserializer
 import com.hoppingmall.notification.config.kafka.BusinessContextConsumerInterceptor
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.StringDeserializer
@@ -10,13 +11,13 @@ import org.springframework.context.annotation.Profile
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
 import org.springframework.kafka.core.ConsumerFactory
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory
-import org.springframework.kafka.support.serializer.JsonDeserializer
 
 @Configuration
 @Profile("!test")
 class KafkaConsumerConfig(
     @Value("\${spring.kafka.bootstrap-servers}") private val bootstrapServers: String,
-    @Value("\${spring.kafka.consumer.group-id}") private val groupId: String
+    @Value("\${spring.kafka.consumer.group-id}") private val groupId: String,
+    @Value("\${spring.kafka.properties.schema.registry.url:http://localhost:8081}") private val schemaRegistryUrl: String
 ) {
 
     @Bean
@@ -25,11 +26,11 @@ class KafkaConsumerConfig(
             ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to bootstrapServers,
             ConsumerConfig.GROUP_ID_CONFIG to groupId,
             ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
-            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to JsonDeserializer::class.java,
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to AvroJsonDeserializer::class.java,
             ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
             ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to false,
             ConsumerConfig.ISOLATION_LEVEL_CONFIG to "read_committed",
-            JsonDeserializer.TRUSTED_PACKAGES to "*"
+            "schema.registry.url" to schemaRegistryUrl
         )
         return DefaultKafkaConsumerFactory(props)
     }

--- a/order-service/build.gradle.kts
+++ b/order-service/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
 
 repositories {
 	mavenCentral()
-tmaven { url = uri("https://packages.confluent.io/maven/") }
+	maven { url = uri("https://packages.confluent.io/maven/") }
 }
 
 val grpcVersion = "1.62.2"

--- a/order-service/build.gradle.kts
+++ b/order-service/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
 
 repositories {
 	mavenCentral()
+tmaven { url = uri("https://packages.confluent.io/maven/") }
 }
 
 val grpcVersion = "1.62.2"

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/KafkaConfig.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/KafkaConfig.kt
@@ -1,7 +1,9 @@
 package com.hoppingmall.order.config
 
+import com.hoppingmall.common.event.AvroJsonDeserializer
 import com.hoppingmall.order.config.kafka.BusinessContextConsumerInterceptor
 import com.hoppingmall.order.config.kafka.BusinessContextProducerInterceptor
+import io.confluent.kafka.serializers.KafkaAvroSerializer
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.errors.SerializationException
@@ -39,6 +41,9 @@ class KafkaConfig {
     @Value("\${spring.kafka.consumer.auto-offset-reset:earliest}")
     private lateinit var autoOffsetReset: String
 
+    @Value("\${spring.kafka.properties.schema.registry.url:http://localhost:8081}")
+    private lateinit var schemaRegistryUrl: String
+
     private val instanceId: String = UUID.randomUUID().toString()
 
     @Bean
@@ -46,7 +51,8 @@ class KafkaConfig {
         val configProps = HashMap<String, Any>()
         configProps[ProducerConfig.BOOTSTRAP_SERVERS_CONFIG] = producerBootstrapServers
         configProps[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java
-        configProps[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JsonSerializer::class.java
+        configProps[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = KafkaAvroSerializer::class.java
+        configProps["schema.registry.url"] = schemaRegistryUrl
 
         configProps[ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG] = true
         configProps[ProducerConfig.ACKS_CONFIG] = "all"
@@ -84,7 +90,8 @@ class KafkaConfig {
         configProps[ConsumerConfig.GROUP_ID_CONFIG] = groupId
         configProps[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = autoOffsetReset
         configProps[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
-        configProps[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+        configProps[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = AvroJsonDeserializer::class.java
+        configProps["schema.registry.url"] = schemaRegistryUrl
 
         configProps[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = false
         configProps[ConsumerConfig.ISOLATION_LEVEL_CONFIG] = "read_committed"

--- a/order-service/src/main/kotlin/com/hoppingmall/order/outbox/service/OutboxEventPublisher.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/outbox/service/OutboxEventPublisher.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.order.outbox.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.common.event.AvroEventConverter
 import com.hoppingmall.order.config.OutboxMetrics
 import com.hoppingmall.order.outbox.domain.OutboxEvent
 import com.hoppingmall.order.outbox.domain.OutboxStatus
@@ -19,7 +20,8 @@ class OutboxEventPublisher(
     private val outboxEventRepository: OutboxEventRepository,
     private val kafkaTemplate: KafkaTemplate<String, Any>,
     private val objectMapper: ObjectMapper,
-    private val outboxMetrics: OutboxMetrics
+    private val outboxMetrics: OutboxMetrics,
+    private val avroEventConverter: AvroEventConverter
 ) {
 
     private val logger = LoggerFactory.getLogger(OutboxEventPublisher::class.java)
@@ -65,13 +67,13 @@ class OutboxEventPublisher(
                 return
             }
 
-            val eventData = objectMapper.readValue(event.eventData, Map::class.java)
+            val avroRecord = avroEventConverter.convertJsonToAvro(event.eventType, event.eventData)
 
             val result = kafkaTemplate.executeInTransaction { template ->
                 template.send(
                     event.topic,
                     event.partitionKey ?: "",
-                    eventData
+                    avroRecord
                 ).get(10, java.util.concurrent.TimeUnit.SECONDS)
             }
 

--- a/payment-service/build.gradle.kts
+++ b/payment-service/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
 
 repositories {
 	mavenCentral()
-tmaven { url = uri("https://packages.confluent.io/maven/") }
+	maven { url = uri("https://packages.confluent.io/maven/") }
 }
 
 val grpcVersion = "1.62.2"

--- a/payment-service/build.gradle.kts
+++ b/payment-service/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
 
 repositories {
 	mavenCentral()
+tmaven { url = uri("https://packages.confluent.io/maven/") }
 }
 
 val grpcVersion = "1.62.2"

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/KafkaConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/KafkaConfig.kt
@@ -1,9 +1,11 @@
 package com.hoppingmall.payment.config
 
+import com.hoppingmall.common.event.AvroJsonDeserializer
 import com.hoppingmall.payment.config.kafka.BusinessContextConsumerInterceptor
 import com.hoppingmall.payment.config.kafka.BusinessContextProducerInterceptor
 import com.hoppingmall.payment.dlq.domain.DeadLetterMessage
 import com.hoppingmall.payment.dlq.service.DLQCommandService
+import io.confluent.kafka.serializers.KafkaAvroSerializer
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization.StringDeserializer
@@ -16,7 +18,6 @@ import org.springframework.context.annotation.Profile
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
 import org.springframework.kafka.core.*
 import org.springframework.kafka.listener.DefaultErrorHandler
-import org.springframework.kafka.support.serializer.JsonSerializer
 import org.springframework.messaging.converter.MessageConversionException
 import org.apache.kafka.common.errors.SerializationException
 import org.springframework.kafka.support.serializer.DeserializationException
@@ -40,6 +41,9 @@ class KafkaConfig(
     @Value("\${spring.kafka.consumer.auto-offset-reset:earliest}")
     private lateinit var autoOffsetReset: String
 
+    @Value("\${spring.kafka.properties.schema.registry.url:http://localhost:8081}")
+    private lateinit var schemaRegistryUrl: String
+
     private val instanceId: String = UUID.randomUUID().toString()
 
     @Bean
@@ -47,7 +51,8 @@ class KafkaConfig(
         val configProps = HashMap<String, Any>()
         configProps[ProducerConfig.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers
         configProps[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java
-        configProps[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JsonSerializer::class.java
+        configProps[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = KafkaAvroSerializer::class.java
+        configProps["schema.registry.url"] = schemaRegistryUrl
 
         configProps[ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG] = true
         configProps[ProducerConfig.ACKS_CONFIG] = "all"
@@ -84,7 +89,8 @@ class KafkaConfig(
         configProps[ConsumerConfig.GROUP_ID_CONFIG] = groupId
         configProps[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = autoOffsetReset
         configProps[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
-        configProps[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+        configProps[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = AvroJsonDeserializer::class.java
+        configProps["schema.registry.url"] = schemaRegistryUrl
 
         configProps[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = false
         configProps[ConsumerConfig.ISOLATION_LEVEL_CONFIG] = "read_committed"

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/outbox/service/OutboxEventPublisher.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/outbox/service/OutboxEventPublisher.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.payment.outbox.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.common.event.AvroEventConverter
 import com.hoppingmall.payment.config.OutboxMetrics
 import com.hoppingmall.payment.outbox.domain.OutboxEvent
 import com.hoppingmall.payment.outbox.domain.OutboxStatus
@@ -19,7 +20,8 @@ class OutboxEventPublisher(
     private val outboxEventRepository: OutboxEventRepository,
     private val kafkaTemplate: KafkaTemplate<String, Any>,
     private val objectMapper: ObjectMapper,
-    private val outboxMetrics: OutboxMetrics
+    private val outboxMetrics: OutboxMetrics,
+    private val avroEventConverter: AvroEventConverter
 ) {
 
     private val logger = LoggerFactory.getLogger(OutboxEventPublisher::class.java)
@@ -64,13 +66,13 @@ class OutboxEventPublisher(
                 return
             }
 
-            val eventData = objectMapper.readValue(event.eventData, Map::class.java)
+            val avroRecord = avroEventConverter.convertJsonToAvro(event.eventType, event.eventData)
 
             kafkaTemplate.executeInTransaction { template ->
                 val future: CompletableFuture<SendResult<String, Any>> = template.send(
                     event.topic,
                     event.partitionKey ?: "",
-                    eventData
+                    avroRecord
                 )
 
                 future.whenComplete { result, throwable ->

--- a/product-service/build.gradle.kts
+++ b/product-service/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
 
 repositories {
 	mavenCentral()
-tmaven { url = uri("https://packages.confluent.io/maven/") }
+	maven { url = uri("https://packages.confluent.io/maven/") }
 }
 
 val grpcVersion = "1.62.2"

--- a/product-service/build.gradle.kts
+++ b/product-service/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
 
 repositories {
 	mavenCentral()
+tmaven { url = uri("https://packages.confluent.io/maven/") }
 }
 
 val grpcVersion = "1.62.2"

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/KafkaConsumerConfig.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/KafkaConsumerConfig.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.product.config
 
+import com.hoppingmall.common.event.AvroJsonDeserializer
 import com.hoppingmall.product.config.kafka.BusinessContextConsumerInterceptor
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.errors.SerializationException
@@ -32,6 +33,9 @@ class KafkaConsumerConfig {
     @Value("\${spring.kafka.consumer.auto-offset-reset:earliest}")
     private lateinit var autoOffsetReset: String
 
+    @Value("\${spring.kafka.properties.schema.registry.url:http://localhost:8081}")
+    private lateinit var schemaRegistryUrl: String
+
     @Bean
     fun consumerFactory(): ConsumerFactory<String, Any> {
         val configProps = HashMap<String, Any>()
@@ -39,7 +43,8 @@ class KafkaConsumerConfig {
         configProps[ConsumerConfig.GROUP_ID_CONFIG] = groupId
         configProps[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = autoOffsetReset
         configProps[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
-        configProps[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+        configProps[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = AvroJsonDeserializer::class.java
+        configProps["schema.registry.url"] = schemaRegistryUrl
 
         configProps[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = false
         configProps[ConsumerConfig.ISOLATION_LEVEL_CONFIG] = "read_committed"

--- a/settlement-service/build.gradle.kts
+++ b/settlement-service/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
 
 repositories {
 	mavenCentral()
-tmaven { url = uri("https://packages.confluent.io/maven/") }
+	maven { url = uri("https://packages.confluent.io/maven/") }
 }
 
 dependencies {

--- a/settlement-service/build.gradle.kts
+++ b/settlement-service/build.gradle.kts
@@ -23,6 +23,7 @@ kotlin {
 
 repositories {
 	mavenCentral()
+tmaven { url = uri("https://packages.confluent.io/maven/") }
 }
 
 dependencies {

--- a/user-service/build.gradle.kts
+++ b/user-service/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
 
 repositories {
 	mavenCentral()
-tmaven { url = uri("https://packages.confluent.io/maven/") }
+	maven { url = uri("https://packages.confluent.io/maven/") }
 }
 
 val grpcVersion = "1.62.2"

--- a/user-service/build.gradle.kts
+++ b/user-service/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
 
 repositories {
 	mavenCentral()
+tmaven { url = uri("https://packages.confluent.io/maven/") }
 }
 
 val grpcVersion = "1.62.2"

--- a/user-service/src/main/kotlin/com/hoppingmall/user/config/KafkaConsumerConfig.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/config/KafkaConsumerConfig.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.user.config
 
+import com.hoppingmall.common.event.AvroJsonDeserializer
 import com.hoppingmall.user.config.kafka.BusinessContextConsumerInterceptor
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.StringDeserializer
@@ -10,13 +11,13 @@ import org.springframework.context.annotation.Profile
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
 import org.springframework.kafka.core.ConsumerFactory
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory
-import org.springframework.kafka.support.serializer.JsonDeserializer
 
 @Configuration
 @Profile("!test")
 class KafkaConsumerConfig(
     @Value("\${spring.kafka.bootstrap-servers}") private val bootstrapServers: String,
-    @Value("\${spring.kafka.consumer.group-id}") private val groupId: String
+    @Value("\${spring.kafka.consumer.group-id}") private val groupId: String,
+    @Value("\${spring.kafka.properties.schema.registry.url:http://localhost:8081}") private val schemaRegistryUrl: String
 ) {
 
     @Bean
@@ -25,11 +26,11 @@ class KafkaConsumerConfig(
             ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to bootstrapServers,
             ConsumerConfig.GROUP_ID_CONFIG to groupId,
             ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
-            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to JsonDeserializer::class.java,
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to AvroJsonDeserializer::class.java,
             ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
             ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to false,
             ConsumerConfig.ISOLATION_LEVEL_CONFIG to "read_committed",
-            JsonDeserializer.TRUSTED_PACKAGES to "*"
+            "schema.registry.url" to schemaRegistryUrl
         )
         return DefaultKafkaConsumerFactory(props)
     }


### PR DESCRIPTION
Closes #258

### 📌 작업 개요
Confluent Schema Registry + Avro를 도입하여 Kafka 이벤트 스키마를 중앙 관리합니다. Producer는 Avro로 직렬화하고, Consumer는 AvroJsonDeserializer 어댑터로 기존 JSON 파싱 코드를 그대로 유지합니다.

---

### ✅ 주요 변경 사항

- `hoppingmall-common`
  - Avro Gradle 플러그인 + Confluent kafka-avro-serializer 의존성 추가
  - 7개 Avro 스키마 정의 (.avsc): PaymentCompleted/Failed/Cancelled, PointEarnRequest, MembershipUpdateRequest, Notification, RefundCompleted
  - `AvroEventConverter`: Outbox JSON → Avro GenericRecord 변환
  - `AvroJsonDeserializer`: Avro GenericRecord → JSON String 어댑터 (Consumer 호환)

- `docker-compose.yml`
  - Confluent Schema Registry 7.6.0 컨테이너 추가 (포트 8081)

- `payment-service`, `order-service` (Producer + Consumer)
  - KafkaConfig: JsonSerializer → KafkaAvroSerializer, StringDeserializer → AvroJsonDeserializer
  - OutboxEventPublisher: JSON Map → Avro GenericRecord 변환 후 발행

- `notification-service`, `product-service`, `user-service` (Consumer only)
  - KafkaConsumerConfig: JsonDeserializer/StringDeserializer → AvroJsonDeserializer

- 6개 서비스 build.gradle.kts에 Confluent Maven repo 추가

---

### 🧪 테스트

- payment, order, notification, user, product 서비스 전체 `./gradlew test` 통과
- Consumer 코드 변경 없음 (AvroJsonDeserializer가 JSON String으로 변환하여 호환 유지)

---

### 📎 관련 이슈
- #258
