### PR TITLE
config: API Gateway CORS 설정 외부화

### DIFF
--- a/api-gateway/src/main/resources/application-docker.yml
+++ b/api-gateway/src/main/resources/application-docker.yml
@@ -30,6 +30,22 @@ spring:
 
   cloud:
     gateway:
+      globalcors:
+        cors-configurations:
+          '[/**]':
+            allowedOrigins:
+              - "${CORS_ALLOWED_ORIGINS:http://localhost:3000}"
+            allowedMethods:
+              - GET
+              - POST
+              - PUT
+              - PATCH
+              - DELETE
+              - OPTIONS
+            allowedHeaders:
+              - "*"
+            allowCredentials: true
+            maxAge: 3600
       routes:
         - id: user-service-api-docs
           uri: http://user-service:8082

--- a/api-gateway/src/main/resources/application-k8s.yml
+++ b/api-gateway/src/main/resources/application-k8s.yml
@@ -6,6 +6,22 @@ spring:
 
   cloud:
     gateway:
+      globalcors:
+        cors-configurations:
+          '[/**]':
+            allowedOrigins:
+              - "${CORS_ALLOWED_ORIGINS:http://localhost:3000}"
+            allowedMethods:
+              - GET
+              - POST
+              - PUT
+              - PATCH
+              - DELETE
+              - OPTIONS
+            allowedHeaders:
+              - "*"
+            allowCredentials: true
+            maxAge: 3600
       routes:
         - id: user-service-public
           uri: http://user-service.hoppingmall.svc.cluster.local:8082

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -28,6 +28,22 @@ spring:
 
   cloud:
     gateway:
+      globalcors:
+        cors-configurations:
+          '[/**]':
+            allowedOrigins:
+              - http://localhost:3000
+            allowedMethods:
+              - GET
+              - POST
+              - PUT
+              - PATCH
+              - DELETE
+              - OPTIONS
+            allowedHeaders:
+              - "*"
+            allowCredentials: true
+            maxAge: 3600
       routes:
         - id: user-service-api-docs
           uri: ${ROUTES_USER_SERVICE:http://localhost:8082}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -456,6 +456,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: docker
       JWT_SECRET: ${JWT_SECRET:-default-docker-secret-key-for-development-only-32chars!}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:3000}
     ports:
       - "8000:8000"
     healthcheck:


### PR DESCRIPTION
Closes #314

### 📌 작업 개요
MSA 전환(e39836f)에서 유실된 CORS 설정을 API Gateway에 복구합니다.
Spring Cloud Gateway 공식 `globalcors` 메커니즘으로 3개 프로파일 모두에 CORS 설정을 추가했습니다.

---

### ✅ 주요 변경 사항

- `api-gateway/src/main/resources`
  - `application.yml`: globalcors CORS 설정 추가 (allowedOrigins: localhost:3000)
  - `application-docker.yml`: globalcors CORS 설정 추가 (CORS_ALLOWED_ORIGINS 환경변수)
  - `application-k8s.yml`: globalcors CORS 설정 추가 (CORS_ALLOWED_ORIGINS 환경변수)

- `docker-compose.yml`
  - api-gateway 컨테이너에 CORS_ALLOWED_ORIGINS 환경변수 전달

---

### 🧪 테스트

- 코드 변경 없이 YAML 설정만 추가하여 자동 테스트 대상 없음
- API Gateway 기동 후 curl preflight 요청으로 수동 검증 가능

---

### 📎 관련 이슈
- #314