### PR TITLE
refactor: Outbox 공통 모듈 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       run_tests: ${{ steps.matrices.outputs.run_tests }}
       run_docker: ${{ steps.matrices.outputs.run_docker }}
       run_k8s: ${{ steps.matrices.outputs.run_k8s }}
+      run_shared_modules: ${{ steps.matrices.outputs.run_shared_modules }}
       test_matrix: ${{ steps.matrices.outputs.test_matrix }}
       docker_matrix: ${{ steps.matrices.outputs.docker_matrix }}
     steps:
@@ -44,11 +45,13 @@ jobs:
               - 'hoppingmall-common/**'
               - 'hoppingmall-idempotency/**'
               - 'hoppingmall-dlq/**'
+              - 'hoppingmall-outbox/**'
               - '.github/workflows/**'
             payment_service:
               - 'payment-service/**'
               - 'hoppingmall-common/**'
               - 'hoppingmall-dlq/**'
+              - 'hoppingmall-outbox/**'
               - '.github/workflows/**'
             product_service:
               - 'product-service/**'
@@ -69,6 +72,12 @@ jobs:
             k8s:
               - 'k8s/**'
               - 'k8s-cd/**'
+            shared_modules:
+              - 'hoppingmall-common/**'
+              - 'hoppingmall-cache/**'
+              - 'hoppingmall-dlq/**'
+              - 'hoppingmall-idempotency/**'
+              - 'hoppingmall-outbox/**'
 
       - name: 실행 매트릭스 생성
         id: matrices
@@ -82,6 +91,7 @@ jobs:
           SETTLEMENT_SERVICE: ${{ steps.changes.outputs.settlement_service }}
           USER_SERVICE: ${{ steps.changes.outputs.user_service }}
           K8S_CHANGED: ${{ steps.changes.outputs.k8s }}
+          SHARED_MODULES: ${{ steps.changes.outputs.shared_modules }}
         run: |
           impacted_services=()
 
@@ -135,6 +145,12 @@ jobs:
             echo "run_k8s=false" >> "$GITHUB_OUTPUT"
           fi
 
+          if [[ "$SHARED_MODULES" == "true" ]]; then
+            echo "run_shared_modules=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_shared_modules=false" >> "$GITHUB_OUTPUT"
+          fi
+
   services-test:
     name: ${{ matrix.service }} 테스트
     runs-on: ubuntu-latest
@@ -159,7 +175,7 @@ jobs:
           cache: 'gradle'
 
       - name: 테스트
-        run: cd ${{ matrix.service }} && ./gradlew test --no-daemon --build-cache
+        run: cd ${{ matrix.service }} && ./gradlew test jacocoTestVerification --no-daemon --build-cache
 
       - name: 테스트 리포트 업로드
         if: failure()
@@ -219,6 +235,36 @@ jobs:
             kubeconform -strict -summary "$f" || exit 1
           done
 
+  shared-modules-test:
+    name: 공유 모듈 테스트
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.run_shared_modules == 'true'
+    steps:
+      - name: 소스 체크아웃
+        uses: actions/checkout@v3
+
+      - name: JDK 21 설정
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: 공유 모듈 테스트
+        run: |
+          for module in hoppingmall-common hoppingmall-cache hoppingmall-dlq hoppingmall-idempotency hoppingmall-outbox; do
+            if [ -d "$module" ] && [ -f "$module/build.gradle.kts" ]; then
+              echo "Testing $module..."
+              if [ -f "$module/gradlew" ]; then
+                chmod +x "$module/gradlew"
+                cd "$module" && ./gradlew test --no-daemon --build-cache && cd ..
+              else
+                ./gradlew -p "$module" test --no-daemon --build-cache
+              fi
+            fi
+          done
+
   final-check:
     name: CI 최종 검증
     runs-on: ubuntu-latest
@@ -227,6 +273,7 @@ jobs:
       - services-test
       - services-docker-build
       - k8s-validate
+      - shared-modules-test
     if: always()
     steps:
       - name: 모든 선행 job 결과 확인
@@ -246,3 +293,4 @@ jobs:
           check_result "services-test" "${{ needs.services-test.result }}"
           check_result "services-docker-build" "${{ needs.services-docker-build.result }}"
           check_result "k8s-validate" "${{ needs.k8s-validate.result }}"
