### PR TITLE
test: hoppingmall-dlq 공유 모듈 단위 테스트 복구

### DIFF
--- a/hoppingmall-dlq/build.gradle.kts
+++ b/hoppingmall-dlq/build.gradle.kts
@@ -34,4 +34,12 @@ dependencies {
 	compileOnly("org.springframework.kafka:spring-kafka")
 	compileOnly("io.micrometer:micrometer-core")
 	compileOnly("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
+
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
+	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.withType<Test> {
+	useJUnitPlatform()
 }

--- a/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/controller/DLQControllerTest.kt
+++ b/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/controller/DLQControllerTest.kt
@@ -1,0 +1,164 @@
+package com.hoppingmall.dlq.controller
+
+import com.hoppingmall.dlq.domain.DLQMessage
+import com.hoppingmall.dlq.domain.DLQStatus
+import com.hoppingmall.dlq.service.DLQCommandService
+import com.hoppingmall.dlq.service.DLQQueryService
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+
+@DisplayName("DLQController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class DLQControllerTest {
+
+    private val dlqCommandService: DLQCommandService = mock()
+    private val dlqQueryService: DLQQueryService = mock()
+    private val controller = DLQController(dlqCommandService, dlqQueryService)
+
+    @Nested
+    @DisplayName("getDLQStats")
+    inner class GetDLQStats {
+
+        @Test
+        fun DLQ_통계_조회_성공() {
+            val expectedStats = mapOf(
+                "totalMessages" to 100L,
+                "pendingCount" to 50L,
+                "processedCount" to 30L,
+                "failedCount" to 20L
+            )
+            whenever(dlqQueryService.getDLQStats()).thenReturn(expectedStats)
+
+            val response = controller.getDLQStats()
+
+            assertEquals("SUCCESS", response.code)
+            assertEquals(100L, response.data!!["totalMessages"])
+            assertEquals(50L, response.data!!["pendingCount"])
+            verify(dlqQueryService).getDLQStats()
+        }
+    }
+
+    @Nested
+    @DisplayName("getDLQMessages")
+    inner class GetDLQMessages {
+
+        @Test
+        fun 토픽별_DLQ_메시지_조회_성공() {
+            val topic = "payment"
+            val dlqMessages = listOf(createDLQMessage(topic = topic))
+            val expectedPage = PageImpl(dlqMessages, PageRequest.of(0, 20), 1)
+            whenever(dlqQueryService.getDLQMessages(topic, 0, 20)).thenReturn(expectedPage)
+
+            val response = controller.getDLQMessages(topic, 0, 20)
+
+            assertEquals("SUCCESS", response.code)
+            assertEquals(1, response.data!!.totalElements)
+            verify(dlqQueryService).getDLQMessages(topic, 0, 20)
+        }
+    }
+
+    @Nested
+    @DisplayName("getDLQMessagesByStatus")
+    inner class GetDLQMessagesByStatus {
+
+        @Test
+        fun 상태별_DLQ_메시지_조회_성공() {
+            val status = DLQStatus.PENDING
+            val dlqMessages = listOf(createDLQMessage(status = status))
+            val expectedPage = PageImpl(dlqMessages, PageRequest.of(0, 20), 1)
+            whenever(dlqQueryService.getDLQMessagesByStatus(status, 0, 20)).thenReturn(expectedPage)
+
+            val response = controller.getDLQMessagesByStatus(status, 0, 20)
+
+            assertEquals("SUCCESS", response.code)
+            assertEquals(1, response.data!!.totalElements)
+            verify(dlqQueryService).getDLQMessagesByStatus(status, 0, 20)
+        }
+    }
+
+    @Nested
+    @DisplayName("retryDLQMessage")
+    inner class RetryDLQMessage {
+
+        @Test
+        fun 개별_DLQ_메시지_재처리_성공() {
+            val messageId = 123L
+            whenever(dlqCommandService.retryDLQMessage(messageId)).thenReturn(true)
+
+            val response = controller.retryDLQMessage(messageId)
+
+            assertEquals("SUCCESS", response.code)
+            verify(dlqCommandService).retryDLQMessage(messageId)
+        }
+    }
+
+    @Nested
+    @DisplayName("retryDLQMessages")
+    inner class RetryDLQMessages {
+
+        @Test
+        fun 토픽별_DLQ_메시지_일괄_재처리_성공() {
+            val topic = "payment"
+            val maxCount = 30
+            val expectedResult = mapOf(
+                "topic" to topic,
+                "totalAttempted" to 10,
+                "successCount" to 8,
+                "failureCount" to 2
+            )
+            whenever(dlqCommandService.retryDLQMessagesByTopic(topic, maxCount)).thenReturn(expectedResult)
+
+            val response = controller.retryDLQMessages(topic, maxCount)
+
+            assertEquals("SUCCESS", response.code)
+            verify(dlqCommandService).retryDLQMessagesByTopic(topic, maxCount)
+        }
+    }
+
+    @Nested
+    @DisplayName("clearProcessedDLQMessages")
+    inner class ClearProcessedDLQMessages {
+
+        @Test
+        fun 처리_완료된_DLQ_메시지_삭제_성공() {
+            val topic = "payment"
+            val deletedCount = 25L
+            whenever(dlqCommandService.clearProcessedDLQMessages(topic)).thenReturn(deletedCount)
+
+            val response = controller.clearProcessedDLQMessages(topic)
+
+            assertEquals("SUCCESS", response.code)
+            verify(dlqCommandService).clearProcessedDLQMessages(topic)
+        }
+    }
+
+    private fun createDLQMessage(
+        topic: String = "test-topic",
+        partition: Int = 0,
+        offset: Long = 1000L,
+        key: String? = "test-key",
+        value: String? = "test-value",
+        exception: String? = "Test exception",
+        timestamp: Long = System.currentTimeMillis(),
+        status: DLQStatus = DLQStatus.PENDING
+    ): DLQMessage {
+        return DLQMessage(
+            originalTopic = topic,
+            originalPartition = partition,
+            originalOffset = offset,
+            originalKey = key,
+            originalValue = value,
+            exceptionMessage = exception,
+            errorTimestamp = timestamp
+        ).apply { this.status = status }
+    }
+}

--- a/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/domain/DLQMessageTest.kt
+++ b/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/domain/DLQMessageTest.kt
@@ -1,0 +1,224 @@
+package com.hoppingmall.dlq.domain
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("DLQMessage")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class DLQMessageTest {
+
+    @Nested
+    @DisplayName("incrementRetry")
+    inner class IncrementRetry {
+
+        @Test
+        fun 재시도_카운트를_증가시키고_상태를_RETRYING으로_변경한다() {
+            val dlqMessage = createDLQMessage()
+            val originalRetryCount = dlqMessage.retryCount
+
+            dlqMessage.incrementRetry()
+
+            assertEquals(originalRetryCount + 1, dlqMessage.retryCount)
+            assertEquals(DLQStatus.RETRYING, dlqMessage.status)
+            assertNotNull(dlqMessage.lastRetryAt)
+        }
+
+        @Test
+        fun 여러번_호출하면_재시도_카운트가_누적된다() {
+            val dlqMessage = createDLQMessage()
+
+            dlqMessage.incrementRetry()
+            dlqMessage.incrementRetry()
+            dlqMessage.incrementRetry()
+
+            assertEquals(3, dlqMessage.retryCount)
+            assertEquals(DLQStatus.RETRYING, dlqMessage.status)
+        }
+    }
+
+    @Nested
+    @DisplayName("markAsProcessed")
+    inner class MarkAsProcessed {
+
+        @Test
+        fun 상태를_PROCESSED로_변경하고_처리_시간을_설정한다() {
+            val dlqMessage = createDLQMessage()
+            val notes = "수동 재처리 성공"
+
+            dlqMessage.markAsProcessed(notes)
+
+            assertEquals(DLQStatus.PROCESSED, dlqMessage.status)
+            assertEquals(notes, dlqMessage.notes)
+            assertNotNull(dlqMessage.processedAt)
+        }
+
+        @Test
+        fun notes_없이도_처리_완료_처리가_가능하다() {
+            val dlqMessage = createDLQMessage()
+
+            dlqMessage.markAsProcessed()
+
+            assertEquals(DLQStatus.PROCESSED, dlqMessage.status)
+            assertNull(dlqMessage.notes)
+            assertNotNull(dlqMessage.processedAt)
+        }
+    }
+
+    @Nested
+    @DisplayName("markAsFailed")
+    inner class MarkAsFailed {
+
+        @Test
+        fun 상태를_FAILED로_변경하고_노트를_설정한다() {
+            val dlqMessage = createDLQMessage()
+            val notes = "최대 재시도 횟수 초과"
+
+            dlqMessage.markAsFailed(notes)
+
+            assertEquals(DLQStatus.FAILED, dlqMessage.status)
+            assertEquals(notes, dlqMessage.notes)
+        }
+    }
+
+    @Nested
+    @DisplayName("getMessageKey")
+    inner class GetMessageKey {
+
+        @Test
+        fun 토픽_파티션_오프셋으로_유니크_키를_생성한다() {
+            val dlqMessage = createDLQMessage(
+                topic = "payment",
+                partition = 0,
+                offset = 12345L
+            )
+
+            val messageKey = dlqMessage.getMessageKey()
+
+            assertEquals("payment:0:12345", messageKey)
+        }
+
+        @Test
+        fun 서로_다른_메시지는_다른_키를_가진다() {
+            val dlqMessage1 = createDLQMessage(topic = "payment", partition = 0, offset = 100L)
+            val dlqMessage2 = createDLQMessage(topic = "payment", partition = 0, offset = 101L)
+            val dlqMessage3 = createDLQMessage(topic = "order", partition = 0, offset = 100L)
+
+            assertNotEquals(dlqMessage1.getMessageKey(), dlqMessage2.getMessageKey())
+            assertNotEquals(dlqMessage1.getMessageKey(), dlqMessage3.getMessageKey())
+        }
+    }
+
+    @Nested
+    @DisplayName("scheduleNextRetry")
+    inner class ScheduleNextRetry {
+
+        @Test
+        fun 다음_재시도를_스케줄링하고_상태를_PENDING으로_변경한다() {
+            val dlqMessage = createDLQMessage()
+            dlqMessage.incrementRetry()
+            assertEquals(DLQStatus.RETRYING, dlqMessage.status)
+
+            dlqMessage.scheduleNextRetry()
+
+            assertEquals(DLQStatus.PENDING, dlqMessage.status)
+            assertNotNull(dlqMessage.nextRetryAt)
+        }
+    }
+
+    @Nested
+    @DisplayName("isNonRetryableException")
+    inner class IsNonRetryableException {
+
+        @Test
+        fun DeserializationException이_포함된_에러는_비재시도로_판별한다() {
+            val dlqMessage = createDLQMessage(exception = "org.apache.kafka.common.errors.DeserializationException: Error")
+
+            assertTrue(dlqMessage.isNonRetryableException())
+        }
+
+        @Test
+        fun IllegalArgumentException이_포함된_에러는_비재시도로_판별한다() {
+            val dlqMessage = createDLQMessage(exception = "java.lang.IllegalArgumentException: Invalid value")
+
+            assertTrue(dlqMessage.isNonRetryableException())
+        }
+
+        @Test
+        fun 일반_런타임_에러는_재시도_가능으로_판별한다() {
+            val dlqMessage = createDLQMessage(exception = "java.net.SocketTimeoutException: Connection timed out")
+
+            assertFalse(dlqMessage.isNonRetryableException())
+        }
+
+        @Test
+        fun 예외_메시지가_null이면_재시도_가능으로_판별한다() {
+            val dlqMessage = createDLQMessage(exception = null)
+
+            assertFalse(dlqMessage.isNonRetryableException())
+        }
+    }
+
+    @Nested
+    @DisplayName("calculateNextRetryAt")
+    inner class CalculateNextRetryAt {
+
+        @Test
+        fun 재시도_횟수에_따라_백오프_간격이_증가한다() {
+            val before = System.currentTimeMillis()
+            val firstRetry = DLQMessage.calculateNextRetryAt(0)
+            val secondRetry = DLQMessage.calculateNextRetryAt(1)
+            val thirdRetry = DLQMessage.calculateNextRetryAt(2)
+
+            assertTrue(firstRetry >= before + 60_000L)
+            assertTrue(secondRetry >= before + 300_000L)
+            assertTrue(thirdRetry >= before + 1_800_000L)
+        }
+
+        @Test
+        fun 최대_인덱스를_초과해도_마지막_간격을_사용한다() {
+            val before = System.currentTimeMillis()
+            val retryAt = DLQMessage.calculateNextRetryAt(10)
+
+            assertTrue(retryAt >= before + 1_800_000L)
+        }
+    }
+
+    @Nested
+    @DisplayName("incrementRetry with nextRetryAt")
+    inner class IncrementRetryWithNextRetryAt {
+
+        @Test
+        fun 재시도_증가_시_nextRetryAt도_설정된다() {
+            val dlqMessage = createDLQMessage()
+
+            dlqMessage.incrementRetry()
+
+            assertNotNull(dlqMessage.nextRetryAt)
+            assertTrue(dlqMessage.nextRetryAt!! > System.currentTimeMillis())
+        }
+    }
+
+    private fun createDLQMessage(
+        topic: String = "test-topic",
+        partition: Int = 0,
+        offset: Long = 1000L,
+        key: String? = "test-key",
+        value: String? = "test-value",
+        exception: String? = "Test exception",
+        timestamp: Long = System.currentTimeMillis()
+    ): DLQMessage {
+        return DLQMessage(
+            originalTopic = topic,
+            originalPartition = partition,
+            originalOffset = offset,
+            originalKey = key,
+            originalValue = value,
+            exceptionMessage = exception,
+            errorTimestamp = timestamp
+        )
+    }
+}

--- a/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/service/DLQCommandServiceTest.kt
+++ b/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/service/DLQCommandServiceTest.kt
@@ -1,0 +1,378 @@
+package com.hoppingmall.dlq.service
+
+import com.hoppingmall.dlq.domain.DLQMessage
+import com.hoppingmall.dlq.domain.DLQStatus
+import com.hoppingmall.dlq.domain.DeadLetterMessage
+import com.hoppingmall.dlq.domain.repository.DLQMessageRepository
+import com.hoppingmall.dlq.metrics.DLQMetrics
+import com.hoppingmall.dlq.publisher.DLQMessagePublisher
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.util.*
+
+@DisplayName("DLQCommandService")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class DLQCommandServiceTest {
+
+    private val dlqMessageRepository: DLQMessageRepository = mock()
+    private val dlqMessagePublisher: DLQMessagePublisher = mock()
+    private val dlqMetrics: DLQMetrics = mock()
+    private val dlqCommandService = DLQCommandService(dlqMessageRepository, dlqMessagePublisher, dlqMetrics)
+
+    @Nested
+    @DisplayName("saveDLQMessage")
+    inner class SaveDLQMessage {
+
+        @Test
+        fun 중복되지_않은_DLQ_메시지를_저장한다() {
+            val deadLetterMessage = createDeadLetterMessage()
+            whenever(dlqMessageRepository.existsByOriginalTopicAndOriginalPartitionAndOriginalOffset(
+                deadLetterMessage.originalTopic,
+                deadLetterMessage.originalPartition,
+                deadLetterMessage.originalOffset
+            )).thenReturn(false)
+
+            dlqCommandService.saveDLQMessage(deadLetterMessage)
+
+            verify(dlqMessageRepository).save(any<DLQMessage>())
+            verify(dlqMetrics).recordDlqSaved(deadLetterMessage.originalTopic)
+        }
+
+        @Test
+        fun 비재시도_에러는_즉시_FAILED로_저장한다() {
+            val deadLetterMessage = createDeadLetterMessage(
+                exception = "org.apache.kafka.common.errors.DeserializationException: Error"
+            )
+            whenever(dlqMessageRepository.existsByOriginalTopicAndOriginalPartitionAndOriginalOffset(
+                deadLetterMessage.originalTopic,
+                deadLetterMessage.originalPartition,
+                deadLetterMessage.originalOffset
+            )).thenReturn(false)
+
+            dlqCommandService.saveDLQMessage(deadLetterMessage)
+
+            verify(dlqMessageRepository).save(argThat<DLQMessage> {
+                this.status == DLQStatus.FAILED && this.nextRetryAt == null
+            })
+            verify(dlqMetrics, never()).recordDlqSaved(any())
+        }
+
+        @Test
+        fun 재시도_가능한_에러는_nextRetryAt을_설정하여_저장한다() {
+            val deadLetterMessage = createDeadLetterMessage(
+                exception = "java.net.SocketTimeoutException: Connection timed out"
+            )
+            whenever(dlqMessageRepository.existsByOriginalTopicAndOriginalPartitionAndOriginalOffset(
+                deadLetterMessage.originalTopic,
+                deadLetterMessage.originalPartition,
+                deadLetterMessage.originalOffset
+            )).thenReturn(false)
+
+            dlqCommandService.saveDLQMessage(deadLetterMessage)
+
+            verify(dlqMessageRepository).save(argThat<DLQMessage> {
+                this.status == DLQStatus.PENDING && this.nextRetryAt != null
+            })
+        }
+
+        @Test
+        fun 중복된_DLQ_메시지는_저장하지_않는다() {
+            val deadLetterMessage = createDeadLetterMessage()
+            whenever(dlqMessageRepository.existsByOriginalTopicAndOriginalPartitionAndOriginalOffset(
+                deadLetterMessage.originalTopic,
+                deadLetterMessage.originalPartition,
+                deadLetterMessage.originalOffset
+            )).thenReturn(true)
+
+            dlqCommandService.saveDLQMessage(deadLetterMessage)
+
+            verify(dlqMessageRepository, never()).save(any<DLQMessage>())
+        }
+    }
+
+    @Nested
+    @DisplayName("retryDLQMessage")
+    inner class RetryDLQMessage {
+
+        @Test
+        fun PENDING_상태의_메시지를_성공적으로_재처리한다() {
+            val dlqMessageId = 1L
+            val dlqMessage = createDLQMessage(
+                id = dlqMessageId,
+                status = DLQStatus.PENDING,
+                retryCount = 1
+            )
+
+            whenever(dlqMessageRepository.findById(dlqMessageId))
+                .thenReturn(Optional.of(dlqMessage))
+            whenever(dlqMessagePublisher.publish(any(), any(), any()))
+                .thenReturn(true)
+
+            val result = dlqCommandService.retryDLQMessage(dlqMessageId)
+
+            assertTrue(result)
+            verify(dlqMessagePublisher).publish(
+                eq(dlqMessage.originalTopic),
+                eq(dlqMessage.originalKey ?: ""),
+                any()
+            )
+            verify(dlqMessageRepository, atLeast(2)).save(dlqMessage)
+            assertEquals(DLQStatus.PROCESSED, dlqMessage.status)
+            verify(dlqMetrics).recordDlqRetrySuccess()
+        }
+
+        @Test
+        fun 존재하지_않는_메시지_ID로_재처리_시_false를_반환한다() {
+            val dlqMessageId = 999L
+            whenever(dlqMessageRepository.findById(dlqMessageId))
+                .thenReturn(Optional.empty())
+
+            val result = dlqCommandService.retryDLQMessage(dlqMessageId)
+
+            assertFalse(result)
+            verify(dlqMessagePublisher, never()).publish(any(), any(), any())
+        }
+
+        @Test
+        fun PENDING이_아닌_상태의_메시지는_재처리하지_않는다() {
+            val dlqMessageId = 1L
+            val dlqMessage = createDLQMessage(
+                id = dlqMessageId,
+                status = DLQStatus.PROCESSED
+            )
+
+            whenever(dlqMessageRepository.findById(dlqMessageId))
+                .thenReturn(Optional.of(dlqMessage))
+
+            val result = dlqCommandService.retryDLQMessage(dlqMessageId)
+
+            assertFalse(result)
+            verify(dlqMessagePublisher, never()).publish(any(), any(), any())
+        }
+
+        @Test
+        fun 최대_재시도_횟수를_초과한_메시지는_FAILED로_처리한다() {
+            val dlqMessageId = 1L
+            val dlqMessage = createDLQMessage(
+                id = dlqMessageId,
+                status = DLQStatus.PENDING,
+                retryCount = 3
+            )
+
+            whenever(dlqMessageRepository.findById(dlqMessageId))
+                .thenReturn(Optional.of(dlqMessage))
+
+            val result = dlqCommandService.retryDLQMessage(dlqMessageId)
+
+            assertFalse(result)
+            assertEquals(DLQStatus.FAILED, dlqMessage.status)
+            verify(dlqMessagePublisher, never()).publish(any(), any(), any())
+            verify(dlqMessageRepository).save(dlqMessage)
+        }
+
+        @Test
+        fun Publisher가_false를_반환하면_다음_재시도를_스케줄링한다() {
+            val dlqMessageId = 1L
+            val dlqMessage = createDLQMessage(
+                id = dlqMessageId,
+                status = DLQStatus.PENDING,
+                retryCount = 1
+            )
+
+            whenever(dlqMessageRepository.findById(dlqMessageId))
+                .thenReturn(Optional.of(dlqMessage))
+            whenever(dlqMessagePublisher.publish(any(), any(), any()))
+                .thenReturn(false)
+
+            val result = dlqCommandService.retryDLQMessage(dlqMessageId)
+
+            assertFalse(result)
+            assertEquals(DLQStatus.PENDING, dlqMessage.status)
+            assertNotNull(dlqMessage.nextRetryAt)
+        }
+
+        @Test
+        fun 발행_예외_시_재시도_가능하면_다음_재시도를_스케줄링한다() {
+            val dlqMessageId = 1L
+            val dlqMessage = createDLQMessage(
+                id = dlqMessageId,
+                status = DLQStatus.PENDING,
+                retryCount = 1
+            )
+
+            whenever(dlqMessageRepository.findById(dlqMessageId))
+                .thenReturn(Optional.of(dlqMessage))
+            whenever(dlqMessagePublisher.publish(any(), any(), any()))
+                .thenThrow(RuntimeException("Kafka 전송 실패"))
+
+            val result = dlqCommandService.retryDLQMessage(dlqMessageId)
+
+            assertFalse(result)
+            verify(dlqMetrics).recordDlqRetryFailed()
+        }
+
+        @Test
+        fun 발행_예외_시_최대_재시도_초과하면_FAILED로_처리한다() {
+            val dlqMessageId = 1L
+            val dlqMessage = createDLQMessage(
+                id = dlqMessageId,
+                status = DLQStatus.PENDING,
+                retryCount = 2
+            )
+
+            whenever(dlqMessageRepository.findById(dlqMessageId))
+                .thenReturn(Optional.of(dlqMessage))
+            whenever(dlqMessagePublisher.publish(any(), any(), any()))
+                .thenThrow(RuntimeException("Kafka 전송 실패"))
+
+            val result = dlqCommandService.retryDLQMessage(dlqMessageId)
+
+            assertFalse(result)
+            verify(dlqMetrics).recordDlqRetryFailed()
+        }
+    }
+
+    @Nested
+    @DisplayName("retryDLQMessagesByTopic")
+    inner class RetryDLQMessagesByTopic {
+
+        @Test
+        fun 토픽별_DLQ_메시지를_일괄_재처리한다() {
+            val topic = "payment"
+            val maxCount = 50
+            val dlqMessage1 = createDLQMessage(id = 1L, topic = topic, status = DLQStatus.PENDING)
+            val dlqMessage2 = createDLQMessage(id = 2L, topic = topic, status = DLQStatus.PENDING)
+            val pendingMessages = PageImpl(listOf(dlqMessage1, dlqMessage2))
+
+            whenever(dlqMessageRepository.findByOriginalTopicAndStatusOrderByCreatedAtDesc(
+                eq(topic), eq(DLQStatus.PENDING), any()
+            )).thenReturn(pendingMessages)
+
+            whenever(dlqMessageRepository.findById(1L)).thenReturn(Optional.of(dlqMessage1))
+            whenever(dlqMessageRepository.findById(2L)).thenReturn(Optional.of(dlqMessage2))
+            whenever(dlqMessagePublisher.publish(any(), any(), any())).thenReturn(true)
+
+            val result = dlqCommandService.retryDLQMessagesByTopic(topic, maxCount)
+
+            assertEquals(topic, result["topic"])
+            assertEquals(2, result["totalAttempted"])
+            assertEquals(2, result["successCount"])
+            assertEquals(0, result["failureCount"])
+        }
+    }
+
+    @Nested
+    @DisplayName("clearProcessedDLQMessages")
+    inner class ClearProcessedDLQMessages {
+
+        @Test
+        fun 처리_완료된_DLQ_메시지들을_삭제한다() {
+            val topic = "payment"
+            val processedMessage1 = createDLQMessage(topic = topic, status = DLQStatus.PROCESSED)
+            val processedMessage2 = createDLQMessage(topic = topic, status = DLQStatus.PROCESSED)
+            val processedMessages = PageImpl(listOf(processedMessage1, processedMessage2))
+
+            whenever(dlqMessageRepository.findByOriginalTopicAndStatusOrderByCreatedAtDesc(
+                eq(topic), eq(DLQStatus.PROCESSED), any()
+            )).thenReturn(processedMessages)
+
+            val deletedCount = dlqCommandService.clearProcessedDLQMessages(topic)
+
+            assertEquals(2, deletedCount)
+            verify(dlqMessageRepository).deleteAll(processedMessages.content)
+        }
+    }
+
+    @Nested
+    @DisplayName("reconstructOriginalMessage")
+    inner class ReconstructOriginalMessage {
+
+        @Test
+        fun JSON_객체_형태의_원본_메시지를_그대로_반환한다() {
+            val dlqMessage = createDLQMessage(value = """{"orderId": 1}""")
+
+            val result = dlqCommandService.reconstructOriginalMessage(dlqMessage)
+
+            assertEquals("""{"orderId": 1}""", result)
+        }
+
+        @Test
+        fun JSON_배열_형태의_원본_메시지를_그대로_반환한다() {
+            val dlqMessage = createDLQMessage(value = """[1, 2, 3]""")
+
+            val result = dlqCommandService.reconstructOriginalMessage(dlqMessage)
+
+            assertEquals("""[1, 2, 3]""", result)
+        }
+
+        @Test
+        fun null_값은_null을_반환한다() {
+            val dlqMessage = createDLQMessage(value = null)
+
+            val result = dlqCommandService.reconstructOriginalMessage(dlqMessage)
+
+            assertNull(result)
+        }
+    }
+
+    private fun createDeadLetterMessage(
+        topic: String = "test-topic",
+        partition: Int = 0,
+        offset: Long = 1000L,
+        key: String? = "test-key",
+        value: String? = "test-value",
+        exception: String? = "Test exception",
+        timestamp: Long = System.currentTimeMillis()
+    ): DeadLetterMessage {
+        return DeadLetterMessage(
+            originalTopic = topic,
+            originalPartition = partition,
+            originalOffset = offset,
+            originalKey = key,
+            originalValue = value,
+            exception = exception,
+            timestamp = timestamp
+        )
+    }
+
+    private fun createDLQMessage(
+        id: Long? = 1L,
+        topic: String = "test-topic",
+        partition: Int = 0,
+        offset: Long = 1000L,
+        key: String? = "test-key",
+        value: String? = "test-value",
+        exception: String? = "Test exception",
+        timestamp: Long = System.currentTimeMillis(),
+        status: DLQStatus = DLQStatus.PENDING,
+        retryCount: Int = 0
+    ): DLQMessage {
+        val dlqMessage = DLQMessage(
+            originalTopic = topic,
+            originalPartition = partition,
+            originalOffset = offset,
+            originalKey = key,
+            originalValue = value,
+            exceptionMessage = exception,
+            errorTimestamp = timestamp
+        ).apply {
+            this.status = status
+            this.retryCount = retryCount
+        }
+
+        id?.let {
+            val idField = DLQMessage::class.java.superclass.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(dlqMessage, it)
+        }
+
+        return dlqMessage
+    }
+}

--- a/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/service/DLQQueryServiceTest.kt
+++ b/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/service/DLQQueryServiceTest.kt
@@ -1,0 +1,153 @@
+package com.hoppingmall.dlq.service
+
+import com.hoppingmall.dlq.domain.DLQMessage
+import com.hoppingmall.dlq.domain.DLQStatus
+import com.hoppingmall.dlq.domain.repository.DLQMessageRepository
+import com.hoppingmall.dlq.domain.repository.DLQStatsProjection
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+
+@DisplayName("DLQQueryService")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class DLQQueryServiceTest {
+
+    private val dlqMessageRepository: DLQMessageRepository = mock()
+    private val dlqQueryService = DLQQueryService(dlqMessageRepository)
+
+    @Nested
+    @DisplayName("getDLQMessages")
+    inner class GetDLQMessages {
+
+        @Test
+        fun 토픽별_DLQ_메시지를_페이징하여_조회한다() {
+            val topic = "payment"
+            val page = 0
+            val size = 20
+            val expectedMessages = listOf(createDLQMessage(topic = topic))
+            val expectedPage = PageImpl(expectedMessages, PageRequest.of(page, size), 1)
+
+            whenever(dlqMessageRepository.findByOriginalTopicOrderByCreatedAtDesc(
+                eq(topic), any()
+            )).thenReturn(expectedPage)
+
+            val result = dlqQueryService.getDLQMessages(topic, page, size)
+
+            assertEquals(expectedPage, result)
+            verify(dlqMessageRepository).findByOriginalTopicOrderByCreatedAtDesc(
+                eq(topic), eq(PageRequest.of(page, size))
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("getDLQMessagesByStatus")
+    inner class GetDLQMessagesByStatus {
+
+        @Test
+        fun 상태별_DLQ_메시지를_페이징하여_조회한다() {
+            val status = DLQStatus.PENDING
+            val page = 0
+            val size = 20
+            val expectedMessages = listOf(createDLQMessage(status = status))
+            val expectedPage = PageImpl(expectedMessages, PageRequest.of(page, size), 1)
+
+            whenever(dlqMessageRepository.findByStatusOrderByCreatedAtDesc(
+                eq(status), any()
+            )).thenReturn(expectedPage)
+
+            val result = dlqQueryService.getDLQMessagesByStatus(status, page, size)
+
+            assertEquals(expectedPage, result)
+            verify(dlqMessageRepository).findByStatusOrderByCreatedAtDesc(
+                eq(status), eq(PageRequest.of(page, size))
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("getDLQStats")
+    inner class GetDLQStats {
+
+        @Test
+        fun DLQ_통계를_조회한다() {
+            whenever(dlqMessageRepository.count()).thenReturn(10)
+            whenever(dlqMessageRepository.countByStatus(DLQStatus.PENDING)).thenReturn(5)
+            whenever(dlqMessageRepository.countByStatus(DLQStatus.PROCESSED)).thenReturn(3)
+            whenever(dlqMessageRepository.countByStatus(DLQStatus.FAILED)).thenReturn(2)
+            whenever(dlqMessageRepository.getDLQStatsByTopic()).thenReturn(emptyList())
+
+            val stats = dlqQueryService.getDLQStats()
+
+            assertEquals(10L, stats["totalMessages"])
+            assertEquals(5L, stats["pendingCount"])
+            assertEquals(3L, stats["processedCount"])
+            assertEquals(2L, stats["failedCount"])
+            assertNotNull(stats["lastUpdated"])
+            assertNotNull(stats["topicStats"])
+        }
+
+        @Test
+        fun 토픽별_통계를_포함하여_조회한다() {
+            whenever(dlqMessageRepository.count()).thenReturn(5)
+            whenever(dlqMessageRepository.countByStatus(DLQStatus.PENDING)).thenReturn(3)
+            whenever(dlqMessageRepository.countByStatus(DLQStatus.PROCESSED)).thenReturn(1)
+            whenever(dlqMessageRepository.countByStatus(DLQStatus.FAILED)).thenReturn(1)
+
+            val topicStats = listOf(
+                object : DLQStatsProjection {
+                    override val topic = "payment"
+                    override val totalCount = 3L
+                    override val pendingCount = 2L
+                    override val processedCount = 1L
+                    override val failedCount = 0L
+                },
+                object : DLQStatsProjection {
+                    override val topic = "order"
+                    override val totalCount = 2L
+                    override val pendingCount = 1L
+                    override val processedCount = 0L
+                    override val failedCount = 1L
+                }
+            )
+            whenever(dlqMessageRepository.getDLQStatsByTopic()).thenReturn(topicStats)
+
+            val stats = dlqQueryService.getDLQStats()
+
+            @Suppress("UNCHECKED_CAST")
+            val resultTopicStats = stats["topicStats"] as List<Map<String, Any>>
+            assertEquals(2, resultTopicStats.size)
+            assertEquals("payment", resultTopicStats[0]["topic"])
+            assertEquals(3L, resultTopicStats[0]["total"])
+            assertEquals("order", resultTopicStats[1]["topic"])
+            assertEquals(2L, resultTopicStats[1]["total"])
+        }
+    }
+
+    private fun createDLQMessage(
+        topic: String = "test-topic",
+        partition: Int = 0,
+        offset: Long = 1000L,
+        key: String? = "test-key",
+        value: String? = "test-value",
+        exception: String? = "Test exception",
+        timestamp: Long = System.currentTimeMillis(),
+        status: DLQStatus = DLQStatus.PENDING
+    ): DLQMessage {
+        return DLQMessage(
+            originalTopic = topic,
+            originalPartition = partition,
+            originalOffset = offset,
+            originalKey = key,
+            originalValue = value,
+            exceptionMessage = exception,
+            errorTimestamp = timestamp
+        ).apply { this.status = status }
+    }
+}

--- a/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/service/DLQSchedulerTest.kt
+++ b/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/service/DLQSchedulerTest.kt
@@ -1,0 +1,113 @@
+package com.hoppingmall.dlq.service
+
+import com.hoppingmall.dlq.domain.DLQMessage
+import com.hoppingmall.dlq.domain.DLQStatus
+import com.hoppingmall.dlq.domain.repository.DLQMessageRepository
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+
+@DisplayName("DLQScheduler")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class DLQSchedulerTest {
+
+    private val dlqMessageRepository: DLQMessageRepository = mock()
+    private val dlqCommandService: DLQCommandService = mock()
+    private val dlqScheduler = DLQScheduler(dlqMessageRepository, dlqCommandService)
+
+    @Nested
+    @DisplayName("autoRetryPendingMessages")
+    inner class AutoRetryPendingMessages {
+
+        @Test
+        fun 재시도_대상_메시지를_자동으로_재처리한다() {
+            val dlqMessage = createDLQMessage(
+                id = 1L,
+                status = DLQStatus.PENDING,
+                retryCount = 0
+            ).apply { nextRetryAt = System.currentTimeMillis() - 1000 }
+
+            val page = PageImpl(listOf(dlqMessage))
+            whenever(dlqMessageRepository.findAutoRetryableMessages(
+                eq(DLQStatus.PENDING), eq(3), any(), any()
+            )).thenReturn(page)
+            whenever(dlqCommandService.retryDLQMessage(1L)).thenReturn(true)
+
+            dlqScheduler.autoRetryPendingMessages()
+
+            verify(dlqCommandService).retryDLQMessage(1L)
+        }
+
+        @Test
+        fun 재시도_대상이_없으면_아무_작업도_하지_않는다() {
+            whenever(dlqMessageRepository.findAutoRetryableMessages(
+                eq(DLQStatus.PENDING), eq(3), any(), any()
+            )).thenReturn(Page.empty())
+
+            dlqScheduler.autoRetryPendingMessages()
+
+            verify(dlqCommandService, never()).retryDLQMessage(any())
+        }
+
+        @Test
+        fun 여러_메시지를_배치로_재처리한다() {
+            val dlqMessage1 = createDLQMessage(id = 1L, status = DLQStatus.PENDING, retryCount = 0)
+            val dlqMessage2 = createDLQMessage(id = 2L, status = DLQStatus.PENDING, retryCount = 1)
+            val dlqMessage3 = createDLQMessage(id = 3L, status = DLQStatus.PENDING, retryCount = 2)
+
+            val page = PageImpl(listOf(dlqMessage1, dlqMessage2, dlqMessage3))
+            whenever(dlqMessageRepository.findAutoRetryableMessages(
+                eq(DLQStatus.PENDING), eq(3), any(), any()
+            )).thenReturn(page)
+            whenever(dlqCommandService.retryDLQMessage(1L)).thenReturn(true)
+            whenever(dlqCommandService.retryDLQMessage(2L)).thenReturn(true)
+            whenever(dlqCommandService.retryDLQMessage(3L)).thenReturn(false)
+
+            dlqScheduler.autoRetryPendingMessages()
+
+            verify(dlqCommandService).retryDLQMessage(1L)
+            verify(dlqCommandService).retryDLQMessage(2L)
+            verify(dlqCommandService).retryDLQMessage(3L)
+        }
+    }
+
+    private fun createDLQMessage(
+        id: Long? = 1L,
+        topic: String = "test-topic",
+        partition: Int = 0,
+        offset: Long = 1000L,
+        key: String? = "test-key",
+        value: String? = "test-value",
+        exception: String? = "Test exception",
+        timestamp: Long = System.currentTimeMillis(),
+        status: DLQStatus = DLQStatus.PENDING,
+        retryCount: Int = 0
+    ): DLQMessage {
+        val dlqMessage = DLQMessage(
+            originalTopic = topic,
+            originalPartition = partition,
+            originalOffset = offset,
+            originalKey = key,
+            originalValue = value,
+            exceptionMessage = exception,
+            errorTimestamp = timestamp
+        ).apply {
+            this.status = status
+            this.retryCount = retryCount
+        }
+
+        id?.let {
+            val idField = DLQMessage::class.java.superclass.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(dlqMessage, it)
+        }
+
+        return dlqMessage
+    }
+}


### PR DESCRIPTION
Closes #318

### 📌 작업 개요
멀티모듈 전환(#152) 시 유실된 hoppingmall-dlq 공유 모듈의 단위 테스트를 복구합니다.
모놀리스 DLQService가 DLQCommandService/DLQQueryService/DLQScheduler로 분리된 구조에 맞게 테스트를 재구성하였습니다.

---

### ✅ 주요 변경 사항

- `dlq.domain`
  - `DLQMessageTest`: 엔티티 메서드 단위 테스트 13개 케이스 (incrementRetry, markAsProcessed, markAsFailed, getMessageKey, scheduleNextRetry, isNonRetryableException, calculateNextRetryAt)

- `dlq.service`
  - `DLQCommandServiceTest`: 저장/재처리/일괄재처리/삭제/메시지복원 14개 케이스 (KafkaTemplate → DLQMessagePublisher 인터페이스 전환 반영)
  - `DLQQueryServiceTest`: 토픽별/상태별 조회, 통계 조회 4개 케이스
  - `DLQSchedulerTest`: 자동 재처리 스케줄러 3개 케이스

- `dlq.controller`
  - `DLQControllerTest`: 관리자 API 6개 엔드포인트 (stats, messages, retry, clear)

- `build.gradle.kts`
  - 테스트 의존성 추가 (spring-boot-starter-test, mockito-kotlin, junit-platform-launcher)

---

### 🧪 테스트

- `./gradlew test` (hoppingmall-dlq) 44개 테스트 전체 통과

---

### 📎 관련 이슈
- #318
