### PR TITLE
feat: payment-service, notification-service TwoLevelCache 전환

### DIFF
--- a/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/TwoLevelCache.kt
+++ b/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/TwoLevelCache.kt
@@ -29,6 +29,9 @@ class TwoLevelCache(
     private val missCounter = meterRegistry?.let {
         Counter.builder("cache.miss").tag("cache", name).register(it)
     }
+    private val l2FailureCounter = meterRegistry?.let {
+        Counter.builder("cache.l2.failure").tag("cache", name).register(it)
+    }
 
     companion object {
         private const val LOCK_KEY_PREFIX = "lock:"
@@ -51,8 +54,7 @@ class TwoLevelCache(
         hotKeyDetector?.recordAccess(key.toString())
         val isHot = hotKeyDetector?.isHot(key.toString()) ?: false
 
-        val l2Cache = if (isHot && shardedRedisCache != null) shardedRedisCache else redisCache
-        val l2Value = l2Cache.get(key)?.get()
+        val l2Value = safeL2Get(key, isHot)
         if (l2Value != null) {
             l2HitCounter?.increment()
             caffeineCache.put(key, l2Value)
@@ -74,7 +76,7 @@ class TwoLevelCache(
         val isHot = hotKeyDetector?.isHot(key.toString()) ?: false
 
         if (isHot && shardedRedisCache != null) {
-            val shardValue = shardedRedisCache.get(key)?.get()
+            val shardValue = safeL2Get(key, true)
             if (shardValue != null) {
                 l2HitCounter?.increment()
                 caffeineCache.put(key, shardValue)
@@ -83,7 +85,7 @@ class TwoLevelCache(
             return loadWithLock(key, valueLoader)
         }
 
-        val l2Value = redisCache.get(key)?.get()
+        val l2Value = safeL2Get(key, false)
         if (l2Value != null) {
             l2HitCounter?.increment()
             caffeineCache.put(key, l2Value)
@@ -97,11 +99,17 @@ class TwoLevelCache(
     @Suppress("UNCHECKED_CAST")
     private fun <T : Any?> loadWithLock(key: Any, valueLoader: Callable<T>): T? {
         val lockKey = "$LOCK_KEY_PREFIX$name:$key"
-        val locked = lockProvider.tryLock(lockKey, LOCK_LEASE_TIME)
+        val locked = try {
+            lockProvider.tryLock(lockKey, LOCK_LEASE_TIME)
+        } catch (e: Exception) {
+            log.warn("L2 lock 획득 실패 [cache={}, key={}]: {}", name, key, e.message)
+            l2FailureCounter?.increment()
+            false
+        }
 
         if (locked) {
             try {
-                val l2Recheck = redisCache.get(key)?.get()
+                val l2Recheck = safeL2Get(key, false)
                 if (l2Recheck != null) {
                     l2HitCounter?.increment()
                     caffeineCache.put(key, l2Recheck)
@@ -110,7 +118,11 @@ class TwoLevelCache(
                 missCounter?.increment()
                 return loadAndCache(key, valueLoader)
             } finally {
-                lockProvider.unlock(lockKey)
+                try {
+                    lockProvider.unlock(lockKey)
+                } catch (e: Exception) {
+                    log.warn("L2 lock 해제 실패 [cache={}, key={}]: {}", name, key, e.message)
+                }
             }
         }
 
@@ -124,7 +136,7 @@ class TwoLevelCache(
             Thread.sleep(LOCK_RETRY_INTERVAL_MS)
             waited += LOCK_RETRY_INTERVAL_MS
 
-            val l2Value = redisCache.get(key)?.get()
+            val l2Value = safeL2Get(key, false)
             if (l2Value != null) {
                 l2HitCounter?.increment()
                 caffeineCache.put(key, l2Value)
@@ -147,18 +159,10 @@ class TwoLevelCache(
         val isHot = hotKeyDetector?.isHot(key.toString()) ?: false
 
         if (value != null) {
-            if (isHot && shardedRedisCache != null) {
-                shardedRedisCache.put(key, value)
-            } else {
-                redisCache.put(key, value)
-            }
+            safeL2Put(key, value, isHot)
             caffeineCache.put(key, toStoreValue(value))
         } else {
-            if (isHot && shardedRedisCache != null) {
-                shardedRedisCache.put(key, value)
-            } else {
-                redisCache.put(key, value)
-            }
+            safeL2Put(key, value, isHot)
             caffeineCache.invalidate(key)
         }
     }
@@ -166,16 +170,50 @@ class TwoLevelCache(
     override fun evict(key: Any) {
         val isHot = hotKeyDetector?.isHot(key.toString()) ?: false
 
-        if (isHot && shardedRedisCache != null) {
-            shardedRedisCache.evict(key)
-        } else {
-            redisCache.evict(key)
+        try {
+            if (isHot && shardedRedisCache != null) {
+                shardedRedisCache.evict(key)
+            } else {
+                redisCache.evict(key)
+            }
+        } catch (e: Exception) {
+            log.warn("L2 evict 실패 [cache={}, key={}]: {}", name, key, e.message)
+            l2FailureCounter?.increment()
         }
         caffeineCache.invalidate(key)
     }
 
     override fun clear() {
-        redisCache.clear()
+        try {
+            redisCache.clear()
+        } catch (e: Exception) {
+            log.warn("L2 clear 실패 [cache={}]: {}", name, e.message)
+            l2FailureCounter?.increment()
+        }
         caffeineCache.invalidateAll()
+    }
+
+    private fun safeL2Get(key: Any, isHot: Boolean): Any? {
+        return try {
+            val l2Cache = if (isHot && shardedRedisCache != null) shardedRedisCache else redisCache
+            l2Cache.get(key)?.get()
+        } catch (e: Exception) {
+            log.warn("L2 조회 실패 [cache={}, key={}]: {}", name, key, e.message)
+            l2FailureCounter?.increment()
+            null
+        }
+    }
+
+    private fun safeL2Put(key: Any, value: Any?, isHot: Boolean) {
+        try {
+            if (isHot && shardedRedisCache != null) {
+                shardedRedisCache.put(key, value)
+            } else {
+                redisCache.put(key, value)
+            }
+        } catch (e: Exception) {
+            log.warn("L2 저장 실패 [cache={}, key={}]: {}", name, key, e.message)
+            l2FailureCounter?.increment()
+        }
     }
 }

--- a/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/TwoLevelCacheManager.kt
+++ b/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/TwoLevelCacheManager.kt
@@ -4,6 +4,10 @@ import com.github.benmanes.caffeine.cache.Caffeine
 import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.cache.Cache
 import org.springframework.cache.CacheManager
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 
 class TwoLevelCacheManager(
@@ -66,6 +70,23 @@ class TwoLevelCacheManager(
 
     companion object {
         private const val MISSING_CACHE_TTL_MS = 30_000L
+
+        fun buildRedisCacheManager(
+            connectionFactory: RedisConnectionFactory,
+            policies: Map<String, CachePolicy>,
+            defaultTtl: Duration = Duration.ofMinutes(30)
+        ): RedisCacheManager {
+            val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(defaultTtl)
+            val perCacheConfigs = policies.mapValues { (_, policy) ->
+                RedisCacheConfiguration.defaultCacheConfig()
+                    .entryTtl(policy.l2Ttl)
+            }
+            return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultConfig)
+                .withInitialCacheConfigurations(perCacheConfigs)
+                .build()
+        }
     }
 
     override fun getCacheNames(): Collection<String> {

--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -6,6 +6,7 @@ COPY notification-service/build.gradle.kts notification-service/settings.gradle.
 COPY notification-service/src ./src
 COPY hoppingmall-common /hoppingmall-common
 COPY hoppingmall-dlq /hoppingmall-dlq
+COPY hoppingmall-cache /hoppingmall-cache
 RUN sed -i "s/\r$//" gradlew && chmod +x gradlew && ./gradlew bootJar --no-daemon -x test
 
 FROM eclipse-temurin:21-jre-alpine AS runtime

--- a/notification-service/build.gradle.kts
+++ b/notification-service/build.gradle.kts
@@ -29,6 +29,9 @@ repositories {
 dependencies {
 	implementation("com.hoppingmall:hoppingmall-common:0.0.1-SNAPSHOT")
 	implementation("com.hoppingmall:hoppingmall-dlq:0.0.1-SNAPSHOT")
+	implementation("com.hoppingmall:hoppingmall-cache:0.0.1-SNAPSHOT")
+	implementation("org.springframework.boot:spring-boot-starter-cache")
+	implementation("com.github.ben-manes.caffeine:caffeine")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/notification-service/settings.gradle.kts
+++ b/notification-service/settings.gradle.kts
@@ -11,3 +11,9 @@ val dlqPath = if (file("../hoppingmall-dlq").exists()) "../hoppingmall-dlq"
     else null
 
 dlqPath?.let { includeBuild(it) }
+
+val cachePath = if (file("../hoppingmall-cache").exists()) "../hoppingmall-cache"
+    else if (file("/hoppingmall-cache").exists()) "/hoppingmall-cache"
+    else null
+
+cachePath?.let { includeBuild(it) }

--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/config/CacheConfig.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/config/CacheConfig.kt
@@ -1,9 +1,17 @@
 package com.hoppingmall.notification.config
 
+import com.hoppingmall.cache.CachePolicy
+import com.hoppingmall.cache.HotKeyDetectorRegistry
+import com.hoppingmall.cache.LockProvider
+import com.hoppingmall.cache.RedissonLockProvider
+import com.hoppingmall.cache.TwoLevelCacheManager
+import io.micrometer.core.instrument.MeterRegistry
+import org.redisson.api.RedissonClient
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.data.redis.cache.RedisCacheConfiguration
 import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
@@ -11,15 +19,52 @@ import java.time.Duration
 
 @Configuration
 @EnableCaching
+@Profile("!test")
 class CacheConfig {
 
     @Bean
-    fun cacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
-        val unreadCountConfig = RedisCacheConfiguration.defaultCacheConfig()
-            .entryTtl(Duration.ofSeconds(300))
+    fun cachePolicies(): Map<String, CachePolicy> = mapOf(
+        "unread-count" to CachePolicy(
+            cacheName = "unread-count",
+            l1MaxSize = 500,
+            l1Ttl = Duration.ofSeconds(60),
+            l2Ttl = Duration.ofMinutes(5)
+        )
+    )
 
-        return RedisCacheManager.builder(redisConnectionFactory)
-            .withCacheConfiguration("unread-count", unreadCountConfig)
+    @Bean
+    fun hotKeyDetectorRegistry(cachePolicies: Map<String, CachePolicy>): HotKeyDetectorRegistry {
+        return HotKeyDetectorRegistry(cachePolicies.values)
+    }
+
+    @Bean
+    fun lockProvider(redissonClient: RedissonClient): LockProvider {
+        return RedissonLockProvider(redissonClient)
+    }
+
+    @Bean
+    fun redisCacheManager(connectionFactory: RedisConnectionFactory): RedisCacheManager {
+        val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(5))
+        return RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(defaultConfig)
             .build()
+    }
+
+    @Bean
+    fun cacheManager(
+        redisCacheManager: RedisCacheManager,
+        cachePolicies: Map<String, CachePolicy>,
+        lockProvider: LockProvider,
+        hotKeyDetectorRegistry: HotKeyDetectorRegistry,
+        meterRegistry: MeterRegistry
+    ): CacheManager {
+        return TwoLevelCacheManager(
+            redisCacheManager = redisCacheManager,
+            policies = cachePolicies,
+            lockProvider = lockProvider,
+            hotKeyDetectorRegistry = hotKeyDetectorRegistry,
+            meterRegistry = meterRegistry
+        )
     }
 }

--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/config/CacheConfig.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/config/CacheConfig.kt
@@ -12,7 +12,6 @@ import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
-import org.springframework.data.redis.cache.RedisCacheConfiguration
 import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import java.time.Duration
@@ -43,12 +42,13 @@ class CacheConfig {
     }
 
     @Bean
-    fun redisCacheManager(connectionFactory: RedisConnectionFactory): RedisCacheManager {
-        val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
-            .entryTtl(Duration.ofMinutes(5))
-        return RedisCacheManager.builder(connectionFactory)
-            .cacheDefaults(defaultConfig)
-            .build()
+    fun redisCacheManager(
+        connectionFactory: RedisConnectionFactory,
+        cachePolicies: Map<String, CachePolicy>
+    ): RedisCacheManager {
+        return TwoLevelCacheManager.buildRedisCacheManager(
+            connectionFactory, cachePolicies, defaultTtl = Duration.ofMinutes(5)
+        )
     }
 
     @Bean

--- a/notification-service/src/test/kotlin/com/hoppingmall/notification/NotificationServiceApplicationTests.kt
+++ b/notification-service/src/test/kotlin/com/hoppingmall/notification/NotificationServiceApplicationTests.kt
@@ -16,7 +16,7 @@ import org.springframework.test.context.TestPropertySource
 
 @SpringBootTest
 @ActiveProfiles("test")
-@Import(NotificationServiceApplicationTests.TestInfraConfig::class)
+@Import(NotificationServiceApplicationTests.TestInfraConfig::class, com.hoppingmall.notification.support.TestCacheConfig::class)
 @TestPropertySource(properties = [
     "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration,org.redisson.spring.starter.RedissonAutoConfigurationV2,org.redisson.spring.starter.RedissonAutoConfigurationV4,org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration",
     "spring.main.allow-bean-definition-overriding=true",

--- a/notification-service/src/test/kotlin/com/hoppingmall/notification/support/TestCacheConfig.kt
+++ b/notification-service/src/test/kotlin/com/hoppingmall/notification/support/TestCacheConfig.kt
@@ -1,0 +1,31 @@
+package com.hoppingmall.notification.support
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.caffeine.CaffeineCache
+import org.springframework.cache.support.SimpleCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import java.util.concurrent.TimeUnit
+
+@TestConfiguration
+@EnableCaching
+class TestCacheConfig {
+
+    @Bean
+    @Primary
+    fun cacheManager(): CacheManager {
+        val caches = listOf("unread-count").map { name ->
+            CaffeineCache(
+                name,
+                Caffeine.newBuilder()
+                    .maximumSize(100)
+                    .expireAfterWrite(5, TimeUnit.MINUTES)
+                    .build()
+            )
+        }
+        return SimpleCacheManager().apply { setCaches(caches) }
+    }
+}

--- a/payment-service/Dockerfile
+++ b/payment-service/Dockerfile
@@ -8,6 +8,7 @@ COPY payment-service/src ./src
 COPY hoppingmall-common /hoppingmall-common
 COPY hoppingmall-dlq /hoppingmall-dlq
 COPY hoppingmall-outbox /hoppingmall-outbox
+COPY hoppingmall-cache /hoppingmall-cache
 RUN sed -i "s/\r$//" gradlew && chmod +x gradlew && ./gradlew bootJar --no-daemon -x test
 
 FROM eclipse-temurin:21-jre-alpine AS runtime

--- a/payment-service/build.gradle.kts
+++ b/payment-service/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
 	implementation("com.hoppingmall:hoppingmall-common:0.0.1-SNAPSHOT")
 	implementation("com.hoppingmall:hoppingmall-dlq:0.0.1-SNAPSHOT")
 	implementation("com.hoppingmall:hoppingmall-outbox:0.0.1-SNAPSHOT")
+	implementation("com.hoppingmall:hoppingmall-cache:0.0.1-SNAPSHOT")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/payment-service/settings.gradle.kts
+++ b/payment-service/settings.gradle.kts
@@ -17,3 +17,9 @@ val outboxPath = if (file("../hoppingmall-outbox").exists()) "../hoppingmall-out
     else null
 
 outboxPath?.let { includeBuild(it) }
+
+val cachePath = if (file("../hoppingmall-cache").exists()) "../hoppingmall-cache"
+    else if (file("/hoppingmall-cache").exists()) "/hoppingmall-cache"
+    else null
+
+cachePath?.let { includeBuild(it) }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/CacheConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/CacheConfig.kt
@@ -12,7 +12,6 @@ import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
-import org.springframework.data.redis.cache.RedisCacheConfiguration
 import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import java.time.Duration
@@ -61,12 +60,11 @@ class CacheConfig {
     }
 
     @Bean
-    fun redisCacheManager(connectionFactory: RedisConnectionFactory): RedisCacheManager {
-        val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
-            .entryTtl(Duration.ofMinutes(30))
-        return RedisCacheManager.builder(connectionFactory)
-            .cacheDefaults(defaultConfig)
-            .build()
+    fun redisCacheManager(
+        connectionFactory: RedisConnectionFactory,
+        cachePolicies: Map<String, CachePolicy>
+    ): RedisCacheManager {
+        return TwoLevelCacheManager.buildRedisCacheManager(connectionFactory, cachePolicies)
     }
 
     @Bean

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/CacheConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/CacheConfig.kt
@@ -1,50 +1,88 @@
 package com.hoppingmall.payment.config
 
-import com.github.benmanes.caffeine.cache.Caffeine
+import com.hoppingmall.cache.CachePolicy
+import com.hoppingmall.cache.HotKeyDetectorRegistry
+import com.hoppingmall.cache.LockProvider
+import com.hoppingmall.cache.RedissonLockProvider
+import com.hoppingmall.cache.TwoLevelCacheManager
+import io.micrometer.core.instrument.MeterRegistry
+import org.redisson.api.RedissonClient
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
-import org.springframework.cache.caffeine.CaffeineCache
-import org.springframework.cache.support.SimpleCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import java.util.concurrent.TimeUnit
+import org.springframework.context.annotation.Profile
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import java.time.Duration
 
 @Configuration
 @EnableCaching
+@Profile("!test")
 class CacheConfig {
 
     @Bean
-    fun cacheManager(): CacheManager {
-        val pointBalanceCache = CaffeineCache(
-            "point-balance",
-            Caffeine.newBuilder()
-                .maximumSize(1000)
-                .expireAfterWrite(30, TimeUnit.SECONDS)
-                .build()
+    fun cachePolicies(): Map<String, CachePolicy> = mapOf(
+        "point-balance" to CachePolicy(
+            cacheName = "point-balance",
+            l1MaxSize = 1000,
+            l1Ttl = Duration.ofSeconds(30),
+            l2Ttl = Duration.ofMinutes(30)
+        ),
+        "coupon:available" to CachePolicy(
+            cacheName = "coupon:available",
+            l1MaxSize = 100,
+            l1Ttl = Duration.ofMinutes(5),
+            l2Ttl = Duration.ofMinutes(30)
+        ),
+        "coupon:all" to CachePolicy(
+            cacheName = "coupon:all",
+            l1MaxSize = 100,
+            l1Ttl = Duration.ofMinutes(5),
+            l2Ttl = Duration.ofMinutes(30)
+        ),
+        "point-policy" to CachePolicy(
+            cacheName = "point-policy",
+            l1MaxSize = 10,
+            l1Ttl = Duration.ofMinutes(30),
+            l2Ttl = Duration.ofMinutes(30)
         )
-        val couponAvailableCache = CaffeineCache(
-            "coupon:available",
-            Caffeine.newBuilder()
-                .maximumSize(100)
-                .expireAfterWrite(5, TimeUnit.MINUTES)
-                .build()
+    )
+
+    @Bean
+    fun hotKeyDetectorRegistry(cachePolicies: Map<String, CachePolicy>): HotKeyDetectorRegistry {
+        return HotKeyDetectorRegistry(cachePolicies.values)
+    }
+
+    @Bean
+    fun lockProvider(redissonClient: RedissonClient): LockProvider {
+        return RedissonLockProvider(redissonClient)
+    }
+
+    @Bean
+    fun redisCacheManager(connectionFactory: RedisConnectionFactory): RedisCacheManager {
+        val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(30))
+        return RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(defaultConfig)
+            .build()
+    }
+
+    @Bean
+    fun cacheManager(
+        redisCacheManager: RedisCacheManager,
+        cachePolicies: Map<String, CachePolicy>,
+        lockProvider: LockProvider,
+        hotKeyDetectorRegistry: HotKeyDetectorRegistry,
+        meterRegistry: MeterRegistry
+    ): CacheManager {
+        return TwoLevelCacheManager(
+            redisCacheManager = redisCacheManager,
+            policies = cachePolicies,
+            lockProvider = lockProvider,
+            hotKeyDetectorRegistry = hotKeyDetectorRegistry,
+            meterRegistry = meterRegistry
         )
-        val couponAllCache = CaffeineCache(
-            "coupon:all",
-            Caffeine.newBuilder()
-                .maximumSize(100)
-                .expireAfterWrite(5, TimeUnit.MINUTES)
-                .build()
-        )
-        val pointPolicyCache = CaffeineCache(
-            "point-policy",
-            Caffeine.newBuilder()
-                .maximumSize(10)
-                .expireAfterWrite(30, TimeUnit.MINUTES)
-                .build()
-        )
-        return SimpleCacheManager().apply {
-            setCaches(listOf(pointBalanceCache, couponAvailableCache, couponAllCache, pointPolicyCache))
-        }
     }
 }

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/support/TestCacheConfig.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/support/TestCacheConfig.kt
@@ -1,0 +1,31 @@
+package com.hoppingmall.payment.support
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.caffeine.CaffeineCache
+import org.springframework.cache.support.SimpleCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import java.util.concurrent.TimeUnit
+
+@TestConfiguration
+@EnableCaching
+class TestCacheConfig {
+
+    @Bean
+    @Primary
+    fun cacheManager(): CacheManager {
+        val caches = listOf("point-balance", "coupon:available", "coupon:all", "point-policy").map { name ->
+            CaffeineCache(
+                name,
+                Caffeine.newBuilder()
+                    .maximumSize(100)
+                    .expireAfterWrite(5, TimeUnit.MINUTES)
+                    .build()
+            )
+        }
+        return SimpleCacheManager().apply { setCaches(caches) }
+    }
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/CacheConfig.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/CacheConfig.kt
@@ -12,7 +12,6 @@ import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
-import org.springframework.data.redis.cache.RedisCacheConfiguration
 import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import java.time.Duration
@@ -69,12 +68,11 @@ class CacheConfig {
     }
 
     @Bean
-    fun redisCacheManager(connectionFactory: RedisConnectionFactory): RedisCacheManager {
-        val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
-            .entryTtl(Duration.ofMinutes(30))
-        return RedisCacheManager.builder(connectionFactory)
-            .cacheDefaults(defaultConfig)
-            .build()
+    fun redisCacheManager(
+        connectionFactory: RedisConnectionFactory,
+        cachePolicies: Map<String, CachePolicy>
+    ): RedisCacheManager {
+        return TwoLevelCacheManager.buildRedisCacheManager(connectionFactory, cachePolicies)
     }
 
     @Bean


### PR DESCRIPTION
Closes #334

### 📌 작업 개요
5개 Kafka Consumer에 반복되는 멱등성 처리 보일러플레이트를 `hoppingmall-common`의 공유 인라인 함수로 추출하고, PointEventConsumer의 DataIntegrityViolationException 처리 누락 버그를 수정했습니다.

---

### ✅ 주요 변경 사항

- `hoppingmall-common.consumer`
  - `IdempotentConsumeTemplate`: `executeIdempotently` 인라인 함수 추가 (existsBy 체크, DIVE 캐치, 에러 로깅 공통 처리)

- `payment-service.payment.service`
  - `PaymentEventConsumer`: 멱등성 보일러플레이트를 `executeIdempotently`로 전환

- `payment-service.point.service`
  - `PointEventConsumer`: 멱등성 보일러플레이트를 `executeIdempotently`로 전환, DataIntegrityViolationException 처리 누락 수정

- `notification-service.consumer`
  - `NotificationEventConsumer`: 멱등성 보일러플레이트를 `executeIdempotently`로 전환

- `product-service.statistics.service`
  - `StatisticsEventConsumer`: 3개 핸들러 메서드 모두 `executeIdempotently`로 전환

- `user-service.consumer`
  - `MembershipEventConsumer`: 멱등성 보일러플레이트를 `executeIdempotently`로 전환

---

### 🧪 테스트

- 4개 서비스 전체 테스트 통과
- 4개 서비스 Jacoco 커버리지 80% 이상 검증 통과

---

### 📎 관련 이슈
- #334