+          check_result "shared-modules-test" "${{ needs.shared-modules-test.result }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
           cache: 'gradle'
 
       - name: 테스트
-        run: cd ${{ matrix.service }} && ./gradlew test jacocoTestVerification --no-daemon --build-cache
+        run: cd ${{ matrix.service }} && ./gradlew test --no-daemon --build-cache
 
       - name: 테스트 리포트 업로드
         if: failure()

--- a/hoppingmall-outbox/build.gradle.kts
+++ b/hoppingmall-outbox/build.gradle.kts
@@ -1,0 +1,48 @@
+plugins {
+    kotlin("jvm") version "1.9.25"
+    kotlin("plugin.spring") version "1.9.25"
+    kotlin("plugin.jpa") version "1.9.25"
+    id("io.spring.dependency-management") version "1.1.7"
+    `java-library`
+}
+
+group = "com.hoppingmall"
+version = "0.0.1-SNAPSHOT"
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    mavenCentral()
+    maven { url = uri("https://packages.confluent.io/maven/") }
+}
+
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.boot:spring-boot-dependencies:3.5.0")
+    }
+}
+
+dependencies {
+    implementation("com.hoppingmall:hoppingmall-common:0.0.1-SNAPSHOT")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-cache")
+    implementation("org.springframework.kafka:spring-kafka")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("io.micrometer:micrometer-core")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
+    testImplementation("org.assertj:assertj-core:3.24.2")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/hoppingmall-outbox/settings.gradle.kts
+++ b/hoppingmall-outbox/settings.gradle.kts
@@ -1,0 +1,7 @@
+rootProject.name = "hoppingmall-outbox"
+
+val commonPath = if (file("../hoppingmall-common").exists()) "../hoppingmall-common"
+    else if (file("/hoppingmall-common").exists()) "/hoppingmall-common"
+    else null
+
+commonPath?.let { includeBuild(it) }

--- a/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/domain/OutboxEvent.kt
+++ b/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/domain/OutboxEvent.kt
@@ -1,0 +1,92 @@
+package com.hoppingmall.outbox.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "outbox_events",
+    indexes = [
+        Index(name = "idx_outbox_processed_created", columnList = "processed, created_at"),
+        Index(name = "idx_outbox_aggregate_id", columnList = "aggregate_id"),
+        Index(name = "idx_outbox_status_retry", columnList = "processed, status, retry_count")
+    ]
+)
+class OutboxEvent(
+    @Column(name = "aggregate_type", nullable = false, length = 100)
+    val aggregateType: String,
+
+    @Column(name = "aggregate_id", nullable = false, length = 100)
+    val aggregateId: String,
+
+    @Column(name = "event_type", nullable = false, length = 100)
+    val eventType: String,
+
+    @Column(name = "event_data", nullable = false, columnDefinition = "TEXT")
+    val eventData: String,
+
+    @Column(name = "topic", nullable = false, length = 100)
+    val topic: String,
+
+    @Column(name = "partition_key", length = 100)
+    val partitionKey: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: OutboxStatus = OutboxStatus.PENDING,
+
+    @Column(name = "retry_count", nullable = false)
+    var retryCount: Int = 0,
+
+    @Column(name = "error_message", columnDefinition = "TEXT")
+    var errorMessage: String? = null,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "processed_at")
+    var processedAt: LocalDateTime? = null
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null
+
+    @Column(name = "processed", nullable = false)
+    var processed: Boolean = false
+
+    fun markAsProcessed() {
+        this.processed = true
+        this.status = OutboxStatus.PUBLISHED
+        this.processedAt = LocalDateTime.now()
+        this.updatedAt = LocalDateTime.now()
+    }
+
+    fun markAsFailed(errorMessage: String) {
+        this.status = OutboxStatus.FAILED
+        this.errorMessage = errorMessage
+        this.retryCount++
+        this.updatedAt = LocalDateTime.now()
+    }
+
+    fun markAsFailedPermanently(errorMessage: String) {
+        markAsFailed(errorMessage)
+        this.processed = true
+        this.processedAt = LocalDateTime.now()
+    }
+
+    fun markAsRetrying() {
+        this.status = OutboxStatus.RETRYING
+        this.updatedAt = LocalDateTime.now()
+    }
+}

