### PR TITLE
refactor: Consumer 멱등성 보일러플레이트 공유 템플릿 추출

### DIFF
--- a/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/consumer/IdempotentConsumeTemplate.kt
+++ b/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/consumer/IdempotentConsumeTemplate.kt
@@ -1,0 +1,25 @@
+package com.hoppingmall.common.consumer
+
+import org.slf4j.Logger
+import org.springframework.dao.DataIntegrityViolationException
+
+inline fun executeIdempotently(
+    eventId: String,
+    eventDescription: String,
+    logger: Logger,
+    existsCheck: () -> Boolean,
+    action: () -> Unit
+) {
+    try {
+        if (existsCheck()) {
+            logger.info("이미 처리된 {} 이벤트: eventId={}", eventDescription, eventId)
+            return
+        }
+        action()
+    } catch (e: DataIntegrityViolationException) {
+        logger.info("이미 처리된 {} 이벤트: eventId={}", eventDescription, eventId)
+    } catch (e: Exception) {
+        logger.error("{} 처리 실패: eventId={}, 오류={}", eventDescription, eventId, e.message)
+        throw e
+    }
+}

--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/consumer/NotificationEventConsumer.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/consumer/NotificationEventConsumer.kt
@@ -1,6 +1,8 @@
 package com.hoppingmall.notification.consumer
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.common.KafkaTopics
+import com.hoppingmall.common.consumer.executeIdempotently
 import com.hoppingmall.notification.domain.Notification
 import com.hoppingmall.notification.domain.NotificationRepository
 import com.hoppingmall.notification.dto.response.NotificationResponse
