### PR TITLE
feat: CommonErrorCode 공통 에러코드 복구

### DIFF
--- a/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/CommonErrorCode.kt
+++ b/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/CommonErrorCode.kt
@@ -1,0 +1,15 @@
+package com.hoppingmall.common
+
+import org.springframework.http.HttpStatus
+
+enum class CommonErrorCode(
+    override val code: String,
+    override val message: String,
+    override val status: HttpStatus
+) : ErrorCode {
+    INVALID_INPUT("C001", "잘못된 입력입니다.", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED("A001", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
+    FORBIDDEN("A002", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    INTERNAL_ERROR("S001", "서버 내부 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    LOCK_ACQUISITION_FAILED("S002", "요청 처리 중입니다. 잠시 후 다시 시도해 주세요.", HttpStatus.CONFLICT)
+}

--- a/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/GlobalExceptionHandler.kt
+++ b/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/GlobalExceptionHandler.kt
@@ -22,15 +22,15 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleValidationException(ex: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Unit>> {
-        val message = ex.bindingResult.fieldErrors.firstOrNull()?.defaultMessage ?: "유효성 검증 실패"
+        val message = ex.bindingResult.fieldErrors.firstOrNull()?.defaultMessage ?: CommonErrorCode.INVALID_INPUT.message
         log.warn("ValidationException: {}", message)
-        return ResponseEntity.badRequest().body(ApiResponse.failure(message))
+        return ResponseEntity.badRequest().body(ApiResponse.failure(CommonErrorCode.INVALID_INPUT))
     }
 
     @ExceptionHandler(Exception::class)
     fun handleException(ex: Exception): ResponseEntity<ApiResponse<Unit>> {
         log.error("UnhandledException: {}", ex.message, ex)
-        val response = ApiResponse.failure<Unit>("알 수 없는 오류가 발생했습니다.")
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response)
+        return ResponseEntity.status(CommonErrorCode.INTERNAL_ERROR.status)
+            .body(ApiResponse.failure(CommonErrorCode.INTERNAL_ERROR))
     }
 }


### PR DESCRIPTION
Closes #282

### 📌 작업 개요
멀티모듈 전환 시 유실된 CommonErrorCode enum을 hoppingmall-common에 복구하고,
GlobalExceptionHandler의 하드코딩 문자열을 공통 에러코드로 교체했습니다.

---

### ✅ 주요 변경 사항

- `hoppingmall-common`
  - `CommonErrorCode`: INVALID_INPUT, UNAUTHORIZED, FORBIDDEN, INTERNAL_ERROR, LOCK_ACQUISITION_FAILED 5개 공통 에러코드
  - `GlobalExceptionHandler`: ValidationException/UnhandledException 응답을 CommonErrorCode 기반으로 변경

---

### 📎 관련 이슈
- #282