--- a/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/domain/OutboxStatus.kt
+++ b/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/domain/OutboxStatus.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.outbox.domain
+
+enum class OutboxStatus {
+    PENDING,
+    RETRYING,
+    PUBLISHED,
+    FAILED
+}

--- a/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/metrics/OutboxMetrics.kt
+++ b/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/metrics/OutboxMetrics.kt
@@ -1,0 +1,67 @@
+package com.hoppingmall.outbox.metrics
+
+import com.hoppingmall.outbox.domain.OutboxStatus
+import com.hoppingmall.outbox.repository.OutboxEventRepository
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.LocalDateTime
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+class OutboxMetrics(
+    private val registry: MeterRegistry,
+    private val outboxEventRepository: OutboxEventRepository
+) {
+
+    private val publishedCounter = Counter.builder("outbox.event.published.count")
+        .description("Total number of outbox events published")
+        .register(registry)
+
+    private val failedCounter = Counter.builder("outbox.event.failed.count")
+        .description("Total number of outbox event publish failures")
+        .register(registry)
+
+    private val topicPublishedCounters = ConcurrentHashMap<String, Counter>()
+    private val topicFailedCounters = ConcurrentHashMap<String, Counter>()
+
+    private val publishLatency = Timer.builder("outbox.event.publish.latency")
+        .description("Time from event creation to successful publish")
+        .register(registry)
+
+    init {
+        Gauge.builder("outbox.event.pending.count") {
+            outboxEventRepository.countByStatus(OutboxStatus.PENDING).toDouble()
+        }.description("Pending outbox events").register(registry)
+
+        Gauge.builder("outbox.event.retrying.count") {
+            outboxEventRepository.countByStatus(OutboxStatus.RETRYING).toDouble()
+        }.description("Retrying outbox events").register(registry)
+
+        Gauge.builder("outbox.event.failed.current") {
+            outboxEventRepository.countByStatus(OutboxStatus.FAILED).toDouble()
+        }.description("Failed outbox events").register(registry)
+    }
+
+    fun recordOutboxPublished(topic: String) {
+        publishedCounter.increment()
+        topicPublishedCounters.computeIfAbsent(topic) {
+            Counter.builder("outbox.event.published.by_topic").tag("topic", it).register(registry)
+        }.increment()
+    }
+
+    fun recordOutboxFailed(topic: String) {
+        failedCounter.increment()
+        topicFailedCounters.computeIfAbsent(topic) {
+            Counter.builder("outbox.event.failed.by_topic").tag("topic", it).register(registry)
+        }.increment()
+    }
+
+    fun recordPublishLatency(createdAt: LocalDateTime) {
+        val latencyMs = Duration.between(createdAt, LocalDateTime.now()).toMillis()
+        publishLatency.record(Duration.ofMillis(latencyMs))
+    }
+}

