### PR TITLE
perf: TwoLevelCache 전략 개선

### DIFF
--- a/hoppingmall-cache/build.gradle.kts
+++ b/hoppingmall-cache/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-stdlib")
 	implementation("org.springframework.boot:spring-boot-starter-cache")
 	implementation("com.github.ben-manes.caffeine:caffeine")
+	implementation("io.micrometer:micrometer-core")
 	compileOnly("org.springframework.boot:spring-boot-starter-data-redis")
 	compileOnly("org.redisson:redisson-spring-boot-starter:4.3.0")
 

--- a/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/TwoLevelCache.kt
+++ b/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/TwoLevelCache.kt
@@ -1,6 +1,8 @@
 package com.hoppingmall.cache
 
 import com.github.benmanes.caffeine.cache.Cache
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.cache.support.AbstractValueAdaptingCache
 import java.time.Duration
@@ -13,10 +15,20 @@ class TwoLevelCache(
     private val policy: CachePolicy,
     private val lockProvider: LockProvider,
     private val shardedRedisCache: org.springframework.cache.Cache? = null,
-    private val hotKeyDetector: HotKeyDetector? = null
+    private val hotKeyDetector: HotKeyDetector? = null,
+    meterRegistry: MeterRegistry? = null
 ) : AbstractValueAdaptingCache(true) {
 
     private val log = LoggerFactory.getLogger(TwoLevelCache::class.java)
+    private val l1HitCounter = meterRegistry?.let {
+        Counter.builder("cache.l1.hit").tag("cache", name).register(it)
+    }
+    private val l2HitCounter = meterRegistry?.let {
+        Counter.builder("cache.l2.hit").tag("cache", name).register(it)
+    }
+    private val missCounter = meterRegistry?.let {
+        Counter.builder("cache.miss").tag("cache", name).register(it)
+    }
 
     companion object {
         private const val LOCK_KEY_PREFIX = "lock:"
@@ -31,7 +43,10 @@ class TwoLevelCache(
 
     override fun lookup(key: Any): Any? {
         val l1Value = caffeineCache.getIfPresent(key)
-        if (l1Value != null) return l1Value
+        if (l1Value != null) {
+            l1HitCounter?.increment()
+            return l1Value
+        }
 
         hotKeyDetector?.recordAccess(key.toString())
         val isHot = hotKeyDetector?.isHot(key.toString()) ?: false
@@ -39,7 +54,10 @@ class TwoLevelCache(
         val l2Cache = if (isHot && shardedRedisCache != null) shardedRedisCache else redisCache
         val l2Value = l2Cache.get(key)?.get()
         if (l2Value != null) {
+            l2HitCounter?.increment()
             caffeineCache.put(key, l2Value)
+        } else {
+            missCounter?.increment()
         }
         return l2Value
     }
@@ -47,7 +65,10 @@ class TwoLevelCache(
     @Suppress("UNCHECKED_CAST")
     override fun <T : Any?> get(key: Any, valueLoader: Callable<T>): T? {
         val l1Value = caffeineCache.getIfPresent(key)
-        if (l1Value != null) return fromStoreValue(l1Value) as T?
+        if (l1Value != null) {
+            l1HitCounter?.increment()
+            return fromStoreValue(l1Value) as T?
+        }
 
         hotKeyDetector?.recordAccess(key.toString())
         val isHot = hotKeyDetector?.isHot(key.toString()) ?: false
@@ -55,6 +76,7 @@ class TwoLevelCache(
         if (isHot && shardedRedisCache != null) {
             val shardValue = shardedRedisCache.get(key)?.get()
             if (shardValue != null) {
+                l2HitCounter?.increment()
                 caffeineCache.put(key, shardValue)
                 return fromStoreValue(shardValue) as T?
             }
@@ -63,10 +85,12 @@ class TwoLevelCache(
 
         val l2Value = redisCache.get(key)?.get()
         if (l2Value != null) {
+            l2HitCounter?.increment()
             caffeineCache.put(key, l2Value)
             return fromStoreValue(l2Value) as T?
         }
 
+        missCounter?.increment()
         return loadAndCache(key, valueLoader)
     }
 
@@ -79,9 +103,11 @@ class TwoLevelCache(
             try {
                 val l2Recheck = redisCache.get(key)?.get()
                 if (l2Recheck != null) {
+                    l2HitCounter?.increment()
                     caffeineCache.put(key, l2Recheck)
                     return fromStoreValue(l2Recheck) as T?
                 }
+                missCounter?.increment()
                 return loadAndCache(key, valueLoader)
             } finally {
                 lockProvider.unlock(lockKey)
@@ -100,12 +126,14 @@ class TwoLevelCache(
 
             val l2Value = redisCache.get(key)?.get()
             if (l2Value != null) {
+                l2HitCounter?.increment()
                 caffeineCache.put(key, l2Value)
                 return fromStoreValue(l2Value) as T?
             }
         }
 
         log.warn("Lock 대기 초과 [cache={}, key={}], DB 로더 직접 호출", name, key)
+        missCounter?.increment()
         return loadAndCache(key, valueLoader)
     }
 

--- a/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/TwoLevelCacheManager.kt
+++ b/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/TwoLevelCacheManager.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.cache
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.cache.Cache
 import org.springframework.cache.CacheManager
 import java.util.concurrent.ConcurrentHashMap
@@ -9,34 +10,62 @@ class TwoLevelCacheManager(
     private val redisCacheManager: CacheManager,
     private val policies: Map<String, CachePolicy>,
     private val lockProvider: LockProvider,
-    private val hotKeyDetectorRegistry: HotKeyDetectorRegistry
+    private val hotKeyDetectorRegistry: HotKeyDetectorRegistry,
+    private val meterRegistry: MeterRegistry? = null
 ) : CacheManager {
 
-    private val cacheMap = ConcurrentHashMap<String, Cache>()
+    private sealed interface CacheLookupResult {
+        data class Present(val cache: Cache) : CacheLookupResult
+        data class Missing(val expireAt: Long) : CacheLookupResult
+    }
+
+    private val cacheMap = ConcurrentHashMap<String, CacheLookupResult>()
 
     override fun getCache(name: String): Cache? {
         val existing = cacheMap[name]
-        if (existing != null) return existing
+        if (existing is CacheLookupResult.Missing) {
+            return if (System.currentTimeMillis() < existing.expireAt) {
+                null
+            } else {
+                cacheMap.remove(name, existing)
+                getCache(name)
+            }
+        }
 
-        val redisCache = redisCacheManager.getCache(name) ?: return null
-        val policy = policies[name] ?: return redisCache
+        val lookupResult = cacheMap.computeIfAbsent(name) { cacheName ->
+            val redisCache = redisCacheManager.getCache(cacheName)
+                ?: return@computeIfAbsent CacheLookupResult.Missing(
+                    System.currentTimeMillis() + MISSING_CACHE_TTL_MS
+                )
+            val policy = policies[cacheName]
+                ?: return@computeIfAbsent CacheLookupResult.Present(redisCache)
 
-        val caffeineCache = Caffeine.newBuilder()
-            .maximumSize(policy.l1MaxSize)
-            .expireAfterWrite(policy.l1Ttl)
-            .build<Any, Any>()
+            val caffeineCache = Caffeine.newBuilder()
+                .maximumSize(policy.l1MaxSize)
+                .expireAfterWrite(policy.l1Ttl)
+                .build<Any, Any>()
 
-        val detector = hotKeyDetectorRegistry.getDetector(name)
-        val shardedRedisCache = if (policy.dynamicHotKeyEnabled) {
-            ShardedRedisCache(redisCache, policy.hotKeyShardCount)
-        } else null
+            val detector = hotKeyDetectorRegistry.getDetector(cacheName)
+            val shardedRedisCache = if (policy.dynamicHotKeyEnabled) {
+                ShardedRedisCache(redisCache, policy.hotKeyShardCount)
+            } else null
 
-        val twoLevelCache = TwoLevelCache(
-            name, caffeineCache, redisCache, policy, lockProvider,
-            shardedRedisCache, detector
-        )
-        cacheMap[name] = twoLevelCache
-        return twoLevelCache
+            CacheLookupResult.Present(
+                TwoLevelCache(
+                cacheName, caffeineCache, redisCache, policy, lockProvider,
+                shardedRedisCache, detector, meterRegistry
+            )
+            )
+        }
+
+        return when (lookupResult) {
+            is CacheLookupResult.Present -> lookupResult.cache
+            is CacheLookupResult.Missing -> null
+        }
+    }
+
+    companion object {
+        private const val MISSING_CACHE_TTL_MS = 30_000L
     }
 
     override fun getCacheNames(): Collection<String> {

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TwoLevelCacheManagerTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TwoLevelCacheManagerTest.kt
@@ -1,0 +1,145 @@
+package com.hoppingmall.cache
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@DisplayName("TwoLevelCacheManager")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class TwoLevelCacheManagerTest {
+
+    private fun createManager(redisCacheManager: CacheManager, vararg policies: CachePolicy): TwoLevelCacheManager {
+        return TwoLevelCacheManager(
+            redisCacheManager = redisCacheManager,
+            policies = policies.associateBy { it.cacheName },
+            lockProvider = FakeLockProvider(),
+            hotKeyDetectorRegistry = HotKeyDetectorRegistry(policies.toList()),
+            meterRegistry = SimpleMeterRegistry()
+        )
+    }
+
+    private fun defaultPolicy(name: String = "product") = CachePolicy(
+        cacheName = name,
+        l1MaxSize = 100,
+        l1Ttl = Duration.ofSeconds(10),
+        l2Ttl = Duration.ofMinutes(1),
+        hotKeyThreshold = 5
+    )
+
+    @Suppress("UNCHECKED_CAST")
+    private fun injectExpiredMissing(manager: TwoLevelCacheManager, cacheName: String) {
+        val field = TwoLevelCacheManager::class.java.getDeclaredField("cacheMap")
+        field.isAccessible = true
+        val cacheMap = field.get(manager) as ConcurrentHashMap<String, Any>
+        val missingClass = Class.forName("com.hoppingmall.cache.TwoLevelCacheManager\$CacheLookupResult\$Missing")
+        val constructor = missingClass.getDeclaredConstructor(Long::class.java)
+        constructor.isAccessible = true
+        val expiredMissing = constructor.newInstance(System.currentTimeMillis() - 1L)
+        cacheMap[cacheName] = expiredMissing
+    }
+
+    @Test
+    fun getCache_동시_호출_시_하나의_인스턴스만_생성한다() {
+        val redisCacheManager = mock<CacheManager>()
+        val redisCache = mock<Cache>()
+        val policy = defaultPolicy()
+        val manager = createManager(redisCacheManager, policy)
+
+        whenever(redisCacheManager.getCache("product")).thenAnswer {
+            Thread.sleep(50)
+            redisCache
+        }
+
+        val threadCount = 16
+        val startLatch = CountDownLatch(1)
+        val doneLatch = CountDownLatch(threadCount)
+        val executor = Executors.newFixedThreadPool(threadCount)
+        val results = mutableListOf<Cache?>()
+        val resultsLock = Any()
+
+        repeat(threadCount) {
+            executor.submit {
+                try {
+                    startLatch.await()
+                    val cache = manager.getCache("product")
+                    synchronized(resultsLock) {
+                        results += cache
+                    }
+                } finally {
+                    doneLatch.countDown()
+                }
+            }
+        }
+
+        startLatch.countDown()
+        doneLatch.await(5, TimeUnit.SECONDS)
+        executor.shutdown()
+        executor.awaitTermination(5, TimeUnit.SECONDS)
+
+        assertThat(results).hasSize(threadCount)
+        assertThat(results.filterNotNull().distinct()).hasSize(1)
+        verify(redisCacheManager, times(1)).getCache("product")
+    }
+
+    @Test
+    fun Redis_다운_시_첫_호출은_null을_반환하고_30초_내_재호출도_Redis를_재시도하지_않는다() {
+        val redisCacheManager = mock<CacheManager>()
+        val policy = defaultPolicy()
+        val manager = createManager(redisCacheManager, policy)
+
+        whenever(redisCacheManager.getCache("product")).thenReturn(null)
+
+        val first = manager.getCache("product")
+        val second = manager.getCache("product")
+
+        assertThat(first).isNull()
+        assertThat(second).isNull()
+        verify(redisCacheManager, times(1)).getCache("product")
+    }
+
+    @Test
+    fun TTL_만료_후_Redis를_재시도한다() {
+        val redisCacheManager = mock<CacheManager>()
+        val redisCache = mock<Cache>()
+        val policy = defaultPolicy()
+        val manager = createManager(redisCacheManager, policy)
+
+        injectExpiredMissing(manager, "product")
+
+        whenever(redisCacheManager.getCache("product")).thenReturn(redisCache)
+
+        val result = manager.getCache("product")
+
+        assertThat(result).isNotNull()
+        verify(redisCacheManager, times(1)).getCache("product")
+    }
+
+    @Test
+    fun Redis_정상_동작_시_캐시_인스턴스를_반환한다() {
+        val redisCacheManager = mock<CacheManager>()
+        val redisCache = mock<Cache>()
+        val policy = defaultPolicy()
+        val manager = createManager(redisCacheManager, policy)
+
+        whenever(redisCacheManager.getCache("product")).thenReturn(redisCache)
+
+        val result = manager.getCache("product")
+
+        assertThat(result).isNotNull()
+        verify(redisCacheManager, times(1)).getCache("product")
+    }
+}

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TwoLevelCacheTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TwoLevelCacheTest.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.cache
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -26,6 +27,7 @@ class TwoLevelCacheTest {
 
     private val redisCache: Cache = mock()
     private val lockProvider = FakeLockProvider()
+    private lateinit var meterRegistry: SimpleMeterRegistry
 
     private val hotKeyPolicy = CachePolicy(
         cacheName = "product",
@@ -48,6 +50,7 @@ class TwoLevelCacheTest {
     @BeforeEach
     fun setUp() {
         lockProvider.reset()
+        meterRegistry = SimpleMeterRegistry()
     }
 
     private fun createCache(policy: CachePolicy): TwoLevelCache {
@@ -55,7 +58,7 @@ class TwoLevelCacheTest {
             .maximumSize(policy.l1MaxSize)
             .expireAfterWrite(policy.l1Ttl)
             .build<Any, Any>()
-        return TwoLevelCache(policy.cacheName, caffeineCache, redisCache, policy, lockProvider)
+        return TwoLevelCache(policy.cacheName, caffeineCache, redisCache, policy, lockProvider, meterRegistry = meterRegistry)
     }
 
     @Nested
@@ -74,7 +77,7 @@ class TwoLevelCacheTest {
 
             val cache = TwoLevelCache(
                 hotKeyPolicy.cacheName, caffeineCache, redisCache, hotKeyPolicy,
-                lockProvider, shardedCache, fakeDetector
+                lockProvider, shardedCache, fakeDetector, meterRegistry
             )
 
             whenever(shardedCache.get(1L)).thenReturn(null)
@@ -111,7 +114,7 @@ class TwoLevelCacheTest {
 
             val cache = TwoLevelCache(
                 hotKeyPolicy.cacheName, caffeineCache, redisCache, hotKeyPolicy,
-                lockProvider, shardedCache, fakeDetector
+                lockProvider, shardedCache, fakeDetector, meterRegistry
             )
 
             val dbCallCount = AtomicInteger(0)
@@ -169,6 +172,19 @@ class TwoLevelCacheTest {
 
             assertEquals("cached-value", result)
             verify(redisCache, never()).get(1L)
+            assertEquals(1.0, meterRegistry.counter("cache.l1.hit", "cache", "category").count())
+        }
+
+        @Test
+        fun valueLoader_경로에서도_L1_히트_메트릭이_증가한다() {
+            val cache = createCache(normalPolicy)
+
+            cache.put(1L, "cached-value")
+
+            val result = cache.get(1L, Callable { "should-not-call" })
+
+            assertEquals("cached-value", result)
+            assertEquals(1.0, meterRegistry.counter("cache.l1.hit", "cache", "category").count())
         }
     }
 
@@ -186,7 +202,7 @@ class TwoLevelCacheTest {
                 .build<Any, Any>()
             return TwoLevelCache(
                 hotKeyPolicy.cacheName, caffeineCache, redisCache, hotKeyPolicy,
-                lockProvider, shardedCache, fakeDetector
+                lockProvider, shardedCache, fakeDetector, meterRegistry
             )
         }
 
@@ -207,6 +223,7 @@ class TwoLevelCacheTest {
             val result = cache.get(1L, Callable { "should-not-call" })
 
             assertEquals("shard-value", result)
+            assertEquals(1.0, meterRegistry.counter("cache.l2.hit", "cache", "product").count())
         }
 
         @Test
@@ -222,6 +239,7 @@ class TwoLevelCacheTest {
 
             assertEquals("redis-value", result)
             verify(shardedCache, never()).get(any())
+            assertEquals(1.0, meterRegistry.counter("cache.l2.hit", "cache", "product").count())
         }
 
         @Test
@@ -234,6 +252,35 @@ class TwoLevelCacheTest {
             cache.get(1L, Callable { "loaded" })
 
             assertEquals(1, fakeDetector.recordCount)
+            assertEquals(1.0, meterRegistry.counter("cache.miss", "cache", "product").count())
+        }
+
+        @Test
+        fun valueLoader_경로에서_L2_히트_메트릭이_증가한다() {
+            fakeDetector.overrideIsHot = false
+            val cache = createHotKeyCache()
+
+            val valueWrapper: Cache.ValueWrapper = mock()
+            whenever(valueWrapper.get()).thenReturn("redis-value")
+            whenever(redisCache.get(1L)).thenReturn(valueWrapper)
+
+            val result = cache.get(1L, Callable { "should-not-call" })
+
+            assertEquals("redis-value", result)
+            assertEquals(1.0, meterRegistry.counter("cache.l2.hit", "cache", "product").count())
+        }
+
+        @Test
+        fun valueLoader_경로에서_미스_메트릭이_증가한다() {
+            fakeDetector.overrideIsHot = false
+            val cache = createHotKeyCache()
+
+            whenever(redisCache.get(1L)).thenReturn(null)
+
+            val result = cache.get(1L, Callable { "loaded" })
+
+            assertEquals("loaded", result)
+            assertEquals(1.0, meterRegistry.counter("cache.miss", "cache", "product").count())
         }
 
         @Test


### PR DESCRIPTION
Closes #293

### 📌 작업 개요
hoppingmall-cache 모듈의 TwoLevelCache 및 TwoLevelCacheManager 전략을 개선합니다.

---

### ✅ 주요 변경 사항

- `hoppingmall-cache`
  - `TwoLevelCache`: 캐시 로직 개선
  - `TwoLevelCacheManager`: 매니저 로직 개선

---

### 🧪 테스트

- `TwoLevelCacheTest`: 기존 테스트 수정
- `TwoLevelCacheManagerTest`: 신규 추가

---

### 📎 관련 이슈
- #293
