### PR TITLE
feat: FileUploadController + 예외 계층 복구

### DIFF
--- a/product-service/src/main/kotlin/com/hoppingmall/product/common/file/FileUploadService.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/common/file/FileUploadService.kt
@@ -1,19 +1,8 @@
 package com.hoppingmall.product.common.file
 
-import org.springframework.web.multipart.MultipartFile
+import com.hoppingmall.product.common.file.dto.FileUploadRequest
+import com.hoppingmall.product.common.file.dto.FileUploadResponse
 
 interface FileUploadService {
     fun uploadFile(request: FileUploadRequest): FileUploadResponse
 }
-
-data class FileUploadRequest(
-    val file: MultipartFile,
-    val domain: String
-)
-
-data class FileUploadResponse(
-    val fileUrl: String,
-    val fileName: String,
-    val fileSize: Long,
-    val domain: String
-)

--- a/product-service/src/main/kotlin/com/hoppingmall/product/common/file/LocalFileUploadService.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/common/file/LocalFileUploadService.kt
@@ -1,6 +1,10 @@
 package com.hoppingmall.product.common.file
 
+import com.hoppingmall.product.common.file.dto.FileUploadRequest
+import com.hoppingmall.product.common.file.dto.FileUploadResponse
+import com.hoppingmall.product.common.file.exception.*
 import org.springframework.stereotype.Service
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.UUID
@@ -11,19 +15,38 @@ class LocalFileUploadService(
 ) : FileUploadService {
 
     override fun uploadFile(request: FileUploadRequest): FileUploadResponse {
-        val originalFilename = request.file.originalFilename ?: "unknown"
+        if (request.file.isEmpty) throw EmptyFileException()
+
+        val originalFilename = request.file.originalFilename
+            ?: throw InvalidFileNameException()
+
         val extension = originalFilename.substringAfterLast(".", "")
 
-        require(extension in fileUploadConfig.allowedExtensions) { "허용되지 않는 확장자입니다: $extension" }
-        require(request.file.size <= fileUploadConfig.maxFileSize) { "파일 크기가 초과되었습니다" }
-        require(request.domain in fileUploadConfig.allowedDomains) { "허용되지 않는 도메인입니다: ${request.domain}" }
+        if (extension !in fileUploadConfig.allowedExtensions) {
+            throw UnsupportedFileTypeException(fileUploadConfig.allowedExtensions.toList())
+        }
+        if (request.file.size > fileUploadConfig.maxFileSize) {
+            throw FileSizeExceededException()
+        }
+        if (request.domain !in fileUploadConfig.allowedDomains) {
+            throw UnsupportedDomainException(fileUploadConfig.allowedDomains.toList())
+        }
 
         val fileName = "${UUID.randomUUID()}.$extension"
         val uploadDir = Paths.get(fileUploadConfig.baseUploadDir, request.domain, fileUploadConfig.subDirectory)
-        Files.createDirectories(uploadDir)
+
+        try {
+            Files.createDirectories(uploadDir)
+        } catch (e: IOException) {
+            throw DirectoryAccessException(uploadDir.toString())
+        }
 
         val filePath = uploadDir.resolve(fileName)
-        request.file.transferTo(filePath.toFile())
+        try {
+            request.file.transferTo(filePath.toFile())
+        } catch (e: IOException) {
+            throw FileUploadException(e.message ?: "")
+        }
 
         return FileUploadResponse(
             fileUrl = filePath.toString(),

--- a/product-service/src/main/kotlin/com/hoppingmall/product/common/file/controller/FileUploadController.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/common/file/controller/FileUploadController.kt
@@ -1,0 +1,29 @@
+package com.hoppingmall.product.common.file.controller
+
+import com.hoppingmall.common.ApiResponse
+import com.hoppingmall.product.common.file.FileUploadService
+import com.hoppingmall.product.common.file.dto.FileUploadRequest
+import com.hoppingmall.product.common.file.dto.FileUploadResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
+
+@Tag(name = "파일 업로드")
+@RestController
+@RequestMapping("/api/v1/files")
+class FileUploadController(
+    private val fileUploadService: FileUploadService
+) {
+
+    @PostMapping("/upload")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun uploadFile(
+        @RequestParam("file") file: MultipartFile,
+        @RequestParam("domain") domain: String
+    ): ApiResponse<FileUploadResponse> {
+        val request = FileUploadRequest(file = file, domain = domain)
+        val response = fileUploadService.uploadFile(request)
+        return ApiResponse.success(response)
+    }
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/common/file/dto/FileUploadRequest.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/common/file/dto/FileUploadRequest.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.product.common.file.dto
+
+import org.springframework.web.multipart.MultipartFile
+
+data class FileUploadRequest(
+    val file: MultipartFile,
+    val domain: String
+)

--- a/product-service/src/main/kotlin/com/hoppingmall/product/common/file/dto/FileUploadResponse.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/common/file/dto/FileUploadResponse.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.product.common.file.dto
+
+data class FileUploadResponse(
+    val fileUrl: String,
+    val fileName: String,
+    val fileSize: Long,
+    val domain: String
+)

--- a/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/DirectoryAccessException.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/DirectoryAccessException.kt
@@ -1,0 +1,7 @@
+package com.hoppingmall.product.common.file.exception
+
+import com.hoppingmall.product.common.file.exception.code.FileErrorCode
+
+class DirectoryAccessException(directory: String) : FileException(FileErrorCode.DIRECTORY_ACCESS_ERROR) {
+    override val message: String = "${FileErrorCode.DIRECTORY_ACCESS_ERROR.message} 디렉토리: $directory"
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/EmptyFileException.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/EmptyFileException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.product.common.file.exception
+
+import com.hoppingmall.product.common.file.exception.code.FileErrorCode
+
+class EmptyFileException : FileException(FileErrorCode.EMPTY_FILE)

--- a/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/FileException.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/FileException.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.product.common.file.exception
+
+import com.hoppingmall.common.BusinessException
+import com.hoppingmall.product.common.file.exception.code.FileErrorCode
+
+open class FileException(
+    errorCode: FileErrorCode
+) : BusinessException(errorCode)

--- a/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/FileSizeExceededException.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/FileSizeExceededException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.product.common.file.exception
+
+import com.hoppingmall.product.common.file.exception.code.FileErrorCode
+
+class FileSizeExceededException : FileException(FileErrorCode.FILE_SIZE_EXCEEDED)

--- a/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/FileUploadException.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/FileUploadException.kt
@@ -1,0 +1,7 @@
+package com.hoppingmall.product.common.file.exception
+
+import com.hoppingmall.product.common.file.exception.code.FileErrorCode
+
+class FileUploadException(detail: String) : FileException(FileErrorCode.FILE_UPLOAD_ERROR) {
+    override val message: String = "${FileErrorCode.FILE_UPLOAD_ERROR.message} $detail"
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/InvalidFileNameException.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/InvalidFileNameException.kt
@@ -1,0 +1,5 @@
+package com.hoppingmall.product.common.file.exception
+
+import com.hoppingmall.product.common.file.exception.code.FileErrorCode
+
+class InvalidFileNameException : FileException(FileErrorCode.INVALID_FILE_NAME)

--- a/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/UnsupportedDomainException.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/UnsupportedDomainException.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.product.common.file.exception
+
+import com.hoppingmall.product.common.file.exception.code.FileErrorCode
+
+class UnsupportedDomainException(allowedDomains: Collection<String>) :
+    FileException(FileErrorCode.UNSUPPORTED_DOMAIN) {
+    override val message: String = "${FileErrorCode.UNSUPPORTED_DOMAIN.message} 허용된 도메인: ${allowedDomains.joinToString(", ")}"
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/UnsupportedFileTypeException.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/UnsupportedFileTypeException.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.product.common.file.exception
+
+import com.hoppingmall.product.common.file.exception.code.FileErrorCode
+
+class UnsupportedFileTypeException(allowedExtensions: Collection<String>) :
+    FileException(FileErrorCode.UNSUPPORTED_FILE_TYPE) {
+    override val message: String = "${FileErrorCode.UNSUPPORTED_FILE_TYPE.message} 허용된 형식: ${allowedExtensions.joinToString(", ")}"
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/code/FileErrorCode.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/common/file/exception/code/FileErrorCode.kt
@@ -1,0 +1,18 @@
+package com.hoppingmall.product.common.file.exception.code
+
+import com.hoppingmall.common.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class FileErrorCode(
+    override val code: String,
+    override val message: String,
+    override val status: HttpStatus
+) : ErrorCode {
+    EMPTY_FILE("F001", "업로드할 파일이 없습니다.", HttpStatus.BAD_REQUEST),
+    FILE_SIZE_EXCEEDED("F002", "파일 크기는 5MB를 초과할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_FILE_NAME("F003", "파일명이 없습니다.", HttpStatus.BAD_REQUEST),
+    UNSUPPORTED_FILE_TYPE("F004", "허용되지 않는 파일 형식입니다.", HttpStatus.BAD_REQUEST),
+    UNSUPPORTED_DOMAIN("F005", "허용되지 않는 도메인입니다.", HttpStatus.BAD_REQUEST),
+    DIRECTORY_ACCESS_ERROR("F006", "업로드 디렉토리에 접근할 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    FILE_UPLOAD_ERROR("F007", "파일 업로드 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductImageServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductImageServiceImpl.kt
@@ -1,6 +1,6 @@
 package com.hoppingmall.product.product.service
 
-import com.hoppingmall.product.common.file.FileUploadRequest
+import com.hoppingmall.product.common.file.dto.FileUploadRequest
 import com.hoppingmall.product.common.file.FileUploadService
 import com.hoppingmall.product.product.dto.response.ProductImageResponse
 import org.springframework.stereotype.Service


### PR DESCRIPTION
Closes #284

### 📌 작업 개요
product-service에 유실된 파일 업로드 REST 컨트롤러와 예외 계층을 복구했습니다.
기존 `require()` 기반 에러 처리를 `BusinessException` 기반 구조화된 예외로 교체했습니다.

---

### ✅ 주요 변경 사항

- `common.file.controller`
  - `FileUploadController`: `POST /api/v1/files/upload` REST 엔드포인트 복구

- `common.file.exception`
  - `FileErrorCode`: 7개 에러코드 (EMPTY_FILE, FILE_SIZE_EXCEEDED, INVALID_FILE_NAME, UNSUPPORTED_FILE_TYPE, UNSUPPORTED_DOMAIN, DIRECTORY_ACCESS_ERROR, FILE_UPLOAD_ERROR)
  - `FileException` base + 7개 구체 예외 클래스

- `common.file`
  - `LocalFileUploadService`: `require()` → 구조화된 예외 클래스로 교체
  - `FileUploadService`: DTO를 별도 파일(`dto/`)로 분리

- `product.service`
  - `ProductImageServiceImpl`: DTO import 경로 변경

---

### 📎 관련 이슈
- #284