--- a/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/repository/OutboxEventRepository.kt
+++ b/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/repository/OutboxEventRepository.kt
@@ -1,0 +1,137 @@
+package com.hoppingmall.outbox.repository
+
+import com.hoppingmall.outbox.domain.OutboxEvent
+import com.hoppingmall.outbox.domain.OutboxStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
+
+interface OutboxEventRepository : JpaRepository<OutboxEvent, Long> {
+
+    @Query(
+        """
+        SELECT o FROM OutboxEvent o
+        WHERE o.processed = false
+        AND (o.status = :status OR (o.status = :retryStatus AND o.retryCount < :maxRetries))
+        ORDER BY o.createdAt ASC
+        LIMIT :limit
+    """
+    )
+    fun findUnprocessedEvents(
+        @Param("status") status: OutboxStatus = OutboxStatus.PENDING,
+        @Param("retryStatus") retryStatus: OutboxStatus = OutboxStatus.FAILED,
+        @Param("maxRetries") maxRetries: Int = 3,
+        @Param("limit") limit: Int = 100
+    ): List<OutboxEvent>
+
+    @Query(
+        """
+        SELECT COUNT(o) > 0 FROM OutboxEvent o
+        WHERE o.aggregateType = :aggregateType
+        AND o.aggregateId = :aggregateId
+        AND o.eventType = :eventType
+        AND o.eventData = :eventData
+        AND o.status IN :statuses
+    """
+    )
+    fun existsDuplicateEvent(
+        @Param("aggregateType") aggregateType: String,
+        @Param("aggregateId") aggregateId: String,
+        @Param("eventType") eventType: String,
+        @Param("eventData") eventData: String,
+        @Param("statuses") statuses: List<OutboxStatus>
+    ): Boolean
+
+    @Query(
+        """
+        SELECT o FROM OutboxEvent o
+        WHERE o.processed = false
+        AND o.aggregateId = :aggregateId
+        AND o.aggregateType = :aggregateType
+        ORDER BY o.createdAt ASC
+    """
+    )
+    fun findByAggregateIdAndType(
+        @Param("aggregateId") aggregateId: String,
+        @Param("aggregateType") aggregateType: String
+    ): List<OutboxEvent>
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+        """
+        DELETE FROM OutboxEvent o
+        WHERE o.processed = true
+        AND o.processedAt < :cutoffDate
+    """
+    )
+    fun deleteProcessedEventsBefore(@Param("cutoffDate") cutoffDate: LocalDateTime): Int
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+        """
+        UPDATE OutboxEvent o
+        SET o.status = :nextStatus,
+            o.updatedAt = :updatedAt
+        WHERE o.id = :id
+        AND o.processed = false
+        AND (
+            o.status = :pendingStatus
+            OR (o.status = :failedStatus AND o.retryCount < :maxRetries)
+        )
+    """
+    )
+    fun claimEventForPublish(
+        @Param("id") id: Long,
+        @Param("nextStatus") nextStatus: OutboxStatus,
+        @Param("updatedAt") updatedAt: LocalDateTime,
+        @Param("pendingStatus") pendingStatus: OutboxStatus,
+        @Param("failedStatus") failedStatus: OutboxStatus,
+        @Param("maxRetries") maxRetries: Int
+    ): Int
+
+    @Query(
+        """
+        SELECT COUNT(o) FROM OutboxEvent o
+        WHERE o.status = :status
+    """
+    )
+    fun countByStatus(@Param("status") status: OutboxStatus): Long
+
+    @Query(
+        """
+        SELECT o FROM OutboxEvent o
+        WHERE o.processed = false
+        AND o.updatedAt < :cutoffDate
+        ORDER BY o.createdAt ASC
+        LIMIT :limit
+    """
+    )
+    fun findStaleEvents(
+        @Param("cutoffDate") cutoffDate: LocalDateTime,
+        @Param("limit") limit: Int = 100
+    ): List<OutboxEvent>
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+        """
+        UPDATE OutboxEvent o
+        SET o.status = :nextStatus,
+            o.updatedAt = :updatedAt
+        WHERE o.id = :id
+        AND o.processed = false
+        AND o.updatedAt < :cutoffDate
+        AND o.retryCount < :maxRetries
+        AND o.status IN :statuses
+    """
+    )
+    fun claimStaleEvent(
+        @Param("id") id: Long,
+        @Param("nextStatus") nextStatus: OutboxStatus,
+        @Param("updatedAt") updatedAt: LocalDateTime,
+        @Param("cutoffDate") cutoffDate: LocalDateTime,
+        @Param("maxRetries") maxRetries: Int,
+        @Param("statuses") statuses: List<OutboxStatus>
+    ): Int
+}

--- a/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/service/OutboxEventService.kt
+++ b/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/service/OutboxEventService.kt
@@ -1,0 +1,46 @@
+package com.hoppingmall.outbox.service
+
+import com.hoppingmall.outbox.domain.OutboxEvent
+import com.hoppingmall.outbox.domain.OutboxStatus
+import com.hoppingmall.outbox.repository.OutboxEventRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class OutboxEventService(
+    private val outboxEventRepository: OutboxEventRepository,
+    private val outboxEventWriter: OutboxEventWriter
+) {
+
+    @Transactional
+    fun saveEvent(
+        aggregateType: String,
+        aggregateId: String,
+        eventType: String,
+        eventData: Any,
+        topic: String,
+        partitionKey: String? = null
+    ) {
+        outboxEventWriter.saveEvent(
+            aggregateType = aggregateType,
+            aggregateId = aggregateId,
+            eventType = eventType,
+            eventData = eventData,
+            topic = topic,
+            partitionKey = partitionKey
+        )
+    }
+
+    fun getEventsByAggregateId(aggregateId: String, aggregateType: String): List<OutboxEvent> {
+        return outboxEventRepository.findByAggregateIdAndType(aggregateId, aggregateType)
+    }
+
+    fun getEventStats(): Map<String, Long> {
+        return mapOf(
+            "pending" to outboxEventRepository.countByStatus(OutboxStatus.PENDING),
+            "retrying" to outboxEventRepository.countByStatus(OutboxStatus.RETRYING),
+            "published" to outboxEventRepository.countByStatus(OutboxStatus.PUBLISHED),
+            "failed" to outboxEventRepository.countByStatus(OutboxStatus.FAILED)
+        )
+    }
+}

