### PR TITLE
feat: product-service mutation 엔드포인트 역할 기반 접근 제어 추가

### DIFF
--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/SecurityConfig.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/SecurityConfig.kt
@@ -5,8 +5,10 @@ import com.hoppingmall.common.config.InternalTokenFilter
 import com.hoppingmall.common.config.GatewayHeaderAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer
 import org.springframework.security.web.SecurityFilterChain
 
 @Configuration
@@ -15,6 +17,25 @@ class SecurityConfig(
     gatewayHeaderAuthenticationFilter: GatewayHeaderAuthenticationFilter,
     internalTokenFilter: InternalTokenFilter
 ) : BaseSecurityConfig(gatewayHeaderAuthenticationFilter, internalTokenFilter) {
+
+    override fun configureServiceEndpoints(
+        auth: AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry
+    ) {
+        auth
+            .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+            .requestMatchers("/api/v1/files/upload").hasAnyRole("SELLER", "ADMIN")
+            .requestMatchers("/api/v1/products/images/upload").hasAnyRole("SELLER", "ADMIN")
+            .requestMatchers(HttpMethod.POST, "/api/v1/products").hasAnyRole("SELLER", "ADMIN")
+            .requestMatchers(HttpMethod.PUT, "/api/v1/products/{productId}").hasAnyRole("SELLER", "ADMIN")
+            .requestMatchers(HttpMethod.DELETE, "/api/v1/products/{productId}").hasAnyRole("SELLER", "ADMIN")
+            .requestMatchers(HttpMethod.POST, "/api/v1/products/bulk/validate").hasAnyRole("SELLER", "ADMIN")
+            .requestMatchers(HttpMethod.POST, "/api/v1/products/bulk/import").hasAnyRole("SELLER", "ADMIN")
+            .requestMatchers(HttpMethod.POST, "/api/v1/inventories").hasAnyRole("SELLER", "ADMIN")
+            .requestMatchers(HttpMethod.PATCH, "/api/v1/inventories/{productId}").hasAnyRole("SELLER", "ADMIN")
+            .requestMatchers(HttpMethod.POST, "/api/v1/categories").hasRole("ADMIN")
+            .requestMatchers(HttpMethod.PUT, "/api/v1/categories/{categoryId}").hasRole("ADMIN")
+            .requestMatchers(HttpMethod.DELETE, "/api/v1/categories/{categoryId}").hasRole("ADMIN")
+    }
 
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {

--- a/product-service/src/test/kotlin/com/hoppingmall/product/category/controller/CategoryControllerSecurityTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/category/controller/CategoryControllerSecurityTest.kt
@@ -1,0 +1,130 @@
+package com.hoppingmall.product.category.controller
+
+import com.hoppingmall.product.category.service.CategoryCommandService
+import com.hoppingmall.product.category.service.CategoryQueryService
+import com.hoppingmall.product.support.TestCacheConfig
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.put
+
+@DisplayName("카테고리 엔드포인트 보안 통합 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@SpringBootTest(properties = ["spring.main.allow-bean-definition-overriding=true"])
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import(TestCacheConfig::class)
+class CategoryControllerSecurityTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var categoryCommandService: CategoryCommandService
+
+    @MockitoBean
+    private lateinit var categoryQueryService: CategoryQueryService
+
+    private val categoryJson = """{"name":"전자기기","parentId":null}"""
+
+    @Nested
+    @DisplayName("POST /api/v1/categories")
+    inner class CreateCategory {
+
+        @Test
+        fun ADMIN_역할로_카테고리_생성_성공() {
+            mockMvc.post("/api/v1/categories") {
+                contentType = MediaType.APPLICATION_JSON
+                content = categoryJson
+                header("X-User-Id", "1")
+                header("x-user-role", "ADMIN")
+            }.andExpect { status { isCreated() } }
+        }
+
+        @Test
+        fun SELLER_역할로_카테고리_생성_시_403_응답() {
+            mockMvc.post("/api/v1/categories") {
+                contentType = MediaType.APPLICATION_JSON
+                content = categoryJson
+                header("X-User-Id", "1")
+                header("x-user-role", "SELLER")
+            }.andExpect { status { isForbidden() } }
+        }
+
+        @Test
+        fun BUYER_역할로_카테고리_생성_시_403_응답() {
+            mockMvc.post("/api/v1/categories") {
+                contentType = MediaType.APPLICATION_JSON
+                content = categoryJson
+                header("X-User-Id", "1")
+                header("x-user-role", "BUYER")
+            }.andExpect { status { isForbidden() } }
+        }
+
+        @Test
+        fun 인증되지_않은_카테고리_생성_요청_시_403_응답() {
+            mockMvc.post("/api/v1/categories") {
+                contentType = MediaType.APPLICATION_JSON
+                content = categoryJson
+            }.andExpect { status { isForbidden() } }
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/categories/{categoryId}")
+    inner class UpdateCategory {
+
+        @Test
+        fun ADMIN_역할로_카테고리_수정_성공() {
+            mockMvc.put("/api/v1/categories/1") {
+                contentType = MediaType.APPLICATION_JSON
+                content = categoryJson
+                header("X-User-Id", "1")
+                header("x-user-role", "ADMIN")
+            }.andExpect { status { isOk() } }
+        }
+
+        @Test
+        fun SELLER_역할로_카테고리_수정_시_403_응답() {
+            mockMvc.put("/api/v1/categories/1") {
+                contentType = MediaType.APPLICATION_JSON
+                content = categoryJson
+                header("X-User-Id", "1")
+                header("x-user-role", "SELLER")
+            }.andExpect { status { isForbidden() } }
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/categories/{categoryId}")
+    inner class DeleteCategory {
+
+        @Test
+        fun ADMIN_역할로_카테고리_삭제_성공() {
+            mockMvc.delete("/api/v1/categories/1") {
+                header("X-User-Id", "1")
+                header("x-user-role", "ADMIN")
+            }.andExpect { status { isNoContent() } }
+        }
+
+        @Test
+        fun SELLER_역할로_카테고리_삭제_시_403_응답() {
+            mockMvc.delete("/api/v1/categories/1") {
+                header("X-User-Id", "1")
+                header("x-user-role", "SELLER")
+            }.andExpect { status { isForbidden() } }
+        }
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/inventory/controller/InventoryControllerSecurityTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/inventory/controller/InventoryControllerSecurityTest.kt
@@ -1,0 +1,120 @@
+package com.hoppingmall.product.inventory.controller
+
+import com.hoppingmall.product.inventory.service.InventoryCommandService
+import com.hoppingmall.product.inventory.service.InventoryQueryService
+import com.hoppingmall.product.support.TestCacheConfig
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.patch
+import org.springframework.test.web.servlet.post
+
+@DisplayName("재고 엔드포인트 보안 통합 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@SpringBootTest(properties = ["spring.main.allow-bean-definition-overriding=true"])
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import(TestCacheConfig::class)
+class InventoryControllerSecurityTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var inventoryCommandService: InventoryCommandService
+
+    @MockitoBean
+    private lateinit var inventoryQueryService: InventoryQueryService
+
+    private val inventoryJson = """{"productId":1,"quantity":100}"""
+
+    @Nested
+    @DisplayName("POST /api/v1/inventories")
+    inner class InitStock {
+
+        @Test
+        fun SELLER_역할로_재고_초기화_성공() {
+            mockMvc.post("/api/v1/inventories") {
+                contentType = MediaType.APPLICATION_JSON
+                content = inventoryJson
+                header("X-User-Id", "1")
+                header("x-user-role", "SELLER")
+            }.andExpect { status { isCreated() } }
+        }
+
+        @Test
+        fun ADMIN_역할로_재고_초기화_성공() {
+            mockMvc.post("/api/v1/inventories") {
+                contentType = MediaType.APPLICATION_JSON
+                content = inventoryJson
+                header("X-User-Id", "1")
+                header("x-user-role", "ADMIN")
+            }.andExpect { status { isCreated() } }
+        }
+
+        @Test
+        fun BUYER_역할로_재고_초기화_시_403_응답() {
+            mockMvc.post("/api/v1/inventories") {
+                contentType = MediaType.APPLICATION_JSON
+                content = inventoryJson
+                header("X-User-Id", "1")
+                header("x-user-role", "BUYER")
+            }.andExpect { status { isForbidden() } }
+        }
+
+        @Test
+        fun 인증되지_않은_재고_초기화_요청_시_403_응답() {
+            mockMvc.post("/api/v1/inventories") {
+                contentType = MediaType.APPLICATION_JSON
+                content = inventoryJson
+            }.andExpect { status { isForbidden() } }
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/v1/inventories/{productId}")
+    inner class UpdateStock {
+
+        private val updateJson = """{"quantity":50}"""
+
+        @Test
+        fun SELLER_역할로_재고_수정_성공() {
+            mockMvc.patch("/api/v1/inventories/1") {
+                contentType = MediaType.APPLICATION_JSON
+                content = updateJson
+                header("X-User-Id", "1")
+                header("x-user-role", "SELLER")
+            }.andExpect { status { isOk() } }
+        }
+
+        @Test
+        fun ADMIN_역할로_재고_수정_성공() {
+            mockMvc.patch("/api/v1/inventories/1") {
+                contentType = MediaType.APPLICATION_JSON
+                content = updateJson
+                header("X-User-Id", "1")
+                header("x-user-role", "ADMIN")
+            }.andExpect { status { isOk() } }
+        }
+
+        @Test
+        fun BUYER_역할로_재고_수정_시_403_응답() {
+            mockMvc.patch("/api/v1/inventories/1") {
+                contentType = MediaType.APPLICATION_JSON
+                content = updateJson
+                header("X-User-Id", "1")
+                header("x-user-role", "BUYER")
+            }.andExpect { status { isForbidden() } }
+        }
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/controller/ProductControllerSecurityTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/controller/ProductControllerSecurityTest.kt
@@ -1,0 +1,194 @@
+package com.hoppingmall.product.product.controller
+
+import com.hoppingmall.product.common.file.FileUploadService
+import com.hoppingmall.product.product.service.BulkImportService
+import com.hoppingmall.product.product.service.ProductCommandService
+import com.hoppingmall.product.product.service.ProductImageService
+import com.hoppingmall.product.product.service.ProductQueryService
+import com.hoppingmall.product.support.TestCacheConfig
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.multipart
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.put
+
+@DisplayName("상품 엔드포인트 보안 통합 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@SpringBootTest(properties = ["spring.main.allow-bean-definition-overriding=true"])
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import(TestCacheConfig::class)
+class ProductControllerSecurityTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var productCommandService: ProductCommandService
+
+    @MockitoBean
+    private lateinit var productQueryService: ProductQueryService
+
+    @MockitoBean
+    private lateinit var productImageService: ProductImageService
+
+    @MockitoBean
+    private lateinit var fileUploadService: FileUploadService
+
+    @MockitoBean
+    private lateinit var bulkImportService: BulkImportService
+
+    private val productJson = """{"name":"test","price":1000,"description":"desc","categoryId":1}"""
+
+    @Nested
+    @DisplayName("POST /api/v1/products")
+    inner class CreateProduct {
+
+        @Test
+        fun SELLER_역할로_상품_생성_성공() {
+            mockMvc.post("/api/v1/products") {
+                contentType = MediaType.APPLICATION_JSON
+                content = productJson
+                header("X-User-Id", "1")
+                header("x-user-role", "SELLER")
+            }.andExpect { status { isOk() } }
+        }
+
+        @Test
+        fun ADMIN_역할로_상품_생성_성공() {
+            mockMvc.post("/api/v1/products") {
+                contentType = MediaType.APPLICATION_JSON
+                content = productJson
+                header("X-User-Id", "1")
+                header("x-user-role", "ADMIN")
+            }.andExpect { status { isOk() } }
+        }
+
+        @Test
+        fun BUYER_역할로_상품_생성_시_403_응답() {
+            mockMvc.post("/api/v1/products") {
+                contentType = MediaType.APPLICATION_JSON
+                content = productJson
+                header("X-User-Id", "1")
+                header("x-user-role", "BUYER")
+            }.andExpect { status { isForbidden() } }
+        }
+
+        @Test
+        fun 인증되지_않은_상품_생성_요청_시_403_응답() {
+            mockMvc.post("/api/v1/products") {
+                contentType = MediaType.APPLICATION_JSON
+                content = productJson
+            }.andExpect { status { isForbidden() } }
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/products/{productId}")
+    inner class UpdateProduct {
+
+        @Test
+        fun SELLER_역할로_상품_수정_성공() {
+            mockMvc.put("/api/v1/products/1") {
+                contentType = MediaType.APPLICATION_JSON
+                content = productJson
+                header("X-User-Id", "1")
+                header("x-user-role", "SELLER")
+            }.andExpect { status { isOk() } }
+        }
+
+        @Test
+        fun BUYER_역할로_상품_수정_시_403_응답() {
+            mockMvc.put("/api/v1/products/1") {
+                contentType = MediaType.APPLICATION_JSON
+                content = productJson
+                header("X-User-Id", "1")
+                header("x-user-role", "BUYER")
+            }.andExpect { status { isForbidden() } }
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/products/{productId}")
+    inner class DeleteProduct {
+
+        @Test
+        fun SELLER_역할로_상품_삭제_성공() {
+            mockMvc.delete("/api/v1/products/1") {
+                header("X-User-Id", "1")
+                header("x-user-role", "SELLER")
+            }.andExpect { status { isOk() } }
+        }
+
+        @Test
+        fun BUYER_역할로_상품_삭제_시_403_응답() {
+            mockMvc.delete("/api/v1/products/1") {
+                header("X-User-Id", "1")
+                header("x-user-role", "BUYER")
+            }.andExpect { status { isForbidden() } }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/products/bulk/validate")
+    inner class BulkValidate {
+
+        private val csvFile = MockMultipartFile("file", "products.csv", "text/csv", "name,price\ntest,1000".toByteArray())
+
+        @Test
+        fun SELLER_역할로_대량_등록_검증_성공() {
+            mockMvc.multipart("/api/v1/products/bulk/validate") {
+                file(csvFile)
+                header("X-User-Id", "1")
+                header("x-user-role", "SELLER")
+            }.andExpect { status { isOk() } }
+        }
+
+        @Test
+        fun BUYER_역할로_대량_등록_검증_시_403_응답() {
+            mockMvc.multipart("/api/v1/products/bulk/validate") {
+                file(csvFile)
+                header("X-User-Id", "1")
+                header("x-user-role", "BUYER")
+            }.andExpect { status { isForbidden() } }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/products/bulk/import")
+    inner class BulkImport {
+
+        private val csvFile = MockMultipartFile("file", "products.csv", "text/csv", "name,price\ntest,1000".toByteArray())
+
+        @Test
+        fun SELLER_역할로_대량_등록_실행_성공() {
+            mockMvc.multipart("/api/v1/products/bulk/import") {
+                file(csvFile)
+                header("X-User-Id", "1")
+                header("x-user-role", "SELLER")
+            }.andExpect { status { isOk() } }
+        }
+
+        @Test
+        fun BUYER_역할로_대량_등록_실행_시_403_응답() {
+            mockMvc.multipart("/api/v1/products/bulk/import") {
+                file(csvFile)
+                header("X-User-Id", "1")
+                header("x-user-role", "BUYER")
+            }.andExpect { status { isForbidden() } }
+        }
+    }
+}


### PR DESCRIPTION
Closes #326

### 📌 작업 개요
product-service의 모든 mutation 엔드포인트에 역할 기반 접근 제어를 추가합니다.
`BaseSecurityConfig.configureServiceEndpoints()` 오버라이드 패턴으로 HTTP 메서드별 제한을 적용하여
GET 엔드포인트는 영향 없이 mutation만 역할 제한합니다.

---

### ✅ 주요 변경 사항

- `product.config`
  - `SecurityConfig`: `configureServiceEndpoints()` 오버라이드, 13개 RBAC 규칙 추가
    - `/api/v1/admin/**` ADMIN 전용 와일드카드 (user-service, settlement-service 패턴 통일)
    - `/api/v1/files/upload`, `/api/v1/products/images/upload` SELLER/ADMIN
    - `POST/PUT/DELETE /api/v1/products/**` SELLER/ADMIN
    - `POST /api/v1/products/bulk/**` SELLER/ADMIN
    - `POST/PATCH /api/v1/inventories/**` SELLER/ADMIN
    - `POST/PUT/DELETE /api/v1/categories/**` ADMIN 전용

---

### 🧪 테스트

- `ProductControllerSecurityTest`: 상품 CRUD + 대량 등록 보안 검증 (12개)
- `CategoryControllerSecurityTest`: 카테고리 ADMIN 전용 접근 검증 (8개)
- `InventoryControllerSecurityTest`: 재고 SELLER/ADMIN 접근 검증 (7개)

---

### 📎 관련 이슈
- #326