### PR TITLE
config: Docker 모니터링 인프라 구성 및 서비스 설정 정비

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,10 +1,10 @@
 FROM eclipse-temurin:21-jdk-alpine AS build
 WORKDIR /app
-COPY gradlew ./
-COPY gradle ./gradle
-COPY build.gradle.kts settings.gradle.kts ./
-COPY src ./src
-RUN chmod +x gradlew && ./gradlew bootJar --no-daemon -x test
+COPY api-gateway/gradlew ./
+COPY api-gateway/gradle ./gradle
+COPY api-gateway/build.gradle.kts api-gateway/settings.gradle.kts ./
+COPY api-gateway/src ./src
+RUN sed -i "s/\r$//" gradlew && chmod +x gradlew && ./gradlew bootJar --no-daemon -x test
 
 FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app

--- a/api-gateway/src/main/kotlin/com/hoppingmall/gateway/filter/RateLimitGlobalFilter.kt
+++ b/api-gateway/src/main/kotlin/com/hoppingmall/gateway/filter/RateLimitGlobalFilter.kt
@@ -42,6 +42,10 @@ class RateLimitGlobalFilter(
     }
 
     private fun isExcluded(path: String): Boolean {
-        return path.startsWith("/actuator") || path.startsWith("/internal")
+        return path.startsWith("/actuator") ||
+            path.startsWith("/internal") ||
+            path == "/api/v1/users/signup" ||
+            path == "/api/v1/users/login" ||
+            path == "/api/v1/auth/refresh"
     }
 }

--- a/api-gateway/src/main/resources/application-docker.yml
+++ b/api-gateway/src/main/resources/application-docker.yml
@@ -1,8 +1,27 @@
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+    urls:
+      - name: user-service
+        url: /v3/api-docs/user-service
+      - name: product-service
+        url: /v3/api-docs/product-service
+      - name: order-service
+        url: /v3/api-docs/order-service
+      - name: payment-service
+        url: /v3/api-docs/payment-service
+      - name: settlement-service
+        url: /v3/api-docs/settlement-service
+      - name: notification-service
+        url: /v3/api-docs/notification-service
+
 spring:
   data:
     redis:
-      host: ""
-      port: 0
+      host: redis-node-1
+      port: 7001
       cluster:
         nodes:
           - redis-node-1:7001
@@ -12,6 +31,48 @@ spring:
   cloud:
     gateway:
       routes:
+        - id: user-service-api-docs
+          uri: http://user-service:8082
+          predicates:
+            - Path=/v3/api-docs/user-service
+          filters:
+            - RewritePath=/v3/api-docs/user-service, /v3/api-docs
+
+        - id: product-service-api-docs
+          uri: http://product-service:8083
+          predicates:
+            - Path=/v3/api-docs/product-service
+          filters:
+            - RewritePath=/v3/api-docs/product-service, /v3/api-docs
+
+        - id: order-service-api-docs
+          uri: http://order-service:8084
+          predicates:
+            - Path=/v3/api-docs/order-service
+          filters:
+            - RewritePath=/v3/api-docs/order-service, /v3/api-docs
+
+        - id: payment-service-api-docs
+          uri: http://payment-service:8085
+          predicates:
+            - Path=/v3/api-docs/payment-service
+          filters:
+            - RewritePath=/v3/api-docs/payment-service, /v3/api-docs
+
+        - id: settlement-service-api-docs
+          uri: http://settlement-service:8086
+          predicates:
+            - Path=/v3/api-docs/settlement-service
+          filters:
+            - RewritePath=/v3/api-docs/settlement-service, /v3/api-docs
+
+        - id: notification-service-api-docs
+          uri: http://notification-service:8081
+          predicates:
+            - Path=/v3/api-docs/notification-service
+          filters:
+            - RewritePath=/v3/api-docs/notification-service, /v3/api-docs
+
         - id: user-service-public
           uri: http://user-service:8082
           predicates:
@@ -165,12 +226,15 @@ spring:
             - name: JwtValidation
 
 management:
+  metrics:
+    tags:
+      application: api-gateway
   tracing:
     sampling:
       probability: 1.0
-  zipkin:
+  otlp:
     tracing:
-      endpoint: http://zipkin:9411/api/v2/spans
+      endpoint: http://tempo:4318/v1/traces
 
 logging:
   level:

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -1,3 +1,22 @@
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+    urls:
+      - name: user-service
+        url: /v3/api-docs/user-service
+      - name: product-service
+        url: /v3/api-docs/product-service
+      - name: order-service
+        url: /v3/api-docs/order-service
+      - name: payment-service
+        url: /v3/api-docs/payment-service
+      - name: settlement-service
+        url: /v3/api-docs/settlement-service
+      - name: notification-service
+        url: /v3/api-docs/notification-service
+
 spring:
   application:
     name: api-gateway
@@ -10,6 +29,48 @@ spring:
   cloud:
     gateway:
       routes:
