### PR TITLE
refactor: BaseSecurityConfig 공통 추출

### DIFF
--- a/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/config/BaseSecurityConfig.kt
+++ b/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/config/BaseSecurityConfig.kt
@@ -1,0 +1,44 @@
+package com.hoppingmall.common.config
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+abstract class BaseSecurityConfig(
+    private val gatewayHeaderAuthenticationFilter: GatewayHeaderAuthenticationFilter,
+    private val internalTokenFilter: InternalTokenFilter?
+) {
+
+    protected fun configureBase(http: HttpSecurity): HttpSecurity {
+        http
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests { auth ->
+                auth
+                    .requestMatchers("/actuator/**").permitAll()
+                    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
+                configureInternalEndpoints(auth)
+                configureServiceEndpoints(auth)
+                auth.anyRequest().authenticated()
+            }
+
+        internalTokenFilter?.let {
+            http.addFilterBefore(it, UsernamePasswordAuthenticationFilter::class.java)
+        }
+        http.addFilterBefore(gatewayHeaderAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+
+        return http
+    }
+
+    protected open fun configureInternalEndpoints(
+        auth: AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry
+    ) {
+        auth.requestMatchers("/internal/**").permitAll()
+    }
+
+    protected open fun configureServiceEndpoints(
+        auth: AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry
+    ) {
+    }
+}

--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/config/SecurityConfig.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/config/SecurityConfig.kt
@@ -1,32 +1,28 @@
 package com.hoppingmall.notification.config
 
+import com.hoppingmall.common.config.BaseSecurityConfig
 import com.hoppingmall.common.config.GatewayHeaderAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
-    private val gatewayHeaderAuthenticationFilter: GatewayHeaderAuthenticationFilter
-) {
+    gatewayHeaderAuthenticationFilter: GatewayHeaderAuthenticationFilter
+) : BaseSecurityConfig(gatewayHeaderAuthenticationFilter, null) {
 
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-        http
-            .csrf { it.disable() }
-            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
-            .authorizeHttpRequests { auth ->
-                auth
-                    .requestMatchers("/actuator/**").permitAll()
-                    .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-                    .anyRequest().authenticated()
-            }
-            .addFilterBefore(gatewayHeaderAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
-        return http.build()
+        return configureBase(http).build()
+    }
+
+    override fun configureInternalEndpoints(
+        auth: AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry
+    ) {
+        auth.requestMatchers("/internal/**").denyAll()
     }
 }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/SecurityConfig.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/SecurityConfig.kt
@@ -1,36 +1,23 @@
 package com.hoppingmall.order.config
 
+import com.hoppingmall.common.config.BaseSecurityConfig
 import com.hoppingmall.common.config.InternalTokenFilter
 import com.hoppingmall.common.config.GatewayHeaderAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
-    private val gatewayHeaderAuthenticationFilter: GatewayHeaderAuthenticationFilter,
-    private val internalTokenFilter: InternalTokenFilter
-) {
+    gatewayHeaderAuthenticationFilter: GatewayHeaderAuthenticationFilter,
+    internalTokenFilter: InternalTokenFilter
+) : BaseSecurityConfig(gatewayHeaderAuthenticationFilter, internalTokenFilter) {
 
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-        http
-            .csrf { it.disable() }
-            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
-            .authorizeHttpRequests { auth ->
-                auth
-                    .requestMatchers("/actuator/**").permitAll()
-                    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                    .requestMatchers("/internal/**").permitAll()
-                    .anyRequest().authenticated()
-            }
-            .addFilterBefore(internalTokenFilter, UsernamePasswordAuthenticationFilter::class.java)
-            .addFilterBefore(gatewayHeaderAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
-        return http.build()
+        return configureBase(http).build()
     }
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/SecurityConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/SecurityConfig.kt
@@ -1,36 +1,23 @@
 package com.hoppingmall.payment.config
 
+import com.hoppingmall.common.config.BaseSecurityConfig
 import com.hoppingmall.common.config.InternalTokenFilter
 import com.hoppingmall.common.config.GatewayHeaderAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
-    private val gatewayHeaderAuthenticationFilter: GatewayHeaderAuthenticationFilter,
-    private val internalTokenFilter: InternalTokenFilter
-) {
+    gatewayHeaderAuthenticationFilter: GatewayHeaderAuthenticationFilter,
+    internalTokenFilter: InternalTokenFilter
+) : BaseSecurityConfig(gatewayHeaderAuthenticationFilter, internalTokenFilter) {
 
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-        http
-            .csrf { it.disable() }
-            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
-            .authorizeHttpRequests { auth ->
-                auth
-                    .requestMatchers("/actuator/**").permitAll()
-                    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                    .requestMatchers("/internal/**").permitAll()
-                    .anyRequest().authenticated()
-            }
-            .addFilterBefore(internalTokenFilter, UsernamePasswordAuthenticationFilter::class.java)
-            .addFilterBefore(gatewayHeaderAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
-        return http.build()
+        return configureBase(http).build()
     }
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/SecurityConfig.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/SecurityConfig.kt
@@ -1,36 +1,23 @@
 package com.hoppingmall.product.config
 
+import com.hoppingmall.common.config.BaseSecurityConfig
 import com.hoppingmall.common.config.InternalTokenFilter
 import com.hoppingmall.common.config.GatewayHeaderAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
-    private val gatewayHeaderAuthenticationFilter: GatewayHeaderAuthenticationFilter,
-    private val internalTokenFilter: InternalTokenFilter
-) {
+    gatewayHeaderAuthenticationFilter: GatewayHeaderAuthenticationFilter,
+    internalTokenFilter: InternalTokenFilter
+) : BaseSecurityConfig(gatewayHeaderAuthenticationFilter, internalTokenFilter) {
 
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-        http
-            .csrf { it.disable() }
-            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
-            .authorizeHttpRequests { auth ->
-                auth
-                    .requestMatchers("/actuator/**").permitAll()
-                    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                    .requestMatchers("/internal/**").permitAll()
-                    .anyRequest().authenticated()
-            }
-            .addFilterBefore(internalTokenFilter, UsernamePasswordAuthenticationFilter::class.java)
-            .addFilterBefore(gatewayHeaderAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
-        return http.build()
+        return configureBase(http).build()
     }
 }

