### PR TITLE
test: hoppingmall-outbox 공유 모듈 단위 테스트 복구

### DIFF
--- a/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/domain/OutboxEventTest.kt
+++ b/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/domain/OutboxEventTest.kt
@@ -1,0 +1,138 @@
+package com.hoppingmall.outbox.domain
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("OutboxEvent")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class OutboxEventTest {
+
+    @Nested
+    @DisplayName("생성")
+    inner class Creation {
+
+        @Test
+        fun OutboxEvent_생성_시_기본_상태는_PENDING이다() {
+            val event = createOutboxEvent()
+
+            assertEquals("Payment", event.aggregateType)
+            assertEquals("123", event.aggregateId)
+            assertEquals("PaymentCompleted", event.eventType)
+            assertEquals("payment", event.topic)
+            assertEquals("order-123", event.partitionKey)
+            assertEquals(OutboxStatus.PENDING, event.status)
+            assertFalse(event.processed)
+            assertEquals(0, event.retryCount)
+            assertNull(event.processedAt)
+            assertNull(event.errorMessage)
+        }
+
+        @Test
+        fun partitionKey_없이_생성할_수_있다() {
+            val event = createOutboxEvent(partitionKey = null)
+
+            assertNull(event.partitionKey)
+            assertEquals(OutboxStatus.PENDING, event.status)
+        }
+    }
+
+    @Nested
+    @DisplayName("markAsProcessed")
+    inner class MarkAsProcessed {
+
+        @Test
+        fun 상태를_PUBLISHED로_변경하고_처리_시간을_설정한다() {
+            val event = createOutboxEvent()
+
+            event.markAsProcessed()
+
+            assertEquals(OutboxStatus.PUBLISHED, event.status)
+            assertTrue(event.processed)
+            assertNotNull(event.processedAt)
+        }
+    }
+
+    @Nested
+    @DisplayName("markAsFailed")
+    inner class MarkAsFailed {
+
+        @Test
+        fun 상태를_FAILED로_변경하고_재시도_카운트를_증가시킨다() {
+            val event = createOutboxEvent()
+
+            event.markAsFailed("Connection timeout")
+
+            assertEquals(OutboxStatus.FAILED, event.status)
+            assertEquals(1, event.retryCount)
+            assertEquals("Connection timeout", event.errorMessage)
+            assertFalse(event.processed)
+        }
+
+        @Test
+        fun 여러번_호출하면_재시도_카운트가_누적된다() {
+            val event = createOutboxEvent()
+
+            event.markAsFailed("error 1")
+            event.markAsFailed("error 2")
+            event.markAsFailed("error 3")
+
+            assertEquals(3, event.retryCount)
+            assertEquals("error 3", event.errorMessage)
+        }
+    }
+
+    @Nested
+    @DisplayName("markAsFailedPermanently")
+    inner class MarkAsFailedPermanently {
+
+        @Test
+        fun 상태를_FAILED로_변경하고_processed를_true로_설정한다() {
+            val event = createOutboxEvent()
+
+            event.markAsFailedPermanently("최대 재시도 초과")
+
+            assertEquals(OutboxStatus.FAILED, event.status)
+            assertTrue(event.processed)
+            assertNotNull(event.processedAt)
+            assertEquals(1, event.retryCount)
+            assertEquals("최대 재시도 초과", event.errorMessage)
+        }
+    }
+
+    @Nested
+    @DisplayName("markAsRetrying")
+    inner class MarkAsRetrying {
+
+        @Test
+        fun 상태를_RETRYING으로_변경한다() {
+            val event = createOutboxEvent()
+
+            event.markAsRetrying()
+
+            assertEquals(OutboxStatus.RETRYING, event.status)
+            assertFalse(event.processed)
+        }
+    }
+
+    private fun createOutboxEvent(
+        aggregateType: String = "Payment",
+        aggregateId: String = "123",
+        eventType: String = "PaymentCompleted",
+        eventData: String = """{"key": "value"}""",
+        topic: String = "payment",
+        partitionKey: String? = "order-123"
+    ): OutboxEvent {
+        return OutboxEvent(
+            aggregateType = aggregateType,
+            aggregateId = aggregateId,
+            eventType = eventType,
+            eventData = eventData,
+            topic = topic,
+            partitionKey = partitionKey
+        )
+    }
+}

