### PR TITLE
fix: Kafka Consumer DLQ 처리 정책 정렬

### DIFF
--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/config/KafkaConsumerConfig.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/config/KafkaConsumerConfig.kt
@@ -1,9 +1,13 @@
 package com.hoppingmall.notification.config
 
 import com.hoppingmall.common.event.AvroJsonDeserializer
+import com.hoppingmall.dlq.domain.DeadLetterMessage
+import com.hoppingmall.dlq.service.DLQCommandService
 import com.hoppingmall.notification.config.kafka.BusinessContextConsumerInterceptor
 import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.errors.SerializationException
 import org.apache.kafka.common.serialization.StringDeserializer
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -11,14 +15,21 @@ import org.springframework.context.annotation.Profile
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
 import org.springframework.kafka.core.ConsumerFactory
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.listener.DefaultErrorHandler
+import org.springframework.kafka.support.serializer.DeserializationException
+import org.springframework.messaging.converter.MessageConversionException
+import org.springframework.util.backoff.FixedBackOff
 
 @Configuration
 @Profile("!test")
 class KafkaConsumerConfig(
     @Value("\${spring.kafka.bootstrap-servers}") private val bootstrapServers: String,
     @Value("\${spring.kafka.consumer.group-id}") private val groupId: String,
-    @Value("\${spring.kafka.properties.schema.registry.url:http://localhost:8081}") private val schemaRegistryUrl: String
+    @Value("\${spring.kafka.properties.schema.registry.url:http://localhost:8081}") private val schemaRegistryUrl: String,
+    @org.springframework.context.annotation.Lazy private val dlqCommandService: DLQCommandService
 ) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @Bean
     fun consumerFactory(): ConsumerFactory<String, Any> {
@@ -30,6 +41,10 @@ class KafkaConsumerConfig(
             ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
             ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to false,
             ConsumerConfig.ISOLATION_LEVEL_CONFIG to "read_committed",
+            ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG to 300_000,
+            ConsumerConfig.MAX_POLL_RECORDS_CONFIG to 100,
+            ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG to 30_000,
+            ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG to 10_000,
             "schema.registry.url" to schemaRegistryUrl
         )
         return DefaultKafkaConsumerFactory(props)
@@ -40,6 +55,31 @@ class KafkaConsumerConfig(
         val factory = ConcurrentKafkaListenerContainerFactory<String, Any>()
         factory.consumerFactory = consumerFactory()
         factory.setRecordInterceptor(BusinessContextConsumerInterceptor())
+
+        val errorHandler = DefaultErrorHandler(
+            { record, exception ->
+                log.error("Kafka 메시지 처리 실패 (DLQ): topic={}, offset={}, error={}",
+                    record.topic(), record.offset(), exception.message)
+                val deadLetterMessage = DeadLetterMessage(
+                    originalTopic = record.topic(),
+                    originalPartition = record.partition(),
+                    originalOffset = record.offset(),
+                    originalKey = record.key()?.toString(),
+                    originalValue = record.value()?.toString(),
+                    exception = exception.message,
+                    timestamp = System.currentTimeMillis()
+                )
+                dlqCommandService.saveDLQMessage(deadLetterMessage)
+            },
+            FixedBackOff(1000L, 3)
+        )
+        errorHandler.addNotRetryableExceptions(
+            DeserializationException::class.java,
+            SerializationException::class.java,
+            MessageConversionException::class.java
+        )
+        factory.setCommonErrorHandler(errorHandler)
+
         return factory
     }
 }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/KafkaConfig.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/KafkaConfig.kt
@@ -3,6 +3,8 @@ package com.hoppingmall.order.config
 import com.hoppingmall.common.event.AvroJsonDeserializer
 import com.hoppingmall.order.config.kafka.BusinessContextConsumerInterceptor
 import com.hoppingmall.order.config.kafka.BusinessContextProducerInterceptor
+import com.hoppingmall.dlq.domain.DeadLetterMessage
+import com.hoppingmall.dlq.service.DLQCommandService
 import io.confluent.kafka.serializers.KafkaAvroSerializer
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
@@ -26,7 +28,9 @@ import java.util.UUID
 
 @Configuration
 @Profile("!test")