--- a/settlement-service/src/main/kotlin/com/hoppingmall/settlement/config/SecurityConfig.kt
+++ b/settlement-service/src/main/kotlin/com/hoppingmall/settlement/config/SecurityConfig.kt
@@ -1,37 +1,30 @@
 package com.hoppingmall.settlement.config
 
+import com.hoppingmall.common.config.BaseSecurityConfig
 import com.hoppingmall.common.config.InternalTokenFilter
 import com.hoppingmall.common.config.GatewayHeaderAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
-    private val gatewayHeaderAuthenticationFilter: GatewayHeaderAuthenticationFilter,
-    private val internalTokenFilter: InternalTokenFilter
-) {
+    gatewayHeaderAuthenticationFilter: GatewayHeaderAuthenticationFilter,
+    internalTokenFilter: InternalTokenFilter
+) : BaseSecurityConfig(gatewayHeaderAuthenticationFilter, internalTokenFilter) {
 
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-        http
-            .csrf { it.disable() }
-            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
-            .authorizeHttpRequests { auth ->
-                auth
-                    .requestMatchers("/actuator/**").permitAll()
-                    .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-                    .requestMatchers("/internal/**").permitAll()
-                    .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
-                    .anyRequest().authenticated()
-            }
-            .addFilterBefore(internalTokenFilter, UsernamePasswordAuthenticationFilter::class.java)
-            .addFilterBefore(gatewayHeaderAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
-        return http.build()
+        return configureBase(http).build()
+    }
+
+    override fun configureServiceEndpoints(
+        auth: AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry
+    ) {
+        auth.requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
     }
 }

--- a/user-service/src/main/kotlin/com/hoppingmall/user/config/SecurityConfig.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/config/SecurityConfig.kt
@@ -1,41 +1,36 @@
 package com.hoppingmall.user.config
 
+import com.hoppingmall.common.config.BaseSecurityConfig
 import com.hoppingmall.common.config.InternalTokenFilter
 import com.hoppingmall.common.config.GatewayHeaderAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
-    private val gatewayHeaderAuthenticationFilter: GatewayHeaderAuthenticationFilter,
-    private val internalTokenFilter: InternalTokenFilter
-) {
+    gatewayHeaderAuthenticationFilter: GatewayHeaderAuthenticationFilter,
+    internalTokenFilter: InternalTokenFilter
+) : BaseSecurityConfig(gatewayHeaderAuthenticationFilter, internalTokenFilter) {
+
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-        http
-            .csrf { it.disable() }
-            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
-            .authorizeHttpRequests { auth ->
-                auth
-                    .requestMatchers("/actuator/**").permitAll()
-                    .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-                    .requestMatchers("/internal/**").permitAll()
-                    .requestMatchers("/api/v1/users/signup", "/api/v1/users/login").permitAll()
-                    .requestMatchers("/api/v1/auth/refresh").permitAll()
-                    .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
-                    .anyRequest().authenticated()
-            }
-            .addFilterBefore(internalTokenFilter, UsernamePasswordAuthenticationFilter::class.java)
-            .addFilterBefore(gatewayHeaderAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
-        return http.build()
+        return configureBase(http).build()
+    }
+
+    override fun configureServiceEndpoints(
+        auth: AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry
+    ) {
+        auth
+            .requestMatchers("/api/v1/users/signup", "/api/v1/users/login").permitAll()
+            .requestMatchers("/api/v1/auth/refresh").permitAll()
+            .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
     }
 
     @Bean


### PR DESCRIPTION
Closes #290

### 📌 작업 개요
각 서비스에 중복된 SecurityConfig 보안 설정을 hoppingmall-common의 BaseSecurityConfig 추상 클래스로 추출하여 공통화합니다.

---

### ✅ 주요 변경 사항

- `hoppingmall-common.config`
  - `BaseSecurityConfig`: CSRF, 세션, 헤더 등 공통 보안 설정을 담은 추상 클래스 신규 생성

- `각 서비스 config`
  - `SecurityConfig`: BaseSecurityConfig를 상속하도록 변경 (notification, order, payment, product, settlement, user)

---

### 📎 관련 이슈
- #290
