### PR TITLE
test: Password VO 마스킹 전략 단위 테스트 복구

### DIFF
--- a/user-service/src/test/kotlin/com/hoppingmall/user/common/vo/PasswordTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/common/vo/PasswordTest.kt
@@ -1,0 +1,46 @@
+package com.hoppingmall.user.common.vo
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("Password VO 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class PasswordTest {
+
+    @AfterEach
+    fun tearDown() {
+        Password.maskingStrategy = DefaultPasswordMaskingStrategy
+    }
+
+    @Test
+    fun toString은_마스킹된_값을_반환한다() {
+        val password = Password("hashed-secret-value")
+
+        assertThat(password.toString()).isEqualTo("******")
+    }
+
+    @Test
+    fun 커스텀_마스킹_전략을_적용할_수_있다() {
+        Password.maskingStrategy = PasswordMaskingStrategy { "***MASKED***" }
+        val password = Password("hashed-secret-value")
+
+        assertThat(password.toString()).isEqualTo("***MASKED***")
+    }
+
+    @Test
+    fun 기본_마스킹_전략은_별표6개를_반환한다() {
+        assertThat(DefaultPasswordMaskingStrategy.mask()).isEqualTo("******")
+    }
+
+    @Test
+    fun 동일한_해시값이면_true를_반환한다() {
+        val password = Password("hashed-value")
+
+        assertThat(password.isSameHashedValueWith("hashed-value")).isTrue()
+        assertThat(password.isSameHashedValueWith("different-value")).isFalse()
+    }
+}


### PR DESCRIPTION
Closes #312

### 📌 작업 개요
restore.md #12 PasswordMaskingStrategy 항목 해결.
코드 분석 결과 마스킹 전략은 유실이 아닌 `Password.kt`에 통합된 상태였으며,
모놀리스에서 마이그레이션되지 않은 단위 테스트만 복구했습니다.

---

### ✅ 주요 변경 사항

- `user-service/common/vo`
  - `PasswordTest`: Password VO 단위 테스트 4 cases 추가

---

### 🧪 테스트

- `PasswordTest`: toString 마스킹 반환, 커스텀 전략 주입, 기본 전략 별표6개, 해시값 비교 동작 검증

---

### 📎 관련 이슈
- #312
