### PR TITLE
test: user-service 단위 테스트 복구

### DIFF
--- a/user-service/src/test/kotlin/com/hoppingmall/user/auth/controller/AuthControllerTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/auth/controller/AuthControllerTest.kt
@@ -1,0 +1,49 @@
+package com.hoppingmall.user.auth.controller
+
+import com.hoppingmall.common.ApiResponse
+import com.hoppingmall.user.auth.dto.TokenRefreshRequest
+import com.hoppingmall.user.auth.dto.TokenRefreshResponse
+import com.hoppingmall.user.auth.service.AuthService
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("AuthController 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class AuthControllerTest {
+
+    @Mock
+    private lateinit var authService: AuthService
+
+    @InjectMocks
+    private lateinit var authController: AuthController
+
+    @Test
+    fun refreshAccessToken은_응답을_ApiResponse로_감싼다() {
+        val request = TokenRefreshRequest("refresh-token")
+        val expected = TokenRefreshResponse("new-access-token", "new-refresh-token")
+        whenever(authService.refreshAccessToken("refresh-token")).thenReturn(expected)
+
+        val response = authController.refreshAccessToken(request)
+
+        assertEquals(ApiResponse.success(expected), response)
+        verify(authService).refreshAccessToken("refresh-token")
+    }
+
+    @Test
+    fun logout은_Bearer_접두사를_제거하고_service에_위임한다() {
+        val response = authController.logout("Bearer access-token")
+
+        assertEquals(ApiResponse.success(Unit), response)
+        verify(authService).logout("access-token")
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/auth/controller/AuthControllerTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/auth/controller/AuthControllerTest.kt
@@ -4,6 +4,7 @@ import com.hoppingmall.common.ApiResponse
 import com.hoppingmall.user.auth.dto.TokenRefreshRequest
 import com.hoppingmall.user.auth.dto.TokenRefreshResponse
 import com.hoppingmall.user.auth.service.AuthService
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
@@ -14,10 +15,9 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
-@DisplayName("AuthController 단위 테스트")
+@DisplayName("AuthController")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class AuthControllerTest {
 
@@ -28,22 +28,22 @@ class AuthControllerTest {
     private lateinit var authController: AuthController
 
     @Test
-    fun refreshAccessToken은_응답을_ApiResponse로_감싼다() {
+    fun 토큰_재발급_응답을_ApiResponse로_감싼다() {
         val request = TokenRefreshRequest("refresh-token")
         val expected = TokenRefreshResponse("new-access-token", "new-refresh-token")
         whenever(authService.refreshAccessToken("refresh-token")).thenReturn(expected)
 
         val response = authController.refreshAccessToken(request)
 
-        assertEquals(ApiResponse.success(expected), response)
+        assertThat(response).isEqualTo(ApiResponse.success(expected))
         verify(authService).refreshAccessToken("refresh-token")
     }
 
     @Test
-    fun logout은_Bearer_접두사를_제거하고_service에_위임한다() {
+    fun 로그아웃_시_Bearer_접두사_제거_후_서비스에_위임() {
         val response = authController.logout("Bearer access-token")
 
-        assertEquals(ApiResponse.success(Unit), response)
+        assertThat(response).isEqualTo(ApiResponse.success(Unit))
         verify(authService).logout("access-token")
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/auth/service/AuthServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/auth/service/AuthServiceImplTest.kt
@@ -1,0 +1,126 @@
+package com.hoppingmall.user.auth.service
+
+import com.hoppingmall.user.auth.JwtProperties
+import com.hoppingmall.user.auth.TokenProvider
+import com.hoppingmall.user.auth.domain.repository.AccessTokenBlacklistRepository
+import com.hoppingmall.user.auth.dto.TokenRefreshResponse
+import com.hoppingmall.user.common.enums.Role
+import com.hoppingmall.user.domain.repository.UserRepository
+import com.hoppingmall.user.dto.request.SignInRequest
+import com.hoppingmall.user.exception.user.UserNotFoundException
+import com.hoppingmall.user.service.UserQueryService
+import com.hoppingmall.user.support.fixture.fixture
+import com.hoppingmall.user.support.withId
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.lenient
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.util.Optional
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("AuthServiceImpl 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class AuthServiceImplTest {
+
+    @Mock
+    private lateinit var userQueryService: UserQueryService
+
+    @Mock
+    private lateinit var tokenProvider: TokenProvider
+
+    @Mock
+    private lateinit var refreshTokenService: RefreshTokenService
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @Mock
+    private lateinit var redisTemplate: RedisTemplate<String, String>
+
+    @Mock
+    private lateinit var valueOperations: ValueOperations<String, String>
+
+    private lateinit var authService: AuthServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        lenient().whenever(redisTemplate.opsForValue()).thenReturn(valueOperations)
+
+        authService = AuthServiceImpl(
+            userQueryService = userQueryService,
+            tokenProvider = tokenProvider,
+            refreshTokenService = refreshTokenService,
+            jwtProperties = JwtProperties().apply {
+                secret = "test-secret-key-for-testing-purposes-only-32chars!"
+                accessExpirationMs = 3600000
+                refreshExpirationMs = 86400000
+            },
+            userRepository = userRepository,
+            accessTokenBlacklistRepository = AccessTokenBlacklistRepository(redisTemplate)
+        )
+    }
+
+    @Test
+    fun 로그인_성공_시_accessToken과_refreshToken을_발급하고_refreshToken을_회전한다() {
+        val request = SignInRequest(email = "seller@example.com", password = "Password1234")
+        val user = com.hoppingmall.user.domain.User.fixture(role = Role.SELLER).withId(1L)
+        whenever(userQueryService.authenticate(request)).thenReturn(user)
+        whenever(tokenProvider.generateAccessToken(1L, Role.SELLER)).thenReturn("access-token")
+        whenever(tokenProvider.generateRefreshToken(1L)).thenReturn("refresh-token")
+
+        val response = authService.login(request)
+
+        assertEquals("access-token", response.accessToken)
+        assertEquals("refresh-token", response.refreshToken)
+        verify(refreshTokenService).rotateRefreshToken(1L, "refresh-token", 86400000)
+    }
+
+    @Test
+    fun 리프레시_토큰_재발급_성공_시_새로운_accessToken과_refreshToken을_반환한다() {
+        val user = com.hoppingmall.user.domain.User.fixture(role = Role.BUYER).withId(10L)
+        whenever(tokenProvider.parseRefreshToken("refresh-token")).thenReturn(10L)
+        whenever(userRepository.findById(10L)).thenReturn(Optional.of(user))
+        whenever(tokenProvider.generateAccessToken(10L, Role.BUYER)).thenReturn("new-access-token")
+        whenever(tokenProvider.generateRefreshToken(10L)).thenReturn("new-refresh-token")
+
+        val response: TokenRefreshResponse = authService.refreshAccessToken("refresh-token")
+
+        assertEquals("new-access-token", response.accessToken)
+        assertEquals("new-refresh-token", response.refreshToken)
+        verify(refreshTokenService).validate(10L, "refresh-token")
+        verify(refreshTokenService).rotateRefreshToken(10L, "new-refresh-token", 86400000)
+    }
+
+    @Test
+    fun 리프레시_토큰에_해당하는_사용자가_없으면_예외가_발생한다() {
+        whenever(tokenProvider.parseRefreshToken("missing-user-token")).thenReturn(999L)
+        whenever(userRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThrows<UserNotFoundException> {
+            authService.refreshAccessToken("missing-user-token")
+        }
+    }
+
+    @Test
+    fun 로그아웃_시_accessToken을_blacklist에_등록하고_refreshToken을_삭제한다() {
+        whenever(tokenProvider.parseAccessToken("access-token")).thenReturn(7L)
+        whenever(tokenProvider.getRemainingExpirationMs("access-token")).thenReturn(1000L)
+
+        authService.logout("access-token")
+
+        verify(valueOperations).set("blacklist:access-token", "blacklisted", 1000L, TimeUnit.MILLISECONDS)
+        verify(refreshTokenService).delete(7L)
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/auth/service/AuthServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/auth/service/AuthServiceImplTest.kt
@@ -11,26 +11,22 @@ import com.hoppingmall.user.exception.user.UserNotFoundException
 import com.hoppingmall.user.service.UserQueryService
 import com.hoppingmall.user.support.fixture.fixture
 import com.hoppingmall.user.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
-import org.mockito.Mockito.lenient
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.springframework.data.redis.core.RedisTemplate
-import org.springframework.data.redis.core.ValueOperations
 import java.util.Optional
-import java.util.concurrent.TimeUnit
-import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
-@DisplayName("AuthServiceImpl 단위 테스트")
+@DisplayName("AuthServiceImpl")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class AuthServiceImplTest {
 
@@ -47,17 +43,12 @@ class AuthServiceImplTest {
     private lateinit var userRepository: UserRepository
 
     @Mock
-    private lateinit var redisTemplate: RedisTemplate<String, String>
-
-    @Mock
-    private lateinit var valueOperations: ValueOperations<String, String>
+    private lateinit var accessTokenBlacklistRepository: AccessTokenBlacklistRepository
 
     private lateinit var authService: AuthServiceImpl
 
     @BeforeEach
     fun setUp() {
-        lenient().whenever(redisTemplate.opsForValue()).thenReturn(valueOperations)
-
         authService = AuthServiceImpl(
             userQueryService = userQueryService,
             tokenProvider = tokenProvider,
@@ -68,12 +59,12 @@ class AuthServiceImplTest {
                 refreshExpirationMs = 86400000
             },
             userRepository = userRepository,
-            accessTokenBlacklistRepository = AccessTokenBlacklistRepository(redisTemplate)
+            accessTokenBlacklistRepository = accessTokenBlacklistRepository
         )
     }
 
     @Test
-    fun 로그인_성공_시_accessToken과_refreshToken을_발급하고_refreshToken을_회전한다() {
+    fun 로그인_성공_시_토큰을_발급하고_리프레시_토큰을_회전한다() {
         val request = SignInRequest(email = "seller@example.com", password = "Password1234")
         val user = com.hoppingmall.user.domain.User.fixture(role = Role.SELLER).withId(1L)
         whenever(userQueryService.authenticate(request)).thenReturn(user)
@@ -82,13 +73,13 @@ class AuthServiceImplTest {
 
         val response = authService.login(request)
 
-        assertEquals("access-token", response.accessToken)
-        assertEquals("refresh-token", response.refreshToken)
+        assertThat(response.accessToken).isEqualTo("access-token")
+        assertThat(response.refreshToken).isEqualTo("refresh-token")
         verify(refreshTokenService).rotateRefreshToken(1L, "refresh-token", 86400000)
     }
 
     @Test
-    fun 리프레시_토큰_재발급_성공_시_새로운_accessToken과_refreshToken을_반환한다() {
+    fun 리프레시_토큰_재발급_시_새로운_토큰을_반환한다() {
         val user = com.hoppingmall.user.domain.User.fixture(role = Role.BUYER).withId(10L)
         whenever(tokenProvider.parseRefreshToken("refresh-token")).thenReturn(10L)
         whenever(userRepository.findById(10L)).thenReturn(Optional.of(user))
@@ -97,8 +88,8 @@ class AuthServiceImplTest {
 
         val response: TokenRefreshResponse = authService.refreshAccessToken("refresh-token")
 
-        assertEquals("new-access-token", response.accessToken)
-        assertEquals("new-refresh-token", response.refreshToken)
+        assertThat(response.accessToken).isEqualTo("new-access-token")
+        assertThat(response.refreshToken).isEqualTo("new-refresh-token")
         verify(refreshTokenService).validate(10L, "refresh-token")
         verify(refreshTokenService).rotateRefreshToken(10L, "new-refresh-token", 86400000)
     }
@@ -108,19 +99,18 @@ class AuthServiceImplTest {
         whenever(tokenProvider.parseRefreshToken("missing-user-token")).thenReturn(999L)
         whenever(userRepository.findById(999L)).thenReturn(Optional.empty())
 
-        assertThrows<UserNotFoundException> {
-            authService.refreshAccessToken("missing-user-token")
-        }
+        assertThatThrownBy { authService.refreshAccessToken("missing-user-token") }
+            .isInstanceOf(UserNotFoundException::class.java)
     }
 
     @Test
-    fun 로그아웃_시_accessToken을_blacklist에_등록하고_refreshToken을_삭제한다() {
+    fun 로그아웃_시_블랙리스트_등록_및_리프레시_토큰_삭제() {
         whenever(tokenProvider.parseAccessToken("access-token")).thenReturn(7L)
         whenever(tokenProvider.getRemainingExpirationMs("access-token")).thenReturn(1000L)
 
         authService.logout("access-token")
 
-        verify(valueOperations).set("blacklist:access-token", "blacklisted", 1000L, TimeUnit.MILLISECONDS)
+        verify(accessTokenBlacklistRepository).add("access-token", 1000L)
         verify(refreshTokenService).delete(7L)
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/auth/service/RefreshTokenServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/auth/service/RefreshTokenServiceImplTest.kt
@@ -1,0 +1,89 @@
+package com.hoppingmall.user.auth.service
+
+import com.hoppingmall.user.auth.domain.repository.RefreshTokenRepository
+import com.hoppingmall.user.auth.exception.RefreshTokenMismatchException
+import com.hoppingmall.user.auth.exception.RefreshTokenNotFoundException
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.lenient
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("RefreshTokenServiceImpl 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class RefreshTokenServiceImplTest {
+
+    @Mock
+    private lateinit var redisTemplate: RedisTemplate<String, String>
+
+    @Mock
+    private lateinit var valueOperations: ValueOperations<String, String>
+
+    private lateinit var refreshTokenService: RefreshTokenServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        lenient().whenever(redisTemplate.opsForValue()).thenReturn(valueOperations)
+
+        refreshTokenService = RefreshTokenServiceImpl(
+            RefreshTokenRepository(redisTemplate)
+        )
+    }
+
+    @Test
+    fun rotateRefreshToken은_기존_토큰을_삭제하고_새_토큰을_저장한다() {
+        val result = refreshTokenService.rotateRefreshToken(userId = 1L, newToken = "new-token", ttl = 3600L)
+
+        assertEquals(1L, result.userId)
+        assertEquals("new-token", result.token)
+        assertEquals(3600L, result.ttl)
+        verify(redisTemplate).delete("refreshToken:1")
+        verify(valueOperations).set("refreshToken:1", "new-token", 3600L, TimeUnit.MILLISECONDS)
+    }
+
+    @Test
+    fun validate는_저장된_토큰과_일치하면_성공한다() {
+        whenever(valueOperations.get("refreshToken:2")).thenReturn("refresh-token")
+
+        refreshTokenService.validate(2L, "refresh-token")
+
+        verify(valueOperations).get("refreshToken:2")
+    }
+
+    @Test
+    fun validate는_저장된_토큰이_없으면_예외가_발생한다() {
+        whenever(valueOperations.get("refreshToken:3")).thenReturn(null)
+
+        assertThrows<RefreshTokenNotFoundException> {
+            refreshTokenService.validate(3L, "missing")
+        }
+    }
+
+    @Test
+    fun validate는_저장된_토큰과_다르면_예외가_발생한다() {
+        whenever(valueOperations.get("refreshToken:4")).thenReturn("stored-token")
+
+        assertThrows<RefreshTokenMismatchException> {
+            refreshTokenService.validate(4L, "different-token")
+        }
+    }
+
+    @Test
+    fun delete는_userId_기준으로_refreshToken을_삭제한다() {
+        refreshTokenService.delete(5L)
+
+        verify(redisTemplate).delete("refreshToken:5")
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/auth/service/RefreshTokenServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/auth/service/RefreshTokenServiceImplTest.kt
@@ -1,89 +1,76 @@
 package com.hoppingmall.user.auth.service
 
+import com.hoppingmall.user.auth.domain.RefreshToken
 import com.hoppingmall.user.auth.domain.repository.RefreshTokenRepository
 import com.hoppingmall.user.auth.exception.RefreshTokenMismatchException
 import com.hoppingmall.user.auth.exception.RefreshTokenNotFoundException
-import org.junit.jupiter.api.BeforeEach
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
 import org.mockito.Mock
-import org.mockito.Mockito.lenient
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.springframework.data.redis.core.RedisTemplate
-import org.springframework.data.redis.core.ValueOperations
-import java.util.concurrent.TimeUnit
-import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
-@DisplayName("RefreshTokenServiceImpl 단위 테스트")
+@DisplayName("RefreshTokenServiceImpl")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class RefreshTokenServiceImplTest {
 
     @Mock
-    private lateinit var redisTemplate: RedisTemplate<String, String>
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
 
-    @Mock
-    private lateinit var valueOperations: ValueOperations<String, String>
-
+    @InjectMocks
     private lateinit var refreshTokenService: RefreshTokenServiceImpl
 
-    @BeforeEach
-    fun setUp() {
-        lenient().whenever(redisTemplate.opsForValue()).thenReturn(valueOperations)
-
-        refreshTokenService = RefreshTokenServiceImpl(
-            RefreshTokenRepository(redisTemplate)
-        )
-    }
-
     @Test
-    fun rotateRefreshToken은_기존_토큰을_삭제하고_새_토큰을_저장한다() {
+    fun 토큰_회전_시_기존_토큰_삭제_후_새_토큰_저장() {
         val result = refreshTokenService.rotateRefreshToken(userId = 1L, newToken = "new-token", ttl = 3600L)
 
-        assertEquals(1L, result.userId)
-        assertEquals("new-token", result.token)
-        assertEquals(3600L, result.ttl)
-        verify(redisTemplate).delete("refreshToken:1")
-        verify(valueOperations).set("refreshToken:1", "new-token", 3600L, TimeUnit.MILLISECONDS)
+        assertThat(result.userId).isEqualTo(1L)
+        assertThat(result.token).isEqualTo("new-token")
+        assertThat(result.ttl).isEqualTo(3600L)
+        verify(refreshTokenRepository).deleteByUserId(1L)
+        verify(refreshTokenRepository).save(argThat<RefreshToken> {
+            userId == 1L && token == "new-token" && ttl == 3600L
+        })
     }
 
     @Test
-    fun validate는_저장된_토큰과_일치하면_성공한다() {
-        whenever(valueOperations.get("refreshToken:2")).thenReturn("refresh-token")
+    fun 저장된_토큰과_일치하면_검증_성공() {
+        whenever(refreshTokenRepository.findByUserId(2L)).thenReturn("refresh-token")
 
         refreshTokenService.validate(2L, "refresh-token")
 
-        verify(valueOperations).get("refreshToken:2")
+        verify(refreshTokenRepository).findByUserId(2L)
     }
 
     @Test
-    fun validate는_저장된_토큰이_없으면_예외가_발생한다() {
-        whenever(valueOperations.get("refreshToken:3")).thenReturn(null)
+    fun 저장된_토큰이_없으면_예외_발생() {
+        whenever(refreshTokenRepository.findByUserId(3L)).thenReturn(null)
 
-        assertThrows<RefreshTokenNotFoundException> {
-            refreshTokenService.validate(3L, "missing")
-        }
+        assertThatThrownBy { refreshTokenService.validate(3L, "missing") }
+            .isInstanceOf(RefreshTokenNotFoundException::class.java)
     }
 
     @Test
-    fun validate는_저장된_토큰과_다르면_예외가_발생한다() {
-        whenever(valueOperations.get("refreshToken:4")).thenReturn("stored-token")
+    fun 저장된_토큰과_다르면_예외_발생() {
+        whenever(refreshTokenRepository.findByUserId(4L)).thenReturn("stored-token")
 
-        assertThrows<RefreshTokenMismatchException> {
-            refreshTokenService.validate(4L, "different-token")
-        }
+        assertThatThrownBy { refreshTokenService.validate(4L, "different-token") }
+            .isInstanceOf(RefreshTokenMismatchException::class.java)
     }
 
     @Test
-    fun delete는_userId_기준으로_refreshToken을_삭제한다() {
+    fun 삭제_시_리프레시_토큰_제거() {
         refreshTokenService.delete(5L)
 
-        verify(redisTemplate).delete("refreshToken:5")
+        verify(refreshTokenRepository).deleteByUserId(5L)
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/controller/AdminControllerTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/controller/AdminControllerTest.kt
@@ -1,0 +1,37 @@
+package com.hoppingmall.user.controller
+
+import com.hoppingmall.common.ApiResponse
+import com.hoppingmall.user.dto.request.SellerApprovalRequest
+import com.hoppingmall.user.service.AdminCommandService
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("AdminController 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class AdminControllerTest {
+
+    @Mock
+    private lateinit var adminCommandService: AdminCommandService
+
+    @InjectMocks
+    private lateinit var adminController: AdminController
+
+    @Test
+    fun updateSellerApprovalStatus는_service에_승인_변경을_위임한다() {
+        val request = SellerApprovalRequest("APPROVED")
+
+        val response = adminController.updateSellerApprovalStatus(1L, request)
+
+        assertEquals(ApiResponse.success(Unit), response)
+        verify(adminCommandService).updateSellerApprovalStatus(1L, request)
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/controller/AdminControllerTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/controller/AdminControllerTest.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.user.controller
 import com.hoppingmall.common.ApiResponse
 import com.hoppingmall.user.dto.request.SellerApprovalRequest
 import com.hoppingmall.user.service.AdminCommandService
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
@@ -12,10 +13,9 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
-import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
-@DisplayName("AdminController 단위 테스트")
+@DisplayName("AdminController")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class AdminControllerTest {
 
@@ -26,12 +26,12 @@ class AdminControllerTest {
     private lateinit var adminController: AdminController
 
     @Test
-    fun updateSellerApprovalStatus는_service에_승인_변경을_위임한다() {
+    fun 판매자_승인_상태_변경을_서비스에_위임한다() {
         val request = SellerApprovalRequest("APPROVED")
 
         val response = adminController.updateSellerApprovalStatus(1L, request)
 
-        assertEquals(ApiResponse.success(Unit), response)
+        assertThat(response).isEqualTo(ApiResponse.success(Unit))
         verify(adminCommandService).updateSellerApprovalStatus(1L, request)
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/controller/MembershipControllerTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/controller/MembershipControllerTest.kt
@@ -1,0 +1,90 @@
+package com.hoppingmall.user.controller
+
+import com.hoppingmall.common.ApiResponse
+import com.hoppingmall.common.UserPrincipal
+import com.hoppingmall.user.common.enums.Role
+import com.hoppingmall.user.domain.enums.MembershipGrade
+import com.hoppingmall.user.dto.response.MembershipResponse
+import com.hoppingmall.user.service.MembershipCommandService
+import com.hoppingmall.user.service.MembershipQueryService
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("MembershipController 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class MembershipControllerTest {
+
+    @Mock
+    private lateinit var membershipCommandService: MembershipCommandService
+
+    @Mock
+    private lateinit var membershipQueryService: MembershipQueryService
+
+    @InjectMocks
+    private lateinit var membershipController: MembershipController
+
+    @Test
+    fun createMembership은_201과_응답본문을_반환한다() {
+        val principal = UserPrincipal.of(1L, Role.BUYER.name)
+        val expected = membershipResponse(userId = 1L)
+        whenever(membershipCommandService.createMembership(1L)).thenReturn(expected)
+
+        val response = membershipController.createMembership(principal)
+
+        assertEquals(HttpStatus.CREATED, response.statusCode)
+        assertEquals(ApiResponse.success(expected), response.body)
+        verify(membershipCommandService).createMembership(1L)
+    }
+
+    @Test
+    fun getMyMembership은_principal의_userId로_조회한다() {
+        val principal = UserPrincipal.of(2L, Role.BUYER.name)
+        val expected = membershipResponse(userId = 2L)
+        whenever(membershipQueryService.getMembershipByUserId(2L)).thenReturn(expected)
+
+        val response = membershipController.getMyMembership(principal)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(ApiResponse.success(expected), response.body)
+        verify(membershipQueryService).getMembershipByUserId(2L)
+    }
+
+    @Test
+    fun getMembershipByUserId는_pathVariable로_조회한다() {
+        val expected = membershipResponse(userId = 3L)
+        whenever(membershipQueryService.getMembershipByUserId(3L)).thenReturn(expected)
+
+        val response = membershipController.getMembershipByUserId(3L)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(ApiResponse.success(expected), response.body)
+        verify(membershipQueryService).getMembershipByUserId(3L)
+    }
+
+    private fun membershipResponse(userId: Long) = MembershipResponse(
+        id = 1L,
+        userId = userId,
+        grade = MembershipGrade.BRONZE,
+        gradeName = MembershipGrade.BRONZE.gradeName,
+        totalSpent = BigDecimal.ZERO,
+        pointEarningRate = MembershipGrade.BRONZE.pointEarningRate,
+        discountRate = MembershipGrade.BRONZE.discountRate,
+        nextGrade = MembershipGrade.SILVER,
+        amountToNextGrade = MembershipGrade.SILVER.requiredAmount,
+        createdAt = LocalDateTime.now(),
+        updatedAt = null
+    )
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/controller/MembershipControllerTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/controller/MembershipControllerTest.kt
@@ -7,6 +7,7 @@ import com.hoppingmall.user.domain.enums.MembershipGrade
 import com.hoppingmall.user.dto.response.MembershipResponse
 import com.hoppingmall.user.service.MembershipCommandService
 import com.hoppingmall.user.service.MembershipQueryService
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
@@ -20,10 +21,9 @@ import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 import java.math.BigDecimal
 import java.time.LocalDateTime
-import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
-@DisplayName("MembershipController 단위 테스트")
+@DisplayName("MembershipController")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class MembershipControllerTest {
 
@@ -37,40 +37,40 @@ class MembershipControllerTest {
     private lateinit var membershipController: MembershipController
 
     @Test
-    fun createMembership은_201과_응답본문을_반환한다() {
+    fun 멤버십_생성_시_201과_응답본문을_반환한다() {
         val principal = UserPrincipal.of(1L, Role.BUYER.name)
         val expected = membershipResponse(userId = 1L)
         whenever(membershipCommandService.createMembership(1L)).thenReturn(expected)
 
         val response = membershipController.createMembership(principal)
 
-        assertEquals(HttpStatus.CREATED, response.statusCode)
-        assertEquals(ApiResponse.success(expected), response.body)
+        assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
+        assertThat(response.body).isEqualTo(ApiResponse.success(expected))
         verify(membershipCommandService).createMembership(1L)
     }
 
     @Test
-    fun getMyMembership은_principal의_userId로_조회한다() {
+    fun 내_멤버십_조회_시_principal의_userId로_조회한다() {
         val principal = UserPrincipal.of(2L, Role.BUYER.name)
         val expected = membershipResponse(userId = 2L)
         whenever(membershipQueryService.getMembershipByUserId(2L)).thenReturn(expected)
 
         val response = membershipController.getMyMembership(principal)
 
-        assertEquals(HttpStatus.OK, response.statusCode)
-        assertEquals(ApiResponse.success(expected), response.body)
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body).isEqualTo(ApiResponse.success(expected))
         verify(membershipQueryService).getMembershipByUserId(2L)
     }
 
     @Test
-    fun getMembershipByUserId는_pathVariable로_조회한다() {
+    fun 멤버십_조회_시_pathVariable의_userId로_조회한다() {
         val expected = membershipResponse(userId = 3L)
         whenever(membershipQueryService.getMembershipByUserId(3L)).thenReturn(expected)
 
         val response = membershipController.getMembershipByUserId(3L)
 
-        assertEquals(HttpStatus.OK, response.statusCode)
-        assertEquals(ApiResponse.success(expected), response.body)
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body).isEqualTo(ApiResponse.success(expected))
         verify(membershipQueryService).getMembershipByUserId(3L)
     }
 
@@ -84,7 +84,7 @@ class MembershipControllerTest {
         discountRate = MembershipGrade.BRONZE.discountRate,
         nextGrade = MembershipGrade.SILVER,
         amountToNextGrade = MembershipGrade.SILVER.requiredAmount,
-        createdAt = LocalDateTime.now(),
+        createdAt = LocalDateTime.of(2026, 1, 1, 0, 0),
         updatedAt = null
     )
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/controller/SellerControllerTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/controller/SellerControllerTest.kt
@@ -5,6 +5,7 @@ import com.hoppingmall.common.UserPrincipal
 import com.hoppingmall.user.common.enums.Role
 import com.hoppingmall.user.dto.request.SellerApplyRequest
 import com.hoppingmall.user.service.SellerCommandService
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
@@ -14,10 +15,9 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
-import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
-@DisplayName("SellerController 단위 테스트")
+@DisplayName("SellerController")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class SellerControllerTest {
 
@@ -28,13 +28,13 @@ class SellerControllerTest {
     private lateinit var sellerController: SellerController
 
     @Test
-    fun applyForSeller는_principal_userId로_판매자_신청을_위임한다() {
+    fun 판매자_신청을_principal의_userId로_위임한다() {
         val request = SellerApplyRequest("123-45-67890")
         val principal = UserPrincipal.of(10L, Role.SELLER.name)
 
         val response = sellerController.applyForSeller(request, principal)
 
-        assertEquals(ApiResponse.success(Unit), response)
+        assertThat(response).isEqualTo(ApiResponse.success(Unit))
         verify(sellerCommandService).apply(10L, request)
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/controller/SellerControllerTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/controller/SellerControllerTest.kt
@@ -1,0 +1,40 @@
+package com.hoppingmall.user.controller
+
+import com.hoppingmall.common.ApiResponse
+import com.hoppingmall.common.UserPrincipal
+import com.hoppingmall.user.common.enums.Role
+import com.hoppingmall.user.dto.request.SellerApplyRequest
+import com.hoppingmall.user.service.SellerCommandService
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("SellerController 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class SellerControllerTest {
+
+    @Mock
+    private lateinit var sellerCommandService: SellerCommandService
+
+    @InjectMocks
+    private lateinit var sellerController: SellerController
+
+    @Test
+    fun applyForSeller는_principal_userId로_판매자_신청을_위임한다() {
+        val request = SellerApplyRequest("123-45-67890")
+        val principal = UserPrincipal.of(10L, Role.SELLER.name)
+
+        val response = sellerController.applyForSeller(request, principal)
+
+        assertEquals(ApiResponse.success(Unit), response)
+        verify(sellerCommandService).apply(10L, request)
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/controller/UserControllerTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/controller/UserControllerTest.kt
@@ -1,0 +1,101 @@
+package com.hoppingmall.user.controller
+
+import com.hoppingmall.common.ApiResponse
+import com.hoppingmall.common.UserPrincipal
+import com.hoppingmall.user.auth.service.AuthService
+import com.hoppingmall.user.common.enums.Role
+import com.hoppingmall.user.dto.request.SignInRequest
+import com.hoppingmall.user.dto.request.SignUpRequest
+import com.hoppingmall.user.dto.request.UpdateUserRequest
+import com.hoppingmall.user.dto.response.SignInResponse
+import com.hoppingmall.user.dto.response.SignUpResponse
+import com.hoppingmall.user.dto.response.UserProfileResponse
+import com.hoppingmall.user.service.UserCommandService
+import com.hoppingmall.user.service.UserQueryService
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("UserController 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class UserControllerTest {
+
+    @Mock
+    private lateinit var userCommandService: UserCommandService
+
+    @Mock
+    private lateinit var userQueryService: UserQueryService
+
+    @Mock
+    private lateinit var authService: AuthService
+
+    @InjectMocks
+    private lateinit var userController: UserController
+
+    @Test
+    fun signUp은_회원가입_응답을_반환한다() {
+        val request = SignUpRequest("test@example.com", "Password1234", "테스트", Role.SELLER)
+        val expected = SignUpResponse(1L, "test@example.com", "테스트", Role.SELLER)
+        whenever(userCommandService.signUp(request)).thenReturn(expected)
+
+        val response = userController.signUp(request)
+
+        assertEquals(ApiResponse.success(expected), response)
+        verify(userCommandService).signUp(request)
+    }
+
+    @Test
+    fun login은_로그인_응답을_반환한다() {
+        val request = SignInRequest("test@example.com", "Password1234")
+        val expected = SignInResponse("access-token", "refresh-token")
+        whenever(authService.login(request)).thenReturn(expected)
+
+        val response = userController.login(request)
+
+        assertEquals(ApiResponse.success(expected), response)
+        verify(authService).login(request)
+    }
+
+    @Test
+    fun getMyProfile은_principal의_userId로_프로필을_조회한다() {
+        val principal = UserPrincipal.of(1L, Role.BUYER.name)
+        val expected = UserProfileResponse(1L, "buyer@example.com", "구매자", Role.BUYER.name)
+        whenever(userQueryService.getUserProfile(1L)).thenReturn(expected)
+
+        val response = userController.getMyProfile(principal)
+
+        assertEquals(ApiResponse.success(expected), response)
+        verify(userQueryService).getUserProfile(1L)
+    }
+
+    @Test
+    fun updateMyProfile은_principal의_userId로_수정한다() {
+        val request = UpdateUserRequest(name = "새이름", password = "NewPassword1234")
+        val principal = UserPrincipal.of(2L, Role.SELLER.name)
+
+        val response = userController.updateMyProfile(request, principal)
+
+        assertEquals(ApiResponse.success(Unit), response)
+        verify(userCommandService).updateUserProfile(2L, request)
+    }
+
+    @Test
+    fun updateMyProfile은_비밀번호가_없어도_수정한다() {
+        val request = UpdateUserRequest(name = "이름만변경", password = null)
+        val principal = UserPrincipal.of(3L, Role.BUYER.name)
+
+        val response = userController.updateMyProfile(request, principal)
+
+        assertEquals(ApiResponse.success(Unit), response)
+        verify(userCommandService).updateUserProfile(3L, request)
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/controller/UserControllerTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/controller/UserControllerTest.kt
@@ -12,6 +12,7 @@ import com.hoppingmall.user.dto.response.SignUpResponse
 import com.hoppingmall.user.dto.response.UserProfileResponse
 import com.hoppingmall.user.service.UserCommandService
 import com.hoppingmall.user.service.UserQueryService
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
@@ -22,10 +23,9 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
-@DisplayName("UserController 단위 테스트")
+@DisplayName("UserController")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class UserControllerTest {
 
@@ -42,60 +42,60 @@ class UserControllerTest {
     private lateinit var userController: UserController
 
     @Test
-    fun signUp은_회원가입_응답을_반환한다() {
+    fun 회원가입_시_응답을_반환한다() {
         val request = SignUpRequest("test@example.com", "Password1234", "테스트", Role.SELLER)
         val expected = SignUpResponse(1L, "test@example.com", "테스트", Role.SELLER)
         whenever(userCommandService.signUp(request)).thenReturn(expected)
 
         val response = userController.signUp(request)
 
-        assertEquals(ApiResponse.success(expected), response)
+        assertThat(response).isEqualTo(ApiResponse.success(expected))
         verify(userCommandService).signUp(request)
     }
 
     @Test
-    fun login은_로그인_응답을_반환한다() {
+    fun 로그인_시_응답을_반환한다() {
         val request = SignInRequest("test@example.com", "Password1234")
         val expected = SignInResponse("access-token", "refresh-token")
         whenever(authService.login(request)).thenReturn(expected)
 
         val response = userController.login(request)
 
-        assertEquals(ApiResponse.success(expected), response)
+        assertThat(response).isEqualTo(ApiResponse.success(expected))
         verify(authService).login(request)
     }
 
     @Test
-    fun getMyProfile은_principal의_userId로_프로필을_조회한다() {
+    fun 내_프로필_조회_시_principal의_userId로_조회한다() {
         val principal = UserPrincipal.of(1L, Role.BUYER.name)
         val expected = UserProfileResponse(1L, "buyer@example.com", "구매자", Role.BUYER.name)
         whenever(userQueryService.getUserProfile(1L)).thenReturn(expected)
 
         val response = userController.getMyProfile(principal)
 
-        assertEquals(ApiResponse.success(expected), response)
+        assertThat(response).isEqualTo(ApiResponse.success(expected))
         verify(userQueryService).getUserProfile(1L)
     }
 
     @Test
-    fun updateMyProfile은_principal의_userId로_수정한다() {
+    fun 프로필_수정_시_principal의_userId로_수정한다() {
         val request = UpdateUserRequest(name = "새이름", password = "NewPassword1234")
         val principal = UserPrincipal.of(2L, Role.SELLER.name)
 
         val response = userController.updateMyProfile(request, principal)
 
-        assertEquals(ApiResponse.success(Unit), response)
+        assertThat(response).isEqualTo(ApiResponse.success(Unit))
         verify(userCommandService).updateUserProfile(2L, request)
     }
 
     @Test
-    fun updateMyProfile은_비밀번호가_없어도_수정한다() {
+    fun 프로필_수정_시_비밀번호가_없어도_수정한다() {
         val request = UpdateUserRequest(name = "이름만변경", password = null)
         val principal = UserPrincipal.of(3L, Role.BUYER.name)
 
         val response = userController.updateMyProfile(request, principal)
 
-        assertEquals(ApiResponse.success(Unit), response)
+        assertThat(response).isEqualTo(ApiResponse.success(Unit))
         verify(userCommandService).updateUserProfile(3L, request)
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/domain/BuyerTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/domain/BuyerTest.kt
@@ -1,0 +1,20 @@
+package com.hoppingmall.user.domain
+
+import com.hoppingmall.user.support.fixture.fixture
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+@DisplayName("Buyer 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class BuyerTest {
+
+    @Test
+    fun create는_User_ID를_정확히_연결한다() {
+        val buyer = Buyer.fixture()
+
+        assertEquals(1L, buyer.userId)
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/domain/BuyerTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/domain/BuyerTest.kt
@@ -1,20 +1,20 @@
 package com.hoppingmall.user.domain
 
 import com.hoppingmall.user.support.fixture.fixture
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
-@DisplayName("Buyer 단위 테스트")
+@DisplayName("Buyer")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class BuyerTest {
 
     @Test
-    fun create는_User_ID를_정확히_연결한다() {
+    fun 생성_시_User_ID를_정확히_연결한다() {
         val buyer = Buyer.fixture()
 
-        assertEquals(1L, buyer.userId)
+        assertThat(buyer.userId).isEqualTo(1L)
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/domain/MembershipTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/domain/MembershipTest.kt
@@ -1,44 +1,43 @@
 package com.hoppingmall.user.domain
 
 import com.hoppingmall.user.domain.enums.MembershipGrade
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
-import kotlin.test.assertEquals
 
-@DisplayName("Membership 단위 테스트")
+@DisplayName("Membership")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class MembershipTest {
 
     @Test
-    fun create는_기본_BRONZE_멤버십을_생성한다() {
+    fun 기본_BRONZE_멤버십을_생성한다() {
         val membership = Membership.create(1L)
 
-        assertEquals(1L, membership.userId)
-        assertEquals(MembershipGrade.BRONZE, membership.grade)
-        assertEquals(BigDecimal.ZERO, membership.totalSpent)
+        assertThat(membership.userId).isEqualTo(1L)
+        assertThat(membership.grade).isEqualTo(MembershipGrade.BRONZE)
+        assertThat(membership.totalSpent).isEqualTo(BigDecimal.ZERO)
     }
 
     @Test
-    fun addPurchaseAmount는_양수_금액을_누적한다() {
+    fun 양수_금액을_누적한다() {
         val membership = Membership.create(2L)
 
         membership.addPurchaseAmount(BigDecimal("50000"))
 
-        assertEquals(BigDecimal("50000"), membership.totalSpent)
-        assertEquals(MembershipGrade.BRONZE, membership.grade)
+        assertThat(membership.totalSpent).isEqualTo(BigDecimal("50000"))
+        assertThat(membership.grade).isEqualTo(MembershipGrade.BRONZE)
     }
 
     @Test
-    fun addPurchaseAmount는_0_이하_금액이면_예외가_발생한다() {
+    fun 금액이_0_이하이면_예외가_발생한다() {
         val membership = Membership.create(3L)
 
-        assertThrows<IllegalArgumentException> {
-            membership.addPurchaseAmount(BigDecimal.ZERO)
-        }
+        assertThatThrownBy { membership.addPurchaseAmount(BigDecimal.ZERO) }
+            .isInstanceOf(IllegalArgumentException::class.java)
     }
 
     @Test
@@ -55,7 +54,7 @@ class MembershipTest {
 
             membership.addPurchaseAmount(amount)
 
-            assertEquals(expectedGrade, membership.grade)
+            assertThat(membership.grade).isEqualTo(expectedGrade)
         }
     }
 
@@ -69,6 +68,6 @@ class MembershipTest {
 
         membership.addPurchaseAmount(BigDecimal("1"))
 
-        assertEquals(MembershipGrade.GOLD, membership.grade)
+        assertThat(membership.grade).isEqualTo(MembershipGrade.GOLD)
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/domain/MembershipTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/domain/MembershipTest.kt
@@ -1,0 +1,74 @@
+package com.hoppingmall.user.domain
+
+import com.hoppingmall.user.domain.enums.MembershipGrade
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+
+@DisplayName("Membership 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class MembershipTest {
+
+    @Test
+    fun create는_기본_BRONZE_멤버십을_생성한다() {
+        val membership = Membership.create(1L)
+
+        assertEquals(1L, membership.userId)
+        assertEquals(MembershipGrade.BRONZE, membership.grade)
+        assertEquals(BigDecimal.ZERO, membership.totalSpent)
+    }
+
+    @Test
+    fun addPurchaseAmount는_양수_금액을_누적한다() {
+        val membership = Membership.create(2L)
+
+        membership.addPurchaseAmount(BigDecimal("50000"))
+
+        assertEquals(BigDecimal("50000"), membership.totalSpent)
+        assertEquals(MembershipGrade.BRONZE, membership.grade)
+    }
+
+    @Test
+    fun addPurchaseAmount는_0_이하_금액이면_예외가_발생한다() {
+        val membership = Membership.create(3L)
+
+        assertThrows<IllegalArgumentException> {
+            membership.addPurchaseAmount(BigDecimal.ZERO)
+        }
+    }
+
+    @Test
+    fun 누적_금액_경계에_따라_등급이_승급한다() {
+        val expectations = listOf(
+            BigDecimal("100000") to MembershipGrade.SILVER,
+            BigDecimal("500000") to MembershipGrade.GOLD,
+            BigDecimal("1000000") to MembershipGrade.PLATINUM,
+            BigDecimal("5000000") to MembershipGrade.DIAMOND
+        )
+
+        expectations.forEach { (amount, expectedGrade) ->
+            val membership = Membership.create(4L)
+
+            membership.addPurchaseAmount(amount)
+
+            assertEquals(expectedGrade, membership.grade)
+        }
+    }
+
+    @Test
+    fun 이미_높은_등급이면_낮은_구간_금액을_추가해도_등급이_유지된다() {
+        val membership = Membership(
+            userId = 5L,
+            grade = MembershipGrade.GOLD,
+            totalSpent = BigDecimal("500000")
+        )
+
+        membership.addPurchaseAmount(BigDecimal("1"))
+
+        assertEquals(MembershipGrade.GOLD, membership.grade)
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/domain/SellerTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/domain/SellerTest.kt
@@ -1,0 +1,40 @@
+package com.hoppingmall.user.domain
+
+import com.hoppingmall.user.support.fixture.fixture
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+@DisplayName("Seller 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class SellerTest {
+
+    @Test
+    fun fixture는_기본_승인_상태가_PENDING이다() {
+        val seller = Seller.fixture()
+
+        assertEquals(Seller.ApprovalStatus.PENDING, seller.getApprovalStatus())
+        assertEquals("123-45-67890", seller.businessNumber)
+        assertEquals(1L, seller.userId)
+    }
+
+    @Test
+    fun approve는_상태를_APPROVED로_변경한다() {
+        val seller = Seller.fixture()
+
+        seller.approve()
+
+        assertEquals(Seller.ApprovalStatus.APPROVED, seller.getApprovalStatus())
+    }
+
+    @Test
+    fun reject는_상태를_REJECTED로_변경한다() {
+        val seller = Seller.fixture()
+
+        seller.reject()
+
+        assertEquals(Seller.ApprovalStatus.REJECTED, seller.getApprovalStatus())
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/domain/SellerTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/domain/SellerTest.kt
@@ -1,40 +1,40 @@
 package com.hoppingmall.user.domain
 
 import com.hoppingmall.user.support.fixture.fixture
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
-@DisplayName("Seller 단위 테스트")
+@DisplayName("Seller")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class SellerTest {
 
     @Test
-    fun fixture는_기본_승인_상태가_PENDING이다() {
+    fun 기본_승인_상태가_PENDING이다() {
         val seller = Seller.fixture()
 
-        assertEquals(Seller.ApprovalStatus.PENDING, seller.getApprovalStatus())
-        assertEquals("123-45-67890", seller.businessNumber)
-        assertEquals(1L, seller.userId)
+        assertThat(seller.getApprovalStatus()).isEqualTo(Seller.ApprovalStatus.PENDING)
+        assertThat(seller.businessNumber).isEqualTo("123-45-67890")
+        assertThat(seller.userId).isEqualTo(1L)
     }
 
     @Test
-    fun approve는_상태를_APPROVED로_변경한다() {
+    fun 승인_시_상태를_APPROVED로_변경한다() {
         val seller = Seller.fixture()
 
         seller.approve()
 
-        assertEquals(Seller.ApprovalStatus.APPROVED, seller.getApprovalStatus())
+        assertThat(seller.getApprovalStatus()).isEqualTo(Seller.ApprovalStatus.APPROVED)
     }
 
     @Test
-    fun reject는_상태를_REJECTED로_변경한다() {
+    fun 거절_시_상태를_REJECTED로_변경한다() {
         val seller = Seller.fixture()
 
         seller.reject()
 
-        assertEquals(Seller.ApprovalStatus.REJECTED, seller.getApprovalStatus())
+        assertThat(seller.getApprovalStatus()).isEqualTo(Seller.ApprovalStatus.REJECTED)
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/domain/UserCompanionTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/domain/UserCompanionTest.kt
@@ -3,18 +3,18 @@ package com.hoppingmall.user.domain
 import com.hoppingmall.user.common.enums.Role
 import com.hoppingmall.user.common.vo.Email
 import com.hoppingmall.user.common.vo.Password
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
-@DisplayName("User companion 단위 테스트")
+@DisplayName("User companion")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class UserCompanionTest {
 
     @Test
-    fun create는_명시한_role로_사용자를_생성한다() {
+    fun 명시한_role로_사용자를_생성한다() {
         val user = User.create(
             email = Email("seller@example.com"),
             password = Password("encoded-password"),
@@ -22,19 +22,19 @@ class UserCompanionTest {
             role = Role.SELLER
         )
 
-        assertEquals(Email("seller@example.com"), user.email)
-        assertEquals("판매자", user.getName())
-        assertEquals(Role.SELLER, user.getRole())
+        assertThat(user.email).isEqualTo(Email("seller@example.com"))
+        assertThat(user.getName()).isEqualTo("판매자")
+        assertThat(user.getRole()).isEqualTo(Role.SELLER)
     }
 
     @Test
-    fun create는_role을_생략하면_BUYER로_생성한다() {
+    fun role_생략_시_BUYER로_생성한다() {
         val user = User.create(
             email = Email("buyer@example.com"),
             password = Password("encoded-password"),
             name = "구매자"
         )
 
-        assertEquals(Role.BUYER, user.getRole())
+        assertThat(user.getRole()).isEqualTo(Role.BUYER)
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/domain/UserCompanionTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/domain/UserCompanionTest.kt
@@ -1,0 +1,40 @@
+package com.hoppingmall.user.domain
+
+import com.hoppingmall.user.common.enums.Role
+import com.hoppingmall.user.common.vo.Email
+import com.hoppingmall.user.common.vo.Password
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+@DisplayName("User companion 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class UserCompanionTest {
+
+    @Test
+    fun create는_명시한_role로_사용자를_생성한다() {
+        val user = User.create(
+            email = Email("seller@example.com"),
+            password = Password("encoded-password"),
+            name = "판매자",
+            role = Role.SELLER
+        )
+
+        assertEquals(Email("seller@example.com"), user.email)
+        assertEquals("판매자", user.getName())
+        assertEquals(Role.SELLER, user.getRole())
+    }
+
+    @Test
+    fun create는_role을_생략하면_BUYER로_생성한다() {
+        val user = User.create(
+            email = Email("buyer@example.com"),
+            password = Password("encoded-password"),
+            name = "구매자"
+        )
+
+        assertEquals(Role.BUYER, user.getRole())
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/domain/UserTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/domain/UserTest.kt
@@ -1,0 +1,48 @@
+package com.hoppingmall.user.domain
+
+import com.hoppingmall.user.common.enums.Role
+import com.hoppingmall.user.common.vo.Email
+import com.hoppingmall.user.common.vo.Password
+import com.hoppingmall.user.support.fixture.fixture
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+@DisplayName("User 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class UserTest {
+
+    @Test
+    fun fixture는_User_필드를_정확히_매핑한다() {
+        val user = User.fixture(
+            email = Email("test@example.com"),
+            password = Password("encoded-password"),
+            name = "홍길동",
+            role = Role.SELLER
+        )
+
+        assertEquals(Email("test@example.com"), user.email)
+        assertEquals("홍길동", user.getName())
+        assertEquals(Role.SELLER, user.getRole())
+    }
+
+    @Test
+    fun updateName은_이름을_변경한다() {
+        val user = User.fixture(name = "기존이름")
+
+        user.updateName("변경된이름")
+
+        assertEquals("변경된이름", user.getName())
+    }
+
+    @Test
+    fun updatePassword는_비밀번호를_변경한다() {
+        val user = User.fixture(password = Password("old-password"))
+
+        user.updatePassword(Password("new-password"))
+
+        assertEquals("new-password", user.getPassword().value)
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/domain/UserTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/domain/UserTest.kt
@@ -4,18 +4,18 @@ import com.hoppingmall.user.common.enums.Role
 import com.hoppingmall.user.common.vo.Email
 import com.hoppingmall.user.common.vo.Password
 import com.hoppingmall.user.support.fixture.fixture
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
-@DisplayName("User 단위 테스트")
+@DisplayName("User")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class UserTest {
 
     @Test
-    fun fixture는_User_필드를_정확히_매핑한다() {
+    fun 필드를_정확히_매핑한다() {
         val user = User.fixture(
             email = Email("test@example.com"),
             password = Password("encoded-password"),
@@ -23,26 +23,26 @@ class UserTest {
             role = Role.SELLER
         )
 
-        assertEquals(Email("test@example.com"), user.email)
-        assertEquals("홍길동", user.getName())
-        assertEquals(Role.SELLER, user.getRole())
+        assertThat(user.email).isEqualTo(Email("test@example.com"))
+        assertThat(user.getName()).isEqualTo("홍길동")
+        assertThat(user.getRole()).isEqualTo(Role.SELLER)
     }
 
     @Test
-    fun updateName은_이름을_변경한다() {
+    fun 이름_변경_성공() {
         val user = User.fixture(name = "기존이름")
 
         user.updateName("변경된이름")
 
-        assertEquals("변경된이름", user.getName())
+        assertThat(user.getName()).isEqualTo("변경된이름")
     }
 
     @Test
-    fun updatePassword는_비밀번호를_변경한다() {
+    fun 비밀번호_변경_성공() {
         val user = User.fixture(password = Password("old-password"))
 
         user.updatePassword(Password("new-password"))
 
-        assertEquals("new-password", user.getPassword().value)
+        assertThat(user.getPassword().value).isEqualTo("new-password")
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/internal/InternalUserControllerTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/internal/InternalUserControllerTest.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.user.internal
 import com.hoppingmall.user.domain.repository.SellerRepository
 import com.hoppingmall.user.support.fixture.fixture
 import com.hoppingmall.user.support.withId
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
@@ -13,11 +14,9 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 @ExtendWith(MockitoExtension::class)
-@DisplayName("InternalUserController 단위 테스트")
+@DisplayName("InternalUserController")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class InternalUserControllerTest {
 
@@ -34,11 +33,11 @@ class InternalUserControllerTest {
 
         val response = internalUserController.getSellerByUserId(1L)
 
-        assertEquals(HttpStatus.OK, response.statusCode)
-        assertEquals(5L, response.body?.id)
-        assertEquals(1L, response.body?.userId)
-        assertEquals("123-45-67890", response.body?.businessNumber)
-        assertEquals("PENDING", response.body?.approvalStatus)
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.id).isEqualTo(5L)
+        assertThat(response.body?.userId).isEqualTo(1L)
+        assertThat(response.body?.businessNumber).isEqualTo("123-45-67890")
+        assertThat(response.body?.approvalStatus).isEqualTo("PENDING")
     }
 
     @Test
@@ -47,7 +46,7 @@ class InternalUserControllerTest {
 
         val response = internalUserController.getSellerByUserId(2L)
 
-        assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
-        assertNull(response.body)
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(response.body).isNull()
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/internal/InternalUserControllerTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/internal/InternalUserControllerTest.kt
@@ -1,0 +1,53 @@
+package com.hoppingmall.user.internal
+
+import com.hoppingmall.user.domain.repository.SellerRepository
+import com.hoppingmall.user.support.fixture.fixture
+import com.hoppingmall.user.support.withId
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("InternalUserController 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class InternalUserControllerTest {
+
+    @Mock
+    private lateinit var sellerRepository: SellerRepository
+
+    @InjectMocks
+    private lateinit var internalUserController: InternalUserController
+
+    @Test
+    fun 판매자가_있으면_SellerResponse를_반환한다() {
+        val seller = com.hoppingmall.user.domain.Seller.fixture().withId(5L)
+        whenever(sellerRepository.findNullableByUserId(1L)).thenReturn(seller)
+
+        val response = internalUserController.getSellerByUserId(1L)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(5L, response.body?.id)
+        assertEquals(1L, response.body?.userId)
+        assertEquals("123-45-67890", response.body?.businessNumber)
+        assertEquals("PENDING", response.body?.approvalStatus)
+    }
+
+    @Test
+    fun 판매자가_없으면_404를_반환한다() {
+        whenever(sellerRepository.findNullableByUserId(2L)).thenReturn(null)
+
+        val response = internalUserController.getSellerByUserId(2L)
+
+        assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+        assertNull(response.body)
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/service/AdminCommandServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/service/AdminCommandServiceImplTest.kt
@@ -1,0 +1,80 @@
+package com.hoppingmall.user.service
+
+import com.hoppingmall.user.domain.Seller
+import com.hoppingmall.user.domain.repository.SellerRepository
+import com.hoppingmall.user.dto.request.SellerApprovalRequest
+import com.hoppingmall.user.exception.seller.SellerInvalidApprovalCommandException
+import com.hoppingmall.user.exception.seller.SellerNotFoundException
+import com.hoppingmall.user.service.strategy.ApproveSellerCommand
+import com.hoppingmall.user.service.strategy.RejectSellerCommand
+import com.hoppingmall.user.service.strategy.SellerApprovalCommandMapper
+import com.hoppingmall.user.support.fixture.fixture
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import java.util.Optional
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("AdminCommandServiceImpl 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class AdminCommandServiceImplTest {
+
+    @Mock
+    private lateinit var sellerRepository: SellerRepository
+
+    private lateinit var adminCommandService: AdminCommandServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        adminCommandService = AdminCommandServiceImpl(
+            sellerRepository = sellerRepository,
+            commandMapper = SellerApprovalCommandMapper(ApproveSellerCommand(), RejectSellerCommand())
+        )
+    }
+
+    @Test
+    fun 판매자_승인_상태를_APPROVED로_변경할_수_있다() {
+        val seller = Seller.fixture()
+        whenever(sellerRepository.findById(1L)).thenReturn(Optional.of(seller))
+
+        adminCommandService.updateSellerApprovalStatus(1L, SellerApprovalRequest("APPROVED"))
+
+        assertEquals(Seller.ApprovalStatus.APPROVED, seller.getApprovalStatus())
+    }
+
+    @Test
+    fun 판매자_승인_상태를_REJECTED로_변경할_수_있다() {
+        val seller = Seller.fixture()
+        whenever(sellerRepository.findById(2L)).thenReturn(Optional.of(seller))
+
+        adminCommandService.updateSellerApprovalStatus(2L, SellerApprovalRequest("REJECTED"))
+
+        assertEquals(Seller.ApprovalStatus.REJECTED, seller.getApprovalStatus())
+    }
+
+    @Test
+    fun 존재하지_않는_판매자면_예외가_발생한다() {
+        whenever(sellerRepository.findById(404L)).thenReturn(Optional.empty())
+
+        assertThrows<SellerNotFoundException> {
+            adminCommandService.updateSellerApprovalStatus(404L, SellerApprovalRequest("APPROVED"))
+        }
+    }
+
+    @Test
+    fun PENDING_승인_상태는_예외가_발생한다() {
+        whenever(sellerRepository.findById(3L)).thenReturn(Optional.of(Seller.fixture()))
+
+        assertThrows<SellerInvalidApprovalCommandException> {
+            adminCommandService.updateSellerApprovalStatus(3L, SellerApprovalRequest("PENDING"))
+        }
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/service/AdminCommandServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/service/AdminCommandServiceImplTest.kt
@@ -9,21 +9,21 @@ import com.hoppingmall.user.service.strategy.ApproveSellerCommand
 import com.hoppingmall.user.service.strategy.RejectSellerCommand
 import com.hoppingmall.user.service.strategy.SellerApprovalCommandMapper
 import com.hoppingmall.user.support.fixture.fixture
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
 import java.util.Optional
-import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
-@DisplayName("AdminCommandServiceImpl 단위 테스트")
+@DisplayName("AdminCommandServiceImpl")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class AdminCommandServiceImplTest {
 
@@ -47,7 +47,7 @@ class AdminCommandServiceImplTest {
 
         adminCommandService.updateSellerApprovalStatus(1L, SellerApprovalRequest("APPROVED"))
 
-        assertEquals(Seller.ApprovalStatus.APPROVED, seller.getApprovalStatus())
+        assertThat(seller.getApprovalStatus()).isEqualTo(Seller.ApprovalStatus.APPROVED)
     }
 
     @Test
@@ -57,24 +57,22 @@ class AdminCommandServiceImplTest {
 
         adminCommandService.updateSellerApprovalStatus(2L, SellerApprovalRequest("REJECTED"))
 
-        assertEquals(Seller.ApprovalStatus.REJECTED, seller.getApprovalStatus())
+        assertThat(seller.getApprovalStatus()).isEqualTo(Seller.ApprovalStatus.REJECTED)
     }
 
     @Test
     fun 존재하지_않는_판매자면_예외가_발생한다() {
         whenever(sellerRepository.findById(404L)).thenReturn(Optional.empty())
 
-        assertThrows<SellerNotFoundException> {
-            adminCommandService.updateSellerApprovalStatus(404L, SellerApprovalRequest("APPROVED"))
-        }
+        assertThatThrownBy { adminCommandService.updateSellerApprovalStatus(404L, SellerApprovalRequest("APPROVED")) }
+            .isInstanceOf(SellerNotFoundException::class.java)
     }
 
     @Test
     fun PENDING_승인_상태는_예외가_발생한다() {
         whenever(sellerRepository.findById(3L)).thenReturn(Optional.of(Seller.fixture()))
 
-        assertThrows<SellerInvalidApprovalCommandException> {
-            adminCommandService.updateSellerApprovalStatus(3L, SellerApprovalRequest("PENDING"))
-        }
+        assertThatThrownBy { adminCommandService.updateSellerApprovalStatus(3L, SellerApprovalRequest("PENDING")) }
+            .isInstanceOf(SellerInvalidApprovalCommandException::class.java)
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/service/MembershipCommandServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/service/MembershipCommandServiceImplTest.kt
@@ -5,11 +5,12 @@ import com.hoppingmall.user.domain.enums.MembershipGrade
 import com.hoppingmall.user.domain.repository.MembershipRepository
 import com.hoppingmall.user.exception.membership.MembershipAlreadyExistsException
 import com.hoppingmall.user.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
@@ -19,10 +20,9 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
-import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
-@DisplayName("MembershipCommandServiceImpl 단위 테스트")
+@DisplayName("MembershipCommandServiceImpl")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class MembershipCommandServiceImplTest {
 
@@ -33,7 +33,7 @@ class MembershipCommandServiceImplTest {
     private lateinit var membershipCommandService: MembershipCommandServiceImpl
 
     @Test
-    fun createMembership는_멤버십이_없으면_생성한다() {
+    fun 멤버십이_없으면_생성한다() {
         whenever(membershipRepository.existsByUserId(1L)).thenReturn(false)
         whenever(membershipRepository.save(any<Membership>())).thenAnswer {
             (it.arguments[0] as Membership).withId(1L)
@@ -41,36 +41,35 @@ class MembershipCommandServiceImplTest {
 
         val response = membershipCommandService.createMembership(1L)
 
-        assertEquals(1L, response.id)
-        assertEquals(1L, response.userId)
-        assertEquals(MembershipGrade.BRONZE, response.grade)
-        assertEquals(BigDecimal.ZERO, response.totalSpent)
+        assertThat(response.id).isEqualTo(1L)
+        assertThat(response.userId).isEqualTo(1L)
+        assertThat(response.grade).isEqualTo(MembershipGrade.BRONZE)
+        assertThat(response.totalSpent).isEqualTo(BigDecimal.ZERO)
     }
 
     @Test
-    fun createMembership는_이미_멤버십이_있으면_예외가_발생한다() {
+    fun 이미_멤버십이_있으면_예외가_발생한다() {
         whenever(membershipRepository.existsByUserId(2L)).thenReturn(true)
 
-        assertThrows<MembershipAlreadyExistsException> {
-            membershipCommandService.createMembership(2L)
-        }
+        assertThatThrownBy { membershipCommandService.createMembership(2L) }
+            .isInstanceOf(MembershipAlreadyExistsException::class.java)
     }
 
     @Test
-    fun addPurchaseAmount는_기존_멤버십에_금액을_누적한다() {
+    fun 기존_멤버십에_금액을_누적한다() {
         val membership = Membership.create(3L).withId(1L)
         whenever(membershipRepository.findByUserIdForUpdate(3L)).thenReturn(membership)
         whenever(membershipRepository.save(any<Membership>())).thenAnswer { it.arguments[0] }
 
         val response = membershipCommandService.addPurchaseAmount(3L, BigDecimal("100000"))
 
-        assertEquals(BigDecimal("100000"), response.totalSpent)
-        assertEquals(MembershipGrade.SILVER, response.grade)
+        assertThat(response.totalSpent).isEqualTo(BigDecimal("100000"))
+        assertThat(response.grade).isEqualTo(MembershipGrade.SILVER)
         verify(membershipRepository).save(membership)
     }
 
     @Test
-    fun addPurchaseAmount는_멤버십이_없으면_새로_생성한_후_금액을_누적한다() {
+    fun 멤버십이_없으면_새로_생성한_후_금액을_누적한다() {
         whenever(membershipRepository.findByUserIdForUpdate(4L)).thenReturn(null)
         whenever(membershipRepository.save(any<Membership>())).thenAnswer {
             (it.arguments[0] as Membership).withId(2L)
@@ -78,9 +77,9 @@ class MembershipCommandServiceImplTest {
 
         val response = membershipCommandService.addPurchaseAmount(4L, BigDecimal("500000"))
 
-        assertEquals(4L, response.userId)
-        assertEquals(BigDecimal("500000"), response.totalSpent)
-        assertEquals(MembershipGrade.GOLD, response.grade)
+        assertThat(response.userId).isEqualTo(4L)
+        assertThat(response.totalSpent).isEqualTo(BigDecimal("500000"))
+        assertThat(response.grade).isEqualTo(MembershipGrade.GOLD)
         verify(membershipRepository, times(2)).save(any<Membership>())
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/service/MembershipCommandServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/service/MembershipCommandServiceImplTest.kt
@@ -1,0 +1,86 @@
+package com.hoppingmall.user.service
+
+import com.hoppingmall.user.domain.Membership
+import com.hoppingmall.user.domain.enums.MembershipGrade
+import com.hoppingmall.user.domain.repository.MembershipRepository
+import com.hoppingmall.user.exception.membership.MembershipAlreadyExistsException
+import com.hoppingmall.user.support.withId
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("MembershipCommandServiceImpl 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class MembershipCommandServiceImplTest {
+
+    @Mock
+    private lateinit var membershipRepository: MembershipRepository
+
+    @InjectMocks
+    private lateinit var membershipCommandService: MembershipCommandServiceImpl
+
+    @Test
+    fun createMembership는_멤버십이_없으면_생성한다() {
+        whenever(membershipRepository.existsByUserId(1L)).thenReturn(false)
+        whenever(membershipRepository.save(any<Membership>())).thenAnswer {
+            (it.arguments[0] as Membership).withId(1L)
+        }
+
+        val response = membershipCommandService.createMembership(1L)
+
+        assertEquals(1L, response.id)
+        assertEquals(1L, response.userId)
+        assertEquals(MembershipGrade.BRONZE, response.grade)
+        assertEquals(BigDecimal.ZERO, response.totalSpent)
+    }
+
+    @Test
+    fun createMembership는_이미_멤버십이_있으면_예외가_발생한다() {
+        whenever(membershipRepository.existsByUserId(2L)).thenReturn(true)
+
+        assertThrows<MembershipAlreadyExistsException> {
+            membershipCommandService.createMembership(2L)
+        }
+    }
+
+    @Test
+    fun addPurchaseAmount는_기존_멤버십에_금액을_누적한다() {
+        val membership = Membership.create(3L).withId(1L)
+        whenever(membershipRepository.findByUserIdForUpdate(3L)).thenReturn(membership)
+        whenever(membershipRepository.save(any<Membership>())).thenAnswer { it.arguments[0] }
+
+        val response = membershipCommandService.addPurchaseAmount(3L, BigDecimal("100000"))
+
+        assertEquals(BigDecimal("100000"), response.totalSpent)
+        assertEquals(MembershipGrade.SILVER, response.grade)
+        verify(membershipRepository).save(membership)
+    }
+
+    @Test
+    fun addPurchaseAmount는_멤버십이_없으면_새로_생성한_후_금액을_누적한다() {
+        whenever(membershipRepository.findByUserIdForUpdate(4L)).thenReturn(null)
+        whenever(membershipRepository.save(any<Membership>())).thenAnswer {
+            (it.arguments[0] as Membership).withId(2L)
+        }
+
+        val response = membershipCommandService.addPurchaseAmount(4L, BigDecimal("500000"))
+
+        assertEquals(4L, response.userId)
+        assertEquals(BigDecimal("500000"), response.totalSpent)
+        assertEquals(MembershipGrade.GOLD, response.grade)
+        verify(membershipRepository, times(2)).save(any<Membership>())
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/service/MembershipQueryServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/service/MembershipQueryServiceImplTest.kt
@@ -3,20 +3,20 @@ package com.hoppingmall.user.service
 import com.hoppingmall.user.domain.repository.MembershipRepository
 import com.hoppingmall.user.exception.membership.MembershipNotFoundException
 import com.hoppingmall.user.support.fixture.fixture
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
-@DisplayName("MembershipQueryServiceImpl 단위 테스트")
+@DisplayName("MembershipQueryServiceImpl")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class MembershipQueryServiceImplTest {
 
@@ -27,22 +27,21 @@ class MembershipQueryServiceImplTest {
     private lateinit var membershipQueryService: MembershipQueryServiceImpl
 
     @Test
-    fun getMembershipByUserId는_멤버십이_있으면_조회에_성공한다() {
+    fun 멤버십이_있으면_조회에_성공한다() {
         val membership = com.hoppingmall.user.domain.Membership.fixture(userId = 5L)
         whenever(membershipRepository.findByUserId(5L)).thenReturn(membership)
 
         val response = membershipQueryService.getMembershipByUserId(5L)
 
-        assertEquals(5L, response.userId)
-        assertEquals(membership.grade, response.grade)
+        assertThat(response.userId).isEqualTo(5L)
+        assertThat(response.grade).isEqualTo(membership.grade)
     }
 
     @Test
-    fun getMembershipByUserId는_멤버십이_없으면_예외가_발생한다() {
+    fun 멤버십이_없으면_예외가_발생한다() {
         whenever(membershipRepository.findByUserId(6L)).thenReturn(null)
 
-        assertThrows<MembershipNotFoundException> {
-            membershipQueryService.getMembershipByUserId(6L)
-        }
+        assertThatThrownBy { membershipQueryService.getMembershipByUserId(6L) }
+            .isInstanceOf(MembershipNotFoundException::class.java)
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/service/MembershipQueryServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/service/MembershipQueryServiceImplTest.kt
@@ -1,0 +1,48 @@
+package com.hoppingmall.user.service
+
+import com.hoppingmall.user.domain.repository.MembershipRepository
+import com.hoppingmall.user.exception.membership.MembershipNotFoundException
+import com.hoppingmall.user.support.fixture.fixture
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("MembershipQueryServiceImpl 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class MembershipQueryServiceImplTest {
+
+    @Mock
+    private lateinit var membershipRepository: MembershipRepository
+
+    @InjectMocks
+    private lateinit var membershipQueryService: MembershipQueryServiceImpl
+
+    @Test
+    fun getMembershipByUserId는_멤버십이_있으면_조회에_성공한다() {
+        val membership = com.hoppingmall.user.domain.Membership.fixture(userId = 5L)
+        whenever(membershipRepository.findByUserId(5L)).thenReturn(membership)
+
+        val response = membershipQueryService.getMembershipByUserId(5L)
+
+        assertEquals(5L, response.userId)
+        assertEquals(membership.grade, response.grade)
+    }
+
+    @Test
+    fun getMembershipByUserId는_멤버십이_없으면_예외가_발생한다() {
+        whenever(membershipRepository.findByUserId(6L)).thenReturn(null)
+
+        assertThrows<MembershipNotFoundException> {
+            membershipQueryService.getMembershipByUserId(6L)
+        }
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/service/SellerCommandServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/service/SellerCommandServiceImplTest.kt
@@ -1,0 +1,87 @@
+package com.hoppingmall.user.service
+
+import com.hoppingmall.user.domain.Seller
+import com.hoppingmall.user.domain.repository.SellerRepository
+import com.hoppingmall.user.domain.repository.UserRepository
+import com.hoppingmall.user.dto.request.SellerApplyRequest
+import com.hoppingmall.user.exception.seller.SellerAlreadyAppliedException
+import com.hoppingmall.user.exception.seller.SellerBusinessNumberDuplicateException
+import com.hoppingmall.user.exception.user.UserNotFoundException
+import com.hoppingmall.user.support.fixture.fixture
+import com.hoppingmall.user.support.withId
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("SellerCommandServiceImpl 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class SellerCommandServiceImplTest {
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @Mock
+    private lateinit var sellerRepository: SellerRepository
+
+    @InjectMocks
+    private lateinit var sellerCommandService: SellerCommandServiceImpl
+
+    @Test
+    fun apply는_판매자_신청에_성공하면_Seller를_저장한다() {
+        val user = com.hoppingmall.user.domain.User.fixture().withId(1L)
+        val sellerCaptor = argumentCaptor<Seller>()
+        whenever(userRepository.findNullableById(1L)).thenReturn(user)
+        whenever(sellerRepository.findNullableByUserId(1L)).thenReturn(null)
+        whenever(sellerRepository.existsByBusinessNumber("123-45-67890")).thenReturn(false)
+        whenever(sellerRepository.save(sellerCaptor.capture())).thenReturn(Seller.fixture())
+
+        sellerCommandService.apply(1L, SellerApplyRequest("123-45-67890"))
+
+        assertEquals(1L, sellerCaptor.firstValue.userId)
+        assertEquals("123-45-67890", sellerCaptor.firstValue.businessNumber)
+        assertEquals(Seller.ApprovalStatus.PENDING, sellerCaptor.firstValue.getApprovalStatus())
+        verify(sellerRepository).save(any())
+    }
+
+    @Test
+    fun apply는_이미_신청한_판매자면_예외가_발생한다() {
+        whenever(userRepository.findNullableById(2L)).thenReturn(com.hoppingmall.user.domain.User.fixture().withId(2L))
+        whenever(sellerRepository.findNullableByUserId(2L)).thenReturn(Seller.fixture())
+
+        assertThrows<SellerAlreadyAppliedException> {
+            sellerCommandService.apply(2L, SellerApplyRequest("111-22-33333"))
+        }
+    }
+
+    @Test
+    fun apply는_사업자번호가_중복이면_예외가_발생한다() {
+        whenever(userRepository.findNullableById(3L)).thenReturn(com.hoppingmall.user.domain.User.fixture().withId(3L))
+        whenever(sellerRepository.findNullableByUserId(3L)).thenReturn(null)
+        whenever(sellerRepository.existsByBusinessNumber("999-88-77777")).thenReturn(true)
+
+        assertThrows<SellerBusinessNumberDuplicateException> {
+            sellerCommandService.apply(3L, SellerApplyRequest("999-88-77777"))
+        }
+    }
+
+    @Test
+    fun apply는_사용자가_없으면_예외가_발생한다() {
+        whenever(userRepository.findNullableById(404L)).thenReturn(null)
+
+        assertThrows<UserNotFoundException> {
+            sellerCommandService.apply(404L, SellerApplyRequest("000-00-00000"))
+        }
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/service/SellerCommandServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/service/SellerCommandServiceImplTest.kt
@@ -9,11 +9,12 @@ import com.hoppingmall.user.exception.seller.SellerBusinessNumberDuplicateExcept
 import com.hoppingmall.user.exception.user.UserNotFoundException
 import com.hoppingmall.user.support.fixture.fixture
 import com.hoppingmall.user.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
@@ -22,10 +23,9 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
-@DisplayName("SellerCommandServiceImpl 단위 테스트")
+@DisplayName("SellerCommandServiceImpl")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class SellerCommandServiceImplTest {
 
@@ -39,7 +39,7 @@ class SellerCommandServiceImplTest {
     private lateinit var sellerCommandService: SellerCommandServiceImpl
 
     @Test
-    fun apply는_판매자_신청에_성공하면_Seller를_저장한다() {
+    fun 판매자_신청_성공_시_Seller를_저장한다() {
         val user = com.hoppingmall.user.domain.User.fixture().withId(1L)
         val sellerCaptor = argumentCaptor<Seller>()
         whenever(userRepository.findNullableById(1L)).thenReturn(user)
@@ -49,39 +49,36 @@ class SellerCommandServiceImplTest {
 
         sellerCommandService.apply(1L, SellerApplyRequest("123-45-67890"))
 
-        assertEquals(1L, sellerCaptor.firstValue.userId)
-        assertEquals("123-45-67890", sellerCaptor.firstValue.businessNumber)
-        assertEquals(Seller.ApprovalStatus.PENDING, sellerCaptor.firstValue.getApprovalStatus())
+        assertThat(sellerCaptor.firstValue.userId).isEqualTo(1L)
+        assertThat(sellerCaptor.firstValue.businessNumber).isEqualTo("123-45-67890")
+        assertThat(sellerCaptor.firstValue.getApprovalStatus()).isEqualTo(Seller.ApprovalStatus.PENDING)
         verify(sellerRepository).save(any())
     }
 
     @Test
-    fun apply는_이미_신청한_판매자면_예외가_발생한다() {
+    fun 이미_신청한_판매자면_예외가_발생한다() {
         whenever(userRepository.findNullableById(2L)).thenReturn(com.hoppingmall.user.domain.User.fixture().withId(2L))
         whenever(sellerRepository.findNullableByUserId(2L)).thenReturn(Seller.fixture())
 
-        assertThrows<SellerAlreadyAppliedException> {
-            sellerCommandService.apply(2L, SellerApplyRequest("111-22-33333"))
-        }
+        assertThatThrownBy { sellerCommandService.apply(2L, SellerApplyRequest("111-22-33333")) }
+            .isInstanceOf(SellerAlreadyAppliedException::class.java)
     }
 
     @Test
-    fun apply는_사업자번호가_중복이면_예외가_발생한다() {
+    fun 사업자번호_중복이면_예외가_발생한다() {
         whenever(userRepository.findNullableById(3L)).thenReturn(com.hoppingmall.user.domain.User.fixture().withId(3L))
         whenever(sellerRepository.findNullableByUserId(3L)).thenReturn(null)
         whenever(sellerRepository.existsByBusinessNumber("999-88-77777")).thenReturn(true)
 
-        assertThrows<SellerBusinessNumberDuplicateException> {
-            sellerCommandService.apply(3L, SellerApplyRequest("999-88-77777"))
-        }
+        assertThatThrownBy { sellerCommandService.apply(3L, SellerApplyRequest("999-88-77777")) }
+            .isInstanceOf(SellerBusinessNumberDuplicateException::class.java)
     }
 
     @Test
-    fun apply는_사용자가_없으면_예외가_발생한다() {
+    fun 사용자가_없으면_예외가_발생한다() {
         whenever(userRepository.findNullableById(404L)).thenReturn(null)
 
-        assertThrows<UserNotFoundException> {
-            sellerCommandService.apply(404L, SellerApplyRequest("000-00-00000"))
-        }
+        assertThatThrownBy { sellerCommandService.apply(404L, SellerApplyRequest("000-00-00000")) }
+            .isInstanceOf(UserNotFoundException::class.java)
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/service/UserCommandServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/service/UserCommandServiceImplTest.kt
@@ -1,0 +1,158 @@
+package com.hoppingmall.user.service
+
+import com.hoppingmall.user.common.enums.Role
+import com.hoppingmall.user.common.vo.Email
+import com.hoppingmall.user.common.vo.Password
+import com.hoppingmall.user.common.vo.PasswordCreator
+import com.hoppingmall.user.common.vo.PasswordPolicy
+import com.hoppingmall.user.domain.User
+import com.hoppingmall.user.domain.enums.MembershipGrade
+import com.hoppingmall.user.domain.repository.UserRepository
+import com.hoppingmall.user.dto.request.SignUpRequest
+import com.hoppingmall.user.dto.request.UpdateUserRequest
+import com.hoppingmall.user.dto.response.MembershipResponse
+import com.hoppingmall.user.exception.user.UserAlreadyExistsException
+import com.hoppingmall.user.exception.user.UserNotFoundException
+import com.hoppingmall.user.support.fixture.fixture
+import com.hoppingmall.user.support.withId
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.security.crypto.password.PasswordEncoder
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("UserCommandServiceImpl 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class UserCommandServiceImplTest {
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @Mock
+    private lateinit var passwordEncoder: PasswordEncoder
+
+    @Mock
+    private lateinit var passwordPolicy: PasswordPolicy
+
+    @Mock
+    private lateinit var userDomainService: UserDomainService
+
+    @Mock
+    private lateinit var membershipCommandService: MembershipCommandService
+
+    private lateinit var userCommandService: UserCommandServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        val passwordCreator = PasswordCreator(passwordEncoder, passwordPolicy)
+        userCommandService = UserCommandServiceImpl(
+            userRepository = userRepository,
+            passwordCreator = passwordCreator,
+            userDomainService = userDomainService,
+            membershipCommandService = membershipCommandService
+        )
+    }
+
+    @Test
+    fun 회원가입_성공_시_사용자를_저장하고_멤버십을_생성한다() {
+        val request = SignUpRequest(
+            email = "signup@example.com",
+            password = "Password1234",
+            name = "홍길동",
+            role = Role.SELLER
+        )
+        val userCaptor = argumentCaptor<User>()
+        whenever(passwordEncoder.encode(request.password)).thenReturn("encoded-password")
+        whenever(userRepository.save(userCaptor.capture())).thenAnswer {
+            userCaptor.firstValue.withId(1L)
+        }
+        whenever(membershipCommandService.createMembership(1L)).thenReturn(
+            MembershipResponse(
+                id = 1L,
+                userId = 1L,
+                grade = MembershipGrade.BRONZE,
+                gradeName = MembershipGrade.BRONZE.gradeName,
+                totalSpent = BigDecimal.ZERO,
+                pointEarningRate = MembershipGrade.BRONZE.pointEarningRate,
+                discountRate = MembershipGrade.BRONZE.discountRate,
+                nextGrade = MembershipGrade.SILVER,
+                amountToNextGrade = MembershipGrade.SILVER.requiredAmount,
+                createdAt = LocalDateTime.now(),
+                updatedAt = null
+            )
+        )
+
+        val response = userCommandService.signUp(request)
+
+        assertEquals(1L, response.id)
+        assertEquals("signup@example.com", response.email)
+        assertEquals("홍길동", response.name)
+        assertEquals(Role.SELLER, response.role)
+        verify(userDomainService).validateNewUser(Email(request.email), request.password)
+        verify(membershipCommandService).createMembership(1L)
+        assertEquals(Email("signup@example.com"), userCaptor.firstValue.email)
+        assertEquals("홍길동", userCaptor.firstValue.getName())
+    }
+
+    @Test
+    fun 회원가입_시_중복_사용자면_예외를_전파한다() {
+        val request = SignUpRequest(
+            email = "duplicate@example.com",
+            password = "Password1234",
+            name = "중복회원",
+            role = Role.BUYER
+        )
+        doThrow(UserAlreadyExistsException()).whenever(userDomainService)
+            .validateNewUser(Email(request.email), request.password)
+
+        assertThrows<UserAlreadyExistsException> {
+            userCommandService.signUp(request)
+        }
+    }
+
+    @Test
+    fun 프로필_수정_시_이름과_비밀번호를_함께_변경한다() {
+        val user = User.fixture().withId(1L)
+        whenever(userRepository.findNullableById(1L)).thenReturn(user)
+        whenever(passwordEncoder.encode("NewPassword1234")).thenReturn("encoded-new-password")
+
+        userCommandService.updateUserProfile(1L, UpdateUserRequest(name = "새이름", password = "NewPassword1234"))
+
+        assertEquals("새이름", user.getName())
+        assertEquals(Password("encoded-new-password"), user.getPassword())
+    }
+
+    @Test
+    fun 프로필_수정_시_비밀번호가_없으면_이름만_변경한다() {
+        val user = User.fixture().withId(2L)
+        val originalPassword = user.getPassword()
+        whenever(userRepository.findNullableById(2L)).thenReturn(user)
+
+        userCommandService.updateUserProfile(2L, UpdateUserRequest(name = "이름만변경", password = null))
+
+        assertEquals("이름만변경", user.getName())
+        assertEquals(originalPassword, user.getPassword())
+    }
+
+    @Test
+    fun 프로필_수정_대상_사용자가_없으면_예외가_발생한다() {
+        whenever(userRepository.findNullableById(999L)).thenReturn(null)
+
+        assertThrows<UserNotFoundException> {
+            userCommandService.updateUserProfile(999L, UpdateUserRequest(name = "없음", password = "Password1234"))
+        }
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/service/UserCommandServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/service/UserCommandServiceImplTest.kt
@@ -6,35 +6,32 @@ import com.hoppingmall.user.common.vo.Password
 import com.hoppingmall.user.common.vo.PasswordCreator
 import com.hoppingmall.user.common.vo.PasswordPolicy
 import com.hoppingmall.user.domain.User
-import com.hoppingmall.user.domain.enums.MembershipGrade
 import com.hoppingmall.user.domain.repository.UserRepository
 import com.hoppingmall.user.dto.request.SignUpRequest
 import com.hoppingmall.user.dto.request.UpdateUserRequest
-import com.hoppingmall.user.dto.response.MembershipResponse
 import com.hoppingmall.user.exception.user.UserAlreadyExistsException
 import com.hoppingmall.user.exception.user.UserNotFoundException
 import com.hoppingmall.user.support.fixture.fixture
 import com.hoppingmall.user.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.security.crypto.password.PasswordEncoder
-import java.math.BigDecimal
-import java.time.LocalDateTime
-import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
-@DisplayName("UserCommandServiceImpl 단위 테스트")
+@DisplayName("UserCommandServiceImpl")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class UserCommandServiceImplTest {
 
@@ -79,32 +76,18 @@ class UserCommandServiceImplTest {
         whenever(userRepository.save(userCaptor.capture())).thenAnswer {
             userCaptor.firstValue.withId(1L)
         }
-        whenever(membershipCommandService.createMembership(1L)).thenReturn(
-            MembershipResponse(
-                id = 1L,
-                userId = 1L,
-                grade = MembershipGrade.BRONZE,
-                gradeName = MembershipGrade.BRONZE.gradeName,
-                totalSpent = BigDecimal.ZERO,
-                pointEarningRate = MembershipGrade.BRONZE.pointEarningRate,
-                discountRate = MembershipGrade.BRONZE.discountRate,
-                nextGrade = MembershipGrade.SILVER,
-                amountToNextGrade = MembershipGrade.SILVER.requiredAmount,
-                createdAt = LocalDateTime.now(),
-                updatedAt = null
-            )
-        )
+        whenever(membershipCommandService.createMembership(1L)).thenReturn(mock())
 
         val response = userCommandService.signUp(request)
 
-        assertEquals(1L, response.id)
-        assertEquals("signup@example.com", response.email)
-        assertEquals("홍길동", response.name)
-        assertEquals(Role.SELLER, response.role)
+        assertThat(response.id).isEqualTo(1L)
+        assertThat(response.email).isEqualTo("signup@example.com")
+        assertThat(response.name).isEqualTo("홍길동")
+        assertThat(response.role).isEqualTo(Role.SELLER)
         verify(userDomainService).validateNewUser(Email(request.email), request.password)
         verify(membershipCommandService).createMembership(1L)
-        assertEquals(Email("signup@example.com"), userCaptor.firstValue.email)
-        assertEquals("홍길동", userCaptor.firstValue.getName())
+        assertThat(userCaptor.firstValue.email).isEqualTo(Email("signup@example.com"))
+        assertThat(userCaptor.firstValue.getName()).isEqualTo("홍길동")
     }
 
     @Test
@@ -118,9 +101,8 @@ class UserCommandServiceImplTest {
         doThrow(UserAlreadyExistsException()).whenever(userDomainService)
             .validateNewUser(Email(request.email), request.password)
 
-        assertThrows<UserAlreadyExistsException> {
-            userCommandService.signUp(request)
-        }
+        assertThatThrownBy { userCommandService.signUp(request) }
+            .isInstanceOf(UserAlreadyExistsException::class.java)
     }
 
     @Test
@@ -131,8 +113,8 @@ class UserCommandServiceImplTest {
 
         userCommandService.updateUserProfile(1L, UpdateUserRequest(name = "새이름", password = "NewPassword1234"))
 
-        assertEquals("새이름", user.getName())
-        assertEquals(Password("encoded-new-password"), user.getPassword())
+        assertThat(user.getName()).isEqualTo("새이름")
+        assertThat(user.getPassword()).isEqualTo(Password("encoded-new-password"))
     }
 
     @Test
@@ -143,16 +125,15 @@ class UserCommandServiceImplTest {
 
         userCommandService.updateUserProfile(2L, UpdateUserRequest(name = "이름만변경", password = null))
 
-        assertEquals("이름만변경", user.getName())
-        assertEquals(originalPassword, user.getPassword())
+        assertThat(user.getName()).isEqualTo("이름만변경")
+        assertThat(user.getPassword()).isEqualTo(originalPassword)
     }
 
     @Test
     fun 프로필_수정_대상_사용자가_없으면_예외가_발생한다() {
         whenever(userRepository.findNullableById(999L)).thenReturn(null)
 
-        assertThrows<UserNotFoundException> {
-            userCommandService.updateUserProfile(999L, UpdateUserRequest(name = "없음", password = "Password1234"))
-        }
+        assertThatThrownBy { userCommandService.updateUserProfile(999L, UpdateUserRequest(name = "없음", password = "Password1234")) }
+            .isInstanceOf(UserNotFoundException::class.java)
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/service/UserDomainServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/service/UserDomainServiceImplTest.kt
@@ -4,11 +4,11 @@ import com.hoppingmall.user.common.vo.Email
 import com.hoppingmall.user.common.vo.PasswordPolicy
 import com.hoppingmall.user.domain.repository.UserRepository
 import com.hoppingmall.user.exception.user.UserAlreadyExistsException
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
@@ -17,7 +17,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @ExtendWith(MockitoExtension::class)
-@DisplayName("UserDomainServiceImpl 단위 테스트")
+@DisplayName("UserDomainServiceImpl")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class UserDomainServiceImplTest {
 
@@ -35,9 +35,8 @@ class UserDomainServiceImplTest {
         val email = Email("duplicate@example.com")
         whenever(userRepository.existsByEmail(email)).thenReturn(true)
 
-        assertThrows<UserAlreadyExistsException> {
-            userDomainService.validateNewUser(email, "Password1234")
-        }
+        assertThatThrownBy { userDomainService.validateNewUser(email, "Password1234") }
+            .isInstanceOf(UserAlreadyExistsException::class.java)
     }
 
     @Test

--- a/user-service/src/test/kotlin/com/hoppingmall/user/service/UserDomainServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/service/UserDomainServiceImplTest.kt
@@ -1,0 +1,52 @@
+package com.hoppingmall.user.service
+
+import com.hoppingmall.user.common.vo.Email
+import com.hoppingmall.user.common.vo.PasswordPolicy
+import com.hoppingmall.user.domain.repository.UserRepository
+import com.hoppingmall.user.exception.user.UserAlreadyExistsException
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("UserDomainServiceImpl 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class UserDomainServiceImplTest {
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @Mock
+    private lateinit var passwordPolicy: PasswordPolicy
+
+    @InjectMocks
+    private lateinit var userDomainService: UserDomainServiceImpl
+
+    @Test
+    fun 이미_존재하는_이메일이면_예외가_발생한다() {
+        val email = Email("duplicate@example.com")
+        whenever(userRepository.existsByEmail(email)).thenReturn(true)
+
+        assertThrows<UserAlreadyExistsException> {
+            userDomainService.validateNewUser(email, "Password1234")
+        }
+    }
+
+    @Test
+    fun 신규_이메일이면_비밀번호_정책을_검증한다() {
+        val email = Email("new@example.com")
+        whenever(userRepository.existsByEmail(email)).thenReturn(false)
+
+        userDomainService.validateNewUser(email, "Password1234")
+
+        verify(passwordPolicy).validate("Password1234")
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/service/UserQueryServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/service/UserQueryServiceImplTest.kt
@@ -11,22 +11,22 @@ import com.hoppingmall.user.exception.user.UserLoginFailedException
 import com.hoppingmall.user.exception.user.UserNotFoundException
 import com.hoppingmall.user.support.fixture.fixture
 import com.hoppingmall.user.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.security.crypto.password.PasswordEncoder
-import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
-@DisplayName("UserQueryServiceImpl 단위 테스트")
+@DisplayName("UserQueryServiceImpl")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class UserQueryServiceImplTest {
 
@@ -47,7 +47,7 @@ class UserQueryServiceImplTest {
     }
 
     @Test
-    fun authenticate는_이메일과_비밀번호가_정상이면_사용자를_반환한다() {
+    fun 이메일과_비밀번호가_정상이면_사용자를_반환한다() {
         val user = com.hoppingmall.user.domain.User.fixture(
             email = Email("login@example.com"),
             password = Password("encoded-password"),
@@ -58,22 +58,21 @@ class UserQueryServiceImplTest {
 
         val result = userQueryService.authenticate(SignInRequest(user.email.value, "Password1234"))
 
-        assertEquals(1L, result.id)
-        assertEquals(user.email, result.email)
-        assertEquals(Role.BUYER, result.getRole())
+        assertThat(result.id).isEqualTo(1L)
+        assertThat(result.email).isEqualTo(user.email)
+        assertThat(result.getRole()).isEqualTo(Role.BUYER)
     }
 
     @Test
-    fun authenticate는_사용자가_없으면_예외가_발생한다() {
+    fun 사용자가_없으면_로그인_예외가_발생한다() {
         whenever(userRepository.findByEmail(Email("missing@example.com"))).thenReturn(null)
 
-        assertThrows<UserLoginFailedException> {
-            userQueryService.authenticate(SignInRequest("missing@example.com", "Password1234"))
-        }
+        assertThatThrownBy { userQueryService.authenticate(SignInRequest("missing@example.com", "Password1234")) }
+            .isInstanceOf(UserLoginFailedException::class.java)
     }
 
     @Test
-    fun authenticate는_비밀번호가_다르면_예외가_발생한다() {
+    fun 비밀번호가_다르면_예외가_발생한다() {
         val user = com.hoppingmall.user.domain.User.fixture(
             email = Email("wrong-password@example.com"),
             password = Password("encoded-password")
@@ -81,31 +80,29 @@ class UserQueryServiceImplTest {
         whenever(userRepository.findByEmail(user.email)).thenReturn(user)
         whenever(passwordEncoder.matches("WrongPassword1234", "encoded-password")).thenReturn(false)
 
-        assertThrows<PasswordNotMatchedException> {
-            userQueryService.authenticate(SignInRequest(user.email.value, "WrongPassword1234"))
-        }
+        assertThatThrownBy { userQueryService.authenticate(SignInRequest(user.email.value, "WrongPassword1234")) }
+            .isInstanceOf(PasswordNotMatchedException::class.java)
     }
 
     @Test
-    fun getUserProfile은_사용자가_있으면_프로필을_반환한다() {
+    fun 사용자가_있으면_프로필을_반환한다() {
         val user = com.hoppingmall.user.domain.User.fixture(role = Role.SELLER).withId(3L)
         whenever(userRepository.findNullableById(3L)).thenReturn(user)
 
         val result = userQueryService.getUserProfile(3L)
 
-        assertEquals(3L, result.id)
-        assertEquals(user.email.value, result.email)
-        assertEquals(user.getName(), result.name)
-        assertEquals(Role.SELLER.name, result.role)
+        assertThat(result.id).isEqualTo(3L)
+        assertThat(result.email).isEqualTo(user.email.value)
+        assertThat(result.name).isEqualTo(user.getName())
+        assertThat(result.role).isEqualTo(Role.SELLER.name)
     }
 
     @Test
-    fun getUserProfile은_사용자가_없으면_예외가_발생한다() {
+    fun 사용자가_없으면_프로필_조회_예외가_발생한다() {
         whenever(userRepository.findNullableById(404L)).thenReturn(null)
 
-        assertThrows<UserNotFoundException> {
-            userQueryService.getUserProfile(404L)
-        }
+        assertThatThrownBy { userQueryService.getUserProfile(404L) }
+            .isInstanceOf(UserNotFoundException::class.java)
 
         verify(userRepository).findNullableById(404L)
     }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/service/UserQueryServiceImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/service/UserQueryServiceImplTest.kt
@@ -1,0 +1,112 @@
+package com.hoppingmall.user.service
+
+import com.hoppingmall.user.common.enums.Role
+import com.hoppingmall.user.common.vo.Email
+import com.hoppingmall.user.common.vo.Password
+import com.hoppingmall.user.common.vo.PasswordNotMatchedException
+import com.hoppingmall.user.common.vo.PasswordVerifier
+import com.hoppingmall.user.domain.repository.UserRepository
+import com.hoppingmall.user.dto.request.SignInRequest
+import com.hoppingmall.user.exception.user.UserLoginFailedException
+import com.hoppingmall.user.exception.user.UserNotFoundException
+import com.hoppingmall.user.support.fixture.fixture
+import com.hoppingmall.user.support.withId
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.security.crypto.password.PasswordEncoder
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("UserQueryServiceImpl 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class UserQueryServiceImplTest {
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @Mock
+    private lateinit var passwordEncoder: PasswordEncoder
+
+    private lateinit var userQueryService: UserQueryServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        userQueryService = UserQueryServiceImpl(
+            userRepository = userRepository,
+            passwordVerifier = PasswordVerifier(passwordEncoder)
+        )
+    }
+
+    @Test
+    fun authenticate는_이메일과_비밀번호가_정상이면_사용자를_반환한다() {
+        val user = com.hoppingmall.user.domain.User.fixture(
+            email = Email("login@example.com"),
+            password = Password("encoded-password"),
+            role = Role.BUYER
+        ).withId(1L)
+        whenever(userRepository.findByEmail(user.email)).thenReturn(user)
+        whenever(passwordEncoder.matches("Password1234", "encoded-password")).thenReturn(true)
+
+        val result = userQueryService.authenticate(SignInRequest(user.email.value, "Password1234"))
+
+        assertEquals(1L, result.id)
+        assertEquals(user.email, result.email)
+        assertEquals(Role.BUYER, result.getRole())
+    }
+
+    @Test
+    fun authenticate는_사용자가_없으면_예외가_발생한다() {
+        whenever(userRepository.findByEmail(Email("missing@example.com"))).thenReturn(null)
+
+        assertThrows<UserLoginFailedException> {
+            userQueryService.authenticate(SignInRequest("missing@example.com", "Password1234"))
+        }
+    }
+
+    @Test
+    fun authenticate는_비밀번호가_다르면_예외가_발생한다() {
+        val user = com.hoppingmall.user.domain.User.fixture(
+            email = Email("wrong-password@example.com"),
+            password = Password("encoded-password")
+        ).withId(2L)
+        whenever(userRepository.findByEmail(user.email)).thenReturn(user)
+        whenever(passwordEncoder.matches("WrongPassword1234", "encoded-password")).thenReturn(false)
+
+        assertThrows<PasswordNotMatchedException> {
+            userQueryService.authenticate(SignInRequest(user.email.value, "WrongPassword1234"))
+        }
+    }
+
+    @Test
+    fun getUserProfile은_사용자가_있으면_프로필을_반환한다() {
+        val user = com.hoppingmall.user.domain.User.fixture(role = Role.SELLER).withId(3L)
+        whenever(userRepository.findNullableById(3L)).thenReturn(user)
+
+        val result = userQueryService.getUserProfile(3L)
+
+        assertEquals(3L, result.id)
+        assertEquals(user.email.value, result.email)
+        assertEquals(user.getName(), result.name)
+        assertEquals(Role.SELLER.name, result.role)
+    }
+
+    @Test
+    fun getUserProfile은_사용자가_없으면_예외가_발생한다() {
+        whenever(userRepository.findNullableById(404L)).thenReturn(null)
+
+        assertThrows<UserNotFoundException> {
+            userQueryService.getUserProfile(404L)
+        }
+
+        verify(userRepository).findNullableById(404L)
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/service/strategy/SellerApprovalCommandTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/service/strategy/SellerApprovalCommandTest.kt
@@ -3,15 +3,15 @@ package com.hoppingmall.user.service.strategy
 import com.hoppingmall.user.domain.Seller
 import com.hoppingmall.user.exception.seller.SellerInvalidApprovalCommandException
 import com.hoppingmall.user.support.fixture.fixture
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
-import kotlin.test.assertEquals
 
-@DisplayName("SellerApprovalCommand 단위 테스트")
+@DisplayName("SellerApprovalCommand")
 @DisplayNameGeneration(ReplaceUnderscores::class)
 class SellerApprovalCommandTest {
 
@@ -28,7 +28,7 @@ class SellerApprovalCommandTest {
 
         mapper.getCommand(Seller.ApprovalStatus.APPROVED).execute(seller)
 
-        assertEquals(Seller.ApprovalStatus.APPROVED, seller.getApprovalStatus())
+        assertThat(seller.getApprovalStatus()).isEqualTo(Seller.ApprovalStatus.APPROVED)
     }
 
     @Test
@@ -37,13 +37,12 @@ class SellerApprovalCommandTest {
 
         mapper.getCommand(Seller.ApprovalStatus.REJECTED).execute(seller)
 
-        assertEquals(Seller.ApprovalStatus.REJECTED, seller.getApprovalStatus())
+        assertThat(seller.getApprovalStatus()).isEqualTo(Seller.ApprovalStatus.REJECTED)
     }
 
     @Test
     fun PENDING은_유효한_커맨드가_아니라_예외가_발생한다() {
-        assertThrows<SellerInvalidApprovalCommandException> {
-            mapper.getCommand(Seller.ApprovalStatus.PENDING)
-        }
+        assertThatThrownBy { mapper.getCommand(Seller.ApprovalStatus.PENDING) }
+            .isInstanceOf(SellerInvalidApprovalCommandException::class.java)
     }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/service/strategy/SellerApprovalCommandTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/service/strategy/SellerApprovalCommandTest.kt
@@ -1,0 +1,49 @@
+package com.hoppingmall.user.service.strategy
+
+import com.hoppingmall.user.domain.Seller
+import com.hoppingmall.user.exception.seller.SellerInvalidApprovalCommandException
+import com.hoppingmall.user.support.fixture.fixture
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+@DisplayName("SellerApprovalCommand 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class SellerApprovalCommandTest {
+
+    private lateinit var mapper: SellerApprovalCommandMapper
+
+    @BeforeEach
+    fun setUp() {
+        mapper = SellerApprovalCommandMapper(ApproveSellerCommand(), RejectSellerCommand())
+    }
+
+    @Test
+    fun APPROVED_전략은_판매자_상태를_승인으로_변경한다() {
+        val seller = Seller.fixture()
+
+        mapper.getCommand(Seller.ApprovalStatus.APPROVED).execute(seller)
+
+        assertEquals(Seller.ApprovalStatus.APPROVED, seller.getApprovalStatus())
+    }
+
+    @Test
+    fun REJECTED_전략은_판매자_상태를_거절로_변경한다() {
+        val seller = Seller.fixture()
+
+        mapper.getCommand(Seller.ApprovalStatus.REJECTED).execute(seller)
+
+        assertEquals(Seller.ApprovalStatus.REJECTED, seller.getApprovalStatus())
+    }
+
+    @Test
+    fun PENDING은_유효한_커맨드가_아니라_예외가_발생한다() {
+        assertThrows<SellerInvalidApprovalCommandException> {
+            mapper.getCommand(Seller.ApprovalStatus.PENDING)
+        }
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/support/TestEntityExtensions.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/support/TestEntityExtensions.kt
@@ -1,0 +1,16 @@
+package com.hoppingmall.user.support
+
+fun <T : Any> T.withId(id: Long): T {
+    var clazz: Class<*>? = this::class.java
+    while (clazz != null) {
+        try {
+            val field = clazz.getDeclaredField("id")
+            field.trySetAccessible()
+            field.set(this, id)
+            return this
+        } catch (_: NoSuchFieldException) {
+            clazz = clazz.superclass
+        }
+    }
+    throw IllegalStateException("Field 'id' not found in ${this::class.java}")
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/support/TestEntityExtensions.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/support/TestEntityExtensions.kt
@@ -1,16 +1,8 @@
 package com.hoppingmall.user.support
 
+import org.springframework.test.util.ReflectionTestUtils
+
 fun <T : Any> T.withId(id: Long): T {
-    var clazz: Class<*>? = this::class.java
-    while (clazz != null) {
-        try {
-            val field = clazz.getDeclaredField("id")
-            field.trySetAccessible()
-            field.set(this, id)
-            return this
-        } catch (_: NoSuchFieldException) {
-            clazz = clazz.superclass
-        }
-    }
-    throw IllegalStateException("Field 'id' not found in ${this::class.java}")
+    ReflectionTestUtils.setField(this, "id", id)
+    return this
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/support/fixture/BuyerFixture.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/support/fixture/BuyerFixture.kt
@@ -1,0 +1,18 @@
+package com.hoppingmall.user.support.fixture
+
+import com.hoppingmall.user.common.enums.Role
+import com.hoppingmall.user.common.vo.Email
+import com.hoppingmall.user.common.vo.Password
+import com.hoppingmall.user.domain.Buyer
+import com.hoppingmall.user.domain.User
+import com.hoppingmall.user.support.withId
+
+fun Buyer.Companion.fixture(): Buyer {
+    val user = User.fixture(
+        email = Email("buyer@example.com"),
+        password = Password("encoded-password"),
+        name = "구매자",
+        role = Role.BUYER
+    ).withId(1L)
+    return Buyer.create(user)
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/support/fixture/BuyerFixture.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/support/fixture/BuyerFixture.kt
@@ -7,12 +7,14 @@ import com.hoppingmall.user.domain.Buyer
 import com.hoppingmall.user.domain.User
 import com.hoppingmall.user.support.withId
 
-fun Buyer.Companion.fixture(): Buyer {
+fun Buyer.Companion.fixture(
+    userId: Long = 1L
+): Buyer {
     val user = User.fixture(
         email = Email("buyer@example.com"),
         password = Password("encoded-password"),
         name = "구매자",
         role = Role.BUYER
-    ).withId(1L)
+    ).withId(userId)
     return Buyer.create(user)
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/support/fixture/MembershipFixture.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/support/fixture/MembershipFixture.kt
@@ -1,0 +1,17 @@
+package com.hoppingmall.user.support.fixture
+
+import com.hoppingmall.user.domain.Membership
+import com.hoppingmall.user.domain.enums.MembershipGrade
+import com.hoppingmall.user.support.withId
+import java.math.BigDecimal
+
+fun Membership.Companion.fixture(
+    id: Long = 1L,
+    userId: Long = 1L,
+    grade: MembershipGrade = MembershipGrade.BRONZE,
+    totalSpent: BigDecimal = BigDecimal.ZERO
+): Membership = Membership(
+    userId = userId,
+    grade = grade,
+    totalSpent = totalSpent
+).withId(id)

--- a/user-service/src/test/kotlin/com/hoppingmall/user/support/fixture/SellerFixture.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/support/fixture/SellerFixture.kt
@@ -8,6 +8,7 @@ import com.hoppingmall.user.domain.User
 import com.hoppingmall.user.support.withId
 
 fun Seller.Companion.fixture(
+    userId: Long = 1L,
     businessNumber: String = "123-45-67890"
 ): Seller {
     val user = User.fixture(
@@ -15,6 +16,6 @@ fun Seller.Companion.fixture(
         password = Password("encoded-password"),
         name = "판매자",
         role = Role.SELLER
-    ).withId(1L)
+    ).withId(userId)
     return Seller.create(user, businessNumber)
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/support/fixture/SellerFixture.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/support/fixture/SellerFixture.kt
@@ -1,0 +1,20 @@
+package com.hoppingmall.user.support.fixture
+
+import com.hoppingmall.user.common.enums.Role
+import com.hoppingmall.user.common.vo.Email
+import com.hoppingmall.user.common.vo.Password
+import com.hoppingmall.user.domain.Seller
+import com.hoppingmall.user.domain.User
+import com.hoppingmall.user.support.withId
+
+fun Seller.Companion.fixture(
+    businessNumber: String = "123-45-67890"
+): Seller {
+    val user = User.fixture(
+        email = Email("seller@example.com"),
+        password = Password("encoded-password"),
+        name = "판매자",
+        role = Role.SELLER
+    ).withId(1L)
+    return Seller.create(user, businessNumber)
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/support/fixture/UserFixture.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/support/fixture/UserFixture.kt
@@ -1,0 +1,13 @@
+package com.hoppingmall.user.support.fixture
+
+import com.hoppingmall.user.common.enums.Role
+import com.hoppingmall.user.common.vo.Email
+import com.hoppingmall.user.common.vo.Password
+import com.hoppingmall.user.domain.User
+
+fun User.Companion.fixture(
+    email: Email = Email("user@example.com"),
+    password: Password = Password("encoded-password"),
+    name: String = "테스트유저",
+    role: Role = Role.BUYER
+): User = User.create(email = email, password = password, name = name, role = role)


### PR DESCRIPTION
Closes #316

### 📌 작업 개요
user-service에서 유실된 service/domain/controller 단위 테스트를 복구하고,
프로젝트 컨벤션(AssertJ, 한글 메서드명, @Mock 경계)에 맞게 정비했습니다.

---

### ✅ 주요 변경 사항

- `user.support`
  - `TestEntityExtensions`: ReflectionTestUtils 기반 id 주입 (Java 21 호환)
  - `UserFixture`, `SellerFixture`, `BuyerFixture`, `MembershipFixture`: fixture 확장 함수 추가, userId 파라미터화

- `user.auth`
  - `AuthControllerTest`: 토큰 재발급/로그아웃 컨트롤러 위임 테스트
  - `AuthServiceImplTest`: 로그인/리프레시/로그아웃 서비스 테스트 (AccessTokenBlacklistRepository @Mock)
  - `RefreshTokenServiceImplTest`: 토큰 회전/검증/삭제 테스트 (RefreshTokenRepository @Mock)

- `user.service`
  - `UserCommandServiceImplTest`, `UserDomainServiceImplTest`, `UserQueryServiceImplTest`: 회원가입, 로그인 검증, 프로필 수정 테스트
  - `MembershipCommandServiceImplTest`, `MembershipQueryServiceImplTest`: 멤버십 생성/누적/조회 테스트
  - `SellerCommandServiceImplTest`, `AdminCommandServiceImplTest`, `SellerApprovalCommandTest`: 판매자 신청/승인 전략 테스트

- `user.domain`, `user.controller`, `user.internal`
  - `UserCompanionTest`, `UserTest`, `MembershipTest`, `SellerTest`, `BuyerTest`: 도메인 상태 전이 테스트
  - `UserControllerTest`, `MembershipControllerTest`, `SellerControllerTest`, `AdminControllerTest`, `InternalUserControllerTest`: 요청 위임 및 응답 매핑 테스트

- 컨벤션 통일
  - AssertJ assertion 라이브러리 통일 (kotlin.test → assertThat/assertThatThrownBy)
  - 메서드명 한글 스네이크케이스 통일
  - @DisplayName suffix 제거 (기존 서비스 패턴과 일치)

---

### 🧪 테스트

- `cd user-service && ./gradlew test` 79개 전체 통과

---

### 📎 관련 이슈
- #316
- restore.md 테스트 코드 유실 (User 도메인 테스트 ~20개) 복구