--- a/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/service/OutboxEventWriter.kt
+++ b/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/service/OutboxEventWriter.kt
@@ -1,0 +1,54 @@
+package com.hoppingmall.outbox.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.outbox.domain.OutboxEvent
+import com.hoppingmall.outbox.domain.OutboxStatus
+import com.hoppingmall.outbox.repository.OutboxEventRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class OutboxEventWriter(
+    private val outboxEventRepository: OutboxEventRepository,
+    private val objectMapper: ObjectMapper
+) {
+
+    private val logger = LoggerFactory.getLogger(OutboxEventWriter::class.java)
+
+    @Transactional
+    fun saveEvent(
+        aggregateType: String,
+        aggregateId: String,
+        eventType: String,
+        eventData: Any,
+        topic: String,
+        partitionKey: String? = null
+    ) {
+        val serializedData = objectMapper.writeValueAsString(eventData)
+        val duplicated = outboxEventRepository.existsDuplicateEvent(
+            aggregateType = aggregateType,
+            aggregateId = aggregateId,
+            eventType = eventType,
+            eventData = serializedData,
+            statuses = listOf(OutboxStatus.PENDING, OutboxStatus.RETRYING, OutboxStatus.PUBLISHED)
+        )
+
+        if (duplicated) {
+            logger.warn("Duplicate outbox event skipped: aggregateId=$aggregateId, eventType=$eventType")
+            return
+        }
+
+        val outboxEvent = OutboxEvent(
+            aggregateType = aggregateType,
+            aggregateId = aggregateId,
+            eventType = eventType,
+            eventData = serializedData,
+            topic = topic,
+            partitionKey = partitionKey ?: aggregateId
+        )
+
+        outboxEventRepository.save(outboxEvent)
+        logger.debug("Outbox event saved: aggregateId=$aggregateId, eventType=$eventType")
+    }
+}