-class KafkaConfig {
+class KafkaConfig(
+    @org.springframework.context.annotation.Lazy private val dlqCommandService: DLQCommandService
+) {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -127,6 +131,16 @@ class KafkaConfig {
             { record, exception ->
                 log.error("Kafka 메시지 처리 실패 (DLQ): topic={}, offset={}, error={}",
                     record.topic(), record.offset(), exception.message)
+                val deadLetterMessage = DeadLetterMessage(
+                    originalTopic = record.topic(),
+                    originalPartition = record.partition(),
+                    originalOffset = record.offset(),
+                    originalKey = record.key()?.toString(),
+                    originalValue = record.value()?.toString(),
+                    exception = exception.message,
+                    timestamp = System.currentTimeMillis()
+                )
+                dlqCommandService.saveDLQMessage(deadLetterMessage)
             },
             FixedBackOff(1000L, 3)
         )

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/KafkaConsumerConfig.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/KafkaConsumerConfig.kt
@@ -1,6 +1,8 @@
 package com.hoppingmall.product.config
 
 import com.hoppingmall.common.event.AvroJsonDeserializer
+import com.hoppingmall.dlq.domain.DeadLetterMessage
+import com.hoppingmall.dlq.service.DLQCommandService
 import com.hoppingmall.product.config.kafka.BusinessContextConsumerInterceptor
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.errors.SerializationException
@@ -20,7 +22,9 @@ import org.springframework.util.backoff.FixedBackOff
 
 @Configuration
 @Profile("!test")
-class KafkaConsumerConfig {
+class KafkaConsumerConfig(
+    @org.springframework.context.annotation.Lazy private val dlqCommandService: DLQCommandService
+) {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -67,6 +71,16 @@ class KafkaConsumerConfig {
             { record, exception ->
                 log.error("Kafka 메시지 처리 실패 (DLQ): topic={}, offset={}, error={}",
                     record.topic(), record.offset(), exception.message)
+                val deadLetterMessage = DeadLetterMessage(
+                    originalTopic = record.topic(),
+                    originalPartition = record.partition(),
+                    originalOffset = record.offset(),
+                    originalKey = record.key()?.toString(),
+                    originalValue = record.value()?.toString(),
+                    exception = exception.message,
+                    timestamp = System.currentTimeMillis()
+                )
+                dlqCommandService.saveDLQMessage(deadLetterMessage)
             },
             FixedBackOff(1000L, 3)
         )

--- a/user-service/src/main/kotlin/com/hoppingmall/user/config/KafkaConsumerConfig.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/config/KafkaConsumerConfig.kt
@@ -1,9 +1,13 @@
 package com.hoppingmall.user.config
 
 import com.hoppingmall.common.event.AvroJsonDeserializer
+import com.hoppingmall.dlq.domain.DeadLetterMessage
+import com.hoppingmall.dlq.service.DLQCommandService
 import com.hoppingmall.user.config.kafka.BusinessContextConsumerInterceptor
 import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.errors.SerializationException
 import org.apache.kafka.common.serialization.StringDeserializer
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -11,14 +15,21 @@ import org.springframework.context.annotation.Profile
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
 import org.springframework.kafka.core.ConsumerFactory
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.listener.DefaultErrorHandler
+import org.springframework.kafka.support.serializer.DeserializationException
+import org.springframework.messaging.converter.MessageConversionException
+import org.springframework.util.backoff.FixedBackOff
 
 @Configuration
 @Profile("!test")
 class KafkaConsumerConfig(
     @Value("\${spring.kafka.bootstrap-servers}") private val bootstrapServers: String,
     @Value("\${spring.kafka.consumer.group-id}") private val groupId: String,
-    @Value("\${spring.kafka.properties.schema.registry.url:http://localhost:8081}") private val schemaRegistryUrl: String
+    @Value("\${spring.kafka.properties.schema.registry.url:http://localhost:8081}") private val schemaRegistryUrl: String,
+    @org.springframework.context.annotation.Lazy private val dlqCommandService: DLQCommandService
 ) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @Bean
     fun consumerFactory(): ConsumerFactory<String, Any> {
@@ -30,6 +41,10 @@ class KafkaConsumerConfig(
             ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
             ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to false,
             ConsumerConfig.ISOLATION_LEVEL_CONFIG to "read_committed",
+            ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG to 300_000,
+            ConsumerConfig.MAX_POLL_RECORDS_CONFIG to 100,
+            ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG to 30_000,
+            ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG to 10_000,
             "schema.registry.url" to schemaRegistryUrl
         )
         return DefaultKafkaConsumerFactory(props)
@@ -40,6 +55,31 @@ class KafkaConsumerConfig(
         val factory = ConcurrentKafkaListenerContainerFactory<String, Any>()
         factory.consumerFactory = consumerFactory()
         factory.setRecordInterceptor(BusinessContextConsumerInterceptor())
+
+        val errorHandler = DefaultErrorHandler(
+            { record, exception ->
+                log.error("Kafka 메시지 처리 실패 (DLQ): topic={}, offset={}, error={}",
+                    record.topic(), record.offset(), exception.message)
+                val deadLetterMessage = DeadLetterMessage(
+                    originalTopic = record.topic(),
+                    originalPartition = record.partition(),
+                    originalOffset = record.offset(),
+                    originalKey = record.key()?.toString(),
+                    originalValue = record.value()?.toString(),
+                    exception = exception.message,
+                    timestamp = System.currentTimeMillis()
+                )
+                dlqCommandService.saveDLQMessage(deadLetterMessage)
+            },
+            FixedBackOff(1000L, 3)
+        )
+        errorHandler.addNotRetryableExceptions(
+            DeserializationException::class.java,
+            SerializationException::class.java,
+            MessageConversionException::class.java
+        )
+        factory.setCommonErrorHandler(errorHandler)
+
         return factory
     }
 }


### PR DESCRIPTION
Closes #292

### 📌 작업 개요
notification, user, product, order 서비스의 Kafka Consumer DLQ 처리 정책을 통일합니다.

---

### ✅ 주요 변경 사항

- `notification-service.config`
  - `KafkaConsumerConfig`: DLQ 에러 핸들러 정책 정렬

- `user-service.config`
  - `KafkaConsumerConfig`: DLQ 에러 핸들러 정책 정렬

- `product-service.config`
  - `KafkaConsumerConfig`: DLQ 에러 핸들러 정책 정렬

- `order-service.config`
  - `KafkaConfig`: DLQ 에러 핸들러 정책 정렬

---

### 📎 관련 이슈
- #292
