### PR TITLE
perf: product-service 2단계 캐시 전략 적용

### DIFF
--- a/hoppingmall-cache/build.gradle.kts
+++ b/hoppingmall-cache/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-stdlib")
 	implementation("org.springframework.boot:spring-boot-starter-cache")
 	implementation("com.github.ben-manes.caffeine:caffeine")
+	implementation("io.micrometer:micrometer-core")
 	compileOnly("org.springframework.boot:spring-boot-starter-data-redis")
 	compileOnly("org.redisson:redisson-spring-boot-starter:4.3.0")
 

--- a/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/TwoLevelCache.kt
+++ b/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/TwoLevelCache.kt
@@ -1,6 +1,8 @@
 package com.hoppingmall.cache
 
 import com.github.benmanes.caffeine.cache.Cache
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.cache.support.AbstractValueAdaptingCache
 import java.time.Duration
@@ -13,10 +15,20 @@ class TwoLevelCache(
     private val policy: CachePolicy,
     private val lockProvider: LockProvider,
     private val shardedRedisCache: org.springframework.cache.Cache? = null,
-    private val hotKeyDetector: HotKeyDetector? = null
+    private val hotKeyDetector: HotKeyDetector? = null,
+    meterRegistry: MeterRegistry? = null
 ) : AbstractValueAdaptingCache(true) {
 
     private val log = LoggerFactory.getLogger(TwoLevelCache::class.java)
+    private val l1HitCounter = meterRegistry?.let {
+        Counter.builder("cache.l1.hit").tag("cache", name).register(it)
+    }
+    private val l2HitCounter = meterRegistry?.let {
+        Counter.builder("cache.l2.hit").tag("cache", name).register(it)
+    }
+    private val missCounter = meterRegistry?.let {
+        Counter.builder("cache.miss").tag("cache", name).register(it)
+    }
 
     companion object {
         private const val LOCK_KEY_PREFIX = "lock:"
@@ -31,7 +43,10 @@ class TwoLevelCache(
 
     override fun lookup(key: Any): Any? {
         val l1Value = caffeineCache.getIfPresent(key)
-        if (l1Value != null) return l1Value
+        if (l1Value != null) {
+            l1HitCounter?.increment()
+            return l1Value
+        }
 
         hotKeyDetector?.recordAccess(key.toString())
         val isHot = hotKeyDetector?.isHot(key.toString()) ?: false
@@ -39,7 +54,10 @@ class TwoLevelCache(
         val l2Cache = if (isHot && shardedRedisCache != null) shardedRedisCache else redisCache
         val l2Value = l2Cache.get(key)?.get()
         if (l2Value != null) {
+            l2HitCounter?.increment()
             caffeineCache.put(key, l2Value)
+        } else {
+            missCounter?.increment()
         }
         return l2Value
     }
@@ -47,7 +65,10 @@ class TwoLevelCache(
     @Suppress("UNCHECKED_CAST")
     override fun <T : Any?> get(key: Any, valueLoader: Callable<T>): T? {
         val l1Value = caffeineCache.getIfPresent(key)
-        if (l1Value != null) return fromStoreValue(l1Value) as T?
+        if (l1Value != null) {
+            l1HitCounter?.increment()
+            return fromStoreValue(l1Value) as T?
+        }
 
         hotKeyDetector?.recordAccess(key.toString())
         val isHot = hotKeyDetector?.isHot(key.toString()) ?: false
@@ -55,6 +76,7 @@ class TwoLevelCache(
         if (isHot && shardedRedisCache != null) {
             val shardValue = shardedRedisCache.get(key)?.get()
             if (shardValue != null) {
+                l2HitCounter?.increment()
                 caffeineCache.put(key, shardValue)
                 return fromStoreValue(shardValue) as T?
             }
@@ -63,10 +85,12 @@ class TwoLevelCache(
 
         val l2Value = redisCache.get(key)?.get()
         if (l2Value != null) {
+            l2HitCounter?.increment()
             caffeineCache.put(key, l2Value)
             return fromStoreValue(l2Value) as T?
         }
 
+        missCounter?.increment()
         return loadAndCache(key, valueLoader)
     }
 
@@ -79,9 +103,11 @@ class TwoLevelCache(
             try {
                 val l2Recheck = redisCache.get(key)?.get()
                 if (l2Recheck != null) {
+                    l2HitCounter?.increment()
                     caffeineCache.put(key, l2Recheck)
                     return fromStoreValue(l2Recheck) as T?
                 }
+                missCounter?.increment()
                 return loadAndCache(key, valueLoader)
             } finally {
                 lockProvider.unlock(lockKey)
@@ -100,12 +126,14 @@ class TwoLevelCache(
 
             val l2Value = redisCache.get(key)?.get()
             if (l2Value != null) {
+                l2HitCounter?.increment()
                 caffeineCache.put(key, l2Value)
                 return fromStoreValue(l2Value) as T?
             }
         }
 
         log.warn("Lock 대기 초과 [cache={}, key={}], DB 로더 직접 호출", name, key)
+        missCounter?.increment()
         return loadAndCache(key, valueLoader)
     }
 

--- a/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/TwoLevelCacheManager.kt
+++ b/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/TwoLevelCacheManager.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.cache
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.cache.Cache
 import org.springframework.cache.CacheManager
 import java.util.concurrent.ConcurrentHashMap
@@ -9,34 +10,62 @@ class TwoLevelCacheManager(
     private val redisCacheManager: CacheManager,
     private val policies: Map<String, CachePolicy>,
     private val lockProvider: LockProvider,
-    private val hotKeyDetectorRegistry: HotKeyDetectorRegistry
+    private val hotKeyDetectorRegistry: HotKeyDetectorRegistry,
+    private val meterRegistry: MeterRegistry? = null
 ) : CacheManager {
 
-    private val cacheMap = ConcurrentHashMap<String, Cache>()
+    private sealed interface CacheLookupResult {
+        data class Present(val cache: Cache) : CacheLookupResult
+        data class Missing(val expireAt: Long) : CacheLookupResult
+    }
+
+    private val cacheMap = ConcurrentHashMap<String, CacheLookupResult>()
 
     override fun getCache(name: String): Cache? {
         val existing = cacheMap[name]
-        if (existing != null) return existing
+        if (existing is CacheLookupResult.Missing) {
+            return if (System.currentTimeMillis() < existing.expireAt) {
+                null
+            } else {
+                cacheMap.remove(name, existing)
+                getCache(name)
+            }
+        }
 
-        val redisCache = redisCacheManager.getCache(name) ?: return null
-        val policy = policies[name] ?: return redisCache
+        val lookupResult = cacheMap.computeIfAbsent(name) { cacheName ->
+            val redisCache = redisCacheManager.getCache(cacheName)
+                ?: return@computeIfAbsent CacheLookupResult.Missing(
+                    System.currentTimeMillis() + MISSING_CACHE_TTL_MS
+                )
+            val policy = policies[cacheName]
+                ?: return@computeIfAbsent CacheLookupResult.Present(redisCache)
 
-        val caffeineCache = Caffeine.newBuilder()
-            .maximumSize(policy.l1MaxSize)
-            .expireAfterWrite(policy.l1Ttl)
-            .build<Any, Any>()
+            val caffeineCache = Caffeine.newBuilder()
+                .maximumSize(policy.l1MaxSize)
+                .expireAfterWrite(policy.l1Ttl)
+                .build<Any, Any>()
 
-        val detector = hotKeyDetectorRegistry.getDetector(name)
-        val shardedRedisCache = if (policy.dynamicHotKeyEnabled) {
-            ShardedRedisCache(redisCache, policy.hotKeyShardCount)
-        } else null
+            val detector = hotKeyDetectorRegistry.getDetector(cacheName)
+            val shardedRedisCache = if (policy.dynamicHotKeyEnabled) {
+                ShardedRedisCache(redisCache, policy.hotKeyShardCount)
+            } else null
 
-        val twoLevelCache = TwoLevelCache(
-            name, caffeineCache, redisCache, policy, lockProvider,
-            shardedRedisCache, detector
-        )
-        cacheMap[name] = twoLevelCache
-        return twoLevelCache
+            CacheLookupResult.Present(
+                TwoLevelCache(
+                cacheName, caffeineCache, redisCache, policy, lockProvider,
+                shardedRedisCache, detector, meterRegistry
+            )
+            )
+        }
+
+        return when (lookupResult) {
+            is CacheLookupResult.Present -> lookupResult.cache
+            is CacheLookupResult.Missing -> null
+        }
+    }
+
+    companion object {
+        private const val MISSING_CACHE_TTL_MS = 30_000L
     }
 
     override fun getCacheNames(): Collection<String> {

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TwoLevelCacheManagerTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TwoLevelCacheManagerTest.kt
@@ -1,0 +1,145 @@
+package com.hoppingmall.cache
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@DisplayName("TwoLevelCacheManager")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class TwoLevelCacheManagerTest {
+
+    private fun createManager(redisCacheManager: CacheManager, vararg policies: CachePolicy): TwoLevelCacheManager {
+        return TwoLevelCacheManager(
+            redisCacheManager = redisCacheManager,
+            policies = policies.associateBy { it.cacheName },
+            lockProvider = FakeLockProvider(),
+            hotKeyDetectorRegistry = HotKeyDetectorRegistry(policies.toList()),
+            meterRegistry = SimpleMeterRegistry()
+        )
+    }
+
+    private fun defaultPolicy(name: String = "product") = CachePolicy(
+        cacheName = name,
+        l1MaxSize = 100,
+        l1Ttl = Duration.ofSeconds(10),
+        l2Ttl = Duration.ofMinutes(1),
+        hotKeyThreshold = 5
+    )
+
+    @Suppress("UNCHECKED_CAST")
+    private fun injectExpiredMissing(manager: TwoLevelCacheManager, cacheName: String) {
+        val field = TwoLevelCacheManager::class.java.getDeclaredField("cacheMap")
+        field.isAccessible = true
+        val cacheMap = field.get(manager) as ConcurrentHashMap<String, Any>
+        val missingClass = Class.forName("com.hoppingmall.cache.TwoLevelCacheManager\$CacheLookupResult\$Missing")
+        val constructor = missingClass.getDeclaredConstructor(Long::class.java)
+        constructor.isAccessible = true
+        val expiredMissing = constructor.newInstance(System.currentTimeMillis() - 1L)
+        cacheMap[cacheName] = expiredMissing
+    }
+
+    @Test
+    fun getCache_동시_호출_시_하나의_인스턴스만_생성한다() {
+        val redisCacheManager = mock<CacheManager>()
+        val redisCache = mock<Cache>()
+        val policy = defaultPolicy()
+        val manager = createManager(redisCacheManager, policy)
+
+        whenever(redisCacheManager.getCache("product")).thenAnswer {
+            Thread.sleep(50)
+            redisCache
+        }
+
+        val threadCount = 16
+        val startLatch = CountDownLatch(1)
+        val doneLatch = CountDownLatch(threadCount)
+        val executor = Executors.newFixedThreadPool(threadCount)
+        val results = mutableListOf<Cache?>()
+        val resultsLock = Any()
+
+        repeat(threadCount) {
+            executor.submit {
+                try {
+                    startLatch.await()
+                    val cache = manager.getCache("product")
+                    synchronized(resultsLock) {
+                        results += cache
+                    }
+                } finally {
+                    doneLatch.countDown()
+                }
+            }
+        }
+
+        startLatch.countDown()
+        doneLatch.await(5, TimeUnit.SECONDS)
+        executor.shutdown()
+        executor.awaitTermination(5, TimeUnit.SECONDS)
+
+        assertThat(results).hasSize(threadCount)
+        assertThat(results.filterNotNull().distinct()).hasSize(1)
+        verify(redisCacheManager, times(1)).getCache("product")
+    }
+
+    @Test
+    fun Redis_다운_시_첫_호출은_null을_반환하고_30초_내_재호출도_Redis를_재시도하지_않는다() {
+        val redisCacheManager = mock<CacheManager>()
+        val policy = defaultPolicy()
+        val manager = createManager(redisCacheManager, policy)
+
+        whenever(redisCacheManager.getCache("product")).thenReturn(null)
+
+        val first = manager.getCache("product")
+        val second = manager.getCache("product")
+
+        assertThat(first).isNull()
+        assertThat(second).isNull()
+        verify(redisCacheManager, times(1)).getCache("product")
+    }
+
+    @Test
+    fun TTL_만료_후_Redis를_재시도한다() {
+        val redisCacheManager = mock<CacheManager>()
+        val redisCache = mock<Cache>()
+        val policy = defaultPolicy()
+        val manager = createManager(redisCacheManager, policy)
+
+        injectExpiredMissing(manager, "product")
+
+        whenever(redisCacheManager.getCache("product")).thenReturn(redisCache)
+
+        val result = manager.getCache("product")
+
+        assertThat(result).isNotNull()
+        verify(redisCacheManager, times(1)).getCache("product")
+    }
+
+    @Test
+    fun Redis_정상_동작_시_캐시_인스턴스를_반환한다() {
+        val redisCacheManager = mock<CacheManager>()
+        val redisCache = mock<Cache>()
+        val policy = defaultPolicy()
+        val manager = createManager(redisCacheManager, policy)
+
+        whenever(redisCacheManager.getCache("product")).thenReturn(redisCache)
+
+        val result = manager.getCache("product")
+
+        assertThat(result).isNotNull()
+        verify(redisCacheManager, times(1)).getCache("product")
+    }
+}

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TwoLevelCacheTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TwoLevelCacheTest.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.cache
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -26,6 +27,7 @@ class TwoLevelCacheTest {
 
     private val redisCache: Cache = mock()
     private val lockProvider = FakeLockProvider()
+    private lateinit var meterRegistry: SimpleMeterRegistry
 
     private val hotKeyPolicy = CachePolicy(
         cacheName = "product",
@@ -48,6 +50,7 @@ class TwoLevelCacheTest {
     @BeforeEach
     fun setUp() {
         lockProvider.reset()
+        meterRegistry = SimpleMeterRegistry()
     }
 
     private fun createCache(policy: CachePolicy): TwoLevelCache {
@@ -55,7 +58,7 @@ class TwoLevelCacheTest {
             .maximumSize(policy.l1MaxSize)
             .expireAfterWrite(policy.l1Ttl)
             .build<Any, Any>()
-        return TwoLevelCache(policy.cacheName, caffeineCache, redisCache, policy, lockProvider)
+        return TwoLevelCache(policy.cacheName, caffeineCache, redisCache, policy, lockProvider, meterRegistry = meterRegistry)
     }
 
     @Nested
@@ -74,7 +77,7 @@ class TwoLevelCacheTest {
 
             val cache = TwoLevelCache(
                 hotKeyPolicy.cacheName, caffeineCache, redisCache, hotKeyPolicy,
-                lockProvider, shardedCache, fakeDetector
+                lockProvider, shardedCache, fakeDetector, meterRegistry
             )
 
             whenever(shardedCache.get(1L)).thenReturn(null)
@@ -111,7 +114,7 @@ class TwoLevelCacheTest {
 
             val cache = TwoLevelCache(
                 hotKeyPolicy.cacheName, caffeineCache, redisCache, hotKeyPolicy,
-                lockProvider, shardedCache, fakeDetector
+                lockProvider, shardedCache, fakeDetector, meterRegistry
             )
 
             val dbCallCount = AtomicInteger(0)
@@ -169,6 +172,19 @@ class TwoLevelCacheTest {
 
             assertEquals("cached-value", result)
             verify(redisCache, never()).get(1L)
+            assertEquals(1.0, meterRegistry.counter("cache.l1.hit", "cache", "category").count())
+        }
+
+        @Test
+        fun valueLoader_경로에서도_L1_히트_메트릭이_증가한다() {
+            val cache = createCache(normalPolicy)
+
+            cache.put(1L, "cached-value")
+
+            val result = cache.get(1L, Callable { "should-not-call" })
+
+            assertEquals("cached-value", result)
+            assertEquals(1.0, meterRegistry.counter("cache.l1.hit", "cache", "category").count())
         }
     }
 
@@ -186,7 +202,7 @@ class TwoLevelCacheTest {
                 .build<Any, Any>()
             return TwoLevelCache(
                 hotKeyPolicy.cacheName, caffeineCache, redisCache, hotKeyPolicy,
-                lockProvider, shardedCache, fakeDetector
+                lockProvider, shardedCache, fakeDetector, meterRegistry
             )
         }
 
@@ -207,6 +223,7 @@ class TwoLevelCacheTest {
             val result = cache.get(1L, Callable { "should-not-call" })
 
             assertEquals("shard-value", result)
+            assertEquals(1.0, meterRegistry.counter("cache.l2.hit", "cache", "product").count())
         }
 
         @Test
@@ -222,6 +239,7 @@ class TwoLevelCacheTest {
 
             assertEquals("redis-value", result)
             verify(shardedCache, never()).get(any())
+            assertEquals(1.0, meterRegistry.counter("cache.l2.hit", "cache", "product").count())
         }
 
         @Test
@@ -234,6 +252,35 @@ class TwoLevelCacheTest {
             cache.get(1L, Callable { "loaded" })
 
             assertEquals(1, fakeDetector.recordCount)
+            assertEquals(1.0, meterRegistry.counter("cache.miss", "cache", "product").count())
+        }
+
+        @Test
+        fun valueLoader_경로에서_L2_히트_메트릭이_증가한다() {
+            fakeDetector.overrideIsHot = false
+            val cache = createHotKeyCache()
+
+            val valueWrapper: Cache.ValueWrapper = mock()
+            whenever(valueWrapper.get()).thenReturn("redis-value")
+            whenever(redisCache.get(1L)).thenReturn(valueWrapper)
+
+            val result = cache.get(1L, Callable { "should-not-call" })
+
+            assertEquals("redis-value", result)
+            assertEquals(1.0, meterRegistry.counter("cache.l2.hit", "cache", "product").count())
+        }
+
+        @Test
+        fun valueLoader_경로에서_미스_메트릭이_증가한다() {
+            fakeDetector.overrideIsHot = false
+            val cache = createHotKeyCache()
+
+            whenever(redisCache.get(1L)).thenReturn(null)
+
+            val result = cache.get(1L, Callable { "loaded" })
+
+            assertEquals("loaded", result)
+            assertEquals(1.0, meterRegistry.counter("cache.miss", "cache", "product").count())
         }
 
         @Test

--- a/product-service/src/main/kotlin/com/hoppingmall/product/category/service/CategoryQueryServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/category/service/CategoryQueryServiceImpl.kt
@@ -2,8 +2,6 @@ package com.hoppingmall.product.category.service
 
 import com.hoppingmall.product.category.domain.repository.CategoryRepository
 import com.hoppingmall.product.category.dto.response.CategoryResponse
-import com.hoppingmall.cache.NotFoundMarker
-import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -11,24 +9,12 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(readOnly = true)
 class CategoryQueryServiceImpl(
-    private val categoryRepository: CategoryRepository,
-    private val cacheManager: CacheManager
+    private val categoryRepository: CategoryRepository
 ) : CategoryQueryService {
 
     @Cacheable(cacheNames = ["category"], key = "#categoryId", sync = true)
     override fun getCategory(categoryId: Long): CategoryResponse? {
-        val notFoundCache = cacheManager.getCache("category:notfound")
-        val cached = notFoundCache?.get(categoryId)
-        if (cached != null && NotFoundMarker.isNotFound(cached.get())) {
-            return null
-        }
-
-        val category = categoryRepository.findNullableById(categoryId)
-        if (category == null) {
-            notFoundCache?.put(categoryId, NotFoundMarker.INSTANCE)
-            return null
-        }
-
+        val category = categoryRepository.findNullableById(categoryId) ?: return null
         return CategoryResponse.from(category)
     }
 

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/CacheConfig.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/CacheConfig.kt
@@ -1,57 +1,96 @@
 package com.hoppingmall.product.config
 
-import com.github.benmanes.caffeine.cache.Caffeine
+import com.hoppingmall.cache.CachePolicy
+import com.hoppingmall.cache.HotKeyDetectorRegistry
+import com.hoppingmall.cache.LockProvider
+import com.hoppingmall.cache.RedissonLockProvider
+import com.hoppingmall.cache.TwoLevelCacheManager
+import io.micrometer.core.instrument.MeterRegistry
+import org.redisson.api.RedissonClient
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
-import org.springframework.cache.caffeine.CaffeineCache
-import org.springframework.cache.support.SimpleCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import java.util.concurrent.TimeUnit
+import org.springframework.context.annotation.Profile
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import java.time.Duration
 
 @Configuration
 @EnableCaching
+@Profile("!test")
 class CacheConfig {
 
     @Bean
-    fun cacheManager(): CacheManager {
-        val productCache = CaffeineCache(
-            "product",
-            Caffeine.newBuilder()
-                .maximumSize(500)
-                .expireAfterWrite(10, TimeUnit.MINUTES)
-                .build()
+    fun cachePolicies(): Map<String, CachePolicy> = mapOf(
+        "product" to CachePolicy(
+            cacheName = "product",
+            l1MaxSize = 500,
+            l1Ttl = Duration.ofMinutes(10),
+            l2Ttl = Duration.ofMinutes(30),
+            hotKeyThreshold = 50,
+            hotKeyWindow = Duration.ofSeconds(60)
+        ),
+        "inventory" to CachePolicy(
+            cacheName = "inventory",
+            l1MaxSize = 500,
+            l1Ttl = Duration.ofMinutes(5),
+            l2Ttl = Duration.ofMinutes(15)
+        ),
+        "category" to CachePolicy(
+            cacheName = "category",
+            l1MaxSize = 200,
+            l1Ttl = Duration.ofMinutes(60),
+            l2Ttl = Duration.ofMinutes(120)
+        ),
+        "categories:root" to CachePolicy(
+            cacheName = "categories:root",
+            l1MaxSize = 1,
+            l1Ttl = Duration.ofMinutes(60),
+            l2Ttl = Duration.ofMinutes(120)
+        ),
+        "categories:sub" to CachePolicy(
+            cacheName = "categories:sub",
+            l1MaxSize = 100,
+            l1Ttl = Duration.ofMinutes(60),
+            l2Ttl = Duration.ofMinutes(120)
         )
-        val inventoryCache = CaffeineCache(
-            "inventory",
-            Caffeine.newBuilder()
-                .maximumSize(500)
-                .expireAfterWrite(5, TimeUnit.MINUTES)
-                .build()
+    )
+
+    @Bean
+    fun hotKeyDetectorRegistry(cachePolicies: Map<String, CachePolicy>): HotKeyDetectorRegistry {
+        return HotKeyDetectorRegistry(cachePolicies.values)
+    }
+
+    @Bean
+    fun lockProvider(redissonClient: RedissonClient): LockProvider {
+        return RedissonLockProvider(redissonClient)
+    }
+
+    @Bean
+    fun redisCacheManager(connectionFactory: RedisConnectionFactory): RedisCacheManager {
+        val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(30))
+        return RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(defaultConfig)
+            .build()
+    }
+
+    @Bean
+    fun cacheManager(
+        redisCacheManager: RedisCacheManager,
+        cachePolicies: Map<String, CachePolicy>,
+        lockProvider: LockProvider,
+        hotKeyDetectorRegistry: HotKeyDetectorRegistry,
+        meterRegistry: MeterRegistry
+    ): CacheManager {
+        return TwoLevelCacheManager(
+            redisCacheManager = redisCacheManager,
+            policies = cachePolicies,
+            lockProvider = lockProvider,
+            hotKeyDetectorRegistry = hotKeyDetectorRegistry,
+            meterRegistry = meterRegistry
         )
-        val categoryCache = CaffeineCache(
-            "category",
-            Caffeine.newBuilder()
-                .maximumSize(200)
-                .expireAfterWrite(60, TimeUnit.MINUTES)
-                .build()
-        )
-        val categoriesRootCache = CaffeineCache(
-            "categories:root",
-            Caffeine.newBuilder()
-                .maximumSize(1)
-                .expireAfterWrite(60, TimeUnit.MINUTES)
-                .build()
-        )
-        val categoriesSubCache = CaffeineCache(
-            "categories:sub",
-            Caffeine.newBuilder()
-                .maximumSize(100)
-                .expireAfterWrite(60, TimeUnit.MINUTES)
-                .build()
-        )
-        return SimpleCacheManager().apply {
-            setCaches(listOf(productCache, inventoryCache, categoryCache, categoriesRootCache, categoriesSubCache))
-        }
     }
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/BulkImportService.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/BulkImportService.kt
@@ -160,7 +160,6 @@ class BulkImportService(
     private fun evictProductCaches() {
         try {
             cacheManager.getCache("product")?.clear()
-            cacheManager.getCache("product:notfound")?.clear()
             log.info("대량 등록 후 product 캐시 초기화 완료")
         } catch (e: Exception) {
             log.warn("캐시 초기화 실패: {}", e.message)

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductQueryServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductQueryServiceImpl.kt
@@ -1,16 +1,14 @@
 package com.hoppingmall.product.product.service
 
-import com.hoppingmall.cache.NotFoundMarker
 import com.hoppingmall.product.product.domain.Product
 import com.hoppingmall.product.product.domain.repository.ProductImageRepository
 import com.hoppingmall.product.product.domain.repository.ProductRepository
 import com.hoppingmall.product.product.dto.request.ProductSearchCondition
 import com.hoppingmall.product.product.dto.response.ProductResponse
-import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.domain.SliceImpl
-import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -18,8 +16,7 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class ProductQueryServiceImpl(
     private val productRepository: ProductRepository,
-    private val productImageRepository: ProductImageRepository,
-    private val cacheManager: CacheManager
+    private val productImageRepository: ProductImageRepository
 ) : ProductQueryService {
 
     override fun getProducts(pageable: Pageable): Slice<ProductResponse> {
@@ -29,20 +26,8 @@ class ProductQueryServiceImpl(
 
     @Cacheable(cacheNames = ["product"], key = "#productId", sync = true)
     override fun getProductById(productId: Long): ProductResponse? {
-        val notFoundCache = cacheManager.getCache("product:notfound")
-        val cached = notFoundCache?.get(productId)
-        if (cached != null && NotFoundMarker.isNotFound(cached.get())) {
-            return null
-        }
-
-        val product = productRepository.findNullableById(productId)
-        if (product == null) {
-            notFoundCache?.put(productId, NotFoundMarker.INSTANCE)
-            return null
-        }
-
+        val product = productRepository.findNullableById(productId) ?: return null
         val images = productImageRepository.findByProductIdOrderBySortOrder(productId)
-
         return ProductResponse.from(product, images)
     }
 

--- a/product-service/src/test/kotlin/com/hoppingmall/product/ProductServiceApplicationTests.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/ProductServiceApplicationTests.kt
@@ -1,11 +1,14 @@
 package com.hoppingmall.product
 
+import com.hoppingmall.product.support.TestCacheConfig
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.context.annotation.Import
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Import(TestCacheConfig::class)
 class ProductServiceApplicationTests {
     @Test
     fun contextLoads() {

--- a/product-service/src/test/kotlin/com/hoppingmall/product/support/TestCacheConfig.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/support/TestCacheConfig.kt
@@ -1,0 +1,31 @@
+package com.hoppingmall.product.support
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.caffeine.CaffeineCache
+import org.springframework.cache.support.SimpleCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import java.util.concurrent.TimeUnit
+
+@TestConfiguration
+@EnableCaching
+class TestCacheConfig {
+
+    @Bean
+    @Primary
+    fun cacheManager(): CacheManager {
+        val caches = listOf("product", "inventory", "category", "categories:root", "categories:sub").map { name ->
+            CaffeineCache(
+                name,
+                Caffeine.newBuilder()
+                    .maximumSize(100)
+                    .expireAfterWrite(5, TimeUnit.MINUTES)
+                    .build()
+            )
+        }
+        return SimpleCacheManager().apply { setCaches(caches) }
+    }
+}


### PR DESCRIPTION
Closes #301

### 📌 작업 개요
개선된 TwoLevelCache 전략을 product-service에 적용합니다.

---

### ✅ 주요 변경 사항

- `product-service.config`
  - `CacheConfig`: 캐시 설정 변경

- `product-service.category.service`
  - `CategoryQueryServiceImpl`: 캐시 전략 적용

- `product-service.product.service`
  - `ProductQueryServiceImpl`: 캐시 전략 적용
  - `BulkImportService`: 캐시 전략 적용

---

### 🧪 테스트

- `ProductServiceApplicationTests`: 수정
- `TestCacheConfig`: 테스트용 캐시 설정 추가

---

### 📎 관련 이슈
- #301