+        - id: user-service-api-docs
+          uri: ${ROUTES_USER_SERVICE:http://localhost:8082}
+          predicates:
+            - Path=/v3/api-docs/user-service
+          filters:
+            - RewritePath=/v3/api-docs/user-service, /v3/api-docs
+
+        - id: product-service-api-docs
+          uri: ${ROUTES_PRODUCT_SERVICE:http://localhost:8083}
+          predicates:
+            - Path=/v3/api-docs/product-service
+          filters:
+            - RewritePath=/v3/api-docs/product-service, /v3/api-docs
+
+        - id: order-service-api-docs
+          uri: ${ROUTES_ORDER_SERVICE:http://localhost:8084}
+          predicates:
+            - Path=/v3/api-docs/order-service
+          filters:
+            - RewritePath=/v3/api-docs/order-service, /v3/api-docs
+
+        - id: payment-service-api-docs
+          uri: ${ROUTES_PAYMENT_SERVICE:http://localhost:8085}
+          predicates:
+            - Path=/v3/api-docs/payment-service
+          filters:
+            - RewritePath=/v3/api-docs/payment-service, /v3/api-docs
+
+        - id: settlement-service-api-docs
+          uri: ${ROUTES_SETTLEMENT_SERVICE:http://localhost:8086}
+          predicates:
+            - Path=/v3/api-docs/settlement-service
+          filters:
+            - RewritePath=/v3/api-docs/settlement-service, /v3/api-docs
+
+        - id: notification-service-api-docs
+          uri: ${ROUTES_NOTIFICATION_SERVICE:http://localhost:8081}
+          predicates:
+            - Path=/v3/api-docs/notification-service
+          filters:
+            - RewritePath=/v3/api-docs/notification-service, /v3/api-docs
+
         - id: user-service-public
           uri: ${ROUTES_USER_SERVICE:http://localhost:8082}
           predicates:

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -9,14 +9,6 @@ spring:
 
   cloud:
     gateway:
-      default-filters:
-        - name: RequestRateLimiter
-          args:
-            redis-rate-limiter.replenishRate: 20
-            redis-rate-limiter.burstCapacity: 40
-            redis-rate-limiter.requestedTokens: 1
-            key-resolver: "#{@userKeyResolver}"
-            deny-empty-key: false
       routes:
         - id: user-service-public
           uri: ${ROUTES_USER_SERVICE:http://localhost:8082}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -235,6 +235,8 @@ services:
     volumes:
       - ./docker/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-data:/prometheus
+    depends_on:
+      - mimir
 
   loki:
     image: grafana/loki:2.9.0
@@ -244,6 +246,16 @@ services:
     volumes:
       - ./docker/loki.yml:/etc/loki/local-config.yaml
     command: -config.file=/etc/loki/local-config.yaml
+
+  mimir:
+    image: grafana/mimir:2.14.0
+    container_name: mimir
+    command: ["--config.file=/etc/mimir/mimir.yml"]
+    ports:
+      - "9009:9009"
+    volumes:
+      - ./docker/mimir.yml:/etc/mimir/mimir.yml
+      - mimir-data:/data/mimir
 
   promtail:
     image: grafana/promtail:2.9.0
@@ -273,11 +285,12 @@ services:
       - prometheus
       - loki
       - tempo
+      - mimir
 
   notification-service:
     build:
-      context: ./notification-service
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: notification-service/Dockerfile
     container_name: notification-service
     depends_on:
       mysql:
@@ -290,12 +303,18 @@ services:
       SPRING_PROFILES_ACTIVE: docker
       JWT_SECRET: ${JWT_SECRET:-default-docker-secret-key-for-development-only-32chars!}
     ports:
-      - "8081:8081"
+      - "8091:8081"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8081/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
 
   user-service:
     build:
-      context: ./user-service
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: user-service/Dockerfile
     container_name: user-service
     depends_on:
       mysql:
@@ -309,11 +328,17 @@ services:
     ports:
       - "8082:8082"
       - "9082:9082"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8082/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
 
   product-service:
     build:
-      context: ./product-service
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: product-service/Dockerfile
     container_name: product-service
     depends_on:
       mysql:
@@ -327,11 +352,17 @@ services:
     ports:
       - "8083:8083"
       - "9093:9093"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8083/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
 
   order-service:
     build:
-      context: ./order-service
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: order-service/Dockerfile
     container_name: order-service
     depends_on:
       mysql:
@@ -347,11 +378,17 @@ services:
     ports:
       - "8084:8084"
       - "9094:9094"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8084/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
 
   payment-service:
     build:
-      context: ./payment-service
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: payment-service/Dockerfile
     container_name: payment-service
     depends_on:
       mysql:
@@ -367,11 +404,17 @@ services:
     ports:
       - "8085:8085"
       - "9095:9095"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8085/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
 
   settlement-service:
     build:
-      context: ./settlement-service
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: settlement-service/Dockerfile
     container_name: settlement-service
     depends_on:
       mysql:
@@ -382,15 +425,21 @@ services:
       INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-docker-internal-token-2026}
     ports:
       - "8086:8086"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8086/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
 
   api-gateway:
     build:
-      context: ./api-gateway
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: api-gateway/Dockerfile
     container_name: api-gateway
     depends_on:
       redis-cluster-init:
-        condition: service_completed_successfully
+        condition: service_started
       user-service:
         condition: service_started
       notification-service:
@@ -408,9 +457,52 @@ services:
       JWT_SECRET: ${JWT_SECRET:-default-docker-secret-key-for-development-only-32chars!}
     ports:
       - "8000:8000"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8000/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
+
+  kafka-exporter:
+    image: danielqsj/kafka-exporter:latest
+    container_name: kafka-exporter
+    command: --kafka.server=kafka:29092 --offset.show-all
+    depends_on:
+      - kafka
+    ports:
+      - "9308:9308"
+
+  redis-exporter:
+    image: oliver006/redis_exporter:latest
+    container_name: redis-exporter
+    environment:
+      REDIS_ADDR: redis://redis-node-1:7001
+      REDIS_EXPORTER_IS_CLUSTER: "true"
+    depends_on:
+      redis-cluster-init:
+        condition: service_started
+    ports:
+      - "9121:9121"
+
+  seed-runner:
+    image: mysql:8.0
+    container_name: seed-runner
+    depends_on:
+      user-service:
+        condition: service_healthy
+      product-service:
+        condition: service_healthy
+      payment-service:
+        condition: service_healthy
+    volumes:
+      - ./docker/seed-data.sql:/seed-data.sql
+    entrypoint: ["sh", "-c", "sleep 5 && mysql -h mysql -u root -proot < /seed-data.sql && echo 'Seed data inserted successfully'"]
+    restart: "no"
 
 volumes:
   mysql-data:
   prometheus-data:
   grafana-data:
   tempo-data:
+  mimir-data:

--- a/docker/grafana-datasources.yml
+++ b/docker/grafana-datasources.yml
@@ -3,28 +3,31 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
+    uid: prometheus
     access: proxy
-    url: http://prometheus:9090
+    url: http://mimir:9009/prometheus
     isDefault: true
     editable: true
 
   - name: Loki
     type: loki
+    uid: loki
     access: proxy
     url: http://loki:3100
     editable: true
 
   - name: Tempo
     type: tempo
+    uid: tempo
     access: proxy
     url: http://tempo:3200
     editable: true
     jsonData:
-      tracesToLogsV2:
-        datasourceUid: loki
-        filterByTraceID: true
-        filterBySpanID: false
       nodeGraph:
         enabled: true
-      serviceMap:
-        datasourceUid: prometheus
+      tracesToLogsV2:
+        datasourceUid: loki
+        spanStartTimeShift: "-1h"
+        spanEndTimeShift: "1h"
+        filterByTraceID: true
+        filterBySpanID: false

--- a/docker/mimir.yml
+++ b/docker/mimir.yml
@@ -1,0 +1,52 @@
+multitenancy_enabled: false
+
+server:
+  http_listen_port: 9009
+  grpc_listen_port: 9095
+  log_level: warn
+
+common:
+  storage:
+    backend: filesystem
+    filesystem:
+      dir: /data/mimir
+
+blocks_storage:
+  backend: filesystem
+  filesystem:
+    dir: /data/mimir/blocks
+  tsdb:
+    dir: /data/mimir/tsdb
+
+ingester:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: memberlist
+    replication_factor: 1
+
+store_gateway:
+  sharding_ring:
+    replication_factor: 1
+
+compactor:
+  data_dir: /data/mimir/compactor
+  sharding_ring:
+    kvstore:
+      store: memberlist
+
+distributor:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: memberlist
+
+ruler_storage:
+  backend: filesystem
+  filesystem:
+    dir: /data/mimir/rules
+
+limits:
+  ingestion_rate: 100000
+  ingestion_burst_size: 200000
+  max_global_series_per_user: 500000

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -2,9 +2,17 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+remote_write:
+  - url: http://mimir:9009/api/v1/push
+
 scrape_configs:
   - job_name: 'notification-service'
     metrics_path: '/actuator/prometheus'
+    metric_relabel_configs:
+      - source_labels: [application]
+        regex: '^$'
+        target_label: application
+        replacement: 'notification-service'
     static_configs:
       - targets: ['notification-service:8081']
         labels:
@@ -12,6 +20,11 @@ scrape_configs:
 
   - job_name: 'user-service'
     metrics_path: '/actuator/prometheus'
+    metric_relabel_configs:
+      - source_labels: [application]
+        regex: '^$'
+        target_label: application
+        replacement: 'user-service'
     static_configs:
       - targets: ['user-service:8082']
         labels:
@@ -19,6 +32,11 @@ scrape_configs:
 
   - job_name: 'product-service'
     metrics_path: '/actuator/prometheus'
+    metric_relabel_configs:
+      - source_labels: [application]
+        regex: '^$'
+        target_label: application
+        replacement: 'product-service'
     static_configs:
       - targets: ['product-service:8083']
         labels:
@@ -26,6 +44,11 @@ scrape_configs:
 
   - job_name: 'order-service'
     metrics_path: '/actuator/prometheus'
+    metric_relabel_configs:
+      - source_labels: [application]
+        regex: '^$'
+        target_label: application
+        replacement: 'order-service'
     static_configs:
       - targets: ['order-service:8084']
         labels:
@@ -33,6 +56,11 @@ scrape_configs:
 
   - job_name: 'payment-service'
     metrics_path: '/actuator/prometheus'
+    metric_relabel_configs:
+      - source_labels: [application]
+        regex: '^$'
+        target_label: application
+        replacement: 'payment-service'
     static_configs:
       - targets: ['payment-service:8085']
         labels:
@@ -40,6 +68,11 @@ scrape_configs:
 
   - job_name: 'settlement-service'
     metrics_path: '/actuator/prometheus'
+    metric_relabel_configs:
+      - source_labels: [application]
+        regex: '^$'
+        target_label: application
+        replacement: 'settlement-service'
     static_configs:
       - targets: ['settlement-service:8086']
         labels:
@@ -47,5 +80,18 @@ scrape_configs:
 
   - job_name: 'api-gateway'
     metrics_path: '/actuator/prometheus'
+    metric_relabel_configs:
+      - source_labels: [application]
+        regex: '^$'
+        target_label: application
+        replacement: 'api-gateway'
     static_configs:
       - targets: ['api-gateway:8000']
+
+  - job_name: 'kafka-exporter'
+    static_configs:
+      - targets: ['kafka-exporter:9308']
+
+  - job_name: 'redis-exporter'
+    static_configs:
+      - targets: ['redis-exporter:9121']

--- a/docker/promtail.yml
+++ b/docker/promtail.yml
@@ -31,6 +31,8 @@ scrape_configs:
           expressions:
             level: level
             service: service
+            traceId: traceId
       - labels:
           level:
           service:
+          traceId:

--- a/hoppingmall-common/build.gradle.kts
+++ b/hoppingmall-common/build.gradle.kts
@@ -37,4 +37,5 @@ dependencies {
 	api("io.opentelemetry:opentelemetry-exporter-otlp")
 	api("org.apache.avro:avro:1.11.3")
 	api("io.confluent:kafka-avro-serializer:7.6.0")
+	compileOnly("org.redisson:redisson-spring-boot-starter:4.3.0")
 }

--- a/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/config/RedissonConfig.kt
+++ b/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/config/RedissonConfig.kt
@@ -1,0 +1,30 @@
+package com.hoppingmall.common.config
+
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@Configuration
+@Profile("docker")
+@ConditionalOnClass(RedissonClient::class)
+class RedissonDockerConfig(
+    @Value("\${spring.data.redis.cluster.nodes:redis-node-1:7001,redis-node-2:7002,redis-node-3:7003}")
+    private val clusterNodes: List<String>
+) {
+
+    @Bean(destroyMethod = "shutdown")
+    fun redissonClient(): RedissonClient {
+        val config = Config()
+        val clusterConfig = config.useClusterServers()
+        clusterConfig.scanInterval = 1000
+        clusterNodes.forEach { node ->
+            clusterConfig.addNodeAddress("redis://$node")
+        }
+        return Redisson.create(config)
+    }
+}

--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -1,11 +1,11 @@
 FROM eclipse-temurin:21-jdk-alpine AS build
 WORKDIR /app
-COPY gradlew ./
-COPY gradle ./gradle
-COPY build.gradle.kts settings.gradle.kts ./
-COPY src ./src
+COPY notification-service/gradlew ./
+COPY notification-service/gradle ./gradle
+COPY notification-service/build.gradle.kts notification-service/settings.gradle.kts ./
+COPY notification-service/src ./src
 COPY hoppingmall-common /hoppingmall-common
-RUN chmod +x gradlew && ./gradlew bootJar --no-daemon -x test
+RUN sed -i "s/\r$//" gradlew && chmod +x gradlew && ./gradlew bootJar --no-daemon -x test
 
 FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app

--- a/notification-service/src/main/resources/logback-spring.xml
+++ b/notification-service/src/main/resources/logback-spring.xml
@@ -19,6 +19,7 @@
                 <includeMdcKeyName>traceId</includeMdcKeyName>
                 <includeMdcKeyName>spanId</includeMdcKeyName>
                 <includeMdcKeyName>userId</includeMdcKeyName>
+                <includeMdcKeyName>globalTraceId</includeMdcKeyName>
                 <customFields>{"service":"notification-service"}</customFields>
             </encoder>
         </appender>

--- a/order-service/Dockerfile
+++ b/order-service/Dockerfile
@@ -1,12 +1,12 @@
 FROM eclipse-temurin:21-jdk-alpine AS build
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
-COPY gradlew ./
-COPY gradle ./gradle
-COPY build.gradle.kts settings.gradle.kts ./
-COPY src ./src
+COPY order-service/gradlew ./
+COPY order-service/gradle ./gradle
+COPY order-service/build.gradle.kts order-service/settings.gradle.kts ./
+COPY order-service/src ./src
 COPY hoppingmall-common /hoppingmall-common
-RUN chmod +x gradlew && ./gradlew bootJar --no-daemon -x test
+RUN sed -i "s/\r$//" gradlew && chmod +x gradlew && ./gradlew bootJar --no-daemon -x test
 
 FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/KafkaConfig.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/KafkaConfig.kt
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
 import org.springframework.kafka.core.*
@@ -81,6 +82,17 @@ class KafkaConfig {
     @Bean("kafkaTransactionManager")
     fun kafkaTransactionManager(): org.springframework.kafka.transaction.KafkaTransactionManager<String, Any> {
         return org.springframework.kafka.transaction.KafkaTransactionManager(producerFactory())
+    }
+
+    @Primary
+    @Bean("transactionManager")
+    fun jpaTransactionManager(entityManagerFactory: jakarta.persistence.EntityManagerFactory): org.springframework.orm.jpa.JpaTransactionManager {
+        return org.springframework.orm.jpa.JpaTransactionManager(entityManagerFactory)
+    }
+
+    @Bean
+    fun transactionTemplate(@org.springframework.beans.factory.annotation.Qualifier("transactionManager") txManager: org.springframework.transaction.PlatformTransactionManager): org.springframework.transaction.support.TransactionTemplate {
+        return org.springframework.transaction.support.TransactionTemplate(txManager)
     }
 
     @Bean

--- a/order-service/src/main/resources/application-docker.yml
+++ b/order-service/src/main/resources/application-docker.yml
@@ -8,31 +8,32 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
 
-  data:
-    redis:
-      redisson:
-        config: |
-          clusterServersConfig:
-            nodeAddresses:
-              - "redis://redis-node-1:7001"
-              - "redis://redis-node-2:7002"
-              - "redis://redis-node-3:7003"
-            scanInterval: 1000
-
   kafka:
     consumer:
       bootstrap-servers: kafka:29092
     producer:
       bootstrap-servers: kafka:29092
+    properties:
+      schema.registry.url: http://schema-registry:8081
 
+  data:
+    redis:
+      cluster:
+        nodes:
+          - redis-node-1:7001
+          - redis-node-2:7002
+          - redis-node-3:7003
 management:
+  metrics:
+    tags:
+      application: order-service
   tracing:
     sampling:
       probability: 1.0
     enabled: true
-  zipkin:
+  otlp:
     tracing:
-      endpoint: http://zipkin:9411/api/v2/spans
+      endpoint: http://tempo:4318/v1/traces
 
 services:
   payment-service:

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -16,6 +16,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        use_sql_comments: true
         legacy_id_generator_strategy: true
         default_batch_fetch_size: 100
 
@@ -137,3 +138,9 @@ resilience4j:
         baseConfig: default
       payment-query:
         baseConfig: default
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html

--- a/order-service/src/main/resources/logback-spring.xml
+++ b/order-service/src/main/resources/logback-spring.xml
@@ -19,6 +19,7 @@
                 <includeMdcKeyName>traceId</includeMdcKeyName>
                 <includeMdcKeyName>spanId</includeMdcKeyName>
                 <includeMdcKeyName>userId</includeMdcKeyName>
+                <includeMdcKeyName>globalTraceId</includeMdcKeyName>
                 <customFields>{"service":"order-service"}</customFields>
             </encoder>
         </appender>

--- a/payment-service/Dockerfile
+++ b/payment-service/Dockerfile
@@ -1,12 +1,12 @@
 FROM eclipse-temurin:21-jdk-alpine AS build
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
-COPY gradlew ./
-COPY gradle ./gradle
-COPY build.gradle.kts settings.gradle.kts ./
-COPY src ./src
+COPY payment-service/gradlew ./
+COPY payment-service/gradle ./gradle
+COPY payment-service/build.gradle.kts payment-service/settings.gradle.kts ./
+COPY payment-service/src ./src
 COPY hoppingmall-common /hoppingmall-common
-RUN chmod +x gradlew && ./gradlew bootJar --no-daemon -x test
+RUN sed -i "s/\r$//" gradlew && chmod +x gradlew && ./gradlew bootJar --no-daemon -x test
 
 FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/CacheConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/CacheConfig.kt
@@ -22,8 +22,29 @@ class CacheConfig {
                 .expireAfterWrite(30, TimeUnit.SECONDS)
                 .build()
         )
+        val couponAvailableCache = CaffeineCache(
+            "coupon:available",
+            Caffeine.newBuilder()
+                .maximumSize(100)
+                .expireAfterWrite(5, TimeUnit.MINUTES)
+                .build()
+        )
+        val couponAllCache = CaffeineCache(
+            "coupon:all",
+            Caffeine.newBuilder()
+                .maximumSize(100)
+                .expireAfterWrite(5, TimeUnit.MINUTES)
+                .build()
+        )
+        val pointPolicyCache = CaffeineCache(
+            "point-policy",
+            Caffeine.newBuilder()
+                .maximumSize(10)
+                .expireAfterWrite(30, TimeUnit.MINUTES)
+                .build()
+        )
         return SimpleCacheManager().apply {
-            setCaches(listOf(pointBalanceCache))
+            setCaches(listOf(pointBalanceCache, couponAvailableCache, couponAllCache, pointPolicyCache))
         }
     }
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/KafkaConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/KafkaConfig.kt
@@ -27,7 +27,7 @@ import java.util.UUID
 @Configuration
 @Profile("!test")
 class KafkaConfig(
-    private val dlqCommandService: DLQCommandService
+    @org.springframework.context.annotation.Lazy private val dlqCommandService: DLQCommandService
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -80,6 +80,17 @@ class KafkaConfig(
     @Bean("kafkaTransactionManager")
     fun kafkaTransactionManager(): org.springframework.kafka.transaction.KafkaTransactionManager<String, Any> {
         return org.springframework.kafka.transaction.KafkaTransactionManager(producerFactory())
+    }
+
+    @org.springframework.context.annotation.Primary
+    @Bean("transactionManager")
+    fun jpaTransactionManager(entityManagerFactory: jakarta.persistence.EntityManagerFactory): org.springframework.orm.jpa.JpaTransactionManager {
+        return org.springframework.orm.jpa.JpaTransactionManager(entityManagerFactory)
+    }
+
+    @Bean
+    fun transactionTemplate(@org.springframework.beans.factory.annotation.Qualifier("transactionManager") txManager: org.springframework.transaction.PlatformTransactionManager): org.springframework.transaction.support.TransactionTemplate {
+        return org.springframework.transaction.support.TransactionTemplate(txManager)
     }
 
     @Bean

--- a/payment-service/src/main/resources/application-docker.yml
+++ b/payment-service/src/main/resources/application-docker.yml
@@ -8,31 +8,32 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
 
-  data:
-    redis:
-      redisson:
-        config: |
-          clusterServersConfig:
-            nodeAddresses:
-              - "redis://redis-node-1:7001"
-              - "redis://redis-node-2:7002"
-              - "redis://redis-node-3:7003"
-            scanInterval: 1000
-
   kafka:
     consumer:
       bootstrap-servers: kafka:29092
     producer:
       bootstrap-servers: kafka:29092
+    properties:
+      schema.registry.url: http://schema-registry:8081
 
+  data:
+    redis:
+      cluster:
+        nodes:
+          - redis-node-1:7001
+          - redis-node-2:7002
+          - redis-node-3:7003
 management:
+  metrics:
+    tags:
+      application: payment-service
   tracing:
     sampling:
       probability: 1.0
     enabled: true
-  zipkin:
+  otlp:
     tracing:
-      endpoint: http://zipkin:9411/api/v2/spans
+      endpoint: http://tempo:4318/v1/traces
 
 services:
   user-service:

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -16,6 +16,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        use_sql_comments: true
         legacy_id_generator_strategy: true
         default_batch_fetch_size: 100
 
@@ -136,3 +137,9 @@ resilience4j:
         baseConfig: default
       order-query:
         baseConfig: default
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html

--- a/payment-service/src/main/resources/logback-spring.xml
+++ b/payment-service/src/main/resources/logback-spring.xml
@@ -19,6 +19,7 @@
                 <includeMdcKeyName>traceId</includeMdcKeyName>
                 <includeMdcKeyName>spanId</includeMdcKeyName>
                 <includeMdcKeyName>userId</includeMdcKeyName>
+                <includeMdcKeyName>globalTraceId</includeMdcKeyName>
                 <customFields>{"service":"payment-service"}</customFields>
             </encoder>
         </appender>

--- a/product-service/Dockerfile
+++ b/product-service/Dockerfile
@@ -1,12 +1,12 @@
 FROM eclipse-temurin:21-jdk-alpine AS build
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
-COPY gradlew ./
-COPY gradle ./gradle
-COPY build.gradle.kts settings.gradle.kts ./
-COPY src ./src
+COPY product-service/gradlew ./
+COPY product-service/gradle ./gradle
+COPY product-service/build.gradle.kts product-service/settings.gradle.kts ./
+COPY product-service/src ./src
 COPY hoppingmall-common /hoppingmall-common
-RUN chmod +x gradlew && ./gradlew bootJar --no-daemon -x test
+RUN sed -i "s/\r$//" gradlew && chmod +x gradlew && ./gradlew bootJar --no-daemon -x test
 
 FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/CacheConfig.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/CacheConfig.kt
@@ -36,8 +36,22 @@ class CacheConfig {
                 .expireAfterWrite(60, TimeUnit.MINUTES)
                 .build()
         )
+        val categoriesRootCache = CaffeineCache(
+            "categories:root",
+            Caffeine.newBuilder()
+                .maximumSize(1)
+                .expireAfterWrite(60, TimeUnit.MINUTES)
+                .build()
+        )
+        val categoriesSubCache = CaffeineCache(
+            "categories:sub",
+            Caffeine.newBuilder()
+                .maximumSize(100)
+                .expireAfterWrite(60, TimeUnit.MINUTES)
+                .build()
+        )
         return SimpleCacheManager().apply {
-            setCaches(listOf(productCache, inventoryCache, categoryCache))
+            setCaches(listOf(productCache, inventoryCache, categoryCache, categoriesRootCache, categoriesSubCache))
         }
     }
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductCommandServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductCommandServiceImpl.kt
@@ -25,7 +25,7 @@ class ProductCommandServiceImpl(
 ) : ProductCommandService {
 
     override fun createProduct(request: ProductCreateRequest): ProductResponse {
-        if (!categoryRepository.existsById(request.categoryId)) {
+        if (categoryRepository.findNullableById(request.categoryId) == null) {
             throw CategoryNotFoundException()
         }
 
@@ -54,7 +54,7 @@ class ProductCommandServiceImpl(
 
     @CacheEvict(cacheNames = ["product"], key = "#productId")
     override fun updateProduct(productId: Long, request: ProductUpdateRequest): ProductResponse {
-        if (!categoryRepository.existsById(request.categoryId)) {
+        if (request.categoryId == null || categoryRepository.findNullableById(request.categoryId) == null) {
             throw CategoryNotFoundException()
         }
 

--- a/product-service/src/main/resources/application-docker.yml
+++ b/product-service/src/main/resources/application-docker.yml
@@ -7,32 +7,35 @@ spring:
 
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
-
-  data:
-    redis:
-      redisson:
-        config: |
-          clusterServersConfig:
-            nodeAddresses:
-              - "redis://redis-node-1:7001"
-              - "redis://redis-node-2:7002"
-              - "redis://redis-node-3:7003"
-            scanInterval: 1000
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
 
   kafka:
     consumer:
       bootstrap-servers: kafka:29092
-    producer:
-      bootstrap-servers: kafka:29092
+    properties:
+      schema.registry.url: http://schema-registry:8081
 
+  data:
+    redis:
+      cluster:
+        nodes:
+          - redis-node-1:7001
+          - redis-node-2:7002
+          - redis-node-3:7003
 management:
+  metrics:
+    tags:
+      application: product-service
   tracing:
     sampling:
       probability: 1.0
     enabled: true
-  zipkin:
+  otlp:
     tracing:
-      endpoint: http://zipkin:9411/api/v2/spans
+      endpoint: http://tempo:4318/v1/traces
 
 services:
   order-service:
@@ -47,3 +50,4 @@ grpc:
     order-service:
       address: static://order-service:9094
       negotiation-type: plaintext
+

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -16,6 +16,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        use_sql_comments: true
         legacy_id_generator_strategy: true
         default_batch_fetch_size: 100
 
@@ -143,3 +144,9 @@ resilience4j:
         baseConfig: default
       order-item-query:
         baseConfig: default
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html

--- a/product-service/src/main/resources/logback-spring.xml
+++ b/product-service/src/main/resources/logback-spring.xml
@@ -19,6 +19,7 @@
                 <includeMdcKeyName>traceId</includeMdcKeyName>
                 <includeMdcKeyName>spanId</includeMdcKeyName>
                 <includeMdcKeyName>userId</includeMdcKeyName>
+                <includeMdcKeyName>globalTraceId</includeMdcKeyName>
                 <customFields>{"service":"product-service"}</customFields>
             </encoder>
         </appender>

--- a/settlement-service/Dockerfile
+++ b/settlement-service/Dockerfile
@@ -1,11 +1,11 @@
 FROM eclipse-temurin:21-jdk-alpine AS build
 WORKDIR /app
-COPY gradlew ./
-COPY gradle ./gradle
-COPY build.gradle.kts settings.gradle.kts ./
-COPY src ./src
+COPY settlement-service/gradlew ./
+COPY settlement-service/gradle ./gradle
+COPY settlement-service/build.gradle.kts settlement-service/settings.gradle.kts ./
+COPY settlement-service/src ./src
 COPY hoppingmall-common /hoppingmall-common
-RUN chmod +x gradlew && ./gradlew bootJar --no-daemon -x test
+RUN sed -i "s/\r$//" gradlew && chmod +x gradlew && ./gradlew bootJar --no-daemon -x test
 
 FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app

--- a/settlement-service/src/main/resources/application-docker.yml
+++ b/settlement-service/src/main/resources/application-docker.yml
@@ -19,9 +19,9 @@ management:
   tracing:
     sampling:
       probability: 1.0
-  zipkin:
+  otlp:
     tracing:
-      endpoint: http://zipkin:9411/api/v2/spans
+      endpoint: http://tempo:4318/v1/traces
 
 logging:
   level:

--- a/settlement-service/src/main/resources/application.yml
+++ b/settlement-service/src/main/resources/application.yml
@@ -19,6 +19,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        use_sql_comments: true
         show_sql: true
 
 server:

--- a/settlement-service/src/main/resources/logback-spring.xml
+++ b/settlement-service/src/main/resources/logback-spring.xml
@@ -19,6 +19,7 @@
                 <includeMdcKeyName>traceId</includeMdcKeyName>
                 <includeMdcKeyName>spanId</includeMdcKeyName>
                 <includeMdcKeyName>userId</includeMdcKeyName>
+                <includeMdcKeyName>globalTraceId</includeMdcKeyName>
                 <customFields>{"service":"settlement-service"}</customFields>
             </encoder>
         </appender>

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -1,12 +1,12 @@
 FROM eclipse-temurin:21-jdk-alpine AS build
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
-COPY gradlew ./
-COPY gradle ./gradle
-COPY build.gradle.kts settings.gradle.kts ./
-COPY src ./src
+COPY user-service/gradlew ./
+COPY user-service/gradle ./gradle
+COPY user-service/build.gradle.kts user-service/settings.gradle.kts ./
+COPY user-service/src ./src
 COPY hoppingmall-common /hoppingmall-common
-RUN chmod +x gradlew && ./gradlew bootJar --no-daemon -x test
+RUN sed -i "s/\r$//" gradlew && chmod +x gradlew && ./gradlew bootJar --no-daemon -x test
 
 FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app

--- a/user-service/src/main/resources/application-docker.yml
+++ b/user-service/src/main/resources/application-docker.yml
@@ -1,6 +1,10 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   kafka:
-    bootstrap-servers: kafka:9092
+    bootstrap-servers: kafka:29092
+    properties:
+      schema.registry.url: http://schema-registry:8081
     consumer:
       group-id: membership-service
       auto-offset-reset: earliest
@@ -20,22 +24,21 @@ spring:
       ddl-auto: update
   data:
     redis:
-      redisson:
-        config: |
-          clusterServersConfig:
-            nodeAddresses:
-              - "redis://redis-node-1:7001"
-              - "redis://redis-node-2:7002"
-              - "redis://redis-node-3:7003"
-            scanInterval: 1000
-
+      cluster:
+        nodes:
+          - redis-node-1:7001
+          - redis-node-2:7002
+          - redis-node-3:7003
 management:
+  metrics:
+    tags:
+      application: user-service
   tracing:
     sampling:
       probability: 1.0
-  zipkin:
+  otlp:
     tracing:
-      endpoint: http://zipkin:9411/api/v2/spans
+      endpoint: http://tempo:4318/v1/traces
 
 internal:
   service:

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -19,6 +19,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        use_sql_comments: true
         show_sql: true
 
   kafka:

--- a/user-service/src/main/resources/logback-spring.xml
+++ b/user-service/src/main/resources/logback-spring.xml
@@ -19,6 +19,7 @@
                 <includeMdcKeyName>traceId</includeMdcKeyName>
                 <includeMdcKeyName>spanId</includeMdcKeyName>
                 <includeMdcKeyName>userId</includeMdcKeyName>
+                <includeMdcKeyName>globalTraceId</includeMdcKeyName>
                 <customFields>{"service":"user-service"}</customFields>
             </encoder>
         </appender>


### PR DESCRIPTION
Closes #270

### 📌 작업 개요
Docker 환경에서 Prometheus, Mimir, Promtail, Grafana 등 모니터링 스택을 구성하고,
전체 서비스의 Docker 환경 설정(Redis 클러스터, Schema Registry, OTLP, 메트릭 태깅)을 정비했습니다.

---

### ✅ 주요 변경 사항

- `docker-compose.yml`
  - Mimir, kafka-exporter, redis-exporter, seed-runner 컨테이너 추가
  - 전 서비스 healthcheck 설정, build context root 전환

- `docker/prometheus.yml`
  - Mimir remote_write 연동, metric_relabel_configs로 application 라벨 폴백

- `docker/grafana-datasources.yml`
  - UID 명시, Prometheus → Mimir URL 전환, Tempo tracesToLogs 연동

- `docker/mimir.yml`
  - Mimir 설정 파일 신규 추가

- 전 서비스 `application-docker.yml`
  - Redis 클러스터 설정, Kafka Schema Registry URL, metrics.tags, zipkin → OTLP 전환

- 전 서비스 `application.yml`
  - Hibernate `use_sql_comments`, Springdoc 설정 추가

- 전 서비스 `logback-spring.xml`
  - `globalTraceId` MDC 키 추가

---

### 📎 관련 이슈
- #270
