### PR TITLE
feat: 결제 취소 Avro 이벤트 스키마 추가

### DIFF
--- a/hoppingmall-common/src/main/avro/PaymentCancellationCompletedEvent.avsc
+++ b/hoppingmall-common/src/main/avro/PaymentCancellationCompletedEvent.avsc
@@ -1,0 +1,10 @@
+{
+  "type": "record",
+  "name": "PaymentCancellationCompletedEvent",
+  "namespace": "com.hoppingmall.common.event",
+  "fields": [
+    {"name": "eventId", "type": "string"},
+    {"name": "orderId", "type": "long"},
+    {"name": "paymentId", "type": "long"}
+  ]
+}

--- a/hoppingmall-common/src/main/avro/PaymentCancellationFailedEvent.avsc
+++ b/hoppingmall-common/src/main/avro/PaymentCancellationFailedEvent.avsc
@@ -1,0 +1,10 @@
+{
+  "type": "record",
+  "name": "PaymentCancellationFailedEvent",
+  "namespace": "com.hoppingmall.common.event",
+  "fields": [
+    {"name": "eventId", "type": "string"},
+    {"name": "orderId", "type": "long"},
+    {"name": "reason", "type": "string"}
+  ]
+}

--- a/hoppingmall-common/src/main/avro/PaymentCancellationRequestedEvent.avsc
+++ b/hoppingmall-common/src/main/avro/PaymentCancellationRequestedEvent.avsc
@@ -1,0 +1,9 @@
+{
+  "type": "record",
+  "name": "PaymentCancellationRequestedEvent",
+  "namespace": "com.hoppingmall.common.event",
+  "fields": [
+    {"name": "eventId", "type": "string"},
+    {"name": "orderId", "type": "long"}
+  ]
+}

--- a/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/event/AvroEventConverter.kt
+++ b/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/event/AvroEventConverter.kt
@@ -23,7 +23,10 @@ class AvroEventConverter(private val objectMapper: ObjectMapper) {
         "PointEarnRequested" to PointEarnRequestEvent.getClassSchema(),
         "MembershipUpdateRequested" to MembershipUpdateRequestEvent.getClassSchema(),
         "RefundCompleted" to RefundCompletedEvent.getClassSchema(),
-        "PaymentReversalRequested" to PaymentCancelledEvent.getClassSchema()
+        "PaymentReversalRequested" to PaymentCancelledEvent.getClassSchema(),
+        "PaymentCancellationRequested" to PaymentCancellationRequestedEvent.getClassSchema(),
+        "PaymentCancellationCompleted" to PaymentCancellationCompletedEvent.getClassSchema(),
+        "PaymentCancellationFailed" to PaymentCancellationFailedEvent.getClassSchema()
     )
 
     fun convertJsonToAvro(eventType: String, jsonData: String): GenericRecord {


### PR DESCRIPTION
Closes #294

### 📌 작업 개요
결제 취소 Saga에 필요한 Avro 이벤트 스키마 3종을 정의하고, AvroEventConverter에 변환 로직을 추가합니다.

---

### ✅ 주요 변경 사항

- `hoppingmall-common.avro`
  - `PaymentCancellationRequestedEvent.avsc`: 결제 취소 요청 이벤트 스키마
  - `PaymentCancellationCompletedEvent.avsc`: 결제 취소 완료 이벤트 스키마
  - `PaymentCancellationFailedEvent.avsc`: 결제 취소 실패 이벤트 스키마

- `hoppingmall-common.event`
  - `AvroEventConverter`: 신규 이벤트 변환 로직 추가

---

### 📎 관련 이슈
- #294