--- a/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/service/OutboxEventServiceTest.kt
+++ b/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/service/OutboxEventServiceTest.kt
@@ -1,0 +1,140 @@
+package com.hoppingmall.outbox.service
+
+import com.hoppingmall.outbox.domain.OutboxEvent
+import com.hoppingmall.outbox.domain.OutboxStatus
+import com.hoppingmall.outbox.repository.OutboxEventRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@DisplayName("OutboxEventService")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class OutboxEventServiceTest {
+
+    @Mock
+    private lateinit var outboxEventRepository: OutboxEventRepository
+
+    @Mock
+    private lateinit var outboxEventWriter: OutboxEventWriter
+
+    @InjectMocks
+    private lateinit var outboxEventService: OutboxEventService
+
+    @Nested
+    @DisplayName("saveEvent")
+    inner class SaveEvent {
+
+        @Test
+        fun OutboxEventWriter에_이벤트_저장을_위임한다() {
+            val eventData = mapOf("orderId" to 123, "amount" to 50000)
+
+            outboxEventService.saveEvent(
+                aggregateType = "Payment",
+                aggregateId = "123",
+                eventType = "PaymentCompleted",
+                eventData = eventData,
+                topic = "payment",
+                partitionKey = "order-123"
+            )
+
+            verify(outboxEventWriter).saveEvent(
+                aggregateType = "Payment",
+                aggregateId = "123",
+                eventType = "PaymentCompleted",
+                eventData = eventData,
+                topic = "payment",
+                partitionKey = "order-123"
+            )
+        }
+
+        @Test
+        fun partitionKey_없이_저장을_위임한다() {
+            val eventData = mapOf("orderId" to 456)
+
+            outboxEventService.saveEvent(
+                aggregateType = "Order",
+                aggregateId = "456",
+                eventType = "OrderCreated",
+                eventData = eventData,
+                topic = "order-events"
+            )
+
+            verify(outboxEventWriter).saveEvent(
+                aggregateType = "Order",
+                aggregateId = "456",
+                eventType = "OrderCreated",
+                eventData = eventData,
+                topic = "order-events",
+                partitionKey = null
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("getEventsByAggregateId")
+    inner class GetEventsByAggregateId {
+
+        @Test
+        fun aggregateId와_aggregateType으로_이벤트를_조회한다() {
+            val event = OutboxEvent(
+                aggregateType = "Payment",
+                aggregateId = "123",
+                eventType = "PaymentCompleted",
+                eventData = """{"amount": 10000}""",
+                topic = "payment"
+            )
+            whenever(outboxEventRepository.findByAggregateIdAndType("123", "Payment"))
+                .thenReturn(listOf(event))
+
+            val result = outboxEventService.getEventsByAggregateId("123", "Payment")
+
+            assertEquals(1, result.size)
+            assertEquals("PaymentCompleted", result.first().eventType)
+            verify(outboxEventRepository).findByAggregateIdAndType("123", "Payment")
+        }
+
+        @Test
+        fun 결과가_없으면_빈_리스트를_반환한다() {
+            whenever(outboxEventRepository.findByAggregateIdAndType("999", "Payment"))
+                .thenReturn(emptyList())
+
+            val result = outboxEventService.getEventsByAggregateId("999", "Payment")
+
+            assertEquals(0, result.size)
+        }
+    }
+
+    @Nested
+    @DisplayName("getEventStats")
+    inner class GetEventStats {
+
+        @Test
+        fun 상태별_통계를_조회한다() {
+            whenever(outboxEventRepository.countByStatus(OutboxStatus.PENDING)).thenReturn(5L)
+            whenever(outboxEventRepository.countByStatus(OutboxStatus.RETRYING)).thenReturn(2L)
+            whenever(outboxEventRepository.countByStatus(OutboxStatus.PUBLISHED)).thenReturn(10L)
+            whenever(outboxEventRepository.countByStatus(OutboxStatus.FAILED)).thenReturn(1L)
+
+            val stats = outboxEventService.getEventStats()
+
+            assertEquals(5L, stats["pending"])
+            assertEquals(2L, stats["retrying"])
+            assertEquals(10L, stats["published"])
+            assertEquals(1L, stats["failed"])
+            verify(outboxEventRepository).countByStatus(OutboxStatus.PENDING)
+            verify(outboxEventRepository).countByStatus(OutboxStatus.RETRYING)
+            verify(outboxEventRepository).countByStatus(OutboxStatus.PUBLISHED)
+            verify(outboxEventRepository).countByStatus(OutboxStatus.FAILED)
+        }
+    }
+}


### PR DESCRIPTION
Closes #320

### 📌 작업 개요
멀티모듈 전환(#152) 시 유실된 hoppingmall-outbox 공유 모듈의 도메인 및 서비스 단위 테스트를 복구합니다.
기존 OutboxEventWriter/OutboxMetrics 테스트에 더해 OutboxEvent 엔티티와 OutboxEventService 테스트를 추가합니다.

---

### ✅ 주요 변경 사항

- `outbox.domain`
  - `OutboxEventTest`: 엔티티 생성, markAsProcessed, markAsFailed, markAsFailedPermanently, markAsRetrying 8개 케이스

- `outbox.service`
  - `OutboxEventServiceTest`: saveEvent 위임 검증, getEventsByAggregateId, getEventStats 5개 케이스

---

### 🧪 테스트

- `../gradlew test` (hoppingmall-outbox) 18개 테스트 전체 통과

---

### 📎 관련 이슈
- #320
