### PR TITLE
feat: API Gateway Redis Rate Limiting 적용

### DIFF
--- a/api-gateway/src/main/kotlin/com/hoppingmall/gateway/config/RateLimitConfig.kt
+++ b/api-gateway/src/main/kotlin/com/hoppingmall/gateway/config/RateLimitConfig.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.gateway.config
 
 import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver
+import org.springframework.cloud.gateway.filter.ratelimit.RedisRateLimiter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import reactor.core.publisher.Mono
@@ -13,10 +14,15 @@ class RateLimitConfig {
         return KeyResolver { exchange ->
             val userId = exchange.request.headers.getFirst("x-user-id")
             if (userId != null) {
-                Mono.just(userId)
+                Mono.just("user:$userId")
             } else {
-                Mono.just(exchange.request.remoteAddress?.address?.hostAddress ?: "anonymous")
+                Mono.just("ip:${exchange.request.remoteAddress?.address?.hostAddress ?: "anonymous"}")
             }
         }
+    }
+
+    @Bean
+    fun redisRateLimiter(): RedisRateLimiter {
+        return RedisRateLimiter(50, 100, 1)
     }
 }

--- a/api-gateway/src/main/kotlin/com/hoppingmall/gateway/filter/RateLimitGlobalFilter.kt
+++ b/api-gateway/src/main/kotlin/com/hoppingmall/gateway/filter/RateLimitGlobalFilter.kt
@@ -1,0 +1,47 @@
+package com.hoppingmall.gateway.filter
+
+import org.springframework.cloud.gateway.filter.GatewayFilterChain
+import org.springframework.cloud.gateway.filter.GlobalFilter
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver
+import org.springframework.cloud.gateway.filter.ratelimit.RedisRateLimiter
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 5)
+class RateLimitGlobalFilter(
+    private val keyResolver: KeyResolver,
+    private val redisRateLimiter: RedisRateLimiter
+) : GlobalFilter {
+
+    override fun filter(exchange: ServerWebExchange, chain: GatewayFilterChain): Mono<Void> {
+        val path = exchange.request.uri.path
+
+        if (isExcluded(path)) {
+            return chain.filter(exchange)
+        }
+
+        return keyResolver.resolve(exchange).flatMap { key ->
+            redisRateLimiter.isAllowed("gateway", key).flatMap { response ->
+                if (response.isAllowed) {
+                    response.headers.forEach { (name, value) ->
+                        exchange.response.headers[name] = listOf(value)
+                    }
+                    chain.filter(exchange)
+                } else {
+                    exchange.response.statusCode = HttpStatus.TOO_MANY_REQUESTS
+                    exchange.response.headers.set("Retry-After", "1")
+                    exchange.response.setComplete()
+                }
+            }
+        }
+    }
+
+    private fun isExcluded(path: String): Boolean {
+        return path.startsWith("/actuator") || path.startsWith("/internal")
+    }
+}


### PR DESCRIPTION
Closes #264

### 📌 작업 개요
Spring Cloud Gateway + Redis 기반 Rate Limiting을 적용하여 API 요청을 유저/IP별로 제한합니다.

---

### ✅ 주요 변경 사항

- `api-gateway/.../RateLimitConfig.kt` (수정)
  - `RedisRateLimiter` 빈 등록 (50 req/s, burst 100)
  - `KeyResolver`: 인증 유저는 `x-user-id` 기반, 비인증은 IP 기반

- `api-gateway/.../RateLimitGlobalFilter.kt` (신규)
  - 전역 Rate Limiting 필터 (모든 요청에 적용)
  - `/actuator`, `/internal` 경로 제외
  - 초과 시 429 Too Many Requests + `Retry-After: 1` 헤더
  - 응답 헤더에 `X-RateLimit-Remaining` 등 포함

---

### 🧪 테스트

- api-gateway `./gradlew test` 통과

---

### 📎 관련 이슈
- #264