--- a/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/metrics/OutboxMetricsTest.kt
+++ b/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/metrics/OutboxMetricsTest.kt
@@ -1,0 +1,54 @@
+package com.hoppingmall.outbox.metrics
+
+import com.hoppingmall.outbox.domain.OutboxStatus
+import com.hoppingmall.outbox.repository.OutboxEventRepository
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
+
+@DisplayName("OutboxMetrics")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class OutboxMetricsTest {
+
+    private lateinit var registry: SimpleMeterRegistry
+    private lateinit var outboxEventRepository: OutboxEventRepository
+    private lateinit var outboxMetrics: OutboxMetrics
+
+    @BeforeEach
+    fun setUp() {
+        registry = SimpleMeterRegistry()
+        outboxEventRepository = mock()
+        whenever(outboxEventRepository.countByStatus(OutboxStatus.PENDING)).thenReturn(3L)
+        whenever(outboxEventRepository.countByStatus(OutboxStatus.RETRYING)).thenReturn(2L)
+        whenever(outboxEventRepository.countByStatus(OutboxStatus.FAILED)).thenReturn(1L)
+        outboxMetrics = OutboxMetrics(registry, outboxEventRepository)
+    }
+
+    @Test
+    fun outbox_발행_성공_시_카운터가_증가한다() {
+        outboxMetrics.recordOutboxPublished("order-saga")
+
+        assertThat(registry.counter("outbox.event.published.count").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun 현재_상태_gauge가_초기화된다() {
+        assertThat(registry.get("outbox.event.pending.count").gauge().value()).isEqualTo(3.0)
+        assertThat(registry.get("outbox.event.retrying.count").gauge().value()).isEqualTo(2.0)
+        assertThat(registry.get("outbox.event.failed.current").gauge().value()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun publish_latency가_기록된다() {
+        outboxMetrics.recordPublishLatency(LocalDateTime.now().minusNanos(50_000_000))
+
+        assertThat(registry.get("outbox.event.publish.latency").timer().count()).isEqualTo(1L)
+    }
+}

--- a/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/service/OutboxEventWriterTest.kt
+++ b/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/service/OutboxEventWriterTest.kt
@@ -1,0 +1,92 @@
+package com.hoppingmall.outbox.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.outbox.domain.OutboxEvent
+import com.hoppingmall.outbox.repository.OutboxEventRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@DisplayName("OutboxEventWriter")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class OutboxEventWriterTest {
+
+    @Mock
+    private lateinit var outboxEventRepository: OutboxEventRepository
+
+    @Mock
+    private lateinit var objectMapper: ObjectMapper
+
+    @InjectMocks
+    private lateinit var writer: OutboxEventWriter
+
+    @Test
+    fun 이벤트_저장_시_Outbox에_PENDING_상태로_저장된다() {
+        val eventData = mapOf("key" to "value")
+        whenever(objectMapper.writeValueAsString(eventData)).thenReturn("""{"key":"value"}""")
+        whenever(outboxEventRepository.existsDuplicateEvent(any(), any(), any(), any(), any())).thenReturn(false)
+        whenever(outboxEventRepository.save(any<OutboxEvent>())).thenAnswer { it.arguments[0] as OutboxEvent }
+
+        writer.saveEvent(
+            aggregateType = "Order",
+            aggregateId = "1",
+            eventType = "OrderCreated",
+            eventData = eventData,
+            topic = "order-events",
+            partitionKey = "1"
+        )
+
+        verify(outboxEventRepository).save(any<OutboxEvent>())
+    }
+
+    @Test
+    fun 중복_이벤트는_저장하지_않는다() {
+        val eventData = mapOf("key" to "value")
+        whenever(objectMapper.writeValueAsString(eventData)).thenReturn("""{"key":"value"}""")
+        whenever(outboxEventRepository.existsDuplicateEvent(any(), any(), any(), any(), any())).thenReturn(true)
+
+        writer.saveEvent(
+            aggregateType = "Order",
+            aggregateId = "1",
+            eventType = "OrderCreated",
+            eventData = eventData,
+            topic = "order-events",
+            partitionKey = "1"
+        )
+
+        verify(outboxEventRepository, never()).save(any<OutboxEvent>())
+    }
+
+    @Test
+    fun partitionKey_미지정_시_aggregateId를_사용한다() {
+        val eventData = mapOf("key" to "value")
+        whenever(objectMapper.writeValueAsString(eventData)).thenReturn("""{"key":"value"}""")
+        whenever(outboxEventRepository.existsDuplicateEvent(any(), any(), any(), any(), any())).thenReturn(false)
+        whenever(outboxEventRepository.save(any<OutboxEvent>())).thenAnswer {
+            val saved = it.arguments[0] as OutboxEvent
+            assertThat(saved.partitionKey).isEqualTo("123")
+            saved
+        }
+
+        writer.saveEvent(
+            aggregateType = "Order",
+            aggregateId = "123",
+            eventType = "OrderCreated",
+            eventData = eventData,
+            topic = "order-events"
+        )
+
+        verify(outboxEventRepository).save(any<OutboxEvent>())
+    }
+}


### PR DESCRIPTION
Closes #300

### 📌 작업 개요
order-service, payment-service에 중복된 Outbox 도메인/서비스를 hoppingmall-outbox 공통 모듈로 추출합니다.

---

### ✅ 주요 변경 사항

- `hoppingmall-outbox.domain`
  - `OutboxEvent`, `OutboxStatus`: Outbox 도메인 모델

- `hoppingmall-outbox.metrics`
  - `OutboxMetrics`: Outbox 메트릭 수집

- `hoppingmall-outbox.repository`
  - `OutboxEventRepository`: Outbox 이벤트 저장소

- `hoppingmall-outbox.service`
  - `OutboxEventService`: 스케줄러 기반 이벤트 발행
  - `OutboxEventWriter`: 이벤트 저장

- `.github/workflows/ci.yml`
  - CI에 hoppingmall-outbox 모듈 추가

---

### 🧪 테스트

- `OutboxMetricsTest`: 메트릭 수집 테스트
- `OutboxEventWriterTest`: 이벤트 저장 테스트

---

### 📎 관련 이슈
- #300