@@ -9,9 +11,7 @@ import com.hoppingmall.notification.service.NotificationSseService
 import com.hoppingmall.notification.service.SseNotificationMessage
 import org.slf4j.LoggerFactory
 import org.springframework.cache.CacheManager
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.redis.core.RedisTemplate
-import com.hoppingmall.common.KafkaTopics
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Service
@@ -47,42 +47,33 @@ class NotificationEventConsumer(
         val content = event["content"]?.toString() ?: return
         val metadata = event["metadata"]?.toString()
 
-        try {
-            if (notificationRepository.existsByEventId(eventId)) {
-                log.info("이미 처리된 알림 이벤트: eventId={}", eventId)
-                return
-            }
-
+        executeIdempotently(
+            eventId = eventId,
+            eventDescription = "알림",
+            logger = log,
+            existsCheck = { notificationRepository.existsByEventId(eventId) }
+        ) {
             val type = try {
                 NotificationType.valueOf(typeStr)
             } catch (e: IllegalArgumentException) {
                 log.warn("알 수 없는 알림 타입: type={}", typeStr)
-                return
+                return@executeIdempotently
             }
 
-            val notification = Notification(
-                eventId = eventId,
-                userId = userId,
-                type = type,
-                title = title,
-                content = content,
-                metadata = metadata
+            val saved = notificationRepository.save(
+                Notification(
+                    eventId = eventId,
+                    userId = userId,
+                    type = type,
+                    title = title,
+                    content = content,
+                    metadata = metadata
+                )
             )
-
-            val saved: Notification
-            try {
-                saved = notificationRepository.save(notification)
-            } catch (e: DataIntegrityViolationException) {
-                log.info("이미 처리된 알림 이벤트: eventId={}", eventId)
-                return
-            }
 
             cacheManager.getCache("unread-count")?.evict(userId)
             publishSseEvent(saved)
             log.info("알림 처리 완료: userId={}, type={}, title={}", userId, type, title)
-        } catch (e: Exception) {
-            log.error("알림 처리 실패: eventId={}, userId={}, 오류={}", eventId, userId, e.message)
-            throw e
         }
     }
 

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/PaymentEventConsumer.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/PaymentEventConsumer.kt
@@ -1,12 +1,12 @@
 package com.hoppingmall.payment.payment.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.common.consumer.executeIdempotently
 import com.hoppingmall.payment.payment.domain.PaymentEventLog
 import com.hoppingmall.payment.payment.domain.repository.PaymentEventLogRepository
 import com.hoppingmall.payment.payment.dto.event.PaymentCompletedEvent
 import com.hoppingmall.payment.payment.service.strategy.PaymentMethodProcessorRegistry
 import org.slf4j.LoggerFactory
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Service
 
@@ -22,34 +22,22 @@ class PaymentEventConsumer(
     @KafkaListener(topics = ["\${kafka.topics.payment:payment}"], groupId = "payment-consumer-group")
     fun handlePaymentEvent(message: String) {
         val paymentEvent = objectMapper.readValue(message, PaymentCompletedEvent::class.java)
-        try {
-            if (paymentEventLogRepository.existsByTransactionId(paymentEvent.transactionId)) {
-                logger.info("이미 처리된 결제 이벤트: ${paymentEvent.orderId}")
-                return
-            }
-
-            try {
-                paymentEventLogRepository.save(
-                    PaymentEventLog(
-                        transactionId = paymentEvent.transactionId,
-                        paymentId = paymentEvent.paymentId,
-                        orderId = paymentEvent.orderId
-                    )
+        executeIdempotently(
+            eventId = paymentEvent.transactionId,
+            eventDescription = "결제",
+            logger = logger,
+            existsCheck = { paymentEventLogRepository.existsByTransactionId(paymentEvent.transactionId) }
+        ) {
+            paymentEventLogRepository.save(
+                PaymentEventLog(
+                    transactionId = paymentEvent.transactionId,
+                    paymentId = paymentEvent.paymentId,
+                    orderId = paymentEvent.orderId
                 )
-            } catch (e: DataIntegrityViolationException) {
-                logger.info("이미 처리된 결제 이벤트: ${paymentEvent.orderId}")
-                return
-            }
-
+            )
             logger.info("결제 이벤트 처리 시작: ${paymentEvent.orderId}")
-
             processPayment(paymentEvent)
-
             logger.info("결제 이벤트 처리 완료: ${paymentEvent.orderId}")
-
-        } catch (e: Exception) {
-            logger.error("결제 이벤트 처리 실패: ${paymentEvent.orderId}, 오류: ${e.message}")
-            throw e
         }
     }
 

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointEventConsumer.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointEventConsumer.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.payment.point.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.hoppingmall.common.KafkaTopics
+import com.hoppingmall.common.consumer.executeIdempotently
 import com.hoppingmall.payment.common.NotificationType
 import com.hoppingmall.payment.outbox.service.TransactionalEventPublisher
 import com.hoppingmall.payment.payment.dto.event.PointEarnRequestEvent
@@ -31,12 +32,12 @@ class PointEventConsumer(
     @KafkaListener(topics = [KafkaTopics.POINT_EARN_REQUEST], groupId = "point-service")
     fun handlePointEarnRequest(message: String) {
         val event = objectMapper.readValue(message, PointEarnRequestEvent::class.java)
-        try {
-            if (pointHistoryRepository.existsByEventId(event.eventId)) {
-                log.info("이미 처리된 포인트 이벤트: eventId={}", event.eventId)
-                return
-            }
-
+        executeIdempotently(
+            eventId = event.eventId,
+            eventDescription = "포인트",
+            logger = log,
+            existsCheck = { pointHistoryRepository.existsByEventId(event.eventId) }
+        ) {
             val point = pointDomainService.findOrCreatePoint(event.userId)
             point.balance += event.earnAmount
             val savedPoint = pointRepository.save(point)
@@ -79,9 +80,6 @@ class PointEventConsumer(
                 topic = KafkaTopics.NOTIFICATION,
                 partitionKey = event.userId.toString()
             )
-        } catch (e: Exception) {
-            log.error("포인트 적립 처리 실패: userId={}, orderId={}, 오류={}", event.userId, event.orderId, e.message)
-            throw e
         }
     }
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/statistics/service/StatisticsEventConsumer.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/statistics/service/StatisticsEventConsumer.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.product.statistics.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.hoppingmall.common.KafkaTopics
+import com.hoppingmall.common.consumer.executeIdempotently
 import com.hoppingmall.product.product.domain.StatisticsEventLog
 import com.hoppingmall.product.product.domain.repository.StatisticsEventLogRepository
 import com.hoppingmall.product.product.service.ProductStatisticsCommandService
@@ -9,7 +10,6 @@ import com.hoppingmall.product.statistics.dto.PaymentCancelledEvent
 import com.hoppingmall.product.statistics.dto.PaymentCompletedEvent
 import com.hoppingmall.product.statistics.port.OrderItemQueryPort
 import org.slf4j.LoggerFactory
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -28,12 +28,12 @@ class StatisticsEventConsumer(
     @Transactional
     fun handlePaymentCompleted(message: String) {
         val event = objectMapper.readValue(message, PaymentCompletedEvent::class.java)
-        try {
-            if (statisticsEventLogRepository.existsByEventId(event.transactionId)) {
-                logger.info("이미 처리된 통계 이벤트: ${event.transactionId}")
-                return
-            }
-
+        executeIdempotently(
+            eventId = event.transactionId,
+            eventDescription = "통계",
+            logger = logger,
+            existsCheck = { statisticsEventLogRepository.existsByEventId(event.transactionId) }
+        ) {
             val orderItems = orderItemQueryPort.findByOrderId(event.orderId)
             orderItems.forEach { item ->
                 productStatisticsCommandService.incrementSalesStats(
@@ -43,23 +43,15 @@ class StatisticsEventConsumer(
                 )
             }
 
-            try {
-                statisticsEventLogRepository.save(
-                    StatisticsEventLog(
-                        eventId = event.transactionId,
-                        eventType = "PaymentCompleted",
-                        orderId = event.orderId
-                    )
+            statisticsEventLogRepository.save(
+                StatisticsEventLog(
+                    eventId = event.transactionId,
+                    eventType = "PaymentCompleted",
+                    orderId = event.orderId
                 )
-            } catch (e: DataIntegrityViolationException) {
-                logger.info("이미 처리된 통계 이벤트: ${event.transactionId}")
-                return
-            }
+            )
 
             logger.info("결제 완료 통계 반영: orderId=${event.orderId}")
-        } catch (e: Exception) {
-            logger.error("결제 완료 통계 처리 실패: ${event.transactionId}, 오류: ${e.message}")
-            throw e
         }
     }
 
@@ -76,12 +68,12 @@ class StatisticsEventConsumer(
     }
 
     private fun handlePaymentCancelled(event: PaymentCancelledEvent) {
-        try {
-            if (statisticsEventLogRepository.existsByEventId(event.eventId)) {
-                logger.info("이미 처리된 통계 보상 이벤트: ${event.eventId}")
-                return
-            }
-
+        executeIdempotently(
+            eventId = event.eventId,
+            eventDescription = "통계 보상",
+            logger = logger,
+            existsCheck = { statisticsEventLogRepository.existsByEventId(event.eventId) }
+        ) {
             val orderItems = orderItemQueryPort.findByOrderId(event.orderId)
             orderItems.forEach { item ->
                 productStatisticsCommandService.decrementSalesStats(
@@ -91,23 +83,15 @@ class StatisticsEventConsumer(
                 )
             }
 
-            try {
-                statisticsEventLogRepository.save(
-                    StatisticsEventLog(
-                        eventId = event.eventId,
-                        eventType = "PaymentCancelled",
-                        orderId = event.orderId
-                    )
+            statisticsEventLogRepository.save(
+                StatisticsEventLog(
+                    eventId = event.eventId,
+                    eventType = "PaymentCancelled",
+                    orderId = event.orderId
                 )
-            } catch (e: DataIntegrityViolationException) {
-                logger.info("이미 처리된 통계 보상 이벤트: ${event.eventId}")
-                return
-            }
+            )
 
             logger.info("결제 취소 통계 반영: orderId=${event.orderId}")
-        } catch (e: Exception) {
-            logger.error("결제 취소 통계 처리 실패: ${event.eventId}, 오류: ${e.message}")
-            throw e
         }
     }
 
@@ -122,12 +106,12 @@ class StatisticsEventConsumer(
         val eventId = node.get("eventId")?.asText() ?: return
         val orderId = node.get("orderId")?.asLong() ?: return
 
-        try {
-            if (statisticsEventLogRepository.existsByEventId(eventId)) {
-                logger.info("이미 처리된 통계 역보상 이벤트: $eventId")
-                return
-            }
-
+        executeIdempotently(
+            eventId = eventId,
+            eventDescription = "통계 역보상",
+            logger = logger,
+            existsCheck = { statisticsEventLogRepository.existsByEventId(eventId) }
+        ) {
             val orderItems = orderItemQueryPort.findByOrderId(orderId)
             orderItems.forEach { item ->
                 productStatisticsCommandService.decrementSalesStats(
@@ -137,23 +121,15 @@ class StatisticsEventConsumer(
                 )
             }
 
-            try {
-                statisticsEventLogRepository.save(
-                    StatisticsEventLog(
-                        eventId = eventId,
-                        eventType = "PaymentReversalRequested",
-                        orderId = orderId
-                    )
+            statisticsEventLogRepository.save(
+                StatisticsEventLog(
+                    eventId = eventId,
+                    eventType = "PaymentReversalRequested",
+                    orderId = orderId
                 )
-            } catch (e: DataIntegrityViolationException) {
-                logger.info("이미 처리된 통계 역보상 이벤트: $eventId")
-                return
-            }
+            )
 
             logger.info("결제 역보상 통계 반영: orderId=$orderId")
-        } catch (e: Exception) {
-            logger.error("결제 역보상 통계 처리 실패: $eventId, 오류: ${e.message}")
-            throw e
         }
     }
 }

--- a/user-service/src/main/kotlin/com/hoppingmall/user/consumer/MembershipEventConsumer.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/consumer/MembershipEventConsumer.kt
@@ -1,11 +1,11 @@
 package com.hoppingmall.user.consumer
 
+import com.hoppingmall.common.KafkaTopics
+import com.hoppingmall.common.consumer.executeIdempotently
 import com.hoppingmall.user.domain.MembershipEventLog
 import com.hoppingmall.user.domain.repository.MembershipEventLogRepository
 import com.hoppingmall.user.service.MembershipCommandService
 import org.slf4j.LoggerFactory
-import org.springframework.dao.DataIntegrityViolationException
-import com.hoppingmall.common.KafkaTopics
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -21,31 +21,23 @@ class MembershipEventConsumer(
 
     @KafkaListener(topics = [KafkaTopics.MEMBERSHIP_UPDATE_REQUEST], groupId = "membership-service")
     fun handleMembershipUpdateRequest(event: MembershipUpdateRequestEvent) {
-        try {
-            if (membershipEventLogRepository.existsByEventId(event.eventId)) {
-                log.info("이미 처리된 멤버십 이벤트: eventId={}", event.eventId)
-                return
-            }
-
+        executeIdempotently(
+            eventId = event.eventId,
+            eventDescription = "멤버십",
+            logger = log,
+            existsCheck = { membershipEventLogRepository.existsByEventId(event.eventId) }
+        ) {
             membershipCommandService.addPurchaseAmount(event.userId, event.amount)
 
-            try {
-                membershipEventLogRepository.save(
-                    MembershipEventLog(
-                        eventId = event.eventId,
-                        paymentId = event.paymentId,
-                        orderId = event.orderId
-                    )
+            membershipEventLogRepository.save(
+                MembershipEventLog(
+                    eventId = event.eventId,
+                    paymentId = event.paymentId,
+                    orderId = event.orderId
                 )
-            } catch (e: DataIntegrityViolationException) {
-                log.info("이미 처리된 멤버십 이벤트: eventId={}", event.eventId)
-                return
-            }
+            )
 
             log.info("멤버십 업데이트 완료: userId={}, amount={}", event.userId, event.amount)
-        } catch (e: Exception) {
-            log.error("멤버십 업데이트 실패: eventId={}, userId={}, 오류={}", event.eventId, event.userId, e.message)
-            throw e
         }
     }
 }


### PR DESCRIPTION
Closes #332

### 📌 작업 개요
5개 Kafka Consumer에 반복되는 멱등성 처리 보일러플레이트를 `hoppingmall-common`의 공유 인라인 함수로 추출하고, PointEventConsumer의 DataIntegrityViolationException 처리 누락 버그를 수정했습니다.

---

### ✅ 주요 변경 사항

- `hoppingmall-common.consumer`
  - `IdempotentConsumeTemplate`: `executeIdempotently` 인라인 함수 추가 (existsBy 체크, DIVE 캐치, 에러 로깅 공통 처리)

- `payment-service.payment.service`
  - `PaymentEventConsumer`: 멱등성 보일러플레이트를 `executeIdempotently`로 전환

- `payment-service.point.service`
  - `PointEventConsumer`: 멱등성 보일러플레이트를 `executeIdempotently`로 전환, DataIntegrityViolationException 처리 누락 수정

- `notification-service.consumer`
  - `NotificationEventConsumer`: 멱등성 보일러플레이트를 `executeIdempotently`로 전환

- `product-service.statistics.service`
  - `StatisticsEventConsumer`: 3개 핸들러 메서드 모두 `executeIdempotently`로 전환

- `user-service.consumer`
  - `MembershipEventConsumer`: 멱등성 보일러플레이트를 `executeIdempotently`로 전환

---

### 🧪 테스트

- 4개 서비스 전체 테스트 통과
- 4개 서비스 Jacoco 커버리지 80% 이상 검증 통과

---

### 📎 관련 이슈
- #332
