### PR TITLE
config: Jacoco CI 검증 및 빌드 설정 보강

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,10 @@ jobs:
         if: success()
         run: cd ${{ matrix.service }} && ./gradlew jacocoTestReport --no-daemon --build-cache
 
+      - name: Jacoco 커버리지 검증 (80%)
+        if: success()
+        run: cd ${{ matrix.service }} && ./gradlew jacocoTestVerification --no-daemon --build-cache
+
       - name: Codecov 업로드
         if: success()
         uses: codecov/codecov-action@v4

--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
 	implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.8")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/api-gateway/src/test/kotlin/com/hoppingmall/gateway/filter/JwtValidationGatewayFilterFactoryTest.kt
+++ b/api-gateway/src/test/kotlin/com/hoppingmall/gateway/filter/JwtValidationGatewayFilterFactoryTest.kt
@@ -1,0 +1,197 @@
+package com.hoppingmall.gateway.filter
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.security.Keys
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.springframework.cloud.gateway.filter.GatewayFilterChain
+import org.springframework.http.HttpStatus
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+import java.util.Date
+
+@DisplayName("JwtValidationGatewayFilterFactory")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class JwtValidationGatewayFilterFactoryTest {
+
+    private val secret = "test-secret-key-for-testing-purposes-only-32chars!"
+    private val factory = JwtValidationGatewayFilterFactory(secret)
+    private val config = JwtValidationGatewayFilterFactory.Config()
+    private val key = Keys.hmacShaKeyFor(secret.toByteArray())
+
+    private fun chainCapturing(captured: MutableList<ServerWebExchange>): GatewayFilterChain =
+        GatewayFilterChain { exchange ->
+            captured.add(exchange)
+            Mono.empty()
+        }
+
+    private fun buildToken(subject: String, role: String, expiry: Date = Date(System.currentTimeMillis() + 60_000)): String {
+        return Jwts.builder()
+            .setSubject(subject)
+            .claim("role", role)
+            .setExpiration(expiry)
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact()
+    }
+
+    @Test
+    fun Authorization_헤더가_없으면_401을_반환한다() {
+        val request = MockServerHttpRequest.get("/api/test").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        factory.apply(config).filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(exchange.response.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
+        assertThat(captured).isEmpty()
+    }
+
+    @Test
+    fun Bearer_접두사가_없는_토큰이면_401을_반환한다() {
+        val token = buildToken("user1", "BUYER")
+        val request = MockServerHttpRequest.get("/api/test")
+            .header("Authorization", token)
+            .build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        factory.apply(config).filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(exchange.response.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
+        assertThat(captured).isEmpty()
+    }
+
+    @Test
+    fun 유효한_JWT_토큰이면_다음_필터로_전달하고_x_user_id_헤더를_설정한다() {
+        val token = buildToken("42", "BUYER")
+        val request = MockServerHttpRequest.get("/api/test")
+            .header("Authorization", "Bearer $token")
+            .build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        factory.apply(config).filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(exchange.response.statusCode).isNotEqualTo(HttpStatus.UNAUTHORIZED)
+        assertThat(captured).hasSize(1)
+        assertThat(captured[0].request.headers.getFirst("x-user-id")).isEqualTo("42")
+    }
+
+    @Test
+    fun 유효한_JWT_토큰이면_role_클레임이_x_user_role_헤더에_설정된다() {
+        val token = buildToken("10", "SELLER")
+        val request = MockServerHttpRequest.get("/api/test")
+            .header("Authorization", "Bearer $token")
+            .build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        factory.apply(config).filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured[0].request.headers.getFirst("x-user-role")).isEqualTo("SELLER")
+    }
+
+    @Test
+    fun role_클레임이_없으면_기본값_BUYER가_x_user_role_헤더에_설정된다() {
+        val tokenWithoutRole = Jwts.builder()
+            .setSubject("99")
+            .setExpiration(Date(System.currentTimeMillis() + 60_000))
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact()
+        val request = MockServerHttpRequest.get("/api/test")
+            .header("Authorization", "Bearer $tokenWithoutRole")
+            .build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        factory.apply(config).filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured[0].request.headers.getFirst("x-user-role")).isEqualTo("BUYER")
+    }
+
+    @Test
+    fun 잘못된_서명의_JWT_토큰이면_401을_반환한다() {
+        val wrongKey = Keys.hmacShaKeyFor("wrong-secret-key-for-testing-purposes-only-32chars!".toByteArray())
+        val badToken = Jwts.builder()
+            .setSubject("user")
+            .setExpiration(Date(System.currentTimeMillis() + 60_000))
+            .signWith(wrongKey, SignatureAlgorithm.HS256)
+            .compact()
+        val request = MockServerHttpRequest.get("/api/test")
+            .header("Authorization", "Bearer $badToken")
+            .build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        factory.apply(config).filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(exchange.response.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
+        assertThat(captured).isEmpty()
+    }
+
+    @Test
+    fun 만료된_JWT_토큰이면_401을_반환한다() {
+        val expiredToken = buildToken("user", "BUYER", Date(System.currentTimeMillis() - 1_000))
+        val request = MockServerHttpRequest.get("/api/test")
+            .header("Authorization", "Bearer $expiredToken")
+            .build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        factory.apply(config).filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(exchange.response.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
+        assertThat(captured).isEmpty()
+    }
+
+    @Test
+    fun 요청에_이미_x_user_id_헤더가_있으면_토큰_값으로_교체된다() {
+        val token = buildToken("real-user", "ADMIN")
+        val request = MockServerHttpRequest.get("/api/test")
+            .header("Authorization", "Bearer $token")
+            .header("x-user-id", "injected-id")
+            .build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        factory.apply(config).filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured[0].request.headers.getFirst("x-user-id")).isEqualTo("real-user")
+    }
+
+    @Test
+    fun 요청에_이미_x_user_role_헤더가_있으면_토큰_값으로_교체된다() {
+        val token = buildToken("user", "ADMIN")
+        val request = MockServerHttpRequest.get("/api/test")
+            .header("Authorization", "Bearer $token")
+            .header("x-user-role", "BUYER")
+            .build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        factory.apply(config).filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured[0].request.headers.getFirst("x-user-role")).isEqualTo("ADMIN")
+    }
+
+    @Test
+    fun 완전히_잘못된_형식의_토큰이면_401을_반환한다() {
+        val request = MockServerHttpRequest.get("/api/test")
+            .header("Authorization", "Bearer not.a.jwt")
+            .build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        factory.apply(config).filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(exchange.response.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
+        assertThat(captured).isEmpty()
+    }
+}

--- a/api-gateway/src/test/kotlin/com/hoppingmall/gateway/filter/RateLimitGlobalFilterTest.kt
+++ b/api-gateway/src/test/kotlin/com/hoppingmall/gateway/filter/RateLimitGlobalFilterTest.kt
@@ -1,0 +1,191 @@
+package com.hoppingmall.gateway.filter
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.cloud.gateway.filter.GatewayFilterChain
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver
+import org.springframework.cloud.gateway.filter.ratelimit.RateLimiter
+import org.springframework.cloud.gateway.filter.ratelimit.RedisRateLimiter
+import org.springframework.http.HttpStatus
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+
+@DisplayName("RateLimitGlobalFilter")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class RateLimitGlobalFilterTest {
+
+    @Mock
+    private lateinit var keyResolver: KeyResolver
+
+    @Mock
+    private lateinit var redisRateLimiter: RedisRateLimiter
+
+    private fun buildFilter() = RateLimitGlobalFilter(keyResolver, redisRateLimiter)
+
+    private fun chainCapturing(captured: MutableList<ServerWebExchange>): GatewayFilterChain =
+        GatewayFilterChain { exchange ->
+            captured.add(exchange)
+            Mono.empty()
+        }
+
+    private fun allowedResponse(): RateLimiter.Response =
+        RateLimiter.Response(true, mapOf("X-RateLimit-Remaining" to "49"))
+
+    private fun deniedResponse(): RateLimiter.Response =
+        RateLimiter.Response(false, emptyMap())
+
+    @Test
+    fun actuator_경로는_레이트_리밋을_건너뛴다() {
+        val request = MockServerHttpRequest.get("/actuator/health").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured).hasSize(1)
+    }
+
+    @Test
+    fun internal_경로는_레이트_리밋을_건너뛴다() {
+        val request = MockServerHttpRequest.get("/internal/service").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured).hasSize(1)
+    }
+
+    @Test
+    fun swagger_ui_경로는_레이트_리밋을_건너뛴다() {
+        val request = MockServerHttpRequest.get("/swagger-ui/index.html").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured).hasSize(1)
+    }
+
+    @Test
+    fun v3_api_docs_경로는_레이트_리밋을_건너뛴다() {
+        val request = MockServerHttpRequest.get("/v3/api-docs/swagger-config").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured).hasSize(1)
+    }
+
+    @Test
+    fun webjars_경로는_레이트_리밋을_건너뛴다() {
+        val request = MockServerHttpRequest.get("/webjars/swagger-ui/bundle.js").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured).hasSize(1)
+    }
+
+    @Test
+    fun 회원가입_경로는_레이트_리밋을_건너뛴다() {
+        val request = MockServerHttpRequest.post("/api/v1/users/signup").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured).hasSize(1)
+    }
+
+    @Test
+    fun 로그인_경로는_레이트_리밋을_건너뛴다() {
+        val request = MockServerHttpRequest.post("/api/v1/users/login").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured).hasSize(1)
+    }
+
+    @Test
+    fun 토큰_갱신_경로는_레이트_리밋을_건너뛴다() {
+        val request = MockServerHttpRequest.post("/api/v1/auth/refresh").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured).hasSize(1)
+    }
+
+    @Test
+    fun 허용된_요청이면_다음_필터로_전달한다() {
+        whenever(keyResolver.resolve(any())).thenReturn(Mono.just("user:1"))
+        whenever(redisRateLimiter.isAllowed(any(), any())).thenReturn(Mono.just(allowedResponse()))
+
+        val request = MockServerHttpRequest.get("/api/v1/products").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured).hasSize(1)
+    }
+
+    @Test
+    fun 허용된_요청이면_레이트_리밋_헤더가_응답에_포함된다() {
+        whenever(keyResolver.resolve(any())).thenReturn(Mono.just("user:1"))
+        whenever(redisRateLimiter.isAllowed(any(), any())).thenReturn(Mono.just(allowedResponse()))
+
+        val request = MockServerHttpRequest.get("/api/v1/products").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured[0].response.headers["X-RateLimit-Remaining"]).containsExactly("49")
+    }
+
+    @Test
+    fun 허용_한도를_초과하면_429를_반환한다() {
+        whenever(keyResolver.resolve(any())).thenReturn(Mono.just("user:1"))
+        whenever(redisRateLimiter.isAllowed(any(), any())).thenReturn(Mono.just(deniedResponse()))
+
+        val request = MockServerHttpRequest.get("/api/v1/products").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(exchange.response.statusCode).isEqualTo(HttpStatus.TOO_MANY_REQUESTS)
+        assertThat(captured).isEmpty()
+    }
+
+    @Test
+    fun 허용_한도를_초과하면_Retry_After_헤더가_1로_설정된다() {
+        whenever(keyResolver.resolve(any())).thenReturn(Mono.just("user:1"))
+        whenever(redisRateLimiter.isAllowed(any(), any())).thenReturn(Mono.just(deniedResponse()))
+
+        val request = MockServerHttpRequest.get("/api/v1/orders").build()
+        val exchange = MockServerWebExchange.from(request)
+
+        buildFilter().filter(exchange, chainCapturing(mutableListOf())).block()
+
+        assertThat(exchange.response.headers.getFirst("Retry-After")).isEqualTo("1")
+    }
+}

--- a/hoppingmall-cache/build.gradle.kts
+++ b/hoppingmall-cache/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 	kotlin("plugin.spring") version "1.9.25"
 	id("io.spring.dependency-management") version "1.1.7"
 	`java-library`
+	jacoco
 }
 
 group = "com.hoppingmall"
@@ -38,8 +39,59 @@ dependencies {
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
+	testImplementation("org.springframework.boot:spring-boot-starter-data-redis")
+	testImplementation("org.redisson:redisson-spring-boot-starter:4.3.0")
 }
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+}
+
+val jacocoExcludedDirs = listOf(
+	"**/config/**",
+	"**/dto/**",
+	"**/entity/**",
+	"**/response/**",
+	"**/error/**",
+	"**/enum/**",
+	"**/enums/**",
+	"**/vo/**",
+	"**/exception/**",
+	"**/*Application*"
+)
+
+tasks.jacocoTestReport {
+	dependsOn(tasks.test)
+	classDirectories.setFrom(
+		files(classDirectories.files.map {
+			fileTree(it) { exclude(jacocoExcludedDirs) }
+		})
+	)
+	reports {
+		xml.required.set(true)
+		html.required.set(true)
+	}
+}
+
+tasks.jacocoTestCoverageVerification {
+	dependsOn(tasks.jacocoTestReport)
+	classDirectories.setFrom(
+		files(classDirectories.files.map {
+			fileTree(it) { exclude(jacocoExcludedDirs) }
+		})
+	)
+	violationRules {
+		rule {
+			element = "CLASS"
+			limit {
+				counter = "LINE"
+				value = "COVEREDRATIO"
+				minimum = "0.80".toBigDecimal()
+			}
+		}
+	}
+}
+
+tasks.register("jacocoTestVerification") {
+	dependsOn(tasks.jacocoTestCoverageVerification)
 }

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/CachePolicyTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/CachePolicyTest.kt
@@ -1,0 +1,75 @@
+package com.hoppingmall.cache
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+@DisplayName("CachePolicy")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class CachePolicyTest {
+
+    @Test
+    fun hotKeyThreshold가_양수이면_dynamicHotKeyEnabled가_true이다() {
+        val policy = CachePolicy(
+            cacheName = "product",
+            l1MaxSize = 100,
+            l1Ttl = Duration.ofSeconds(10),
+            l2Ttl = Duration.ofMinutes(1),
+            hotKeyThreshold = 1L
+        )
+
+        assertThat(policy.dynamicHotKeyEnabled).isTrue()
+    }
+
+    @Test
+    fun hotKeyThreshold가_0이면_dynamicHotKeyEnabled가_false이다() {
+        val policy = CachePolicy(
+            cacheName = "product",
+            l1MaxSize = 100,
+            l1Ttl = Duration.ofSeconds(10),
+            l2Ttl = Duration.ofMinutes(1),
+            hotKeyThreshold = 0L
+        )
+
+        assertThat(policy.dynamicHotKeyEnabled).isFalse()
+    }
+
+    @Test
+    fun 기본값이_올바르게_설정된다() {
+        val policy = CachePolicy(
+            cacheName = "product",
+            l1MaxSize = 200,
+            l1Ttl = Duration.ofSeconds(30),
+            l2Ttl = Duration.ofMinutes(5)
+        )
+
+        assertThat(policy.jitterPercent).isEqualTo(10)
+        assertThat(policy.hotKeyThreshold).isEqualTo(0L)
+        assertThat(policy.hotKeyWindow).isEqualTo(Duration.ofSeconds(60))
+        assertThat(policy.hotKeyShardCount).isEqualTo(4)
+    }
+
+    @Test
+    fun 커스텀_값으로_생성하면_해당_값이_유지된다() {
+        val policy = CachePolicy(
+            cacheName = "order",
+            l1MaxSize = 500,
+            l1Ttl = Duration.ofSeconds(60),
+            l2Ttl = Duration.ofMinutes(10),
+            jitterPercent = 20,
+            hotKeyThreshold = 100L,
+            hotKeyWindow = Duration.ofSeconds(30),
+            hotKeyShardCount = 8
+        )
+
+        assertThat(policy.cacheName).isEqualTo("order")
+        assertThat(policy.l1MaxSize).isEqualTo(500L)
+        assertThat(policy.jitterPercent).isEqualTo(20)
+        assertThat(policy.hotKeyThreshold).isEqualTo(100L)
+        assertThat(policy.hotKeyWindow).isEqualTo(Duration.ofSeconds(30))
+        assertThat(policy.hotKeyShardCount).isEqualTo(8)
+    }
+}

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/HotKeyDetectorRegistryTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/HotKeyDetectorRegistryTest.kt
@@ -1,0 +1,81 @@
+package com.hoppingmall.cache
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+@DisplayName("HotKeyDetectorRegistry")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class HotKeyDetectorRegistryTest {
+
+    private fun policy(name: String, hotKeyThreshold: Long) = CachePolicy(
+        cacheName = name,
+        l1MaxSize = 100,
+        l1Ttl = Duration.ofSeconds(10),
+        l2Ttl = Duration.ofMinutes(1),
+        hotKeyThreshold = hotKeyThreshold
+    )
+
+    @Test
+    fun hotKeyThreshold가_양수인_정책에_대해_Detector를_생성한다() {
+        val registry = HotKeyDetectorRegistry(listOf(policy("product", 5L)))
+
+        assertThat(registry.getDetector("product")).isNotNull()
+        registry.close()
+    }
+
+    @Test
+    fun hotKeyThreshold가_0인_정책은_Detector를_생성하지_않는다() {
+        val registry = HotKeyDetectorRegistry(listOf(policy("product", 0L)))
+
+        assertThat(registry.getDetector("product")).isNull()
+        registry.close()
+    }
+
+    @Test
+    fun 등록되지_않은_캐시명은_null을_반환한다() {
+        val registry = HotKeyDetectorRegistry(listOf(policy("product", 5L)))
+
+        assertThat(registry.getDetector("unknown")).isNull()
+        registry.close()
+    }
+
+    @Test
+    fun 여러_정책을_동시에_등록할_수_있다() {
+        val registry = HotKeyDetectorRegistry(
+            listOf(
+                policy("product", 5L),
+                policy("category", 10L),
+                policy("user", 0L)
+            )
+        )
+
+        assertThat(registry.getDetector("product")).isNotNull()
+        assertThat(registry.getDetector("category")).isNotNull()
+        assertThat(registry.getDetector("user")).isNull()
+        registry.close()
+    }
+
+    @Test
+    fun close_호출_시_모든_Detector를_종료한다() {
+        val registry = HotKeyDetectorRegistry(
+            listOf(
+                policy("product", 5L),
+                policy("category", 10L)
+            )
+        )
+
+        registry.close()
+    }
+
+    @Test
+    fun 빈_정책_목록으로_생성하면_모든_조회가_null을_반환한다() {
+        val registry = HotKeyDetectorRegistry(emptyList())
+
+        assertThat(registry.getDetector("any")).isNull()
+        registry.close()
+    }
+}

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/NotFoundMarkerTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/NotFoundMarkerTest.kt
@@ -1,0 +1,51 @@
+package com.hoppingmall.cache
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("NotFoundMarker")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class NotFoundMarkerTest {
+
+    @Test
+    fun INSTANCE는_기본_reason을_가진다() {
+        assertThat(NotFoundMarker.INSTANCE.reason).isEqualTo("NOT_FOUND")
+    }
+
+    @Test
+    fun isNotFound는_NotFoundMarker_인스턴스에_대해_true를_반환한다() {
+        assertThat(NotFoundMarker.isNotFound(NotFoundMarker.INSTANCE)).isTrue()
+    }
+
+    @Test
+    fun isNotFound는_커스텀_NotFoundMarker에_대해_true를_반환한다() {
+        assertThat(NotFoundMarker.isNotFound(NotFoundMarker("CUSTOM"))).isTrue()
+    }
+
+    @Test
+    fun isNotFound는_일반_객체에_대해_false를_반환한다() {
+        assertThat(NotFoundMarker.isNotFound("some-string")).isFalse()
+    }
+
+    @Test
+    fun isNotFound는_null에_대해_false를_반환한다() {
+        assertThat(NotFoundMarker.isNotFound(null)).isFalse()
+    }
+
+    @Test
+    fun 같은_reason을_가진_두_인스턴스는_동등하다() {
+        val a = NotFoundMarker("X")
+        val b = NotFoundMarker("X")
+        assertThat(a).isEqualTo(b)
+    }
+
+    @Test
+    fun 다른_reason을_가진_두_인스턴스는_동등하지_않다() {
+        val a = NotFoundMarker("A")
+        val b = NotFoundMarker("B")
+        assertThat(a).isNotEqualTo(b)
+    }
+}

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/RedissonLockProviderTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/RedissonLockProviderTest.kt
@@ -1,0 +1,73 @@
+package com.hoppingmall.cache
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.redisson.api.RLock
+import org.redisson.api.RedissonClient
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+@DisplayName("RedissonLockProvider")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class RedissonLockProviderTest {
+
+    @Mock
+    private lateinit var redissonClient: RedissonClient
+
+    @Mock
+    private lateinit var rLock: RLock
+
+    @InjectMocks
+    private lateinit var lockProvider: RedissonLockProvider
+
+    @Test
+    fun tryLock_성공_시_true를_반환한다() {
+        whenever(redissonClient.getLock("lock:key")).thenReturn(rLock)
+        whenever(rLock.tryLock(0L, 3000L, TimeUnit.MILLISECONDS)).thenReturn(true)
+
+        val result = lockProvider.tryLock("lock:key", Duration.ofSeconds(3))
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun tryLock_실패_시_false를_반환한다() {
+        whenever(redissonClient.getLock("lock:key")).thenReturn(rLock)
+        whenever(rLock.tryLock(0L, 3000L, TimeUnit.MILLISECONDS)).thenReturn(false)
+
+        val result = lockProvider.tryLock("lock:key", Duration.ofSeconds(3))
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun unlock_현재_스레드가_락_보유_시_해제한다() {
+        whenever(redissonClient.getLock("lock:key")).thenReturn(rLock)
+        whenever(rLock.isHeldByCurrentThread).thenReturn(true)
+
+        lockProvider.unlock("lock:key")
+
+        verify(rLock).unlock()
+    }
+
+    @Test
+    fun unlock_현재_스레드가_락_미보유_시_unlock을_호출하지_않는다() {
+        whenever(redissonClient.getLock("lock:key")).thenReturn(rLock)
+        whenever(rLock.isHeldByCurrentThread).thenReturn(false)
+
+        lockProvider.unlock("lock:key")
+
+        verify(rLock, never()).unlock()
+    }
+}

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/ShardedRedisCacheExtraTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/ShardedRedisCacheExtraTest.kt
@@ -1,0 +1,69 @@
+package com.hoppingmall.cache
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.cache.Cache
+import java.util.concurrent.Callable
+
+@DisplayName("ShardedRedisCache 추가 경로")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class ShardedRedisCacheExtraTest {
+
+    private val delegate: Cache = mock()
+    private val nativeCacheObj = Any()
+    private val shardedCache = ShardedRedisCache(delegate, 4)
+
+    @Test
+    fun getNativeCache는_delegate의_nativeCache를_반환한다() {
+        whenever(delegate.nativeCache).thenReturn(nativeCacheObj)
+
+        assertThat(shardedCache.nativeCache).isSameAs(nativeCacheObj)
+    }
+
+    @Test
+    fun get_타입_지정_샤드_히트_시_값을_반환한다() {
+        whenever(delegate.get(any<String>(), eq(String::class.java))).thenReturn("shard-typed-value")
+
+        val result = shardedCache.get("key1", String::class.java)
+
+        assertThat(result).isEqualTo("shard-typed-value")
+    }
+
+    @Test
+    fun get_타입_지정_샤드_미스_원본_히트_시_값을_반환한다() {
+        whenever(delegate.get(any<String>(), eq(String::class.java))).thenAnswer { inv ->
+            val key = inv.getArgument<String>(0)
+            if (key.contains("::shard:")) null else "original-typed-value"
+        }
+
+        val result = shardedCache.get("key1", String::class.java)
+
+        assertThat(result).isEqualTo("original-typed-value")
+    }
+
+    @Test
+    fun get_타입_지정_모두_미스이면_null을_반환한다() {
+        whenever(delegate.get(any<String>(), eq(String::class.java))).thenReturn(null)
+
+        val result = shardedCache.get("key1", String::class.java)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun get_valueLoader는_delegate에_위임한다() {
+        val loader = Callable { "loader-result" }
+        whenever(delegate.get("key1", loader)).thenReturn("loader-result")
+
+        val result = shardedCache.get("key1", loader)
+
+        assertThat(result).isEqualTo("loader-result")
+    }
+}

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TtlJitterEdgeCaseTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TtlJitterEdgeCaseTest.kt
@@ -1,0 +1,42 @@
+package com.hoppingmall.cache
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+@DisplayName("TtlJitter 엣지케이스")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class TtlJitterEdgeCaseTest {
+
+    @Test
+    fun 음수_jitterPercent는_base_TTL을_그대로_반환한다() {
+        val baseTtl = Duration.ofSeconds(300)
+
+        val result = TtlJitter.apply(baseTtl, -5)
+
+        assertThat(result.seconds).isEqualTo(300)
+    }
+
+    @Test
+    fun jitter_100퍼센트면_base의_두배까지_범위다() {
+        val baseTtl = Duration.ofSeconds(100)
+
+        repeat(50) {
+            val result = TtlJitter.apply(baseTtl, 100)
+            assertThat(result.seconds).isBetween(100L, 200L)
+        }
+    }
+
+    @Test
+    fun base가_1초일때_jitter가_적용된다() {
+        val baseTtl = Duration.ofSeconds(1)
+
+        repeat(20) {
+            val result = TtlJitter.apply(baseTtl, 100)
+            assertThat(result.seconds).isBetween(1L, 2L)
+        }
+    }
+}

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TwoLevelCacheLookupTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TwoLevelCacheLookupTest.kt
@@ -1,0 +1,297 @@
+package com.hoppingmall.cache
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.cache.Cache
+import java.time.Duration
+import java.util.concurrent.Callable
+
+@DisplayName("TwoLevelCache 조회 및 부가 경로")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class TwoLevelCacheLookupTest {
+
+    private val redisCache: Cache = mock()
+    private val lockProvider = FakeLockProvider()
+    private lateinit var meterRegistry: SimpleMeterRegistry
+
+    private val normalPolicy = CachePolicy(
+        cacheName = "category",
+        l1MaxSize = 100,
+        l1Ttl = Duration.ofSeconds(30),
+        l2Ttl = Duration.ofMinutes(5),
+        jitterPercent = 10
+    )
+
+    private val hotKeyPolicy = CachePolicy(
+        cacheName = "product",
+        l1MaxSize = 100,
+        l1Ttl = Duration.ofSeconds(10),
+        l2Ttl = Duration.ofMinutes(10),
+        jitterPercent = 10,
+        hotKeyThreshold = 5L,
+        hotKeyShardCount = 4
+    )
+
+    @BeforeEach
+    fun setUp() {
+        lockProvider.reset()
+        meterRegistry = SimpleMeterRegistry()
+    }
+
+    private fun createCache(policy: CachePolicy): TwoLevelCache {
+        val caffeineCache = Caffeine.newBuilder()
+            .maximumSize(policy.l1MaxSize)
+            .expireAfterWrite(policy.l1Ttl)
+            .build<Any, Any>()
+        return TwoLevelCache(policy.cacheName, caffeineCache, redisCache, policy, lockProvider, meterRegistry = meterRegistry)
+    }
+
+    @Nested
+    @DisplayName("lookup 경로")
+    inner class LookupPath {
+
+        @Test
+        fun L1_히트_시_L2를_조회하지_않고_값을_반환한다() {
+            val cache = createCache(normalPolicy)
+            cache.put("k1", "v1")
+
+            val result = cache.get("k1")
+
+            assertThat(result?.get()).isEqualTo("v1")
+            verify(redisCache, never()).get(any<Any>())
+            assertThat(meterRegistry.counter("cache.l1.hit", "cache", "category").count()).isEqualTo(1.0)
+        }
+
+        @Test
+        fun L2_히트_시_값을_반환하고_L1에_승격한다() {
+            val cache = createCache(normalPolicy)
+            val wrapper: Cache.ValueWrapper = mock()
+            whenever(wrapper.get()).thenReturn("redis-val")
+            whenever(redisCache.get("k1")).thenReturn(wrapper)
+
+            val result = cache.get("k1")
+
+            assertThat(result?.get()).isEqualTo("redis-val")
+            assertThat(meterRegistry.counter("cache.l2.hit", "cache", "category").count()).isEqualTo(1.0)
+        }
+
+        @Test
+        fun L1_L2_모두_미스이면_null을_반환하고_miss_메트릭이_증가한다() {
+            val cache = createCache(normalPolicy)
+            whenever(redisCache.get(any<Any>())).thenReturn(null)
+
+            val result = cache.get("missing")
+
+            assertThat(result).isNull()
+            assertThat(meterRegistry.counter("cache.miss", "cache", "category").count()).isEqualTo(1.0)
+        }
+
+        @Test
+        fun getName은_cacheName을_반환한다() {
+            val cache = createCache(normalPolicy)
+            assertThat(cache.name).isEqualTo("category")
+        }
+
+        @Test
+        fun getNativeCache는_caffeineCache를_반환한다() {
+            val cache = createCache(normalPolicy)
+            assertThat(cache.nativeCache).isNotNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("put null 값")
+    inner class PutNull {
+
+        @Test
+        fun null_값을_put하면_L1에서_무효화한다() {
+            val cache = createCache(normalPolicy)
+            cache.put("k1", "v1")
+            cache.put("k1", null)
+
+            val result = cache.get("k1")
+
+            assertThat(result).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("clear")
+    inner class ClearOperation {
+
+        @Test
+        fun clear_호출_시_L2_clear를_위임하고_L1을_비운다() {
+            val cache = createCache(normalPolicy)
+            cache.put("k1", "v1")
+
+            cache.clear()
+
+            verify(redisCache).clear()
+            assertThat(cache.get("k1")).isNull()
+        }
+
+        @Test
+        fun L2_clear_예외_발생_시_L1은_정상_비워진다() {
+            val cache = createCache(normalPolicy)
+            cache.put("k1", "v1")
+            whenever(redisCache.clear()).thenThrow(RuntimeException("redis down"))
+
+            cache.clear()
+
+            assertThat(cache.get("k1")).isNull()
+            assertThat(meterRegistry.counter("cache.l2.failure", "cache", "category").count()).isEqualTo(1.0)
+        }
+    }
+
+    @Nested
+    @DisplayName("evict 예외 처리")
+    inner class EvictException {
+
+        @Test
+        fun L2_evict_예외_발생_시_L1에서는_삭제된다() {
+            val cache = createCache(normalPolicy)
+            cache.put("k1", "v1")
+            whenever(redisCache.evict(any())).thenThrow(RuntimeException("redis down"))
+
+            cache.evict("k1")
+
+            assertThat(cache.get("k1")).isNull()
+            assertThat(meterRegistry.counter("cache.l2.failure", "cache", "category").count()).isEqualTo(1.0)
+        }
+    }
+
+    @Nested
+    @DisplayName("safeL2 예외 처리")
+    inner class SafeL2Exception {
+
+        @Test
+        fun L2_get_예외_발생_시_miss_처리하고_valueLoader를_호출한다() {
+            val cache = createCache(normalPolicy)
+            whenever(redisCache.get(any<Any>())).thenThrow(RuntimeException("redis error"))
+
+            val result = cache.get("k1", Callable { "fallback" })
+
+            assertThat(result).isEqualTo("fallback")
+            assertThat(meterRegistry.counter("cache.l2.failure", "cache", "category").count()).isEqualTo(1.0)
+        }
+
+        @Test
+        fun L2_put_예외_발생_시_메트릭을_증가한다() {
+            val cache = createCache(normalPolicy)
+            whenever(redisCache.put(any(), any())).thenThrow(RuntimeException("redis error"))
+            whenever(redisCache.get(any<Any>())).thenReturn(null)
+
+            cache.get("k1", Callable { "loaded" })
+
+            assertThat(meterRegistry.counter("cache.l2.failure", "cache", "category").count()).isEqualTo(1.0)
+        }
+    }
+
+    @Nested
+    @DisplayName("핫키 락 재확인 경로")
+    inner class HotKeyLockRecheck {
+
+        @Test
+        fun 락_획득_후_L2에_값이_있으면_DB_로더를_호출하지_않는다() {
+            val fakeDetector = FakeHotKeyDetector()
+            fakeDetector.overrideIsHot = true
+            val shardedCache: Cache = mock()
+
+            val caffeineCache = Caffeine.newBuilder()
+                .maximumSize(hotKeyPolicy.l1MaxSize)
+                .expireAfterWrite(hotKeyPolicy.l1Ttl)
+                .build<Any, Any>()
+
+            val cache = TwoLevelCache(
+                hotKeyPolicy.cacheName, caffeineCache, redisCache, hotKeyPolicy,
+                lockProvider, shardedCache, fakeDetector, meterRegistry
+            )
+
+            val wrapper: Cache.ValueWrapper = mock()
+            whenever(wrapper.get()).thenReturn("recheck-value")
+            whenever(shardedCache.get("k1")).thenReturn(null)
+            whenever(redisCache.get("k1")).thenReturn(wrapper)
+
+            var loaderCalled = false
+            val result = cache.get("k1", Callable {
+                loaderCalled = true
+                "should-not-load"
+            })
+
+            assertThat(result).isEqualTo("recheck-value")
+            assertThat(loaderCalled).isFalse()
+            assertThat(meterRegistry.counter("cache.l2.hit", "cache", "product").count()).isEqualTo(1.0)
+        }
+
+        @Test
+        fun 락_획득_예외_발생_시_waitForCacheOrFallback으로_대기한다() {
+            val fakeDetector = FakeHotKeyDetector()
+            fakeDetector.overrideIsHot = true
+            val shardedCache: Cache = mock()
+
+            val failingLock = object : LockProvider {
+                override fun tryLock(key: String, leaseTime: Duration): Boolean =
+                    throw RuntimeException("lock service down")
+                override fun unlock(key: String) {}
+            }
+
+            val caffeineCache = Caffeine.newBuilder()
+                .maximumSize(hotKeyPolicy.l1MaxSize)
+                .expireAfterWrite(hotKeyPolicy.l1Ttl)
+                .build<Any, Any>()
+
+            val cache = TwoLevelCache(
+                hotKeyPolicy.cacheName, caffeineCache, redisCache, hotKeyPolicy,
+                failingLock, shardedCache, fakeDetector, meterRegistry
+            )
+
+            whenever(shardedCache.get("k1")).thenReturn(null)
+            val wrapper: Cache.ValueWrapper = mock()
+            whenever(wrapper.get()).thenReturn("waited-value")
+            whenever(redisCache.get("k1")).thenReturn(wrapper)
+
+            val result = cache.get("k1", Callable { "fallback" })
+
+            assertThat(result).isEqualTo("waited-value")
+        }
+    }
+
+    @Nested
+    @DisplayName("핫키 null 값 put")
+    inner class HotKeyNullPut {
+
+        @Test
+        fun 핫키_상태에서_null_값을_put하면_샤딩된_캐시에_위임한다() {
+            val fakeDetector = FakeHotKeyDetector()
+            fakeDetector.overrideIsHot = true
+            val shardedCache: Cache = mock()
+
+            val caffeineCache = Caffeine.newBuilder()
+                .maximumSize(hotKeyPolicy.l1MaxSize)
+                .expireAfterWrite(hotKeyPolicy.l1Ttl)
+                .build<Any, Any>()
+
+            val cache = TwoLevelCache(
+                hotKeyPolicy.cacheName, caffeineCache, redisCache, hotKeyPolicy,
+                lockProvider, shardedCache, fakeDetector, meterRegistry
+            )
+
+            cache.put("k1", null)
+
+            verify(shardedCache).put("k1", null)
+            verify(redisCache, never()).put(any(), any())
+        }
+    }
+}

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TwoLevelCacheManagerExtraTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TwoLevelCacheManagerExtraTest.kt
@@ -1,0 +1,132 @@
+package com.hoppingmall.cache
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import java.time.Duration
+
+@DisplayName("TwoLevelCacheManager 추가 경로")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class TwoLevelCacheManagerExtraTest {
+
+    private fun createManager(
+        redisCacheManager: CacheManager,
+        vararg policies: CachePolicy
+    ): TwoLevelCacheManager {
+        return TwoLevelCacheManager(
+            redisCacheManager = redisCacheManager,
+            policies = policies.associateBy { it.cacheName },
+            lockProvider = FakeLockProvider(),
+            hotKeyDetectorRegistry = HotKeyDetectorRegistry(policies.toList())
+        )
+    }
+
+    private fun policy(name: String, hotKeyThreshold: Long = 0L) = CachePolicy(
+        cacheName = name,
+        l1MaxSize = 100,
+        l1Ttl = Duration.ofSeconds(10),
+        l2Ttl = Duration.ofMinutes(1),
+        hotKeyThreshold = hotKeyThreshold
+    )
+
+    @Test
+    fun getCacheNames는_redisCacheManager의_캐시명_목록을_반환한다() {
+        val redisCacheManager = mock<CacheManager>()
+        whenever(redisCacheManager.cacheNames).thenReturn(listOf("product", "order"))
+        val manager = createManager(redisCacheManager)
+
+        assertThat(manager.cacheNames).containsExactlyInAnyOrder("product", "order")
+    }
+
+    @Test
+    fun 정책이_없는_캐시명은_redis_캐시를_그대로_반환한다() {
+        val redisCacheManager = mock<CacheManager>()
+        val redisCache = mock<Cache>()
+        whenever(redisCacheManager.getCache("no-policy-cache")).thenReturn(redisCache)
+        val manager = createManager(redisCacheManager)
+
+        val result = manager.getCache("no-policy-cache")
+
+        assertThat(result).isSameAs(redisCache)
+    }
+
+    @Test
+    fun hotKey_비활성_정책은_ShardedRedisCache_없이_TwoLevelCache를_생성한다() {
+        val redisCacheManager = mock<CacheManager>()
+        val redisCache = mock<Cache>()
+        val pol = policy("simple-cache", hotKeyThreshold = 0L)
+        whenever(redisCacheManager.getCache("simple-cache")).thenReturn(redisCache)
+        val manager = createManager(redisCacheManager, pol)
+
+        val result = manager.getCache("simple-cache")
+
+        assertThat(result).isNotNull()
+        assertThat(result).isInstanceOf(TwoLevelCache::class.java)
+    }
+
+    @Test
+    fun hotKey_활성_정책은_TwoLevelCache를_생성한다() {
+        val redisCacheManager = mock<CacheManager>()
+        val redisCache = mock<Cache>()
+        val pol = policy("hot-cache", hotKeyThreshold = 5L)
+        whenever(redisCacheManager.getCache("hot-cache")).thenReturn(redisCache)
+        val manager = createManager(redisCacheManager, pol)
+
+        val result = manager.getCache("hot-cache")
+
+        assertThat(result).isNotNull()
+        assertThat(result).isInstanceOf(TwoLevelCache::class.java)
+    }
+
+    @Test
+    fun 동일_캐시명_두_번_조회_시_같은_인스턴스를_반환한다() {
+        val redisCacheManager = mock<CacheManager>()
+        val redisCache = mock<Cache>()
+        val pol = policy("product")
+        whenever(redisCacheManager.getCache("product")).thenReturn(redisCache)
+        val manager = createManager(redisCacheManager, pol)
+
+        val first = manager.getCache("product")
+        val second = manager.getCache("product")
+
+        assertThat(first).isSameAs(second)
+    }
+
+    @Test
+    fun buildRedisCacheManager_커스텀_TTL로_RedisCacheManager를_생성한다() {
+        val connectionFactory = mock<RedisConnectionFactory>()
+        val policies = mapOf(
+            "product" to policy("product"),
+            "order" to policy("order")
+        )
+
+        val redisCacheManager = TwoLevelCacheManager.buildRedisCacheManager(
+            connectionFactory,
+            policies,
+            Duration.ofMinutes(10)
+        )
+
+        assertThat(redisCacheManager).isNotNull()
+        assertThat(redisCacheManager).isInstanceOf(org.springframework.data.redis.cache.RedisCacheManager::class.java)
+    }
+
+    @Test
+    fun buildRedisCacheManager_기본_TTL로_생성된다() {
+        val connectionFactory = mock<RedisConnectionFactory>()
+
+        val redisCacheManager = TwoLevelCacheManager.buildRedisCacheManager(
+            connectionFactory,
+            emptyMap()
+        )
+
+        assertThat(redisCacheManager).isNotNull()
+        assertThat(redisCacheManager).isInstanceOf(org.springframework.data.redis.cache.RedisCacheManager::class.java)
+    }
+}

--- a/hoppingmall-common/src/test/kotlin/com/hoppingmall/common/GlobalExceptionHandlerTest.kt
+++ b/hoppingmall-common/src/test/kotlin/com/hoppingmall/common/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,118 @@
+package com.hoppingmall.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.springframework.core.MethodParameter
+import org.springframework.http.HttpStatus
+import org.springframework.validation.BeanPropertyBindingResult
+import org.springframework.validation.FieldError
+import org.springframework.web.bind.MethodArgumentNotValidException
+
+@DisplayName("GlobalExceptionHandler 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class GlobalExceptionHandlerTest {
+
+    private val handler = GlobalExceptionHandler()
+
+    private val methodParameter: MethodParameter =
+        MethodParameter(GlobalExceptionHandler::class.java.methods[0], -1)
+
+    @Test
+    fun BusinessException_처리_시_ErrorCode_기반_응답을_반환한다() {
+        val exception = BusinessException(CommonErrorCode.INVALID_INPUT)
+
+        val response = handler.handleBusinessException(exception)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(response.body?.code).isEqualTo("C001")
+        assertThat(response.body?.message).isEqualTo("잘못된 입력입니다.")
+        assertThat(response.body?.data).isNull()
+    }
+
+    @Test
+    fun UNAUTHORIZED_ErrorCode_BusinessException_처리() {
+        val exception = BusinessException(CommonErrorCode.UNAUTHORIZED)
+
+        val response = handler.handleBusinessException(exception)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
+        assertThat(response.body?.code).isEqualTo("A001")
+    }
+
+    @Test
+    fun FORBIDDEN_ErrorCode_BusinessException_처리() {
+        val exception = BusinessException(CommonErrorCode.FORBIDDEN)
+
+        val response = handler.handleBusinessException(exception)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+        assertThat(response.body?.code).isEqualTo("A002")
+    }
+
+    @Test
+    fun INTERNAL_ERROR_ErrorCode_BusinessException_처리() {
+        val exception = BusinessException(CommonErrorCode.INTERNAL_ERROR)
+
+        val response = handler.handleBusinessException(exception)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        assertThat(response.body?.code).isEqualTo("S001")
+    }
+
+    @Test
+    fun LOCK_ACQUISITION_FAILED_ErrorCode_BusinessException_처리() {
+        val exception = BusinessException(CommonErrorCode.LOCK_ACQUISITION_FAILED)
+
+        val response = handler.handleBusinessException(exception)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.CONFLICT)
+        assertThat(response.body?.code).isEqualTo("S002")
+    }
+
+    @Test
+    fun MethodArgumentNotValidException_처리_시_첫번째_필드_에러_메시지를_사용한다() {
+        val bindingResult = BeanPropertyBindingResult(Any(), "target")
+        bindingResult.addError(FieldError("target", "name", "이름은 필수입니다."))
+        val exception = MethodArgumentNotValidException(methodParameter, bindingResult)
+
+        val response = handler.handleValidationException(exception)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(response.body?.code).isEqualTo(CommonErrorCode.INVALID_INPUT.code)
+    }
+
+    @Test
+    fun MethodArgumentNotValidException_필드에러가_없으면_기본_메시지를_사용한다() {
+        val bindingResult = BeanPropertyBindingResult(Any(), "target")
+        val exception = MethodArgumentNotValidException(methodParameter, bindingResult)
+
+        val response = handler.handleValidationException(exception)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(response.body?.code).isEqualTo(CommonErrorCode.INVALID_INPUT.code)
+    }
+
+    @Test
+    fun 일반_Exception_처리_시_INTERNAL_ERROR_응답을_반환한다() {
+        val exception = RuntimeException("예상치 못한 오류")
+
+        val response = handler.handleException(exception)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        assertThat(response.body?.code).isEqualTo(CommonErrorCode.INTERNAL_ERROR.code)
+        assertThat(response.body?.message).isEqualTo(CommonErrorCode.INTERNAL_ERROR.message)
+    }
+
+    @Test
+    fun NullPointerException_처리() {
+        val exception = NullPointerException()
+
+        val response = handler.handleException(exception)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        assertThat(response.body?.code).isEqualTo("S001")
+    }
+}

--- a/hoppingmall-common/src/test/kotlin/com/hoppingmall/common/UserPrincipalTest.kt
+++ b/hoppingmall-common/src/test/kotlin/com/hoppingmall/common/UserPrincipalTest.kt
@@ -1,0 +1,76 @@
+package com.hoppingmall.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("UserPrincipal 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class UserPrincipalTest {
+
+    @Test
+    fun of_팩토리_메서드로_UserPrincipal을_생성한다() {
+        val principal = UserPrincipal.of(1L, "BUYER")
+
+        assertThat(principal.getUserId()).isEqualTo(1L)
+        assertThat(principal.getRole()).isEqualTo("BUYER")
+    }
+
+    @Test
+    fun getAuthorities는_ROLE_접두사가_붙은_권한을_반환한다() {
+        val principal = UserPrincipal.of(1L, "SELLER")
+
+        val authorities = principal.authorities
+
+        assertThat(authorities).hasSize(1)
+        assertThat(authorities.first().authority).isEqualTo("ROLE_SELLER")
+    }
+
+    @Test
+    fun ADMIN_역할의_권한을_확인한다() {
+        val principal = UserPrincipal.of(99L, "ADMIN")
+
+        assertThat(principal.authorities.first().authority).isEqualTo("ROLE_ADMIN")
+    }
+
+    @Test
+    fun getUsername은_userId를_문자열로_반환한다() {
+        val principal = UserPrincipal.of(42L, "BUYER")
+
+        assertThat(principal.username).isEqualTo("42")
+    }
+
+    @Test
+    fun getPassword는_null을_반환한다() {
+        val principal = UserPrincipal.of(1L, "BUYER")
+
+        assertThat(principal.password).isNull()
+    }
+
+    @Test
+    fun 계정_상태_플래그는_모두_true를_반환한다() {
+        val principal = UserPrincipal.of(1L, "BUYER")
+
+        assertThat(principal.isAccountNonExpired).isTrue()
+        assertThat(principal.isAccountNonLocked).isTrue()
+        assertThat(principal.isCredentialsNonExpired).isTrue()
+        assertThat(principal.isEnabled).isTrue()
+    }
+
+    @Test
+    fun getUserId는_생성자에_전달된_userId를_반환한다() {
+        val principal = UserPrincipal.of(Long.MAX_VALUE, "BUYER")
+
+        assertThat(principal.getUserId()).isEqualTo(Long.MAX_VALUE)
+    }
+
+    @Test
+    fun getRole은_생성자에_전달된_role을_반환한다() {
+        val principal = UserPrincipal.of(1L, "CUSTOM_ROLE")
+
+        assertThat(principal.getRole()).isEqualTo("CUSTOM_ROLE")
+        assertThat(principal.authorities.first().authority).isEqualTo("ROLE_CUSTOM_ROLE")
+    }
+}

--- a/hoppingmall-common/src/test/kotlin/com/hoppingmall/common/consumer/IdempotentConsumeTemplateTest.kt
+++ b/hoppingmall-common/src/test/kotlin/com/hoppingmall/common/consumer/IdempotentConsumeTemplateTest.kt
@@ -1,0 +1,107 @@
+package com.hoppingmall.common.consumer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
+
+@DisplayName("IdempotentConsumeTemplate 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class IdempotentConsumeTemplateTest {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Test
+    fun 중복되지_않은_이벤트는_액션을_실행한다() {
+        var executed = false
+
+        executeIdempotently(
+            eventId = "event-1",
+            eventDescription = "테스트",
+            logger = logger,
+            existsCheck = { false },
+            action = { executed = true }
+        )
+
+        assertThat(executed).isTrue()
+    }
+
+    @Test
+    fun 이미_처리된_이벤트는_액션을_실행하지_않는다() {
+        var executed = false
+
+        executeIdempotently(
+            eventId = "event-1",
+            eventDescription = "테스트",
+            logger = logger,
+            existsCheck = { true },
+            action = { executed = true }
+        )
+
+        assertThat(executed).isFalse()
+    }
+
+    @Test
+    fun DataIntegrityViolationException_발생_시_이미_처리된_것으로_간주한다() {
+        var actionCalled = false
+
+        executeIdempotently(
+            eventId = "event-1",
+            eventDescription = "테스트",
+            logger = logger,
+            existsCheck = { false },
+            action = {
+                actionCalled = true
+                throw DataIntegrityViolationException("Duplicate entry")
+            }
+        )
+
+        assertThat(actionCalled).isTrue()
+    }
+
+    @Test
+    fun 일반_Exception_발생_시_예외를_다시_던진다() {
+        assertThatThrownBy {
+            executeIdempotently(
+                eventId = "event-1",
+                eventDescription = "테스트",
+                logger = logger,
+                existsCheck = { false },
+                action = { throw IllegalStateException("처리 실패") }
+            )
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("처리 실패")
+    }
+
+    @Test
+    fun RuntimeException_발생_시_예외를_다시_던진다() {
+        assertThatThrownBy {
+            executeIdempotently(
+                eventId = "event-2",
+                eventDescription = "결제",
+                logger = logger,
+                existsCheck = { false },
+                action = { throw RuntimeException("런타임 오류") }
+            )
+        }.isInstanceOf(RuntimeException::class.java)
+            .hasMessage("런타임 오류")
+    }
+
+    @Test
+    fun existsCheck에서_예외가_발생하면_그대로_전파된다() {
+        assertThatThrownBy {
+            executeIdempotently(
+                eventId = "event-3",
+                eventDescription = "포인트",
+                logger = logger,
+                existsCheck = { throw RuntimeException("DB 연결 실패") },
+                action = { }
+            )
+        }.isInstanceOf(RuntimeException::class.java)
+            .hasMessage("DB 연결 실패")
+    }
+}

--- a/hoppingmall-common/src/test/kotlin/com/hoppingmall/common/event/AvroEventConverterTest.kt
+++ b/hoppingmall-common/src/test/kotlin/com/hoppingmall/common/event/AvroEventConverterTest.kt
@@ -1,0 +1,366 @@
+package com.hoppingmall.common.event
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("AvroEventConverter 단위 테스트")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class AvroEventConverterTest {
+
+    private val objectMapper = ObjectMapper()
+    private val converter = AvroEventConverter(objectMapper)
+
+    @Test
+    fun PaymentCompletedEvent_JSON을_Avro_레코드로_변환한다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "paymentId" to 1,
+                "orderId" to 10,
+                "userId" to 100,
+                "amount" to "50000",
+                "pointAmount" to "500",
+                "method" to "CREDIT_CARD",
+                "status" to "SUCCESS",
+                "transactionId" to "tx-001",
+                "completedAt" to "2026-01-01T00:00:00"
+            )
+        )
+
+        val record = converter.convertJsonToAvro("PaymentCompletedEvent", json)
+
+        assertThat(record.get("paymentId")).isEqualTo(1L)
+        assertThat(record.get("orderId")).isEqualTo(10L)
+        assertThat(record.get("userId")).isEqualTo(100L)
+        assertThat(record.get("amount").toString()).isEqualTo("50000")
+        assertThat(record.get("transactionId").toString()).isEqualTo("tx-001")
+    }
+
+    @Test
+    fun PaymentCompleted_별칭으로도_변환이_가능하다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "paymentId" to 1,
+                "orderId" to 10,
+                "userId" to 100,
+                "amount" to "50000",
+                "pointAmount" to "500",
+                "method" to "CREDIT_CARD",
+                "status" to "SUCCESS",
+                "transactionId" to "tx-001",
+                "completedAt" to "2026-01-01T00:00:00"
+            )
+        )
+
+        val record = converter.convertJsonToAvro("PaymentCompleted", json)
+
+        assertThat(record.get("paymentId")).isEqualTo(1L)
+    }
+
+    @Test
+    fun PaymentFailedEvent_JSON을_Avro_레코드로_변환한다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "eventId" to "evt-001",
+                "paymentId" to 1,
+                "orderId" to 10,
+                "userId" to 100,
+                "amount" to "30000",
+                "reason" to "잔액 부족"
+            )
+        )
+
+        val record = converter.convertJsonToAvro("PaymentFailedEvent", json)
+
+        assertThat(record.get("eventId").toString()).isEqualTo("evt-001")
+        assertThat(record.get("reason").toString()).isEqualTo("잔액 부족")
+    }
+
+    @Test
+    fun PaymentCancelledEvent_JSON을_Avro_레코드로_변환한다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "eventId" to "evt-002",
+                "paymentId" to 2,
+                "orderId" to 20,
+                "userId" to 200,
+                "amount" to "10000",
+                "transactionId" to "tx-002"
+            )
+        )
+
+        val record = converter.convertJsonToAvro("PaymentCancelledEvent", json)
+
+        assertThat(record.get("eventId").toString()).isEqualTo("evt-002")
+        assertThat(record.get("paymentId")).isEqualTo(2L)
+    }
+
+    @Test
+    fun PointEarnRequestEvent_JSON을_Avro_레코드로_변환한다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "eventId" to "evt-003",
+                "userId" to 100,
+                "orderId" to 10,
+                "paymentId" to 1,
+                "earnAmount" to "500",
+                "reason" to "결제 완료"
+            )
+        )
+
+        val record = converter.convertJsonToAvro("PointEarnRequestEvent", json)
+
+        assertThat(record.get("earnAmount").toString()).isEqualTo("500")
+        assertThat(record.get("reason").toString()).isEqualTo("결제 완료")
+    }
+
+    @Test
+    fun MembershipUpdateRequestEvent_JSON을_Avro_레코드로_변환한다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "eventId" to "evt-004",
+                "userId" to 100,
+                "orderId" to 10,
+                "paymentId" to 1,
+                "amount" to "50000"
+            )
+        )
+
+        val record = converter.convertJsonToAvro("MembershipUpdateRequestEvent", json)
+
+        assertThat(record.get("amount").toString()).isEqualTo("50000")
+    }
+
+    @Test
+    fun NotificationEvent_JSON을_Avro_레코드로_변환한다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "eventId" to "evt-005",
+                "userId" to 100,
+                "type" to "PAYMENT_COMPLETED",
+                "title" to "결제 완료",
+                "content" to "결제가 완료되었습니다.",
+                "metadata" to null
+            )
+        )
+
+        val record = converter.convertJsonToAvro("NotificationEvent", json)
+
+        assertThat(record.get("title").toString()).isEqualTo("결제 완료")
+        assertThat(record.get("metadata")).isNull()
+    }
+
+    @Test
+    fun NotificationRequested_접미사_이벤트는_NotificationEvent_스키마를_사용한다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "eventId" to "evt-006",
+                "userId" to 100,
+                "type" to "POINT_EARNED",
+                "title" to "포인트 적립",
+                "content" to "포인트가 적립되었습니다.",
+                "metadata" to "extra-info"
+            )
+        )
+
+        val record = converter.convertJsonToAvro("PointEarnedNotificationRequested", json)
+
+        assertThat(record.get("eventId").toString()).isEqualTo("evt-006")
+        assertThat(record.get("metadata").toString()).isEqualTo("extra-info")
+    }
+
+    @Test
+    fun RefundCompletedEvent_JSON을_Avro_레코드로_변환한다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "eventId" to "evt-007",
+                "refundId" to 1,
+                "orderId" to 10,
+                "paymentId" to 1,
+                "buyerId" to 100,
+                "refundAmount" to "50000",
+                "pointRefundAmount" to "500",
+                "isFullRefund" to true,
+                "couponId" to null,
+                "items" to listOf(
+                    mapOf(
+                        "productId" to 1,
+                        "quantity" to 2,
+                        "refundPrice" to "25000"
+                    )
+                )
+            )
+        )
+
+        val record = converter.convertJsonToAvro("RefundCompletedEvent", json)
+
+        assertThat(record.get("refundAmount").toString()).isEqualTo("50000")
+        assertThat(record.get("isFullRefund")).isEqualTo(true)
+        assertThat(record.get("couponId")).isNull()
+        @Suppress("UNCHECKED_CAST")
+        val items = record.get("items") as List<*>
+        assertThat(items).hasSize(1)
+    }
+
+    @Test
+    fun PaymentCancellationRequestedEvent_JSON을_Avro_레코드로_변환한다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "eventId" to "evt-008",
+                "orderId" to 10
+            )
+        )
+
+        val record = converter.convertJsonToAvro("PaymentCancellationRequested", json)
+
+        assertThat(record.get("eventId").toString()).isEqualTo("evt-008")
+        assertThat(record.get("orderId")).isEqualTo(10L)
+    }
+
+    @Test
+    fun PaymentCancellationCompletedEvent_JSON을_Avro_레코드로_변환한다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "eventId" to "evt-009",
+                "orderId" to 10,
+                "paymentId" to 1
+            )
+        )
+
+        val record = converter.convertJsonToAvro("PaymentCancellationCompleted", json)
+
+        assertThat(record.get("eventId").toString()).isEqualTo("evt-009")
+        assertThat(record.get("paymentId")).isEqualTo(1L)
+    }
+
+    @Test
+    fun PaymentCancellationFailedEvent_JSON을_Avro_레코드로_변환한다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "eventId" to "evt-010",
+                "orderId" to 10,
+                "reason" to "이미 취소됨"
+            )
+        )
+
+        val record = converter.convertJsonToAvro("PaymentCancellationFailed", json)
+
+        assertThat(record.get("reason").toString()).isEqualTo("이미 취소됨")
+    }
+
+    @Test
+    fun 알_수_없는_이벤트_타입이면_예외를_던진다() {
+        val json = objectMapper.writeValueAsString(mapOf("field" to "value"))
+
+        assertThatThrownBy {
+            converter.convertJsonToAvro("UnknownEvent", json)
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Unknown event type: UnknownEvent")
+    }
+
+    @Test
+    fun PaymentReversalRequested_별칭으로_PaymentCancelledEvent_스키마를_사용한다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "eventId" to "evt-011",
+                "paymentId" to 5,
+                "orderId" to 50,
+                "userId" to 500,
+                "amount" to "20000",
+                "transactionId" to "tx-011"
+            )
+        )
+
+        val record = converter.convertJsonToAvro("PaymentReversalRequested", json)
+
+        assertThat(record.get("eventId").toString()).isEqualTo("evt-011")
+        assertThat(record.get("paymentId")).isEqualTo(5L)
+    }
+
+    @Test
+    fun LONG_타입_필드에_null이_오면_기본값_0을_사용한다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "eventId" to "evt-012",
+                "paymentId" to null,
+                "orderId" to 10,
+                "userId" to 100,
+                "amount" to "30000",
+                "reason" to ""
+            )
+        )
+
+        val record = converter.convertJsonToAvro("PaymentFailedEvent", json)
+
+        assertThat(record.get("paymentId")).isEqualTo(0L)
+    }
+
+    @Test
+    fun RefundCompletedEvent_빈_items_배열을_처리한다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "eventId" to "evt-013",
+                "refundId" to 1,
+                "orderId" to 10,
+                "paymentId" to 1,
+                "buyerId" to 100,
+                "refundAmount" to "50000",
+                "pointRefundAmount" to "0",
+                "isFullRefund" to false,
+                "couponId" to null,
+                "items" to emptyList<Any>()
+            )
+        )
+
+        val record = converter.convertJsonToAvro("RefundCompletedEvent", json)
+
+        @Suppress("UNCHECKED_CAST")
+        val items = record.get("items") as List<*>
+        assertThat(items).isEmpty()
+    }
+
+    @Test
+    fun BOOLEAN_타입_필드에_null이_오면_기본값_false를_사용한다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "eventId" to "evt-014",
+                "refundId" to 1,
+                "orderId" to 10,
+                "paymentId" to 1,
+                "buyerId" to 100,
+                "refundAmount" to "50000",
+                "pointRefundAmount" to "0",
+                "isFullRefund" to null,
+                "couponId" to null,
+                "items" to emptyList<Any>()
+            )
+        )
+
+        val record = converter.convertJsonToAvro("RefundCompletedEvent", json)
+
+        assertThat(record.get("isFullRefund")).isEqualTo(false)
+    }
+
+    @Test
+    fun STRING_타입_필드에_null이_오면_빈_문자열을_사용한다() {
+        val json = objectMapper.writeValueAsString(
+            mapOf(
+                "eventId" to "evt-015",
+                "paymentId" to 1,
+                "orderId" to 10,
+                "userId" to 100,
+                "amount" to null,
+                "reason" to null
+            )
+        )
+
+        val record = converter.convertJsonToAvro("PaymentFailedEvent", json)
+
+        assertThat(record.get("amount").toString()).isEqualTo("")
+        assertThat(record.get("reason").toString()).isEqualTo("")
+    }
+}

--- a/hoppingmall-dlq/build.gradle.kts
+++ b/hoppingmall-dlq/build.gradle.kts
@@ -36,6 +36,8 @@ dependencies {
 	compileOnly("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	testImplementation("io.micrometer:micrometer-core")
+	testImplementation("org.springframework.kafka:spring-kafka")
 	testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/controller/DLQControllerTest.kt
+++ b/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/controller/DLQControllerTest.kt
@@ -97,6 +97,19 @@ class DLQControllerTest {
             val response = controller.retryDLQMessage(messageId)
 
             assertEquals("SUCCESS", response.code)
+            assertEquals("DLQ 메시지 재처리 성공: ID 123", response.data)
+            verify(dlqCommandService).retryDLQMessage(messageId)
+        }
+
+        @Test
+        fun 개별_DLQ_메시지_재처리_실패() {
+            val messageId = 456L
+            whenever(dlqCommandService.retryDLQMessage(messageId)).thenReturn(false)
+
+            val response = controller.retryDLQMessage(messageId)
+
+            assertEquals("SUCCESS", response.code)
+            assertEquals("DLQ 메시지 재처리 실패: ID 456", response.data)
             verify(dlqCommandService).retryDLQMessage(messageId)
         }
     }

--- a/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/metrics/DefaultDLQMetricsTest.kt
+++ b/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/metrics/DefaultDLQMetricsTest.kt
@@ -1,0 +1,56 @@
+package com.hoppingmall.dlq.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("DefaultDLQMetrics")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class DefaultDLQMetricsTest {
+
+    private val meterRegistry: MeterRegistry = SimpleMeterRegistry()
+    private val defaultDLQMetrics = DefaultDLQMetrics(meterRegistry)
+
+    @Test
+    fun DLQ_메시지_저장_카운터가_증가한다() {
+        defaultDLQMetrics.recordDlqSaved("test-topic")
+
+        val counter = meterRegistry.find("dlq.messages.saved").counter()
+        assertThat(counter).isNotNull
+        assertThat(counter!!.count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun DLQ_메시지_저장_카운터가_여러번_증가한다() {
+        defaultDLQMetrics.recordDlqSaved("topic-1")
+        defaultDLQMetrics.recordDlqSaved("topic-2")
+        defaultDLQMetrics.recordDlqSaved("topic-3")
+
+        val counter = meterRegistry.find("dlq.messages.saved").counter()
+        assertThat(counter).isNotNull
+        assertThat(counter!!.count()).isEqualTo(3.0)
+    }
+
+    @Test
+    fun DLQ_재시도_성공_카운터가_증가한다() {
+        defaultDLQMetrics.recordDlqRetrySuccess()
+
+        val counter = meterRegistry.find("dlq.retry.success").counter()
+        assertThat(counter).isNotNull
+        assertThat(counter!!.count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun DLQ_재시도_실패_카운터가_증가한다() {
+        defaultDLQMetrics.recordDlqRetryFailed()
+
+        val counter = meterRegistry.find("dlq.retry.failed").counter()
+        assertThat(counter).isNotNull
+        assertThat(counter!!.count()).isEqualTo(1.0)
+    }
+}

--- a/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/metrics/NoOpDLQMetricsTest.kt
+++ b/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/metrics/NoOpDLQMetricsTest.kt
@@ -1,0 +1,28 @@
+package com.hoppingmall.dlq.metrics
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("NoOpDLQMetrics")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class NoOpDLQMetricsTest {
+
+    private val noOpDLQMetrics = NoOpDLQMetrics()
+
+    @Test
+    fun recordDlqSaved_호출해도_예외가_발생하지_않는다() {
+        noOpDLQMetrics.recordDlqSaved("test-topic")
+    }
+
+    @Test
+    fun recordDlqRetrySuccess_호출해도_예외가_발생하지_않는다() {
+        noOpDLQMetrics.recordDlqRetrySuccess()
+    }
+
+    @Test
+    fun recordDlqRetryFailed_호출해도_예외가_발생하지_않는다() {
+        noOpDLQMetrics.recordDlqRetryFailed()
+    }
+}

--- a/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/publisher/KafkaDLQMessagePublisherTest.kt
+++ b/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/publisher/KafkaDLQMessagePublisherTest.kt
@@ -1,0 +1,48 @@
+package com.hoppingmall.dlq.publisher
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.springframework.kafka.core.KafkaTemplate
+
+@DisplayName("KafkaDLQMessagePublisher")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class KafkaDLQMessagePublisherTest {
+
+    @Mock
+    private lateinit var kafkaTemplate: KafkaTemplate<String, Any>
+
+    @InjectMocks
+    private lateinit var kafkaDLQMessagePublisher: KafkaDLQMessagePublisher
+
+    @Test
+    fun 메시지를_Kafka로_발행하고_true를_반환한다() {
+        val topic = "test-topic"
+        val key = "test-key"
+        val value = """{"orderId": 1}"""
+
+        val result = kafkaDLQMessagePublisher.publish(topic, key, value)
+
+        assertThat(result).isTrue()
+        verify(kafkaTemplate).send(topic, key, value)
+    }
+
+    @Test
+    fun value가_null이어도_발행하고_true를_반환한다() {
+        val topic = "test-topic"
+        val key = "test-key"
+
+        val result = kafkaDLQMessagePublisher.publish(topic, key, null)
+
+        assertThat(result).isTrue()
+        verify(kafkaTemplate).send(topic, key, null)
+    }
+}

--- a/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/publisher/NoOpDLQMessagePublisherTest.kt
+++ b/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/publisher/NoOpDLQMessagePublisherTest.kt
@@ -1,0 +1,28 @@
+package com.hoppingmall.dlq.publisher
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("NoOpDLQMessagePublisher")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class NoOpDLQMessagePublisherTest {
+
+    private val publisher = NoOpDLQMessagePublisher()
+
+    @Test
+    fun publish_호출하면_false를_반환한다() {
+        val result = publisher.publish("test-topic", "test-key", "test-value")
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun publish_value가_null이어도_false를_반환한다() {
+        val result = publisher.publish("test-topic", "test-key", null)
+
+        assertThat(result).isFalse()
+    }
+}

--- a/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/service/DLQCommandServiceTest.kt
+++ b/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/service/DLQCommandServiceTest.kt
@@ -95,6 +95,20 @@ class DLQCommandServiceTest {
 
             verify(dlqMessageRepository, never()).save(any<DLQMessage>())
         }
+
+        @Test
+        fun 저장_중_예외_발생_시_예외를_전파한다() {
+            val deadLetterMessage = createDeadLetterMessage()
+            whenever(dlqMessageRepository.existsByOriginalTopicAndOriginalPartitionAndOriginalOffset(
+                deadLetterMessage.originalTopic,
+                deadLetterMessage.originalPartition,
+                deadLetterMessage.originalOffset
+            )).thenThrow(RuntimeException("DB 연결 실패"))
+
+            assertThrows(RuntimeException::class.java) {
+                dlqCommandService.saveDLQMessage(deadLetterMessage)
+            }
+        }
     }
 
     @Nested
@@ -237,6 +251,52 @@ class DLQCommandServiceTest {
             assertFalse(result)
             verify(dlqMetrics).recordDlqRetryFailed()
         }
+
+        @Test
+        fun originalKey가_null이면_빈_문자열로_발행한다() {
+            val dlqMessageId = 1L
+            val dlqMessage = createDLQMessage(
+                id = dlqMessageId,
+                status = DLQStatus.PENDING,
+                retryCount = 0,
+                key = null
+            )
+
+            whenever(dlqMessageRepository.findById(dlqMessageId))
+                .thenReturn(Optional.of(dlqMessage))
+            whenever(dlqMessagePublisher.publish(any(), any(), any()))
+                .thenReturn(true)
+
+            val result = dlqCommandService.retryDLQMessage(dlqMessageId)
+
+            assertTrue(result)
+            verify(dlqMessagePublisher).publish(
+                eq(dlqMessage.originalTopic),
+                eq(""),
+                any()
+            )
+        }
+
+        @Test
+        fun 예외_발생_후_상태_업데이트도_실패하면_로그만_남긴다() {
+            val dlqMessageId = 1L
+            val dlqMessage = createDLQMessage(
+                id = dlqMessageId,
+                status = DLQStatus.PENDING,
+                retryCount = 0
+            )
+
+            whenever(dlqMessageRepository.findById(dlqMessageId))
+                .thenReturn(Optional.of(dlqMessage))
+                .thenThrow(RuntimeException("DB 연결 실패"))
+            whenever(dlqMessagePublisher.publish(any(), any(), any()))
+                .thenThrow(RuntimeException("Kafka 전송 실패"))
+
+            val result = dlqCommandService.retryDLQMessage(dlqMessageId)
+
+            assertFalse(result)
+            verify(dlqMetrics).recordDlqRetryFailed()
+        }
     }
 
     @Nested
@@ -288,6 +348,21 @@ class DLQCommandServiceTest {
             assertEquals(2, deletedCount)
             verify(dlqMessageRepository).deleteAll(processedMessages.content)
         }
+
+        @Test
+        fun 삭제할_메시지가_없으면_0을_반환하고_deleteAll을_호출하지_않는다() {
+            val topic = "payment"
+            val emptyPage = PageImpl<DLQMessage>(emptyList())
+
+            whenever(dlqMessageRepository.findByOriginalTopicAndStatusOrderByCreatedAtDesc(
+                eq(topic), eq(DLQStatus.PROCESSED), any()
+            )).thenReturn(emptyPage)
+
+            val deletedCount = dlqCommandService.clearProcessedDLQMessages(topic)
+
+            assertEquals(0, deletedCount)
+            verify(dlqMessageRepository, never()).deleteAll(any<List<DLQMessage>>())
+        }
     }
 
     @Nested
@@ -319,6 +394,15 @@ class DLQCommandServiceTest {
             val result = dlqCommandService.reconstructOriginalMessage(dlqMessage)
 
             assertNull(result)
+        }
+
+        @Test
+        fun 일반_문자열_값은_그대로_반환한다() {
+            val dlqMessage = createDLQMessage(value = "plain text message")
+
+            val result = dlqCommandService.reconstructOriginalMessage(dlqMessage)
+
+            assertEquals("plain text message", result)
         }
     }
 

--- a/hoppingmall-idempotency/build.gradle.kts
+++ b/hoppingmall-idempotency/build.gradle.kts
@@ -32,4 +32,14 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	compileOnly("org.redisson:redisson-spring-boot-starter:4.3.0")
+
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
+	testImplementation("org.redisson:redisson-spring-boot-starter:4.3.0")
+}
+
+tasks.withType<Test> {
+	useJUnitPlatform()
 }

--- a/hoppingmall-idempotency/src/test/kotlin/com/hoppingmall/idempotency/IdempotencyAspectTest.kt
+++ b/hoppingmall-idempotency/src/test/kotlin/com/hoppingmall/idempotency/IdempotencyAspectTest.kt
@@ -1,0 +1,312 @@
+package com.hoppingmall.idempotency
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.redisson.api.RLock
+import org.redisson.api.RedissonClient
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import org.aspectj.lang.ProceedingJoinPoint
+import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
+
+@DisplayName("IdempotencyAspect")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class IdempotencyAspectTest {
+
+    @Mock
+    private lateinit var idempotencyService: IdempotencyService
+
+    @Mock
+    private lateinit var redissonClient: RedissonClient
+
+    @Mock
+    private lateinit var lock: RLock
+
+    @Mock
+    private lateinit var joinPoint: ProceedingJoinPoint
+
+    @Mock
+    private lateinit var idempotent: Idempotent
+
+    private val objectMapper = ObjectMapper()
+
+    private lateinit var aspect: IdempotencyAspect
+
+    @BeforeEach
+    fun setUp() {
+        aspect = IdempotencyAspect(idempotencyService, redissonClient, objectMapper)
+    }
+
+    private fun setUpRequest(path: String = "/api/v1/orders", method: String = "POST", idempotencyKey: String? = "test-key"): MockHttpServletRequest {
+        val request = MockHttpServletRequest(method, path)
+        if (idempotencyKey != null) {
+            request.addHeader(IdempotencyAspect.IDEMPOTENCY_KEY_HEADER, idempotencyKey)
+        }
+        RequestContextHolder.setRequestAttributes(ServletRequestAttributes(request))
+        return request
+    }
+
+    @BeforeEach
+    fun clearRequestContext() {
+        RequestContextHolder.resetRequestAttributes()
+    }
+
+    @Nested
+    @DisplayName("요청 컨텍스트 없음")
+    inner class NoRequestContext {
+
+        @Test
+        fun 요청_컨텍스트가_없으면_그대로_진행한다() {
+            RequestContextHolder.resetRequestAttributes()
+            val expected = ResponseEntity.ok("result")
+            whenever(joinPoint.proceed()).thenReturn(expected)
+
+            val result = aspect.handleIdempotency(joinPoint, idempotent)
+
+            assertThat(result).isEqualTo(expected)
+            verify(idempotencyService, never()).findByKey(any())
+        }
+    }
+
+    @Nested
+    @DisplayName("Idempotency-Key 헤더 누락")
+    inner class MissingHeader {
+
+        @Test
+        fun 헤더가_없으면_예외를_던진다() {
+            setUpRequest(idempotencyKey = null)
+
+            assertThatThrownBy {
+                aspect.handleIdempotency(joinPoint, idempotent)
+            }.isInstanceOf(IdempotencyKeyMissingException::class.java)
+
+            verify(idempotencyService, never()).findByKey(any())
+        }
+    }
+
+    @Nested
+    @DisplayName("캐시 히트")
+    inner class CacheHit {
+
+        @Test
+        fun 기존_레코드가_있으면_캐시된_응답을_반환한다() {
+            setUpRequest()
+            val body = mapOf("id" to 1)
+            val record = IdempotencyRecord(
+                id = 1L,
+                idempotencyKey = "test-key",
+                httpMethod = "POST",
+                endpoint = "/api/v1/orders",
+                responseStatus = 200,
+                responseBody = objectMapper.writeValueAsString(body),
+                expiresAt = LocalDateTime.now().plusHours(1)
+            )
+            whenever(idempotencyService.findByKey("test-key")).thenReturn(record)
+
+            @Suppress("UNCHECKED_CAST")
+            val result = aspect.handleIdempotency(joinPoint, idempotent) as ResponseEntity<Any>
+
+            assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+            verify(joinPoint, never()).proceed()
+            verify(redissonClient, never()).getLock(any<String>())
+        }
+
+        @Test
+        fun 락_획득_후_이중_체크에서_히트하면_캐시된_응답을_반환한다() {
+            setUpRequest()
+            whenever(idempotent.lockTimeoutSeconds).thenReturn(10L)
+            whenever(redissonClient.getLock(eq("idempotency:test-key"))).thenReturn(lock)
+            whenever(lock.tryLock(0L, 10L, TimeUnit.SECONDS)).thenReturn(true)
+            whenever(lock.isHeldByCurrentThread).thenReturn(true)
+
+            val body = mapOf("status" to "ok")
+            val record = IdempotencyRecord(
+                id = 2L,
+                idempotencyKey = "test-key",
+                httpMethod = "POST",
+                endpoint = "/api/v1/orders",
+                responseStatus = 201,
+                responseBody = objectMapper.writeValueAsString(body),
+                expiresAt = LocalDateTime.now().plusHours(1)
+            )
+            whenever(idempotencyService.findByKey("test-key"))
+                .thenReturn(null)
+                .thenReturn(record)
+
+            @Suppress("UNCHECKED_CAST")
+            val result = aspect.handleIdempotency(joinPoint, idempotent) as ResponseEntity<Any>
+
+            assertThat(result.statusCode).isEqualTo(HttpStatus.CREATED)
+            verify(joinPoint, never()).proceed()
+            verify(lock).unlock()
+        }
+    }
+
+    @Nested
+    @DisplayName("락 획득 실패")
+    inner class LockAcquisitionFailure {
+
+        @Test
+        fun 락_획득에_실패하면_충돌_예외를_던진다() {
+            setUpRequest()
+            whenever(idempotent.lockTimeoutSeconds).thenReturn(10L)
+            whenever(idempotencyService.findByKey("test-key")).thenReturn(null)
+            whenever(redissonClient.getLock(eq("idempotency:test-key"))).thenReturn(lock)
+            whenever(lock.tryLock(0L, 10L, TimeUnit.SECONDS)).thenReturn(false)
+
+            assertThatThrownBy {
+                aspect.handleIdempotency(joinPoint, idempotent)
+            }.isInstanceOf(IdempotencyConflictException::class.java)
+
+            verify(joinPoint, never()).proceed()
+        }
+    }
+
+    @Nested
+    @DisplayName("정상 처리 및 저장")
+    inner class SuccessfulProcessingAndSave {
+
+        @Test
+        fun 성공_응답이면_레코드를_저장하고_결과를_반환한다() {
+            setUpRequest(path = "/api/v1/orders", method = "POST")
+            whenever(idempotent.lockTimeoutSeconds).thenReturn(10L)
+            whenever(idempotent.ttlHours).thenReturn(24L)
+            whenever(idempotencyService.findByKey("test-key")).thenReturn(null)
+            whenever(redissonClient.getLock(eq("idempotency:test-key"))).thenReturn(lock)
+            whenever(lock.tryLock(0L, 10L, TimeUnit.SECONDS)).thenReturn(true)
+            whenever(lock.isHeldByCurrentThread).thenReturn(true)
+
+            val responseBody = mapOf("orderId" to 42)
+            val response = ResponseEntity.status(201).body(responseBody)
+            whenever(joinPoint.proceed()).thenReturn(response)
+
+            val savedRecord = IdempotencyRecord(
+                id = 3L,
+                idempotencyKey = "test-key",
+                httpMethod = "POST",
+                endpoint = "/api/v1/orders",
+                responseStatus = 201,
+                responseBody = objectMapper.writeValueAsString(responseBody),
+                expiresAt = LocalDateTime.now().plusHours(24)
+            )
+            whenever(idempotencyService.save(any(), any(), any(), any(), any(), any()))
+                .thenReturn(savedRecord)
+
+            val result = aspect.handleIdempotency(joinPoint, idempotent)
+
+            assertThat(result).isEqualTo(response)
+            verify(idempotencyService).save(
+                key = eq("test-key"),
+                httpMethod = eq("POST"),
+                endpoint = eq("/api/v1/orders"),
+                responseStatus = eq(201),
+                responseBody = any(),
+                ttlHours = eq(24L)
+            )
+            verify(lock).unlock()
+        }
+
+        @Test
+        fun 비2xx_응답이면_레코드를_저장하지_않는다() {
+            setUpRequest()
+            whenever(idempotent.lockTimeoutSeconds).thenReturn(10L)
+            whenever(idempotencyService.findByKey("test-key")).thenReturn(null)
+            whenever(redissonClient.getLock(eq("idempotency:test-key"))).thenReturn(lock)
+            whenever(lock.tryLock(0L, 10L, TimeUnit.SECONDS)).thenReturn(true)
+            whenever(lock.isHeldByCurrentThread).thenReturn(true)
+
+            val response = ResponseEntity.status(400).body("bad request")
+            whenever(joinPoint.proceed()).thenReturn(response)
+
+            val result = aspect.handleIdempotency(joinPoint, idempotent)
+
+            assertThat(result).isEqualTo(response)
+            verify(idempotencyService, never()).save(any(), any(), any(), any(), any(), any())
+            verify(lock).unlock()
+        }
+
+        @Test
+        fun ResponseEntity가_아닌_반환값이면_저장하지_않는다() {
+            setUpRequest()
+            whenever(idempotent.lockTimeoutSeconds).thenReturn(10L)
+            whenever(idempotencyService.findByKey("test-key")).thenReturn(null)
+            whenever(redissonClient.getLock(eq("idempotency:test-key"))).thenReturn(lock)
+            whenever(lock.tryLock(0L, 10L, TimeUnit.SECONDS)).thenReturn(true)
+            whenever(lock.isHeldByCurrentThread).thenReturn(true)
+
+            whenever(joinPoint.proceed()).thenReturn("plain string")
+
+            val result = aspect.handleIdempotency(joinPoint, idempotent)
+
+            assertThat(result).isEqualTo("plain string")
+            verify(idempotencyService, never()).save(any(), any(), any(), any(), any(), any())
+            verify(lock).unlock()
+        }
+
+        @Test
+        fun 처리_중_예외가_발생해도_락을_해제한다() {
+            setUpRequest()
+            whenever(idempotent.lockTimeoutSeconds).thenReturn(10L)
+            whenever(idempotencyService.findByKey("test-key")).thenReturn(null)
+            whenever(redissonClient.getLock(eq("idempotency:test-key"))).thenReturn(lock)
+            whenever(lock.tryLock(0L, 10L, TimeUnit.SECONDS)).thenReturn(true)
+            whenever(lock.isHeldByCurrentThread).thenReturn(true)
+            whenever(joinPoint.proceed()).thenThrow(RuntimeException("downstream error"))
+
+            assertThatThrownBy {
+                aspect.handleIdempotency(joinPoint, idempotent)
+            }.isInstanceOf(RuntimeException::class.java)
+                .hasMessage("downstream error")
+
+            verify(lock).unlock()
+        }
+
+        @Test
+        fun 락을_보유하지_않으면_unlock을_호출하지_않는다() {
+            setUpRequest()
+            whenever(idempotent.lockTimeoutSeconds).thenReturn(10L)
+            whenever(idempotencyService.findByKey("test-key")).thenReturn(null)
+            whenever(redissonClient.getLock(eq("idempotency:test-key"))).thenReturn(lock)
+            whenever(lock.tryLock(0L, 10L, TimeUnit.SECONDS)).thenReturn(true)
+            whenever(lock.isHeldByCurrentThread).thenReturn(false)
+
+            val response = ResponseEntity.ok("result")
+            whenever(joinPoint.proceed()).thenReturn(response)
+
+            aspect.handleIdempotency(joinPoint, idempotent)
+
+            verify(lock, never()).unlock()
+        }
+    }
+
+    @Nested
+    @DisplayName("상수")
+    inner class Constants {
+
+        @Test
+        fun 멱등성_키_헤더_이름이_올바르다() {
+            assertThat(IdempotencyAspect.IDEMPOTENCY_KEY_HEADER).isEqualTo("Idempotency-Key")
+        }
+    }
+}

--- a/hoppingmall-idempotency/src/test/kotlin/com/hoppingmall/idempotency/IdempotencyServiceTest.kt
+++ b/hoppingmall-idempotency/src/test/kotlin/com/hoppingmall/idempotency/IdempotencyServiceTest.kt
@@ -1,0 +1,198 @@
+package com.hoppingmall.idempotency
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
+import java.util.Optional
+
+@DisplayName("IdempotencyService")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class IdempotencyServiceTest {
+
+    @Mock
+    private lateinit var idempotencyRecordRepository: IdempotencyRecordRepository
+
+    @InjectMocks
+    private lateinit var idempotencyService: IdempotencyService
+
+    @Nested
+    @DisplayName("findByKey")
+    inner class FindByKey {
+
+        @Test
+        fun 키가_존재하고_만료되지_않았으면_레코드를_반환한다() {
+            val record = IdempotencyRecord(
+                idempotencyKey = "test-key",
+                httpMethod = "POST",
+                endpoint = "/api/v1/orders",
+                responseStatus = 200,
+                responseBody = """{"id":1}""",
+                expiresAt = LocalDateTime.now().plusHours(1)
+            )
+            whenever(idempotencyRecordRepository.findByIdempotencyKey("test-key"))
+                .thenReturn(Optional.of(record))
+
+            val result = idempotencyService.findByKey("test-key")
+
+            assertThat(result).isEqualTo(record)
+        }
+
+        @Test
+        fun 키가_존재하지만_만료되었으면_null을_반환한다() {
+            val expiredRecord = IdempotencyRecord(
+                idempotencyKey = "test-key",
+                httpMethod = "POST",
+                endpoint = "/api/v1/orders",
+                responseStatus = 200,
+                responseBody = """{"id":1}""",
+                expiresAt = LocalDateTime.now().minusHours(1)
+            )
+            whenever(idempotencyRecordRepository.findByIdempotencyKey("test-key"))
+                .thenReturn(Optional.of(expiredRecord))
+
+            val result = idempotencyService.findByKey("test-key")
+
+            assertThat(result).isNull()
+        }
+
+        @Test
+        fun 키가_존재하지_않으면_null을_반환한다() {
+            whenever(idempotencyRecordRepository.findByIdempotencyKey("missing-key"))
+                .thenReturn(Optional.empty())
+
+            val result = idempotencyService.findByKey("missing-key")
+
+            assertThat(result).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("save")
+    inner class Save {
+
+        @Test
+        fun 레코드를_정상적으로_저장한다() {
+            val expectedRecord = IdempotencyRecord(
+                id = 1L,
+                idempotencyKey = "save-key",
+                httpMethod = "POST",
+                endpoint = "/api/v1/payments",
+                responseStatus = 201,
+                responseBody = """{"status":"ok"}""",
+                expiresAt = LocalDateTime.now().plusHours(24)
+            )
+            whenever(idempotencyRecordRepository.save(any<IdempotencyRecord>()))
+                .thenReturn(expectedRecord)
+
+            val result = idempotencyService.save(
+                key = "save-key",
+                httpMethod = "POST",
+                endpoint = "/api/v1/payments",
+                responseStatus = 201,
+                responseBody = """{"status":"ok"}""",
+                ttlHours = 24
+            )
+
+            assertThat(result).isEqualTo(expectedRecord)
+        }
+
+        @Test
+        fun 저장할_때_올바른_필드로_레코드를_생성한다() {
+            val captor = argumentCaptor<IdempotencyRecord>()
+            val savedRecord = IdempotencyRecord(
+                id = 1L,
+                idempotencyKey = "cap-key",
+                httpMethod = "PUT",
+                endpoint = "/api/v1/items/1",
+                responseStatus = 200,
+                responseBody = """{}""",
+                expiresAt = LocalDateTime.now().plusHours(12)
+            )
+            whenever(idempotencyRecordRepository.save(captor.capture()))
+                .thenReturn(savedRecord)
+
+            idempotencyService.save(
+                key = "cap-key",
+                httpMethod = "PUT",
+                endpoint = "/api/v1/items/1",
+                responseStatus = 200,
+                responseBody = """{}""",
+                ttlHours = 12
+            )
+
+            val captured = captor.firstValue
+            assertThat(captured.idempotencyKey).isEqualTo("cap-key")
+            assertThat(captured.httpMethod).isEqualTo("PUT")
+            assertThat(captured.endpoint).isEqualTo("/api/v1/items/1")
+            assertThat(captured.responseStatus).isEqualTo(200)
+            assertThat(captured.responseBody).isEqualTo("""{}""")
+            assertThat(captured.expiresAt).isAfter(LocalDateTime.now())
+        }
+
+        @Test
+        fun TTL이_0이면_즉시_만료되는_레코드를_생성한다() {
+            val captor = argumentCaptor<IdempotencyRecord>()
+            val savedRecord = IdempotencyRecord(
+                idempotencyKey = "zero-ttl",
+                httpMethod = "POST",
+                endpoint = "/api/test",
+                responseStatus = 200,
+                responseBody = """{}""",
+                expiresAt = LocalDateTime.now()
+            )
+            whenever(idempotencyRecordRepository.save(captor.capture()))
+                .thenReturn(savedRecord)
+
+            idempotencyService.save(
+                key = "zero-ttl",
+                httpMethod = "POST",
+                endpoint = "/api/test",
+                responseStatus = 200,
+                responseBody = """{}""",
+                ttlHours = 0
+            )
+
+            val captured = captor.firstValue
+            assertThat(captured.expiresAt).isBeforeOrEqualTo(LocalDateTime.now().plusSeconds(1))
+        }
+    }
+
+    @Nested
+    @DisplayName("cleanupExpiredRecords")
+    inner class CleanupExpiredRecords {
+
+        @Test
+        fun 만료된_레코드가_있으면_삭제한다() {
+            whenever(idempotencyRecordRepository.deleteExpiredRecords(any()))
+                .thenReturn(5)
+
+            idempotencyService.cleanupExpiredRecords()
+
+            verify(idempotencyRecordRepository).deleteExpiredRecords(any())
+        }
+
+        @Test
+        fun 만료된_레코드가_없어도_삭제를_호출한다() {
+            whenever(idempotencyRecordRepository.deleteExpiredRecords(any()))
+                .thenReturn(0)
+
+            idempotencyService.cleanupExpiredRecords()
+
+            verify(idempotencyRecordRepository).deleteExpiredRecords(any())
+        }
+    }
+}

--- a/hoppingmall-outbox/build.gradle.kts
+++ b/hoppingmall-outbox/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     kotlin("plugin.jpa") version "1.9.25"
     id("io.spring.dependency-management") version "1.1.7"
     `java-library`
+    jacoco
 }
 
 group = "com.hoppingmall"
@@ -45,4 +46,55 @@ dependencies {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+val jacocoExcludedDirs = listOf(
+    "**/config/**",
+    "**/dto/**",
+    "**/entity/**",
+    "**/response/**",
+    "**/error/**",
+    "**/enum/**",
+    "**/enums/**",
+    "**/vo/**",
+    "**/exception/**",
+    "**/repository/**",
+    "**/*Application*",
+    "**/*\$DefaultImpls*"
+)
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    classDirectories.setFrom(
+        files(classDirectories.files.map {
+            fileTree(it) { exclude(jacocoExcludedDirs) }
+        })
+    )
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.jacocoTestReport)
+    classDirectories.setFrom(
+        files(classDirectories.files.map {
+            fileTree(it) { exclude(jacocoExcludedDirs) }
+        })
+    )
+    violationRules {
+        rule {
+            element = "CLASS"
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "0.80".toBigDecimal()
+            }
+        }
+    }
+}
+
+tasks.register("jacocoTestVerification") {
+    dependsOn(tasks.jacocoTestCoverageVerification)
 }

--- a/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/domain/OutboxEventTest.kt
+++ b/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/domain/OutboxEventTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
 
 @DisplayName("OutboxEvent")
 @DisplayNameGeneration(ReplaceUnderscores::class)
@@ -115,6 +116,52 @@ class OutboxEventTest {
 
             assertEquals(OutboxStatus.RETRYING, event.status)
             assertFalse(event.processed)
+        }
+    }
+
+    @Nested
+    @DisplayName("updatedAt 갱신")
+    inner class UpdatedAtRefresh {
+
+        @Test
+        fun markAsProcessed_호출_시_updatedAt이_갱신된다() {
+            val event = createOutboxEvent()
+            val before = LocalDateTime.now().minusSeconds(1)
+
+            event.markAsProcessed()
+
+            assertTrue(event.updatedAt.isAfter(before))
+        }
+
+        @Test
+        fun markAsFailed_호출_시_updatedAt이_갱신된다() {
+            val event = createOutboxEvent()
+            val before = LocalDateTime.now().minusSeconds(1)
+
+            event.markAsFailed("error")
+
+            assertTrue(event.updatedAt.isAfter(before))
+        }
+
+        @Test
+        fun markAsRetrying_호출_시_updatedAt이_갱신된다() {
+            val event = createOutboxEvent()
+            val before = LocalDateTime.now().minusSeconds(1)
+
+            event.markAsRetrying()
+
+            assertTrue(event.updatedAt.isAfter(before))
+        }
+
+        @Test
+        fun markAsFailedPermanently_호출_시_processedAt이_설정된다() {
+            val event = createOutboxEvent()
+            val before = LocalDateTime.now().minusSeconds(1)
+
+            event.markAsFailedPermanently("permanent error")
+
+            assertNotNull(event.processedAt)
+            assertTrue(event.processedAt!!.isAfter(before))
         }
     }
 

--- a/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/metrics/OutboxMetricsTest.kt
+++ b/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/metrics/OutboxMetricsTest.kt
@@ -51,4 +51,43 @@ class OutboxMetricsTest {
 
         assertThat(registry.get("outbox.event.publish.latency").timer().count()).isEqualTo(1L)
     }
+
+    @Test
+    fun outbox_발행_실패_시_카운터가_증가한다() {
+        outboxMetrics.recordOutboxFailed("payment")
+
+        assertThat(registry.counter("outbox.event.failed.count").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun 토픽별_발행_성공_카운터가_증가한다() {
+        outboxMetrics.recordOutboxPublished("payment")
+        outboxMetrics.recordOutboxPublished("payment")
+        outboxMetrics.recordOutboxPublished("order-events")
+
+        assertThat(
+            registry.counter("outbox.event.published.by_topic", "topic", "payment").count()
+        ).isEqualTo(2.0)
+        assertThat(
+            registry.counter("outbox.event.published.by_topic", "topic", "order-events").count()
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun 토픽별_발행_실패_카운터가_증가한다() {
+        outboxMetrics.recordOutboxFailed("payment")
+        outboxMetrics.recordOutboxFailed("payment")
+
+        assertThat(
+            registry.counter("outbox.event.failed.by_topic", "topic", "payment").count()
+        ).isEqualTo(2.0)
+    }
+
+    @Test
+    fun 전체_발행_성공_카운터가_누적된다() {
+        outboxMetrics.recordOutboxPublished("payment")
+        outboxMetrics.recordOutboxPublished("order-events")
+
+        assertThat(registry.counter("outbox.event.published.count").count()).isEqualTo(2.0)
+    }
 }

--- a/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/scheduler/OutboxEventPublisherTest.kt
+++ b/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/scheduler/OutboxEventPublisherTest.kt
@@ -198,6 +198,76 @@ class OutboxEventPublisherTest {
     }
 
     @Test
+    fun null_id를_가진_이벤트는_클레임하지_않는다() {
+        val eventWithNullId = OutboxEvent(
+            aggregateType = "Payment",
+            aggregateId = "1",
+            eventType = "PaymentCompleted",
+            eventData = """{"paymentId":1}""",
+            topic = "payment",
+            partitionKey = "1",
+            status = OutboxStatus.PENDING
+        )
+
+        whenever(
+            outboxEventRepository.findUnprocessedEvents(
+                status = OutboxStatus.PENDING,
+                retryStatus = OutboxStatus.FAILED,
+                maxRetries = 3,
+                limit = 100
+            )
+        ).thenReturn(listOf(eventWithNullId))
+
+        outboxEventPublisher.publishPendingEvents()
+
+        verify(outboxEventRepository, never()).claimEventForPublish(any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun 클레임_실패한_이벤트는_발행하지_않는다() {
+        val event = createOutboxEvent(status = OutboxStatus.PENDING)
+
+        whenever(
+            outboxEventRepository.findUnprocessedEvents(
+                status = OutboxStatus.PENDING,
+                retryStatus = OutboxStatus.FAILED,
+                maxRetries = 3,
+                limit = 100
+            )
+        ).thenReturn(listOf(event))
+        whenever(
+            outboxEventRepository.claimEventForPublish(
+                id = eq(1L),
+                nextStatus = eq(OutboxStatus.RETRYING),
+                updatedAt = any(),
+                pendingStatus = eq(OutboxStatus.PENDING),
+                failedStatus = eq(OutboxStatus.FAILED),
+                maxRetries = eq(3)
+            )
+        ).thenReturn(0)
+
+        outboxEventPublisher.publishPendingEvents()
+
+        verify(outboxEventRepository, never()).findById(any())
+    }
+
+    @Test
+    fun 발행_실패_시_에러_메시지가_null이면_Unknown_error를_사용한다() {
+        val event = createOutboxEvent(retryCount = 0)
+
+        whenever(outboxEventRepository.findById(1L)).thenReturn(Optional.of(event))
+        whenever(avroEventConverter.convertJsonToAvro(event.eventType, event.eventData))
+            .thenThrow(RuntimeException())
+        whenever(outboxEventRepository.save(any<OutboxEvent>())).thenAnswer { it.arguments[0] as OutboxEvent }
+
+        outboxEventPublisher.publishEvent(1L)
+
+        assertThat(event.errorMessage).isEqualTo("Unknown error")
+        assertThat(event.status).isEqualTo(OutboxStatus.FAILED)
+        verify(outboxMetrics).recordOutboxFailed("payment")
+    }
+
+    @Test
     fun 대기중인_이벤트를_클레임_후_발행한다() {
         val event = createOutboxEvent(status = OutboxStatus.PENDING)
         val avroRecord = mock<GenericRecord>()

--- a/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/scheduler/OutboxMaintenanceSchedulerTest.kt
+++ b/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/scheduler/OutboxMaintenanceSchedulerTest.kt
@@ -123,6 +123,27 @@ class OutboxMaintenanceSchedulerTest {
     }
 
     @Test
+    fun null_id를_가진_지연_이벤트는_건너뛴다() {
+        val eventWithNullId = OutboxEvent(
+            aggregateType = "Payment",
+            aggregateId = "1",
+            eventType = "PaymentCompleted",
+            eventData = """{"paymentId":1}""",
+            topic = "payment",
+            partitionKey = "1",
+            status = OutboxStatus.PENDING
+        )
+
+        whenever(outboxEventRepository.findStaleEvents(any<LocalDateTime>(), eq(50)))
+            .thenReturn(listOf(eventWithNullId))
+
+        outboxMaintenanceScheduler.handleStaleEvents()
+
+        verify(outboxEventPublisher, never()).publishEvent(any())
+        verify(outboxEventRepository, never()).claimStaleEvent(any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
     fun 클레임_실패한_지연_이벤트는_발행하지_않는다() {
         val staleEvent = createStaleEvent(id = 1L, retryCount = 0)
 

--- a/notification-service/src/test/kotlin/com/hoppingmall/notification/consumer/NotificationEventConsumerTest.kt
+++ b/notification-service/src/test/kotlin/com/hoppingmall/notification/consumer/NotificationEventConsumerTest.kt
@@ -1,0 +1,227 @@
+package com.hoppingmall.notification.consumer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.notification.domain.Notification
+import com.hoppingmall.notification.domain.NotificationRepository
+import com.hoppingmall.notification.enums.NotificationType
+import com.hoppingmall.notification.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.springframework.cache.CacheManager
+import org.springframework.cache.concurrent.ConcurrentMapCache
+import org.springframework.data.redis.core.RedisTemplate
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("NotificationEventConsumer")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class NotificationEventConsumerTest {
+
+    @Mock
+    private lateinit var notificationRepository: NotificationRepository
+
+    @Mock
+    private lateinit var redisTemplate: RedisTemplate<String, String>
+
+    @Mock
+    private lateinit var objectMapper: ObjectMapper
+
+    @Mock
+    private lateinit var cacheManager: CacheManager
+
+    @InjectMocks
+    private lateinit var notificationEventConsumer: NotificationEventConsumer
+
+    private fun stubPublishSseEvent() {
+        whenever(cacheManager.getCache("unread-count")).thenReturn(ConcurrentMapCache("unread-count"))
+        whenever(objectMapper.writeValueAsString(any())).thenReturn("{}")
+        whenever(redisTemplate.convertAndSend(any<String>(), any<String>())).thenReturn(1L)
+    }
+
+    private fun createSavedNotification(eventId: String): Notification {
+        return Notification(
+            eventId = eventId, userId = 1L, type = NotificationType.PAYMENT_COMPLETED,
+            title = "결제", content = "내용"
+        ).withId(1L)
+    }
+
+    @Test
+    fun 알림_이벤트를_처리한다() {
+        val event = mapOf(
+            "eventId" to "evt-001",
+            "userId" to 1L,
+            "type" to "PAYMENT_COMPLETED",
+            "title" to "결제 완료",
+            "content" to "결제가 완료되었습니다.",
+            "metadata" to "{}"
+        )
+        val record = ConsumerRecord<String, Any>("notification", 0, 0, "key", event)
+
+        whenever(notificationRepository.existsByEventId("evt-001")).thenReturn(false)
+        whenever(notificationRepository.save(any<Notification>())).thenReturn(createSavedNotification("evt-001"))
+        stubPublishSseEvent()
+
+        notificationEventConsumer.handleNotificationEvent(record)
+
+        val captor = argumentCaptor<Notification>()
+        verify(notificationRepository).save(captor.capture())
+        assertThat(captor.firstValue.eventId).isEqualTo("evt-001")
+        assertThat(captor.firstValue.type).isEqualTo(NotificationType.PAYMENT_COMPLETED)
+    }
+
+    @Test
+    fun 중복_이벤트는_무시한다() {
+        val event = mapOf(
+            "eventId" to "evt-001",
+            "userId" to 1L,
+            "type" to "PAYMENT_COMPLETED",
+            "title" to "결제 완료",
+            "content" to "결제가 완료되었습니다."
+        )
+        val record = ConsumerRecord<String, Any>("notification", 0, 0, "key", event)
+        whenever(notificationRepository.existsByEventId("evt-001")).thenReturn(true)
+
+        notificationEventConsumer.handleNotificationEvent(record)
+
+        verify(notificationRepository, never()).save(any())
+    }
+
+    @Test
+    fun eventId가_없으면_무시한다() {
+        val event = mapOf(
+            "userId" to 1L,
+            "type" to "PAYMENT_COMPLETED",
+            "title" to "결제 완료",
+            "content" to "결제가 완료되었습니다."
+        )
+        val record = ConsumerRecord<String, Any>("notification", 0, 0, "key", event)
+
+        notificationEventConsumer.handleNotificationEvent(record)
+
+        verify(notificationRepository, never()).existsByEventId(any())
+    }
+
+    @Test
+    fun userId가_없으면_무시한다() {
+        val event = mapOf(
+            "eventId" to "evt-001",
+            "type" to "PAYMENT_COMPLETED",
+            "title" to "결제 완료",
+            "content" to "결제가 완료되었습니다."
+        )
+        val record = ConsumerRecord<String, Any>("notification", 0, 0, "key", event)
+
+        notificationEventConsumer.handleNotificationEvent(record)
+
+        verify(notificationRepository, never()).existsByEventId(any())
+    }
+
+    @Test
+    fun type이_없으면_무시한다() {
+        val event = mapOf(
+            "eventId" to "evt-001",
+            "userId" to 1L,
+            "title" to "결제 완료",
+            "content" to "결제가 완료되었습니다."
+        )
+        val record = ConsumerRecord<String, Any>("notification", 0, 0, "key", event)
+
+        notificationEventConsumer.handleNotificationEvent(record)
+
+        verify(notificationRepository, never()).existsByEventId(any())
+    }
+
+    @Test
+    fun 알_수_없는_알림_타입이면_저장하지_않는다() {
+        val event = mapOf(
+            "eventId" to "evt-001",
+            "userId" to 1L,
+            "type" to "UNKNOWN_TYPE",
+            "title" to "결제 완료",
+            "content" to "결제가 완료되었습니다."
+        )
+        val record = ConsumerRecord<String, Any>("notification", 0, 0, "key", event)
+        whenever(notificationRepository.existsByEventId("evt-001")).thenReturn(false)
+
+        notificationEventConsumer.handleNotificationEvent(record)
+
+        verify(notificationRepository, never()).save(any())
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun String_타입_이벤트를_처리한다() {
+        val jsonString = """{"eventId":"evt-002","userId":1,"type":"PAYMENT_COMPLETED","title":"결제","content":"내용"}"""
+        val parsedMap = mapOf(
+            "eventId" to "evt-002",
+            "userId" to 1,
+            "type" to "PAYMENT_COMPLETED",
+            "title" to "결제",
+            "content" to "내용"
+        )
+        val record = ConsumerRecord<String, Any>("notification", 0, 0, "key", jsonString)
+
+        whenever(objectMapper.readValue(eq(jsonString), eq(Map::class.java))).thenReturn(parsedMap as Map<Any, Any>)
+        whenever(notificationRepository.existsByEventId("evt-002")).thenReturn(false)
+        whenever(notificationRepository.save(any<Notification>())).thenReturn(createSavedNotification("evt-002"))
+        stubPublishSseEvent()
+
+        notificationEventConsumer.handleNotificationEvent(record)
+
+        verify(notificationRepository).save(any())
+    }
+
+    @Test
+    fun SSE_발행_실패시에도_정상_처리된다() {
+        val event = mapOf(
+            "eventId" to "evt-003",
+            "userId" to 1L,
+            "type" to "PAYMENT_COMPLETED",
+            "title" to "결제",
+            "content" to "내용"
+        )
+        val record = ConsumerRecord<String, Any>("notification", 0, 0, "key", event)
+
+        whenever(notificationRepository.existsByEventId("evt-003")).thenReturn(false)
+        whenever(notificationRepository.save(any<Notification>())).thenReturn(createSavedNotification("evt-003"))
+        whenever(cacheManager.getCache("unread-count")).thenReturn(ConcurrentMapCache("unread-count"))
+        whenever(objectMapper.writeValueAsString(any())).thenThrow(RuntimeException("직렬화 실패"))
+
+        notificationEventConsumer.handleNotificationEvent(record)
+
+        verify(notificationRepository).save(any())
+    }
+
+    @Test
+    fun snake_case_키_이벤트를_처리한다() {
+        val event = mapOf(
+            "event_id" to "evt-004",
+            "user_id" to 1L,
+            "type" to "PAYMENT_COMPLETED",
+            "title" to "결제",
+            "content" to "내용"
+        )
+        val record = ConsumerRecord<String, Any>("notification", 0, 0, "key", event)
+
+        whenever(notificationRepository.existsByEventId("evt-004")).thenReturn(false)
+        whenever(notificationRepository.save(any<Notification>())).thenReturn(createSavedNotification("evt-004"))
+        stubPublishSseEvent()
+
+        notificationEventConsumer.handleNotificationEvent(record)
+
+        verify(notificationRepository).save(any())
+    }
+}

--- a/notification-service/src/test/kotlin/com/hoppingmall/notification/controller/NotificationControllerTest.kt
+++ b/notification-service/src/test/kotlin/com/hoppingmall/notification/controller/NotificationControllerTest.kt
@@ -1,0 +1,119 @@
+package com.hoppingmall.notification.controller
+
+import com.hoppingmall.common.UserPrincipal
+import com.hoppingmall.notification.dto.response.NotificationResponse
+import com.hoppingmall.notification.dto.response.UnreadCountResponse
+import com.hoppingmall.notification.enums.NotificationType
+import com.hoppingmall.notification.service.NotificationCommandService
+import com.hoppingmall.notification.service.NotificationQueryService
+import com.hoppingmall.notification.service.NotificationSseService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import org.springframework.http.HttpStatus
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.time.LocalDateTime
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("NotificationController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class NotificationControllerTest {
+
+    @Mock
+    private lateinit var notificationQueryService: NotificationQueryService
+
+    @Mock
+    private lateinit var notificationCommandService: NotificationCommandService
+
+    @Mock
+    private lateinit var notificationSseService: NotificationSseService
+
+    private lateinit var notificationController: NotificationController
+
+    private lateinit var userPrincipal: UserPrincipal
+
+    @BeforeEach
+    fun setUp() {
+        notificationController = NotificationController(
+            notificationQueryService,
+            notificationCommandService,
+            notificationSseService
+        )
+        userPrincipal = UserPrincipal.of(1L, "BUYER")
+    }
+
+    @Test
+    fun SSE_구독을_요청한다() {
+        val emitter = SseEmitter()
+        whenever(notificationSseService.connect(1L)).thenReturn(emitter)
+
+        val result = notificationController.subscribe(userPrincipal)
+
+        assertThat(result).isSameAs(emitter)
+    }
+
+    @Test
+    fun 알림_목록을_조회한다() {
+        val pageable = PageRequest.of(0, 20)
+        val response = NotificationResponse(
+            id = 1L, type = NotificationType.PAYMENT_COMPLETED, title = "결제",
+            content = "내용", metadata = null, isRead = false, createdAt = LocalDateTime.now()
+        )
+        whenever(notificationQueryService.getNotifications(1L, null, pageable))
+            .thenReturn(SliceImpl(listOf(response), pageable, false))
+
+        val result = notificationController.getNotifications(userPrincipal, null, pageable)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data!!.content).hasSize(1)
+    }
+
+    @Test
+    fun 타입별_알림_목록을_조회한다() {
+        val pageable = PageRequest.of(0, 20)
+        val type = NotificationType.PAYMENT_COMPLETED
+        whenever(notificationQueryService.getNotifications(1L, type, pageable))
+            .thenReturn(SliceImpl(emptyList(), pageable, false))
+
+        val result = notificationController.getNotifications(userPrincipal, type, pageable)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun 읽지_않은_알림_수를_조회한다() {
+        whenever(notificationQueryService.getUnreadCount(1L))
+            .thenReturn(UnreadCountResponse(3L))
+
+        val result = notificationController.getUnreadCount(userPrincipal)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data!!.count).isEqualTo(3L)
+    }
+
+    @Test
+    fun 알림을_읽음_처리한다() {
+        val result = notificationController.markAsRead(userPrincipal, 1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        verify(notificationCommandService).markAsRead(1L, 1L)
+    }
+
+    @Test
+    fun 모든_알림을_읽음_처리한다() {
+        val result = notificationController.markAllAsRead(userPrincipal)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        verify(notificationCommandService).markAllAsRead(1L)
+    }
+}

--- a/notification-service/src/test/kotlin/com/hoppingmall/notification/service/NotificationCommandServiceImplTest.kt
+++ b/notification-service/src/test/kotlin/com/hoppingmall/notification/service/NotificationCommandServiceImplTest.kt
@@ -1,0 +1,66 @@
+package com.hoppingmall.notification.service
+
+import com.hoppingmall.notification.domain.NotificationRepository
+import com.hoppingmall.notification.exception.NotificationAccessDeniedException
+import com.hoppingmall.notification.exception.NotificationNotFoundException
+import com.hoppingmall.notification.support.fixture.createNotification
+import com.hoppingmall.notification.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.*
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("NotificationCommandServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class NotificationCommandServiceImplTest {
+
+    @Mock
+    private lateinit var notificationRepository: NotificationRepository
+
+    @InjectMocks
+    private lateinit var notificationCommandService: NotificationCommandServiceImpl
+
+    @Test
+    fun 알림을_읽음_처리한다() {
+        val notification = createNotification(userId = 1L).withId(1L)
+        whenever(notificationRepository.findById(1L)).thenReturn(Optional.of(notification))
+
+        notificationCommandService.markAsRead(1L, 1L)
+
+        assertThat(notification.isRead).isTrue()
+    }
+
+    @Test
+    fun 존재하지_않는_알림을_읽음_처리하면_예외가_발생한다() {
+        whenever(notificationRepository.findById(1L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { notificationCommandService.markAsRead(1L, 1L) }
+            .isInstanceOf(NotificationNotFoundException::class.java)
+    }
+
+    @Test
+    fun 다른_사용자의_알림을_읽으면_접근_거부_예외가_발생한다() {
+        val notification = createNotification(userId = 1L).withId(1L)
+        whenever(notificationRepository.findById(1L)).thenReturn(Optional.of(notification))
+
+        assertThatThrownBy { notificationCommandService.markAsRead(1L, 999L) }
+            .isInstanceOf(NotificationAccessDeniedException::class.java)
+    }
+
+    @Test
+    fun 모든_알림을_읽음_처리한다() {
+        notificationCommandService.markAllAsRead(1L)
+
+        verify(notificationRepository).markAllAsRead(1L)
+    }
+}

--- a/notification-service/src/test/kotlin/com/hoppingmall/notification/service/NotificationQueryServiceImplTest.kt
+++ b/notification-service/src/test/kotlin/com/hoppingmall/notification/service/NotificationQueryServiceImplTest.kt
@@ -1,0 +1,70 @@
+package com.hoppingmall.notification.service
+
+import com.hoppingmall.notification.domain.NotificationRepository
+import com.hoppingmall.notification.dto.response.UnreadCountResponse
+import com.hoppingmall.notification.enums.NotificationType
+import com.hoppingmall.notification.support.fixture.createNotification
+import com.hoppingmall.notification.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("NotificationQueryServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class NotificationQueryServiceImplTest {
+
+    @Mock
+    private lateinit var notificationRepository: NotificationRepository
+
+    @InjectMocks
+    private lateinit var notificationQueryService: NotificationQueryServiceImpl
+
+    @Test
+    fun 사용자의_알림_목록을_조회한다() {
+        val pageable = PageRequest.of(0, 20)
+        val notifications = listOf(
+            createNotification(eventId = "e1", userId = 1L).withId(1L),
+            createNotification(eventId = "e2", userId = 1L).withId(2L)
+        )
+        whenever(notificationRepository.findByUserId(1L, pageable))
+            .thenReturn(SliceImpl(notifications, pageable, false))
+
+        val result = notificationQueryService.getNotifications(1L, null, pageable)
+
+        assertThat(result.content).hasSize(2)
+    }
+
+    @Test
+    fun 타입별_알림_목록을_조회한다() {
+        val pageable = PageRequest.of(0, 20)
+        val type = NotificationType.PAYMENT_COMPLETED
+        val notifications = listOf(
+            createNotification(eventId = "e1", userId = 1L, type = type).withId(1L)
+        )
+        whenever(notificationRepository.findByUserIdAndType(1L, type, pageable))
+            .thenReturn(SliceImpl(notifications, pageable, false))
+
+        val result = notificationQueryService.getNotifications(1L, type, pageable)
+
+        assertThat(result.content).hasSize(1)
+    }
+
+    @Test
+    fun 읽지_않은_알림_수를_조회한다() {
+        whenever(notificationRepository.countByUserIdAndIsRead(1L, false)).thenReturn(5L)
+
+        val result = notificationQueryService.getUnreadCount(1L)
+
+        assertThat(result).isEqualTo(UnreadCountResponse(5L))
+    }
+}

--- a/notification-service/src/test/kotlin/com/hoppingmall/notification/service/NotificationSseServiceTest.kt
+++ b/notification-service/src/test/kotlin/com/hoppingmall/notification/service/NotificationSseServiceTest.kt
@@ -1,0 +1,125 @@
+package com.hoppingmall.notification.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.notification.dto.response.NotificationResponse
+import com.hoppingmall.notification.enums.NotificationType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.connection.DefaultMessage
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.io.IOException
+import java.time.LocalDateTime
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("NotificationSseService")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class NotificationSseServiceTest {
+
+    @Mock
+    private lateinit var sseEmitterRepository: SseEmitterRepository
+
+    @Mock
+    private lateinit var redisMessageListenerContainer: RedisMessageListenerContainer
+
+    private val objectMapper = ObjectMapper().apply {
+        findAndRegisterModules()
+    }
+
+    private lateinit var notificationSseService: NotificationSseService
+
+    @BeforeEach
+    fun setUp() {
+        notificationSseService = NotificationSseService(
+            sseEmitterRepository,
+            redisMessageListenerContainer,
+            objectMapper
+        )
+    }
+
+    @Test
+    fun SSE_연결을_생성한다() {
+        val emitter = notificationSseService.connect(1L)
+
+        assertThat(emitter).isNotNull()
+        verify(sseEmitterRepository).save(eq(1L), any())
+    }
+
+    @Test
+    fun subscribe_호출시_리스너를_등록한다() {
+        notificationSseService.subscribe()
+
+        verify(redisMessageListenerContainer).addMessageListener(eq(notificationSseService), any<org.springframework.data.redis.listener.ChannelTopic>())
+    }
+
+    @Test
+    fun unsubscribe_호출시_리스너를_해제한다() {
+        notificationSseService.unsubscribe()
+
+        verify(redisMessageListenerContainer).removeMessageListener(notificationSseService)
+    }
+
+    @Test
+    fun 사용자에게_알림을_전송한다() {
+        val emitter = SseEmitter(1800000L)
+        val response = createNotificationResponse()
+        whenever(sseEmitterRepository.findByUserId(1L)).thenReturn(listOf(emitter))
+
+        notificationSseService.sendToUser(1L, response)
+
+        verify(sseEmitterRepository).findByUserId(1L)
+    }
+
+    @Test
+    fun 전송할_emitter가_없으면_아무_동작도_하지_않는다() {
+        val response = createNotificationResponse()
+        whenever(sseEmitterRepository.findByUserId(1L)).thenReturn(emptyList())
+
+        notificationSseService.sendToUser(1L, response)
+
+        verify(sseEmitterRepository).findByUserId(1L)
+    }
+
+    @Test
+    fun Redis_메시지를_수신하여_사용자에게_전달한다() {
+        val response = createNotificationResponse()
+        val sseMessage = SseNotificationMessage(userId = 1L, notification = response)
+        val messageBody = objectMapper.writeValueAsBytes(sseMessage)
+        val message = DefaultMessage(ByteArray(0), messageBody)
+        whenever(sseEmitterRepository.findByUserId(1L)).thenReturn(emptyList())
+
+        notificationSseService.onMessage(message, null)
+
+        verify(sseEmitterRepository).findByUserId(1L)
+    }
+
+    @Test
+    fun Redis_메시지_처리_실패시_예외를_던지지_않는다() {
+        val invalidMessage = DefaultMessage(ByteArray(0), "invalid-json".toByteArray())
+
+        notificationSseService.onMessage(invalidMessage, null)
+    }
+
+    private fun createNotificationResponse(): NotificationResponse {
+        return NotificationResponse(
+            id = 1L,
+            type = NotificationType.PAYMENT_COMPLETED,
+            title = "테스트",
+            content = "테스트 내용",
+            metadata = null,
+            isRead = false,
+            createdAt = LocalDateTime.now()
+        )
+    }
+}

--- a/notification-service/src/test/kotlin/com/hoppingmall/notification/service/SseEmitterRepositoryTest.kt
+++ b/notification-service/src/test/kotlin/com/hoppingmall/notification/service/SseEmitterRepositoryTest.kt
@@ -1,0 +1,71 @@
+package com.hoppingmall.notification.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+
+@DisplayName("SseEmitterRepository")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class SseEmitterRepositoryTest {
+
+    private lateinit var sseEmitterRepository: SseEmitterRepository
+
+    @BeforeEach
+    fun setUp() {
+        sseEmitterRepository = SseEmitterRepository()
+    }
+
+    @Test
+    fun emitter를_저장한다() {
+        val emitter = SseEmitter()
+
+        val result = sseEmitterRepository.save(1L, emitter)
+
+        assertThat(result).isSameAs(emitter)
+        assertThat(sseEmitterRepository.findByUserId(1L)).containsExactly(emitter)
+    }
+
+    @Test
+    fun 같은_사용자에_여러_emitter를_저장한다() {
+        val emitter1 = SseEmitter()
+        val emitter2 = SseEmitter()
+
+        sseEmitterRepository.save(1L, emitter1)
+        sseEmitterRepository.save(1L, emitter2)
+
+        assertThat(sseEmitterRepository.findByUserId(1L)).containsExactly(emitter1, emitter2)
+    }
+
+    @Test
+    fun 존재하지_않는_사용자_조회시_빈_목록을_반환한다() {
+        val result = sseEmitterRepository.findByUserId(999L)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun emitter를_제거한다() {
+        val emitter1 = SseEmitter()
+        val emitter2 = SseEmitter()
+        sseEmitterRepository.save(1L, emitter1)
+        sseEmitterRepository.save(1L, emitter2)
+
+        sseEmitterRepository.remove(1L, emitter1)
+
+        assertThat(sseEmitterRepository.findByUserId(1L)).containsExactly(emitter2)
+    }
+
+    @Test
+    fun 마지막_emitter_제거시_사용자_항목을_삭제한다() {
+        val emitter = SseEmitter()
+        sseEmitterRepository.save(1L, emitter)
+
+        sseEmitterRepository.remove(1L, emitter)
+
+        assertThat(sseEmitterRepository.findByUserId(1L)).isEmpty()
+    }
+}

--- a/notification-service/src/test/kotlin/com/hoppingmall/notification/support/TestEntityExtensions.kt
+++ b/notification-service/src/test/kotlin/com/hoppingmall/notification/support/TestEntityExtensions.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.notification.support
+
+import org.springframework.test.util.ReflectionTestUtils
+
+fun <T : Any> T.withId(id: Long): T {
+    ReflectionTestUtils.setField(this, "id", id)
+    return this
+}

--- a/notification-service/src/test/kotlin/com/hoppingmall/notification/support/fixture/NotificationFixture.kt
+++ b/notification-service/src/test/kotlin/com/hoppingmall/notification/support/fixture/NotificationFixture.kt
@@ -1,0 +1,22 @@
+package com.hoppingmall.notification.support.fixture
+
+import com.hoppingmall.notification.domain.Notification
+import com.hoppingmall.notification.enums.NotificationType
+
+fun createNotification(
+    eventId: String = "event-123",
+    userId: Long = 1L,
+    type: NotificationType = NotificationType.PAYMENT_COMPLETED,
+    title: String = "테스트 알림",
+    content: String = "테스트 알림 내용",
+    metadata: String? = null,
+    isRead: Boolean = false
+): Notification = Notification(
+    eventId = eventId,
+    userId = userId,
+    type = type,
+    title = title,
+    content = content,
+    metadata = metadata,
+    isRead = isRead
+)

--- a/order-service/build.gradle.kts
+++ b/order-service/build.gradle.kts
@@ -102,7 +102,8 @@ val jacocoExcludedDirs = listOf(
 	"**/enums/**",
 	"**/vo/**",
 	"**/exception/**",
-	"**/*Application*"
+	"**/*Application*",
+	"**/grpc/**"
 )
 
 tasks.jacocoTestReport {

--- a/order-service/src/test/kotlin/com/hoppingmall/order/cartItem/controller/CartItemControllerTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/cartItem/controller/CartItemControllerTest.kt
@@ -1,0 +1,98 @@
+package com.hoppingmall.order.cartItem.controller
+
+import com.hoppingmall.common.UserPrincipal
+import com.hoppingmall.order.cartItem.dto.request.CartItemCreateRequest
+import com.hoppingmall.order.cartItem.dto.request.CartItemUpdateRequest
+import com.hoppingmall.order.cartItem.dto.response.CartItemResponse
+import com.hoppingmall.order.cartItem.service.CartItemCommandService
+import com.hoppingmall.order.cartItem.service.CartItemQueryService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import org.springframework.http.HttpStatus
+import java.math.BigDecimal
+
+@DisplayName("CartItemController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class CartItemControllerTest {
+
+    @Mock
+    private lateinit var cartItemCommandService: CartItemCommandService
+
+    @Mock
+    private lateinit var cartItemQueryService: CartItemQueryService
+
+    @InjectMocks
+    private lateinit var controller: CartItemController
+
+    private val userPrincipal = UserPrincipal.of(1L, "BUYER")
+
+    private fun createCartItemResponse(id: Long = 1L): CartItemResponse {
+        return CartItemResponse(
+            id = id,
+            productId = 100L,
+            productName = "테스트 상품",
+            productPrice = BigDecimal("10000"),
+            productImageUrl = null,
+            quantity = 2,
+            totalPrice = BigDecimal("20000")
+        )
+    }
+
+    @Test
+    fun 장바구니에_상품을_추가한다() {
+        val request = CartItemCreateRequest(productId = 100L, quantity = 2)
+        val response = createCartItemResponse()
+
+        whenever(cartItemCommandService.addCartItem(1L, request)).thenReturn(response)
+
+        val result = controller.addCartItem(userPrincipal, request)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.CREATED)
+        assertThat(result.body!!.data!!.productId).isEqualTo(100L)
+    }
+
+    @Test
+    fun 장바구니_목록을_조회한다() {
+        val pageable = PageRequest.of(0, 20)
+        val items = listOf(createCartItemResponse())
+        val slice = SliceImpl(items, pageable, false)
+
+        whenever(cartItemQueryService.getCartItems(1L, pageable)).thenReturn(slice)
+
+        val result = controller.getCartItems(userPrincipal, pageable)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data!!.content).hasSize(1)
+    }
+
+    @Test
+    fun 장바구니_수량을_변경한다() {
+        val request = CartItemUpdateRequest(quantity = 5)
+        val response = createCartItemResponse()
+
+        whenever(cartItemCommandService.updateCartItemQuantity(1L, 1L, request)).thenReturn(response)
+
+        val result = controller.updateCartItemQuantity(userPrincipal, 1L, request)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data!!.id).isEqualTo(1L)
+    }
+
+    @Test
+    fun 장바구니에서_상품을_삭제한다() {
+        val result = controller.removeCartItem(userPrincipal, 1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/cartItem/domain/CartItemTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/cartItem/domain/CartItemTest.kt
@@ -1,0 +1,65 @@
+package com.hoppingmall.order.cartItem.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("CartItem")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class CartItemTest {
+
+    @Test
+    fun 장바구니_항목을_생성한다() {
+        val cartItem = CartItem.create(
+            buyerId = 1L,
+            productId = 100L,
+            productName = "테스트 상품",
+            productPrice = BigDecimal("10000"),
+            productImageUrl = "http://example.com/image.jpg",
+            quantity = 3
+        )
+
+        assertThat(cartItem.buyerId).isEqualTo(1L)
+        assertThat(cartItem.productId).isEqualTo(100L)
+        assertThat(cartItem.productName).isEqualTo("테스트 상품")
+        assertThat(cartItem.productPrice).isEqualByComparingTo(BigDecimal("10000"))
+        assertThat(cartItem.productImageUrl).isEqualTo("http://example.com/image.jpg")
+        assertThat(cartItem.quantity).isEqualTo(3)
+        assertThat(cartItem.totalPrice).isEqualByComparingTo(BigDecimal("30000"))
+    }
+
+    @Test
+    fun 이미지URL_없이_장바구니_항목을_생성한다() {
+        val cartItem = CartItem.create(
+            buyerId = 1L,
+            productId = 100L,
+            productName = "테스트 상품",
+            productPrice = BigDecimal("5000"),
+            productImageUrl = null,
+            quantity = 2
+        )
+
+        assertThat(cartItem.productImageUrl).isNull()
+        assertThat(cartItem.totalPrice).isEqualByComparingTo(BigDecimal("10000"))
+    }
+
+    @Test
+    fun 수량을_변경하면_총가격이_재계산된다() {
+        val cartItem = CartItem.create(
+            buyerId = 1L,
+            productId = 100L,
+            productName = "테스트 상품",
+            productPrice = BigDecimal("10000"),
+            productImageUrl = null,
+            quantity = 1
+        )
+
+        cartItem.updateQuantity(5)
+
+        assertThat(cartItem.quantity).isEqualTo(5)
+        assertThat(cartItem.totalPrice).isEqualByComparingTo(BigDecimal("50000"))
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/cartItem/service/CartItemCommandServiceImplTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/cartItem/service/CartItemCommandServiceImplTest.kt
@@ -1,0 +1,165 @@
+package com.hoppingmall.order.cartItem.service
+
+import com.hoppingmall.order.cartItem.domain.CartItem
+import com.hoppingmall.order.cartItem.domain.repository.CartItemRepository
+import com.hoppingmall.order.cartItem.dto.request.CartItemCreateRequest
+import com.hoppingmall.order.cartItem.dto.request.CartItemUpdateRequest
+import com.hoppingmall.order.cartItem.exception.CartItemAccessDeniedException
+import com.hoppingmall.order.cartItem.exception.CartItemNotFoundException
+import com.hoppingmall.order.cartItem.exception.CartItemProductNotFoundException
+import com.hoppingmall.order.port.ProductInfo
+import com.hoppingmall.order.port.ProductQueryPort
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.test.util.ReflectionTestUtils
+import java.math.BigDecimal
+import java.util.Optional
+
+@DisplayName("CartItemCommandServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class CartItemCommandServiceImplTest {
+
+    @Mock
+    private lateinit var cartItemRepository: CartItemRepository
+
+    @Mock
+    private lateinit var productQueryPort: ProductQueryPort
+
+    @InjectMocks
+    private lateinit var service: CartItemCommandServiceImpl
+
+    private fun createProductInfo(id: Long = 100L): ProductInfo {
+        return ProductInfo(
+            id = id,
+            name = "테스트 상품",
+            price = BigDecimal("10000"),
+            sellerId = 5L,
+            imageUrl = "http://example.com/image.jpg"
+        )
+    }
+
+    private fun createCartItem(id: Long = 1L, buyerId: Long = 1L, productId: Long = 100L, quantity: Int = 2): CartItem {
+        val cartItem = CartItem.create(
+            buyerId = buyerId,
+            productId = productId,
+            productName = "테스트 상품",
+            productPrice = BigDecimal("10000"),
+            productImageUrl = null,
+            quantity = quantity
+        )
+        ReflectionTestUtils.setField(cartItem, "id", id)
+        return cartItem
+    }
+
+    @Test
+    fun 새_상품을_장바구니에_추가한다() {
+        val request = CartItemCreateRequest(productId = 100L, quantity = 2)
+        val product = createProductInfo()
+        val cartItem = createCartItem()
+
+        whenever(productQueryPort.findProductById(100L)).thenReturn(product)
+        whenever(cartItemRepository.findByBuyerIdAndProductId(1L, 100L)).thenReturn(null)
+        whenever(cartItemRepository.save(any<CartItem>())).thenReturn(cartItem)
+
+        val result = service.addCartItem(1L, request)
+
+        assertThat(result.productId).isEqualTo(100L)
+    }
+
+    @Test
+    fun 이미_존재하는_상품을_추가하면_수량이_증가한다() {
+        val request = CartItemCreateRequest(productId = 100L, quantity = 3)
+        val product = createProductInfo()
+        val existingCartItem = createCartItem(quantity = 2)
+
+        whenever(productQueryPort.findProductById(100L)).thenReturn(product)
+        whenever(cartItemRepository.findByBuyerIdAndProductId(1L, 100L)).thenReturn(existingCartItem)
+
+        val result = service.addCartItem(1L, request)
+
+        assertThat(result.quantity).isEqualTo(5)
+    }
+
+    @Test
+    fun 존재하지_않는_상품_추가_시_예외가_발생한다() {
+        val request = CartItemCreateRequest(productId = 999L, quantity = 1)
+
+        whenever(productQueryPort.findProductById(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.addCartItem(1L, request) }
+            .isInstanceOf(CartItemProductNotFoundException::class.java)
+    }
+
+    @Test
+    fun 장바구니_수량을_변경한다() {
+        val request = CartItemUpdateRequest(quantity = 5)
+        val cartItem = createCartItem(buyerId = 1L)
+
+        whenever(cartItemRepository.findById(1L)).thenReturn(Optional.of(cartItem))
+
+        val result = service.updateCartItemQuantity(1L, 1L, request)
+
+        assertThat(result.quantity).isEqualTo(5)
+    }
+
+    @Test
+    fun 존재하지_않는_장바구니_수량변경_시_예외가_발생한다() {
+        val request = CartItemUpdateRequest(quantity = 5)
+
+        whenever(cartItemRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.updateCartItemQuantity(1L, 999L, request) }
+            .isInstanceOf(CartItemNotFoundException::class.java)
+    }
+
+    @Test
+    fun 다른_사용자의_장바구니_수량변경_시_예외가_발생한다() {
+        val request = CartItemUpdateRequest(quantity = 5)
+        val cartItem = createCartItem(buyerId = 99L)
+
+        whenever(cartItemRepository.findById(1L)).thenReturn(Optional.of(cartItem))
+
+        assertThatThrownBy { service.updateCartItemQuantity(1L, 1L, request) }
+            .isInstanceOf(CartItemAccessDeniedException::class.java)
+    }
+
+    @Test
+    fun 장바구니에서_상품을_삭제한다() {
+        val cartItem = createCartItem(buyerId = 1L)
+
+        whenever(cartItemRepository.findById(1L)).thenReturn(Optional.of(cartItem))
+
+        service.removeCartItem(1L, 1L)
+
+        assertThat(cartItem.deletedAt).isNotNull()
+    }
+
+    @Test
+    fun 존재하지_않는_장바구니_삭제_시_예외가_발생한다() {
+        whenever(cartItemRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.removeCartItem(1L, 999L) }
+            .isInstanceOf(CartItemNotFoundException::class.java)
+    }
+
+    @Test
+    fun 다른_사용자의_장바구니_삭제_시_예외가_발생한다() {
+        val cartItem = createCartItem(buyerId = 99L)
+
+        whenever(cartItemRepository.findById(1L)).thenReturn(Optional.of(cartItem))
+
+        assertThatThrownBy { service.removeCartItem(1L, 1L) }
+            .isInstanceOf(CartItemAccessDeniedException::class.java)
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/cartItem/service/CartItemQueryServiceImplTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/cartItem/service/CartItemQueryServiceImplTest.kt
@@ -1,0 +1,69 @@
+package com.hoppingmall.order.cartItem.service
+
+import com.hoppingmall.order.cartItem.domain.CartItem
+import com.hoppingmall.order.cartItem.domain.repository.CartItemRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import org.springframework.test.util.ReflectionTestUtils
+import java.math.BigDecimal
+
+@DisplayName("CartItemQueryServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class CartItemQueryServiceImplTest {
+
+    @Mock
+    private lateinit var cartItemRepository: CartItemRepository
+
+    @InjectMocks
+    private lateinit var service: CartItemQueryServiceImpl
+
+    private fun createCartItem(id: Long = 1L, buyerId: Long = 1L): CartItem {
+        val cartItem = CartItem.create(
+            buyerId = buyerId,
+            productId = 100L,
+            productName = "테스트 상품",
+            productPrice = BigDecimal("10000"),
+            productImageUrl = null,
+            quantity = 2
+        )
+        ReflectionTestUtils.setField(cartItem, "id", id)
+        return cartItem
+    }
+
+    @Test
+    fun 구매자의_장바구니_목록을_조회한다() {
+        val pageable = PageRequest.of(0, 20)
+        val cartItems = listOf(createCartItem())
+        val slice = SliceImpl(cartItems, pageable, false)
+
+        whenever(cartItemRepository.findByBuyerId(1L, pageable)).thenReturn(slice)
+
+        val result = service.getCartItems(1L, pageable)
+
+        assertThat(result.content).hasSize(1)
+        assertThat(result.content[0].productId).isEqualTo(100L)
+    }
+
+    @Test
+    fun 장바구니가_비어있으면_빈_목록을_반환한다() {
+        val pageable = PageRequest.of(0, 20)
+        val emptySlice = SliceImpl(emptyList<CartItem>(), pageable, false)
+
+        whenever(cartItemRepository.findByBuyerId(1L, pageable)).thenReturn(emptySlice)
+
+        val result = service.getCartItems(1L, pageable)
+
+        assertThat(result.content).isEmpty()
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/common/NotificationTypeTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/common/NotificationTypeTest.kt
@@ -1,0 +1,38 @@
+package com.hoppingmall.order.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("NotificationType")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class NotificationTypeTest {
+
+    @Test
+    fun 모든_알림_타입이_존재한다() {
+        val types = NotificationType.entries
+
+        assertThat(types).containsExactlyInAnyOrder(
+            NotificationType.PAYMENT_COMPLETED,
+            NotificationType.PAYMENT_FAILED,
+            NotificationType.PAYMENT_CANCELLED,
+            NotificationType.POINT_EARNED,
+            NotificationType.SHIPPING_STARTED,
+            NotificationType.SHIPPING_DELIVERED
+        )
+    }
+
+    @Test
+    fun 알림_타입의_name이_올바르다() {
+        assertThat(NotificationType.SHIPPING_STARTED.name).isEqualTo("SHIPPING_STARTED")
+        assertThat(NotificationType.SHIPPING_DELIVERED.name).isEqualTo("SHIPPING_DELIVERED")
+    }
+
+    @Test
+    fun valueOf로_알림_타입을_조회한다() {
+        assertThat(NotificationType.valueOf("PAYMENT_COMPLETED"))
+            .isEqualTo(NotificationType.PAYMENT_COMPLETED)
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/internal/InternalCartItemControllerTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/internal/InternalCartItemControllerTest.kt
@@ -1,0 +1,60 @@
+package com.hoppingmall.order.internal
+
+import com.hoppingmall.order.cartItem.dto.CartAggregation
+import com.hoppingmall.order.cartItem.domain.repository.CartItemRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+
+@DisplayName("InternalCartItemController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class InternalCartItemControllerTest {
+
+    @Mock
+    private lateinit var cartItemRepository: CartItemRepository
+
+    @InjectMocks
+    private lateinit var controller: InternalCartItemController
+
+    @Test
+    fun 장바구니_상품별_구매자수_집계를_조회한다() {
+        val aggregation1 = object : CartAggregation {
+            override fun getProductId(): Long = 100L
+            override fun getBuyerCount(): Long = 5L
+        }
+        val aggregation2 = object : CartAggregation {
+            override fun getProductId(): Long = 200L
+            override fun getBuyerCount(): Long = 3L
+        }
+
+        whenever(cartItemRepository.aggregateCartByProduct()).thenReturn(listOf(aggregation1, aggregation2))
+
+        val response = controller.aggregateCartByProduct()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body).hasSize(2)
+        assertThat(response.body!![0].productId).isEqualTo(100L)
+        assertThat(response.body!![0].buyerCount).isEqualTo(5L)
+        assertThat(response.body!![1].productId).isEqualTo(200L)
+        assertThat(response.body!![1].buyerCount).isEqualTo(3L)
+    }
+
+    @Test
+    fun 장바구니_집계가_없으면_빈_목록을_반환한다() {
+        whenever(cartItemRepository.aggregateCartByProduct()).thenReturn(emptyList())
+
+        val response = controller.aggregateCartByProduct()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body).isEmpty()
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/internal/InternalOrderControllerTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/internal/InternalOrderControllerTest.kt
@@ -44,6 +44,152 @@ class InternalOrderControllerTest {
     private lateinit var controller: InternalOrderController
 
     @Test
+    fun 주문의_주문상품_목록을_조회한다() {
+        val orderItem = OrderItem.create(
+            orderId = 10L, sellerId = 1L, productId = 100L,
+            productName = "테스트 상품", productPrice = BigDecimal("10000"), quantity = 2
+        )
+        ReflectionTestUtils.setField(orderItem, "id", 1L)
+
+        whenever(orderItemRepository.findByOrderId(10L)).thenReturn(listOf(orderItem))
+
+        val response = controller.getOrderItems(10L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body).hasSize(1)
+        assertThat(response.body!![0].productName).isEqualTo("테스트 상품")
+        assertThat(response.body!![0].totalPrice).isEqualByComparingTo(BigDecimal("20000"))
+    }
+
+    @Test
+    fun 주문상품_단건을_조회한다() {
+        val orderItem = OrderItem.create(
+            orderId = 10L, sellerId = 1L, productId = 100L,
+            productName = "테스트 상품", productPrice = BigDecimal("10000"), quantity = 1
+        )
+        ReflectionTestUtils.setField(orderItem, "id", 1L)
+
+        whenever(orderItemRepository.findById(1L)).thenReturn(java.util.Optional.of(orderItem))
+
+        val response = controller.getOrderItem(1L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body!!.id).isEqualTo(1L)
+    }
+
+    @Test
+    fun 존재하지_않는_주문상품_단건_조회_시_NOT_FOUND를_반환한다() {
+        whenever(orderItemRepository.findById(999L)).thenReturn(java.util.Optional.empty())
+
+        val response = controller.getOrderItem(999L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    @Test
+    fun 내부_API로_주문을_취소한다() {
+        val order = com.hoppingmall.order.order.domain.Order.create(
+            buyerId = 10L, totalAmount = BigDecimal("50000")
+        )
+        ReflectionTestUtils.setField(order, "id", 10L)
+
+        whenever(orderRepository.findById(10L)).thenReturn(java.util.Optional.of(order))
+        whenever(orderRepository.save(order)).thenReturn(order)
+
+        val response = controller.cancelOrder(10L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun 존재하지_않는_주문_취소_시_NOT_FOUND를_반환한다() {
+        whenever(orderRepository.findById(999L)).thenReturn(java.util.Optional.empty())
+
+        val response = controller.cancelOrder(999L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    @Test
+    fun 이미_취소된_주문_취소_시_OK를_반환한다() {
+        val order = com.hoppingmall.order.order.domain.Order.create(
+            buyerId = 10L, totalAmount = BigDecimal("50000")
+        )
+        order.updateStatus(com.hoppingmall.order.order.enum.OrderStatus.CANCELLED)
+        ReflectionTestUtils.setField(order, "id", 10L)
+
+        whenever(orderRepository.findById(10L)).thenReturn(java.util.Optional.of(order))
+
+        val response = controller.cancelOrder(10L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun 배송완료_여부를_조회한다_배송완료() {
+        val order = com.hoppingmall.order.order.domain.Order.create(
+            buyerId = 10L, totalAmount = BigDecimal("50000")
+        )
+        ReflectionTestUtils.setField(order, "id", 10L)
+        val shipping = com.hoppingmall.order.shipping.domain.Shipping.create(
+            orderId = 10L, buyerId = 10L, carrierName = "CJ",
+            trackingNumber = "1234", recipientName = "홍길동",
+            recipientPhone = "010-0000-0000", recipientAddress = "서울"
+        )
+        shipping.updateStatus(com.hoppingmall.order.shipping.enum.ShippingStatus.IN_TRANSIT)
+        shipping.updateStatus(com.hoppingmall.order.shipping.enum.ShippingStatus.DELIVERED)
+
+        whenever(orderRepository.findById(10L)).thenReturn(java.util.Optional.of(order))
+        whenever(shippingRepository.findByOrderId(10L)).thenReturn(shipping)
+
+        val response = controller.isDelivered(10L, 10L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body).isTrue()
+    }
+
+    @Test
+    fun 배송완료_여부를_조회한다_다른_구매자() {
+        val order = com.hoppingmall.order.order.domain.Order.create(
+            buyerId = 10L, totalAmount = BigDecimal("50000")
+        )
+        ReflectionTestUtils.setField(order, "id", 10L)
+
+        whenever(orderRepository.findById(10L)).thenReturn(java.util.Optional.of(order))
+
+        val response = controller.isDelivered(10L, 99L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body).isFalse()
+    }
+
+    @Test
+    fun 배송완료_여부를_조회한다_주문없음() {
+        whenever(orderRepository.findById(999L)).thenReturn(java.util.Optional.empty())
+
+        val response = controller.isDelivered(999L, 10L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body).isFalse()
+    }
+
+    @Test
+    fun 배송완료_여부를_조회한다_배송정보_없음() {
+        val order = com.hoppingmall.order.order.domain.Order.create(
+            buyerId = 10L, totalAmount = BigDecimal("50000")
+        )
+        ReflectionTestUtils.setField(order, "id", 10L)
+
+        whenever(orderRepository.findById(10L)).thenReturn(java.util.Optional.of(order))
+        whenever(shippingRepository.findByOrderId(10L)).thenReturn(null)
+
+        val response = controller.isDelivered(10L, 10L)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body).isFalse()
+    }
+
+    @Test
     fun 배송완료_주문상품을_판매자와_기간으로_조회한다() {
         val sellerId = 1L
         val startDate = LocalDateTime.of(2026, 1, 1, 0, 0)

--- a/order-service/src/test/kotlin/com/hoppingmall/order/order/controller/OrderControllerTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/order/controller/OrderControllerTest.kt
@@ -1,0 +1,120 @@
+package com.hoppingmall.order.order.controller
+
+import com.hoppingmall.common.UserPrincipal
+import com.hoppingmall.order.order.dto.request.OrderCreateRequest
+import com.hoppingmall.order.order.dto.request.OrderStatusUpdateRequest
+import com.hoppingmall.order.order.dto.response.OrderResponse
+import com.hoppingmall.order.order.enum.OrderStatus
+import com.hoppingmall.order.order.service.OrderCommandService
+import com.hoppingmall.order.order.service.OrderQueryService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import org.springframework.http.HttpStatus
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@DisplayName("OrderController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class OrderControllerTest {
+
+    @Mock
+    private lateinit var orderCommandService: OrderCommandService
+
+    @Mock
+    private lateinit var orderQueryService: OrderQueryService
+
+    @InjectMocks
+    private lateinit var controller: OrderController
+
+    private val buyerPrincipal = UserPrincipal.of(1L, "BUYER")
+    private val adminPrincipal = UserPrincipal.of(99L, "ADMIN")
+
+    private fun createOrderResponse(
+        id: Long = 1L,
+        status: OrderStatus = OrderStatus.PAYING
+    ): OrderResponse {
+        return OrderResponse(
+            id = id,
+            buyerId = 1L,
+            status = status,
+            totalAmount = BigDecimal("50000"),
+            items = emptyList(),
+            createdAt = LocalDateTime.now()
+        )
+    }
+
+    @Test
+    fun 주문을_생성한다() {
+        val request = OrderCreateRequest(cartItemIds = listOf(1L, 2L))
+        val response = createOrderResponse()
+
+        whenever(orderCommandService.createOrder(1L, request)).thenReturn(response)
+
+        val result = controller.createOrder(buyerPrincipal, request)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.CREATED)
+        assertThat(result.body!!.data!!.id).isEqualTo(1L)
+    }
+
+    @Test
+    fun 주문을_단건_조회한다() {
+        val response = createOrderResponse()
+
+        whenever(orderQueryService.getOrder(1L, 1L)).thenReturn(response)
+
+        val result = controller.getOrder(buyerPrincipal, 1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data!!.id).isEqualTo(1L)
+    }
+
+    @Test
+    fun 내_주문_목록을_조회한다() {
+        val pageable = PageRequest.of(0, 20)
+        val orders = listOf(createOrderResponse())
+        val slice = SliceImpl(orders, pageable, false)
+
+        whenever(orderQueryService.getMyOrders(1L, pageable)).thenReturn(slice)
+
+        val result = controller.getMyOrders(buyerPrincipal, pageable)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data!!.content).hasSize(1)
+    }
+
+    @Test
+    fun 주문을_취소한다() {
+        val response = createOrderResponse(status = OrderStatus.CANCELLED)
+
+        whenever(orderCommandService.cancelOrder(1L, 1L)).thenReturn(response)
+
+        val result = controller.cancelOrder(buyerPrincipal, 1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data!!.status).isEqualTo(OrderStatus.CANCELLED)
+    }
+
+    @Test
+    fun 관리자가_주문_상태를_변경한다() {
+        val request = OrderStatusUpdateRequest(status = OrderStatus.SHIPPED)
+        val response = createOrderResponse(status = OrderStatus.SHIPPED)
+
+        whenever(orderCommandService.updateOrderStatus(1L, request, 99L, true)).thenReturn(response)
+
+        val result = controller.updateOrderStatus(adminPrincipal, 1L, request)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data!!.status).isEqualTo(OrderStatus.SHIPPED)
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/order/domain/SagaEventLogTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/order/domain/SagaEventLogTest.kt
@@ -1,0 +1,100 @@
+package com.hoppingmall.order.order.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("SagaEventLog")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class SagaEventLogTest {
+
+    @Test
+    fun 스텝_완료를_기록한다() {
+        val log = SagaEventLog(
+            eventId = "evt-1",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 1L
+        )
+
+        log.markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
+
+        assertThat(log.isStepCompleted(SagaEventLog.LOCAL_COMPLETED)).isTrue()
+        assertThat(log.isStepCompleted(SagaEventLog.REMOTE_COMPLETED)).isFalse()
+    }
+
+    @Test
+    fun 모든_스텝이_완료되면_isFullyCompleted가_true이다() {
+        val log = SagaEventLog(
+            eventId = "evt-2",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 1L
+        )
+
+        log.markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
+        log.markStepCompleted(SagaEventLog.REMOTE_COMPLETED)
+
+        assertThat(log.isFullyCompleted()).isTrue()
+    }
+
+    @Test
+    fun 일부_스텝만_완료되면_isFullyCompleted가_false이다() {
+        val log = SagaEventLog(
+            eventId = "evt-3",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 1L
+        )
+
+        log.markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
+
+        assertThat(log.isFullyCompleted()).isFalse()
+    }
+
+    @Test
+    fun 스텝이_없으면_isFullyCompleted가_false이다() {
+        val log = SagaEventLog(
+            eventId = "evt-4",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 1L
+        )
+
+        assertThat(log.isFullyCompleted()).isFalse()
+    }
+
+    @Test
+    fun 중복_스텝_추가를_무시한다() {
+        val log = SagaEventLog(
+            eventId = "evt-5",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 1L
+        )
+
+        log.markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
+        log.markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
+
+        assertThat(log.completedSteps).hasSize(1)
+    }
+
+    @Test
+    fun 생성_시_기본_필드가_초기화된다() {
+        val log = SagaEventLog(
+            eventId = "evt-6",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 1L
+        )
+
+        assertThat(log.id).isNull()
+        assertThat(log.createdAt).isNotNull()
+        assertThat(log.completedSteps).isEmpty()
+        assertThat(log.eventId).isEqualTo("evt-6")
+        assertThat(log.eventType).isEqualTo("PAYMENT_COMPLETED")
+        assertThat(log.orderId).isEqualTo(1L)
+    }
+
+    @Test
+    fun 상수_값이_올바르다() {
+        assertThat(SagaEventLog.LOCAL_COMPLETED).isEqualTo("LOCAL_COMPLETED")
+        assertThat(SagaEventLog.REMOTE_COMPLETED).isEqualTo("REMOTE_COMPLETED")
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImplTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImplTest.kt
@@ -229,6 +229,147 @@ class OrderCommandServiceImplTest {
         return ProductInfo(id = id, name = "상품-$id", price = BigDecimal("25000"), sellerId = sellerId)
     }
 
+    @Test
+    fun PAID_상태_주문_취소_시_CANCEL_REQUESTED로_전환하고_이벤트를_발행한다() {
+        val order = Order.create(buyerId = 10L, totalAmount = BigDecimal("50000"))
+        setEntityId(order, 1L)
+        order.updateStatus(OrderStatus.PAYING)
+        order.updateStatus(OrderStatus.PAID)
+
+        val orderItem = OrderItem.create(
+            orderId = 1L, sellerId = 5L, productId = 100L,
+            productName = "상품A", productPrice = BigDecimal("50000"),
+            quantity = 1, reservationId = "rsv-1"
+        )
+        setEntityId(orderItem, 10L)
+
+        whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+        whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(orderItem))
+
+        service.cancelOrder(10L, 1L)
+
+        assertThat(order.status).isEqualTo(OrderStatus.CANCEL_REQUESTED)
+        verify(transactionalEventPublisher).publishEvent(
+            aggregateType = eq("Order"),
+            aggregateId = eq("1"),
+            eventType = eq("PaymentCancellationRequested"),
+            eventData = any(),
+            topic = any(),
+            partitionKey = eq("1")
+        )
+    }
+
+    @Test
+    fun 취소_불가능한_상태의_주문_취소_시_예외가_발생한다() {
+        val order = Order.create(buyerId = 10L, totalAmount = BigDecimal("50000"))
+        setEntityId(order, 1L)
+        order.updateStatus(OrderStatus.PAYING)
+        order.updateStatus(OrderStatus.PAID)
+        order.updateStatus(OrderStatus.SHIPPED)
+        order.updateStatus(OrderStatus.DELIVERED)
+
+        whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+
+        assertThatThrownBy { service.cancelOrder(10L, 1L) }
+            .isInstanceOf(com.hoppingmall.order.order.exception.OrderInvalidStatusException::class.java)
+    }
+
+    @Test
+    fun 주문_상태를_변경한다() {
+        val order = Order.create(buyerId = 10L, totalAmount = BigDecimal("50000"))
+        setEntityId(order, 1L)
+        order.updateStatus(OrderStatus.PAYING)
+        order.updateStatus(OrderStatus.PAID)
+
+        val orderItem = OrderItem.create(
+            orderId = 1L, sellerId = 5L, productId = 100L,
+            productName = "상품A", productPrice = BigDecimal("50000"),
+            quantity = 1
+        )
+        setEntityId(orderItem, 10L)
+
+        whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+        whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(orderItem))
+
+        val result = service.updateOrderStatus(
+            1L,
+            com.hoppingmall.order.order.dto.request.OrderStatusUpdateRequest(status = OrderStatus.SHIPPED),
+            10L,
+            false
+        )
+
+        assertThat(result.status).isEqualTo(OrderStatus.SHIPPED)
+    }
+
+    @Test
+    fun 관리자가_다른_사용자의_주문_상태를_변경한다() {
+        val order = Order.create(buyerId = 10L, totalAmount = BigDecimal("50000"))
+        setEntityId(order, 1L)
+        order.updateStatus(OrderStatus.PAYING)
+        order.updateStatus(OrderStatus.PAID)
+
+        val orderItem = OrderItem.create(
+            orderId = 1L, sellerId = 5L, productId = 100L,
+            productName = "상품A", productPrice = BigDecimal("50000"),
+            quantity = 1
+        )
+        setEntityId(orderItem, 10L)
+
+        whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+        whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(orderItem))
+
+        val result = service.updateOrderStatus(
+            1L,
+            com.hoppingmall.order.order.dto.request.OrderStatusUpdateRequest(status = OrderStatus.SHIPPED),
+            99L,
+            true
+        )
+
+        assertThat(result.status).isEqualTo(OrderStatus.SHIPPED)
+    }
+
+    @Test
+    fun 관리자가_아닌_다른_사용자가_주문_상태변경_시_예외가_발생한다() {
+        val order = Order.create(buyerId = 10L, totalAmount = BigDecimal("50000"))
+        setEntityId(order, 1L)
+
+        whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+
+        assertThatThrownBy {
+            service.updateOrderStatus(
+                1L,
+                com.hoppingmall.order.order.dto.request.OrderStatusUpdateRequest(status = OrderStatus.CANCELLED),
+                99L,
+                false
+            )
+        }.isInstanceOf(OrderAccessDeniedException::class.java)
+    }
+
+    @Test
+    fun 존재하지_않는_주문의_상태변경_시_예외가_발생한다() {
+        whenever(orderRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy {
+            service.updateOrderStatus(
+                999L,
+                com.hoppingmall.order.order.dto.request.OrderStatusUpdateRequest(status = OrderStatus.CANCELLED),
+                10L,
+                false
+            )
+        }.isInstanceOf(OrderNotFoundException::class.java)
+    }
+
+    @Test
+    fun 존재하지_않는_상품으로_주문_시_예외가_발생한다() {
+        val cartItem = createCartItem(id = 1L, buyerId = 10L, productId = 100L, quantity = 1)
+
+        whenever(cartItemRepository.findAllById(listOf(1L))).thenReturn(listOf(cartItem))
+        whenever(productQueryPort.findProductsByIds(listOf(100L))).thenReturn(emptyList())
+
+        assertThatThrownBy { service.createOrder(10L, OrderCreateRequest(cartItemIds = listOf(1L))) }
+            .isInstanceOf(com.hoppingmall.order.order.exception.OrderProductNotFoundException::class.java)
+    }
+
     private fun setEntityId(entity: Any, id: Long) {
         ReflectionTestUtils.setField(entity, "id", id)
     }

--- a/order-service/src/test/kotlin/com/hoppingmall/order/port/HttpInventoryCommandAdapterTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/port/HttpInventoryCommandAdapterTest.kt
@@ -104,4 +104,103 @@ class HttpInventoryCommandAdapterTest {
         assertThatThrownBy { adapter.cancelReservations(listOf("rsv-1", "rsv-2")) }
             .isInstanceOf(RuntimeException::class.java)
     }
+
+    @Test
+    fun 재고_감소를_수행한다() {
+        whenever(restTemplate.postForEntity(
+            any<String>(), eq(null), eq(Void::class.java)
+        )).thenReturn(ResponseEntity.ok().build())
+
+        adapter.decreaseStock(1L, 5)
+
+        org.mockito.kotlin.verify(restTemplate).postForEntity(
+            any<String>(), eq(null), eq(Void::class.java)
+        )
+    }
+
+    @Test
+    fun 재고_증가를_수행한다() {
+        whenever(restTemplate.postForEntity(
+            any<String>(), eq(null), eq(Void::class.java)
+        )).thenReturn(ResponseEntity.ok().build())
+
+        adapter.increaseStock(1L, 5)
+
+        org.mockito.kotlin.verify(restTemplate).postForEntity(
+            any<String>(), eq(null), eq(Void::class.java)
+        )
+    }
+
+    @Test
+    fun 배치_재고_예약을_수행한다() {
+        val responseBody = mapOf(100L to "rsv-100", 200L to "rsv-200")
+        val responseEntity = ResponseEntity.ok(responseBody)
+
+        whenever(restTemplate.exchange(
+            any<String>(),
+            any<org.springframework.http.HttpMethod>(),
+            any<org.springframework.http.HttpEntity<*>>(),
+            any<org.springframework.core.ParameterizedTypeReference<Map<Long, String>>>()
+        )).thenReturn(responseEntity)
+
+        val result = adapter.batchReserveStock(listOf(100L to 1, 200L to 2))
+
+        assertThat(result).hasSize(2)
+        assertThat(result[100L]).isEqualTo("rsv-100")
+        assertThat(result[200L]).isEqualTo("rsv-200")
+    }
+
+    @Test
+    fun 배치_재고_예약_응답이_null이면_예외를_발생시킨다() {
+        val responseEntity = ResponseEntity.ok<Map<Long, String>>(null)
+
+        whenever(restTemplate.exchange(
+            any<String>(),
+            any<org.springframework.http.HttpMethod>(),
+            any<org.springframework.http.HttpEntity<*>>(),
+            any<org.springframework.core.ParameterizedTypeReference<Map<Long, String>>>()
+        )).thenReturn(responseEntity)
+
+        assertThatThrownBy { adapter.batchReserveStock(listOf(100L to 1)) }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("배치 재고 예약 응답 없음")
+    }
+
+    @Test
+    fun 예약_취소를_수행한다() {
+        whenever(restTemplate.postForEntity(
+            any<String>(), eq(null), eq(Void::class.java)
+        )).thenReturn(ResponseEntity.ok().build())
+
+        adapter.cancelReservation("rsv-1")
+
+        org.mockito.kotlin.verify(restTemplate).postForEntity(
+            any<String>(), eq(null), eq(Void::class.java)
+        )
+    }
+
+    @Test
+    fun 일괄_예약_취소를_수행한다() {
+        whenever(restTemplate.postForEntity(
+            any<String>(), any(), eq(Void::class.java)
+        )).thenReturn(ResponseEntity.ok().build())
+
+        adapter.cancelReservations(listOf("rsv-1", "rsv-2"))
+
+        org.mockito.kotlin.verify(restTemplate).postForEntity(
+            any<String>(), any(), eq(Void::class.java)
+        )
+    }
+
+    @Test
+    fun 배치_확정_응답이_null이면_false를_반환한다() {
+        val response = ResponseEntity.ok<HttpInventoryCommandAdapter.ConfirmationResponse>(null)
+        whenever(restTemplate.postForEntity(
+            any<String>(), any(), eq(HttpInventoryCommandAdapter.ConfirmationResponse::class.java)
+        )).thenReturn(response)
+
+        val result = adapter.confirmReservations(listOf("rsv-1"))
+
+        assertThat(result).isFalse()
+    }
 }

--- a/order-service/src/test/kotlin/com/hoppingmall/order/port/HttpPaymentCommandAdapterTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/port/HttpPaymentCommandAdapterTest.kt
@@ -1,0 +1,61 @@
+package com.hoppingmall.order.port
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.http.ResponseEntity
+import org.springframework.web.client.RestTemplate
+
+@DisplayName("HttpPaymentCommandAdapter")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class HttpPaymentCommandAdapterTest {
+
+    @Mock
+    private lateinit var restTemplate: RestTemplate
+
+    @Mock
+    private lateinit var restTemplateBuilder: RestTemplateBuilder
+
+    private lateinit var adapter: HttpPaymentCommandAdapter
+
+    @BeforeEach
+    fun setUp() {
+        whenever(restTemplateBuilder.connectTimeout(any())).thenReturn(restTemplateBuilder)
+        whenever(restTemplateBuilder.readTimeout(any())).thenReturn(restTemplateBuilder)
+        whenever(restTemplateBuilder.build()).thenReturn(restTemplate)
+        adapter = HttpPaymentCommandAdapter("http://localhost:8085", restTemplateBuilder)
+    }
+
+    @Test
+    fun 결제_취소_성공_시_true를_반환한다() {
+        whenever(restTemplate.postForEntity(
+            any<String>(), eq(null), eq(Void::class.java)
+        )).thenReturn(ResponseEntity.ok().build())
+
+        val result = adapter.cancelPayment(1L)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun 결제_취소_API_호출에_성공하면_true를_반환한다() {
+        whenever(restTemplate.postForEntity(
+            any<String>(), eq(null), eq(Void::class.java)
+        )).thenReturn(ResponseEntity.ok().build())
+
+        val result = adapter.cancelPayment(100L)
+
+        assertThat(result).isTrue()
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/port/HttpPaymentQueryAdapterTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/port/HttpPaymentQueryAdapterTest.kt
@@ -1,0 +1,119 @@
+package com.hoppingmall.order.port
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.web.client.RestTemplate
+import java.math.BigDecimal
+
+@DisplayName("HttpPaymentQueryAdapter")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class HttpPaymentQueryAdapterTest {
+
+    @Mock
+    private lateinit var restTemplate: RestTemplate
+
+    @Mock
+    private lateinit var restTemplateBuilder: RestTemplateBuilder
+
+    private lateinit var adapter: HttpPaymentQueryAdapter
+
+    @BeforeEach
+    fun setUp() {
+        whenever(restTemplateBuilder.connectTimeout(any())).thenReturn(restTemplateBuilder)
+        whenever(restTemplateBuilder.readTimeout(any())).thenReturn(restTemplateBuilder)
+        whenever(restTemplateBuilder.build()).thenReturn(restTemplate)
+        adapter = HttpPaymentQueryAdapter("http://localhost:8085", restTemplateBuilder)
+    }
+
+    @Test
+    fun 주문ID로_결제정보를_조회한다() {
+        val paymentInfo = PaymentInfo(
+            id = 1L, orderId = 10L, amount = BigDecimal("50000"),
+            pointAmount = BigDecimal("500"), couponId = null, status = "SUCCESS"
+        )
+        whenever(restTemplate.getForObject(
+            any<String>(), eq(PaymentInfo::class.java)
+        )).thenReturn(paymentInfo)
+
+        val result = adapter.findByOrderId(10L)
+
+        assertThat(result).isNotNull
+        assertThat(result!!.id).isEqualTo(1L)
+        assertThat(result.orderId).isEqualTo(10L)
+    }
+
+    @Test
+    fun 주문ID로_결제정보가_없으면_null을_반환한다() {
+        whenever(restTemplate.getForObject(
+            any<String>(), eq(PaymentInfo::class.java)
+        )).thenReturn(null)
+
+        val result = adapter.findByOrderId(999L)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun 결제ID로_결제정보를_조회한다() {
+        val paymentInfo = PaymentInfo(
+            id = 5L, orderId = 10L, amount = BigDecimal("50000"),
+            pointAmount = BigDecimal("500"), couponId = 1L, status = "SUCCESS"
+        )
+        whenever(restTemplate.getForObject(
+            any<String>(), eq(PaymentInfo::class.java)
+        )).thenReturn(paymentInfo)
+
+        val result = adapter.findById(5L)
+
+        assertThat(result).isNotNull
+        assertThat(result!!.id).isEqualTo(5L)
+        assertThat(result.couponId).isEqualTo(1L)
+    }
+
+    @Test
+    fun 결제ID로_결제정보가_없으면_null을_반환한다() {
+        whenever(restTemplate.getForObject(
+            any<String>(), eq(PaymentInfo::class.java)
+        )).thenReturn(null)
+
+        val result = adapter.findById(999L)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun 주문별조회_CB_폴백_시_null을_반환한다() {
+        val method = HttpPaymentQueryAdapter::class.java.getDeclaredMethod(
+            "findByOrderIdFallback", Long::class.java, Exception::class.java
+        )
+        method.isAccessible = true
+
+        val result = method.invoke(adapter, 1L, RuntimeException("fail"))
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun 결제조회_CB_폴백_시_null을_반환한다() {
+        val method = HttpPaymentQueryAdapter::class.java.getDeclaredMethod(
+            "findByIdFallback", Long::class.java, Exception::class.java
+        )
+        method.isAccessible = true
+
+        val result = method.invoke(adapter, 1L, RuntimeException("fail"))
+
+        assertThat(result).isNull()
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/port/HttpProductQueryAdapterTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/port/HttpProductQueryAdapterTest.kt
@@ -1,0 +1,120 @@
+package com.hoppingmall.order.port
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.web.client.RestTemplate
+import java.math.BigDecimal
+
+@DisplayName("HttpProductQueryAdapter")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class HttpProductQueryAdapterTest {
+
+    @Mock
+    private lateinit var restTemplate: RestTemplate
+
+    @Mock
+    private lateinit var restTemplateBuilder: RestTemplateBuilder
+
+    private lateinit var adapter: HttpProductQueryAdapter
+
+    @BeforeEach
+    fun setUp() {
+        whenever(restTemplateBuilder.connectTimeout(any())).thenReturn(restTemplateBuilder)
+        whenever(restTemplateBuilder.readTimeout(any())).thenReturn(restTemplateBuilder)
+        whenever(restTemplateBuilder.build()).thenReturn(restTemplate)
+        adapter = HttpProductQueryAdapter("http://localhost:8083", restTemplateBuilder)
+    }
+
+    @Test
+    fun 상품ID로_상품정보를_조회한다() {
+        val productInfo = ProductInfo(
+            id = 100L, name = "테스트 상품",
+            price = BigDecimal("10000"), sellerId = 5L, imageUrl = "http://example.com/img.jpg"
+        )
+        whenever(restTemplate.getForObject(
+            any<String>(), eq(ProductInfo::class.java)
+        )).thenReturn(productInfo)
+
+        val result = adapter.findProductById(100L)
+
+        assertThat(result).isNotNull
+        assertThat(result!!.id).isEqualTo(100L)
+        assertThat(result.name).isEqualTo("테스트 상품")
+    }
+
+    @Test
+    fun 상품이_없으면_null을_반환한다() {
+        whenever(restTemplate.getForObject(
+            any<String>(), eq(ProductInfo::class.java)
+        )).thenReturn(null)
+
+        val result = adapter.findProductById(999L)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun 상품ID_목록으로_상품정보를_조회한다() {
+        val products = arrayOf(
+            ProductInfo(id = 1L, name = "상품A", price = BigDecimal("10000"), sellerId = 5L),
+            ProductInfo(id = 2L, name = "상품B", price = BigDecimal("20000"), sellerId = 6L)
+        )
+        whenever(restTemplate.getForObject(
+            any<String>(), eq(Array<ProductInfo>::class.java)
+        )).thenReturn(products)
+
+        val result = adapter.findProductsByIds(listOf(1L, 2L))
+
+        assertThat(result).hasSize(2)
+        assertThat(result[0].id).isEqualTo(1L)
+        assertThat(result[1].id).isEqualTo(2L)
+    }
+
+    @Test
+    fun 상품_목록_조회결과가_null이면_빈_목록을_반환한다() {
+        whenever(restTemplate.getForObject(
+            any<String>(), eq(Array<ProductInfo>::class.java)
+        )).thenReturn(null)
+
+        val result = adapter.findProductsByIds(listOf(1L, 2L))
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun 단건조회_CB_폴백_시_null을_반환한다() {
+        val method = HttpProductQueryAdapter::class.java.getDeclaredMethod(
+            "findProductByIdFallback", Long::class.java, Exception::class.java
+        )
+        method.isAccessible = true
+
+        val result = method.invoke(adapter, 1L, RuntimeException("fail"))
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun 목록조회_CB_폴백_시_빈_목록을_반환한다() {
+        val method = HttpProductQueryAdapter::class.java.getDeclaredMethod(
+            "findProductsByIdsFallback", List::class.java, Exception::class.java
+        )
+        method.isAccessible = true
+
+        @Suppress("UNCHECKED_CAST")
+        val result = method.invoke(adapter, listOf(1L, 2L), RuntimeException("fail")) as List<ProductInfo>
+
+        assertThat(result).isEmpty()
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/port/PaymentInfoTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/port/PaymentInfoTest.kt
@@ -1,0 +1,43 @@
+package com.hoppingmall.order.port
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("PaymentInfo")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class PaymentInfoTest {
+
+    @Test
+    fun SUCCESS_상태이면_isSuccess가_true이다() {
+        val paymentInfo = PaymentInfo(
+            id = 1L, orderId = 10L, amount = BigDecimal("50000"),
+            pointAmount = BigDecimal("500"), couponId = null, status = "SUCCESS"
+        )
+
+        assertThat(paymentInfo.isSuccess()).isTrue()
+    }
+
+    @Test
+    fun SUCCESS가_아니면_isSuccess가_false이다() {
+        val paymentInfo = PaymentInfo(
+            id = 1L, orderId = 10L, amount = BigDecimal("50000"),
+            pointAmount = BigDecimal("500"), couponId = null, status = "FAILED"
+        )
+
+        assertThat(paymentInfo.isSuccess()).isFalse()
+    }
+
+    @Test
+    fun PENDING_상태이면_isSuccess가_false이다() {
+        val paymentInfo = PaymentInfo(
+            id = 1L, orderId = 10L, amount = BigDecimal("50000"),
+            pointAmount = BigDecimal("500"), couponId = 1L, status = "PENDING"
+        )
+
+        assertThat(paymentInfo.isSuccess()).isFalse()
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/refund/controller/RefundControllerTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/refund/controller/RefundControllerTest.kt
@@ -1,0 +1,151 @@
+package com.hoppingmall.order.refund.controller
+
+import com.hoppingmall.common.UserPrincipal
+import com.hoppingmall.order.refund.dto.request.RefundApprovalRequest
+import com.hoppingmall.order.refund.dto.request.RefundCreateRequest
+import com.hoppingmall.order.refund.dto.request.RefundItemRequest
+import com.hoppingmall.order.refund.dto.response.RefundResponse
+import com.hoppingmall.order.refund.enum.RefundReason
+import com.hoppingmall.order.refund.enum.RefundStatus
+import com.hoppingmall.order.refund.service.RefundCommandService
+import com.hoppingmall.order.refund.service.RefundQueryService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import org.springframework.http.HttpStatus
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@DisplayName("RefundController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class RefundControllerTest {
+
+    @Mock
+    private lateinit var refundCommandService: RefundCommandService
+
+    @Mock
+    private lateinit var refundQueryService: RefundQueryService
+
+    @InjectMocks
+    private lateinit var controller: RefundController
+
+    private val buyerPrincipal = UserPrincipal.of(1L, "BUYER")
+    private val sellerPrincipal = UserPrincipal.of(5L, "SELLER")
+
+    private fun createRefundResponse(
+        id: Long = 1L,
+        status: RefundStatus = RefundStatus.REQUESTED
+    ): RefundResponse {
+        return RefundResponse(
+            id = id,
+            orderId = 10L,
+            paymentId = 20L,
+            buyerId = 1L,
+            sellerId = 5L,
+            status = status,
+            reason = RefundReason.CHANGE_OF_MIND,
+            reasonDetail = null,
+            refundAmount = BigDecimal("10000"),
+            isFullRefund = false,
+            rejectionReason = null,
+            approvedBy = null,
+            completedAt = null,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
+            items = emptyList()
+        )
+    }
+
+    @Test
+    fun 환불을_요청한다() {
+        val request = RefundCreateRequest(
+            orderId = 10L,
+            reason = RefundReason.CHANGE_OF_MIND,
+            reasonDetail = null,
+            items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 1))
+        )
+        val response = createRefundResponse()
+
+        whenever(refundCommandService.requestRefund(1L, request)).thenReturn(response)
+
+        val result = controller.requestRefund(request, buyerPrincipal)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.id).isEqualTo(1L)
+    }
+
+    @Test
+    fun 환불을_단건_조회한다() {
+        val response = createRefundResponse()
+
+        whenever(refundQueryService.getRefund(1L, 1L)).thenReturn(response)
+
+        val result = controller.getRefund(1L, buyerPrincipal)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.id).isEqualTo(1L)
+    }
+
+    @Test
+    fun 내_환불_목록을_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+        val refunds = listOf(createRefundResponse())
+        val slice = SliceImpl(refunds, pageable, false)
+
+        whenever(refundQueryService.getMyRefunds(1L, pageable)).thenReturn(slice)
+
+        val result = controller.getMyRefunds(buyerPrincipal, 0, 10)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.content).hasSize(1)
+    }
+
+    @Test
+    fun 판매자_환불_목록을_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+        val refunds = listOf(createRefundResponse())
+        val slice = SliceImpl(refunds, pageable, false)
+
+        whenever(refundQueryService.getSellerRefunds(5L, pageable)).thenReturn(slice)
+
+        val result = controller.getSellerRefunds(sellerPrincipal, 0, 10)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.content).hasSize(1)
+    }
+
+    @Test
+    fun 환불을_승인한다() {
+        val response = createRefundResponse(status = RefundStatus.COMPLETED)
+
+        whenever(refundCommandService.approveRefund(1L, 5L)).thenReturn(response)
+
+        val result = controller.approveRefund(1L, sellerPrincipal)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.status).isEqualTo(RefundStatus.COMPLETED)
+    }
+
+    @Test
+    fun 환불을_거절한다() {
+        val request = RefundApprovalRequest(rejectionReason = "사유 불충분")
+        val response = createRefundResponse(status = RefundStatus.REJECTED)
+
+        whenever(refundCommandService.rejectRefund(1L, 5L, request)).thenReturn(response)
+
+        val result = controller.rejectRefund(1L, request, sellerPrincipal)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.status).isEqualTo(RefundStatus.REJECTED)
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/refund/domain/RefundEventLogTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/refund/domain/RefundEventLogTest.kt
@@ -1,0 +1,27 @@
+package com.hoppingmall.order.refund.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("RefundEventLog")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class RefundEventLogTest {
+
+    @Test
+    fun 환불_이벤트_로그를_생성한다() {
+        val log = RefundEventLog(
+            eventId = "evt-refund-1",
+            eventType = "REFUND_COMPLETED",
+            refundId = 1L,
+            orderId = 10L
+        )
+
+        assertThat(log.eventId).isEqualTo("evt-refund-1")
+        assertThat(log.eventType).isEqualTo("REFUND_COMPLETED")
+        assertThat(log.refundId).isEqualTo(1L)
+        assertThat(log.orderId).isEqualTo(10L)
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/refund/domain/RefundItemTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/refund/domain/RefundItemTest.kt
@@ -1,0 +1,47 @@
+package com.hoppingmall.order.refund.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("RefundItem")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class RefundItemTest {
+
+    @Test
+    fun 환불_항목을_생성한다() {
+        val item = RefundItem.create(
+            refundId = 1L,
+            orderItemId = 10L,
+            productId = 100L,
+            productName = "테스트 상품",
+            productPrice = BigDecimal("10000"),
+            quantity = 3
+        )
+
+        assertThat(item.refundId).isEqualTo(1L)
+        assertThat(item.orderItemId).isEqualTo(10L)
+        assertThat(item.productId).isEqualTo(100L)
+        assertThat(item.productName).isEqualTo("테스트 상품")
+        assertThat(item.productPrice).isEqualByComparingTo(BigDecimal("10000"))
+        assertThat(item.quantity).isEqualTo(3)
+        assertThat(item.refundPrice).isEqualByComparingTo(BigDecimal("30000"))
+    }
+
+    @Test
+    fun 수량이_1일_때_환불금액은_단가와_같다() {
+        val item = RefundItem.create(
+            refundId = 1L,
+            orderItemId = 10L,
+            productId = 100L,
+            productName = "상품A",
+            productPrice = BigDecimal("25000"),
+            quantity = 1
+        )
+
+        assertThat(item.refundPrice).isEqualByComparingTo(BigDecimal("25000"))
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/refund/domain/RefundTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/refund/domain/RefundTest.kt
@@ -1,0 +1,116 @@
+package com.hoppingmall.order.refund.domain
+
+import com.hoppingmall.order.refund.enum.RefundReason
+import com.hoppingmall.order.refund.enum.RefundStatus
+import com.hoppingmall.order.refund.exception.RefundInvalidStatusException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("Refund")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class RefundTest {
+
+    private fun createRefund(): Refund {
+        return Refund.create(
+            orderId = 1L,
+            paymentId = 10L,
+            buyerId = 100L,
+            sellerId = 200L,
+            reason = RefundReason.CHANGE_OF_MIND,
+            reasonDetail = "단순 변심",
+            refundAmount = BigDecimal("10000"),
+            isFullRefund = false
+        )
+    }
+
+    @Test
+    fun 환불을_생성한다() {
+        val refund = createRefund()
+
+        assertThat(refund.orderId).isEqualTo(1L)
+        assertThat(refund.paymentId).isEqualTo(10L)
+        assertThat(refund.buyerId).isEqualTo(100L)
+        assertThat(refund.sellerId).isEqualTo(200L)
+        assertThat(refund.status).isEqualTo(RefundStatus.REQUESTED)
+        assertThat(refund.reason).isEqualTo(RefundReason.CHANGE_OF_MIND)
+        assertThat(refund.reasonDetail).isEqualTo("단순 변심")
+        assertThat(refund.refundAmount).isEqualByComparingTo(BigDecimal("10000"))
+        assertThat(refund.isFullRefund).isFalse()
+    }
+
+    @Test
+    fun 환불을_승인한다() {
+        val refund = createRefund()
+
+        refund.approve(300L)
+
+        assertThat(refund.status).isEqualTo(RefundStatus.APPROVED)
+        assertThat(refund.approvedBy).isEqualTo(300L)
+    }
+
+    @Test
+    fun 환불을_거절한다() {
+        val refund = createRefund()
+
+        refund.reject("사유 불충분", 300L)
+
+        assertThat(refund.status).isEqualTo(RefundStatus.REJECTED)
+        assertThat(refund.rejectionReason).isEqualTo("사유 불충분")
+        assertThat(refund.approvedBy).isEqualTo(300L)
+    }
+
+    @Test
+    fun 승인된_환불을_완료한다() {
+        val refund = createRefund()
+        refund.approve(300L)
+
+        refund.complete()
+
+        assertThat(refund.status).isEqualTo(RefundStatus.COMPLETED)
+        assertThat(refund.completedAt).isNotNull()
+    }
+
+    @Test
+    fun REQUESTED_에서_COMPLETED로_직접_전환하면_예외가_발생한다() {
+        val refund = createRefund()
+
+        assertThatThrownBy { refund.complete() }
+            .isInstanceOf(RefundInvalidStatusException::class.java)
+    }
+
+    @Test
+    fun COMPLETED_에서_APPROVED로_전환하면_예외가_발생한다() {
+        val refund = createRefund()
+        refund.approve(300L)
+        refund.complete()
+
+        assertThatThrownBy { refund.approve(300L) }
+            .isInstanceOf(RefundInvalidStatusException::class.java)
+    }
+
+    @Test
+    fun REJECTED_에서_APPROVED로_전환하면_예외가_발생한다() {
+        val refund = createRefund()
+        refund.reject("사유", 300L)
+
+        assertThatThrownBy { refund.approve(300L) }
+            .isInstanceOf(RefundInvalidStatusException::class.java)
+    }
+
+    @Test
+    fun reasonDetail_없이_환불을_생성한다() {
+        val refund = Refund.create(
+            orderId = 1L, paymentId = 10L, buyerId = 100L, sellerId = 200L,
+            reason = RefundReason.CHANGE_OF_MIND, reasonDetail = null,
+            refundAmount = BigDecimal("5000"), isFullRefund = true
+        )
+
+        assertThat(refund.reasonDetail).isNull()
+        assertThat(refund.isFullRefund).isTrue()
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/refund/service/KafkaRefundEventPublisherTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/refund/service/KafkaRefundEventPublisherTest.kt
@@ -1,0 +1,89 @@
+package com.hoppingmall.order.refund.service
+
+import com.hoppingmall.common.KafkaTopics
+import com.hoppingmall.order.refund.dto.event.RefundCompletedEvent
+import com.hoppingmall.order.refund.dto.event.RefundItemEvent
+import com.hoppingmall.outbox.service.TransactionalEventPublisher
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import java.math.BigDecimal
+
+@DisplayName("KafkaRefundEventPublisher")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class KafkaRefundEventPublisherTest {
+
+    @Mock
+    private lateinit var transactionalEventPublisher: TransactionalEventPublisher
+
+    @InjectMocks
+    private lateinit var publisher: KafkaRefundEventPublisher
+
+    @Test
+    fun 환불_완료_이벤트를_발행한다() {
+        val event = RefundCompletedEvent(
+            eventId = "evt-1",
+            refundId = 1L,
+            orderId = 10L,
+            paymentId = 20L,
+            buyerId = 100L,
+            refundAmount = BigDecimal("10000"),
+            pointRefundAmount = BigDecimal("100"),
+            isFullRefund = false,
+            couponId = null,
+            items = listOf(
+                RefundItemEvent(productId = 200L, quantity = 1, refundPrice = BigDecimal("10000"))
+            )
+        )
+
+        publisher.publishRefundCompletedEvent(event)
+
+        verify(transactionalEventPublisher).publishEvent(
+            aggregateType = eq("Refund"),
+            aggregateId = eq("1"),
+            eventType = eq("RefundCompleted"),
+            eventData = any(),
+            topic = eq(KafkaTopics.REFUND_COMPLETION),
+            partitionKey = eq("1")
+        )
+    }
+
+    @Test
+    fun 전액환불_이벤트를_발행한다() {
+        val event = RefundCompletedEvent(
+            eventId = "evt-2",
+            refundId = 2L,
+            orderId = 10L,
+            paymentId = 20L,
+            buyerId = 100L,
+            refundAmount = BigDecimal("50000"),
+            pointRefundAmount = BigDecimal("500"),
+            isFullRefund = true,
+            couponId = 5L,
+            items = listOf(
+                RefundItemEvent(productId = 200L, quantity = 2, refundPrice = BigDecimal("20000")),
+                RefundItemEvent(productId = 300L, quantity = 1, refundPrice = BigDecimal("30000"))
+            )
+        )
+
+        publisher.publishRefundCompletedEvent(event)
+
+        verify(transactionalEventPublisher).publishEvent(
+            aggregateType = eq("Refund"),
+            aggregateId = eq("2"),
+            eventType = eq("RefundCompleted"),
+            eventData = any(),
+            topic = eq(KafkaTopics.REFUND_COMPLETION),
+            partitionKey = eq("2")
+        )
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/refund/service/RefundCommandServiceImplTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/refund/service/RefundCommandServiceImplTest.kt
@@ -1,0 +1,289 @@
+package com.hoppingmall.order.refund.service
+
+import com.hoppingmall.order.order.domain.Order
+import com.hoppingmall.order.order.domain.OrderItem
+import com.hoppingmall.order.order.domain.repository.OrderItemRepository
+import com.hoppingmall.order.order.domain.repository.OrderRepository
+import com.hoppingmall.order.order.enum.OrderStatus
+import com.hoppingmall.order.order.exception.OrderNotFoundException
+import com.hoppingmall.order.port.PaymentInfo
+import com.hoppingmall.order.port.PaymentQueryPort
+import com.hoppingmall.order.refund.domain.Refund
+import com.hoppingmall.order.refund.domain.RefundItem
+import com.hoppingmall.order.refund.domain.repository.RefundItemRepository
+import com.hoppingmall.order.refund.domain.repository.RefundRepository
+import com.hoppingmall.order.refund.domain.repository.RefundedQuantityProjection
+import com.hoppingmall.order.refund.dto.request.RefundApprovalRequest
+import com.hoppingmall.order.refund.dto.request.RefundCreateRequest
+import com.hoppingmall.order.refund.dto.request.RefundItemRequest
+import com.hoppingmall.order.refund.enum.RefundReason
+import com.hoppingmall.order.refund.exception.RefundAccessDeniedException
+import com.hoppingmall.order.refund.exception.RefundException
+import com.hoppingmall.order.refund.exception.RefundNotFoundException
+import com.hoppingmall.order.refund.exception.RefundPaymentNotFoundException
+import com.hoppingmall.order.shipping.domain.Shipping
+import com.hoppingmall.order.shipping.domain.repository.ShippingRepository
+import com.hoppingmall.order.shipping.enum.ShippingStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.test.util.ReflectionTestUtils
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
+import java.math.BigDecimal
+import java.util.Optional
+
+@DisplayName("RefundCommandServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class RefundCommandServiceImplTest {
+
+    @Mock
+    private lateinit var refundRepository: RefundRepository
+
+    @Mock
+    private lateinit var refundItemRepository: RefundItemRepository
+
+    @Mock
+    private lateinit var orderRepository: OrderRepository
+
+    @Mock
+    private lateinit var orderItemRepository: OrderItemRepository
+
+    @Mock
+    private lateinit var paymentQueryPort: PaymentQueryPort
+
+    @Mock
+    private lateinit var shippingRepository: ShippingRepository
+
+    @Mock
+    private lateinit var refundEventPublisher: RefundEventPublisher
+
+    @Mock
+    private lateinit var transactionTemplate: TransactionTemplate
+
+    private lateinit var service: RefundCommandServiceImpl
+
+    private val payment = PaymentInfo(
+        id = 20L, orderId = 10L, amount = BigDecimal("50000"),
+        pointAmount = BigDecimal("500"), couponId = null, status = "SUCCESS"
+    )
+
+    @BeforeEach
+    fun setUp() {
+        Mockito.lenient().`when`(transactionTemplate.execute(any<TransactionCallback<Any>>())).thenAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            val callback = invocation.arguments[0] as TransactionCallback<Any?>
+            callback.doInTransaction(mock())
+        }
+        service = RefundCommandServiceImpl(
+            refundRepository, refundItemRepository, orderRepository,
+            orderItemRepository, paymentQueryPort, shippingRepository,
+            refundEventPublisher, transactionTemplate
+        )
+    }
+
+    private fun createOrder(buyerId: Long = 1L, status: OrderStatus = OrderStatus.PAID): Order {
+        val order = Order.create(buyerId = buyerId, totalAmount = BigDecimal("50000"))
+        order.updateStatus(OrderStatus.PAYING)
+        order.updateStatus(OrderStatus.PAID)
+        if (status == OrderStatus.SHIPPED) {
+            order.updateStatus(OrderStatus.SHIPPED)
+        } else if (status == OrderStatus.DELIVERED) {
+            order.updateStatus(OrderStatus.SHIPPED)
+            order.updateStatus(OrderStatus.DELIVERED)
+        }
+        ReflectionTestUtils.setField(order, "id", 10L)
+        return order
+    }
+
+    private fun createOrderItem(id: Long = 1L, quantity: Int = 2): OrderItem {
+        val item = OrderItem.create(
+            orderId = 10L, sellerId = 5L, productId = 100L,
+            productName = "테스트 상품", productPrice = BigDecimal("25000"),
+            quantity = quantity
+        )
+        ReflectionTestUtils.setField(item, "id", id)
+        return item
+    }
+
+    private fun createRefund(id: Long = 1L): Refund {
+        val refund = Refund.create(
+            orderId = 10L, paymentId = 20L, buyerId = 1L, sellerId = 5L,
+            reason = RefundReason.CHANGE_OF_MIND, reasonDetail = null,
+            refundAmount = BigDecimal("25000"), isFullRefund = false
+        )
+        ReflectionTestUtils.setField(refund, "id", id)
+        return refund
+    }
+
+    @Test
+    fun 환불_요청을_생성한다_배송_준비중이면_자동승인() {
+        val request = RefundCreateRequest(
+            orderId = 10L, reason = RefundReason.CHANGE_OF_MIND, reasonDetail = null,
+            items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 1))
+        )
+        val order = createOrder()
+        val orderItem = createOrderItem()
+        val refund = createRefund()
+        val refundItem = RefundItem.create(
+            refundId = 1L, orderItemId = 1L, productId = 100L,
+            productName = "테스트 상품", productPrice = BigDecimal("25000"), quantity = 1
+        )
+        ReflectionTestUtils.setField(refundItem, "id", 1L)
+        val shipping = Shipping.create(
+            orderId = 10L, buyerId = 1L, carrierName = "CJ",
+            trackingNumber = "1234", recipientName = "홍길동",
+            recipientPhone = "010-0000-0000", recipientAddress = "서울"
+        )
+
+        whenever(paymentQueryPort.findByOrderId(10L)).thenReturn(payment)
+        whenever(orderRepository.findById(10L)).thenReturn(Optional.of(order))
+        whenever(orderItemRepository.findByOrderId(10L)).thenReturn(listOf(orderItem))
+        whenever(refundItemRepository.findRefundedQuantitiesByOrderId(10L)).thenReturn(emptyList())
+        whenever(refundRepository.save(any<Refund>())).thenReturn(refund)
+        whenever(refundItemRepository.saveAll(any<List<RefundItem>>())).thenReturn(listOf(refundItem))
+        whenever(shippingRepository.findByOrderId(10L)).thenReturn(shipping)
+
+        val result = service.requestRefund(1L, request)
+
+        assertThat(result).isNotNull
+        verify(refundEventPublisher).publishRefundCompletedEvent(any())
+    }
+
+    @Test
+    fun 결제정보가_없으면_예외가_발생한다() {
+        val request = RefundCreateRequest(
+            orderId = 10L, reason = RefundReason.CHANGE_OF_MIND, reasonDetail = null,
+            items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 1))
+        )
+
+        whenever(paymentQueryPort.findByOrderId(10L)).thenReturn(null)
+
+        assertThatThrownBy { service.requestRefund(1L, request) }
+            .isInstanceOf(RefundPaymentNotFoundException::class.java)
+    }
+
+    @Test
+    fun 결제상태가_SUCCESS가_아니면_예외가_발생한다() {
+        val request = RefundCreateRequest(
+            orderId = 10L, reason = RefundReason.CHANGE_OF_MIND, reasonDetail = null,
+            items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 1))
+        )
+        val failedPayment = PaymentInfo(
+            id = 20L, orderId = 10L, amount = BigDecimal("50000"),
+            pointAmount = BigDecimal("500"), couponId = null, status = "FAILED"
+        )
+
+        whenever(paymentQueryPort.findByOrderId(10L)).thenReturn(failedPayment)
+
+        assertThatThrownBy { service.requestRefund(1L, request) }
+            .isInstanceOf(RefundException::class.java)
+    }
+
+    @Test
+    fun 다른_구매자의_주문에_환불_요청하면_예외가_발생한다() {
+        val request = RefundCreateRequest(
+            orderId = 10L, reason = RefundReason.CHANGE_OF_MIND, reasonDetail = null,
+            items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 1))
+        )
+        val order = createOrder(buyerId = 99L)
+
+        whenever(paymentQueryPort.findByOrderId(10L)).thenReturn(payment)
+        whenever(orderRepository.findById(10L)).thenReturn(Optional.of(order))
+
+        assertThatThrownBy { service.requestRefund(1L, request) }
+            .isInstanceOf(RefundAccessDeniedException::class.java)
+    }
+
+    @Test
+    fun 환불을_승인한다() {
+        val refund = createRefund()
+        val refundItem = RefundItem.create(
+            refundId = 1L, orderItemId = 1L, productId = 100L,
+            productName = "테스트 상품", productPrice = BigDecimal("25000"), quantity = 1
+        )
+        ReflectionTestUtils.setField(refundItem, "id", 1L)
+
+        whenever(refundRepository.findById(1L)).thenReturn(Optional.of(refund))
+        whenever(paymentQueryPort.findById(20L)).thenReturn(payment)
+        whenever(refundItemRepository.findByRefundId(1L)).thenReturn(listOf(refundItem))
+        whenever(refundRepository.save(any<Refund>())).thenReturn(refund)
+
+        val result = service.approveRefund(1L, 5L)
+
+        assertThat(result).isNotNull
+        verify(refundEventPublisher).publishRefundCompletedEvent(any())
+    }
+
+    @Test
+    fun 다른_판매자가_환불_승인하면_예외가_발생한다() {
+        val refund = createRefund()
+
+        whenever(refundRepository.findById(1L)).thenReturn(Optional.of(refund))
+        whenever(paymentQueryPort.findById(20L)).thenReturn(payment)
+
+        assertThatThrownBy { service.approveRefund(1L, 999L) }
+            .isInstanceOf(RefundAccessDeniedException::class.java)
+    }
+
+    @Test
+    fun 존재하지_않는_환불_승인_시_예외가_발생한다() {
+        whenever(refundRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.approveRefund(999L, 5L) }
+            .isInstanceOf(RefundNotFoundException::class.java)
+    }
+
+    @Test
+    fun 환불을_거절한다() {
+        val refund = createRefund()
+        val refundItem = RefundItem.create(
+            refundId = 1L, orderItemId = 1L, productId = 100L,
+            productName = "테스트 상품", productPrice = BigDecimal("25000"), quantity = 1
+        )
+        ReflectionTestUtils.setField(refundItem, "id", 1L)
+        val request = RefundApprovalRequest(rejectionReason = "사유 불충분")
+
+        whenever(refundRepository.findById(1L)).thenReturn(Optional.of(refund))
+        whenever(refundRepository.save(any<Refund>())).thenReturn(refund)
+        whenever(refundItemRepository.findByRefundId(1L)).thenReturn(listOf(refundItem))
+
+        val result = service.rejectRefund(1L, 5L, request)
+
+        assertThat(result).isNotNull
+    }
+
+    @Test
+    fun 다른_판매자가_환불_거절하면_예외가_발생한다() {
+        val refund = createRefund()
+        val request = RefundApprovalRequest(rejectionReason = "사유 불충분")
+
+        whenever(refundRepository.findById(1L)).thenReturn(Optional.of(refund))
+
+        assertThatThrownBy { service.rejectRefund(1L, 999L, request) }
+            .isInstanceOf(RefundAccessDeniedException::class.java)
+    }
+
+    @Test
+    fun 존재하지_않는_환불_거절_시_예외가_발생한다() {
+        val request = RefundApprovalRequest(rejectionReason = "사유 불충분")
+
+        whenever(refundRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.rejectRefund(999L, 5L, request) }
+            .isInstanceOf(RefundNotFoundException::class.java)
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/refund/service/RefundQueryServiceImplTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/refund/service/RefundQueryServiceImplTest.kt
@@ -1,0 +1,161 @@
+package com.hoppingmall.order.refund.service
+
+import com.hoppingmall.order.refund.domain.Refund
+import com.hoppingmall.order.refund.domain.RefundItem
+import com.hoppingmall.order.refund.domain.repository.RefundItemRepository
+import com.hoppingmall.order.refund.domain.repository.RefundRepository
+import com.hoppingmall.order.refund.enum.RefundReason
+import com.hoppingmall.order.refund.exception.RefundAccessDeniedException
+import com.hoppingmall.order.refund.exception.RefundNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import org.springframework.test.util.ReflectionTestUtils
+import java.math.BigDecimal
+import java.util.Optional
+
+@DisplayName("RefundQueryServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class RefundQueryServiceImplTest {
+
+    @Mock
+    private lateinit var refundRepository: RefundRepository
+
+    @Mock
+    private lateinit var refundItemRepository: RefundItemRepository
+
+    @InjectMocks
+    private lateinit var service: RefundQueryServiceImpl
+
+    private fun createRefund(id: Long = 1L, buyerId: Long = 1L, sellerId: Long = 5L): Refund {
+        val refund = Refund.create(
+            orderId = 10L, paymentId = 20L, buyerId = buyerId, sellerId = sellerId,
+            reason = RefundReason.CHANGE_OF_MIND, reasonDetail = null,
+            refundAmount = BigDecimal("10000"), isFullRefund = false
+        )
+        ReflectionTestUtils.setField(refund, "id", id)
+        return refund
+    }
+
+    private fun createRefundItem(id: Long = 1L, refundId: Long = 1L): RefundItem {
+        val item = RefundItem.create(
+            refundId = refundId, orderItemId = 10L, productId = 100L,
+            productName = "테스트 상품", productPrice = BigDecimal("10000"), quantity = 1
+        )
+        ReflectionTestUtils.setField(item, "id", id)
+        return item
+    }
+
+    @Test
+    fun 구매자가_환불을_조회한다() {
+        val refund = createRefund()
+        val items = listOf(createRefundItem())
+
+        whenever(refundRepository.findById(1L)).thenReturn(Optional.of(refund))
+        whenever(refundItemRepository.findByRefundId(1L)).thenReturn(items)
+
+        val result = service.getRefund(1L, 1L)
+
+        assertThat(result.id).isEqualTo(1L)
+        assertThat(result.items).hasSize(1)
+    }
+
+    @Test
+    fun 판매자가_환불을_조회한다() {
+        val refund = createRefund()
+        val items = listOf(createRefundItem())
+
+        whenever(refundRepository.findById(1L)).thenReturn(Optional.of(refund))
+        whenever(refundItemRepository.findByRefundId(1L)).thenReturn(items)
+
+        val result = service.getRefund(1L, 5L)
+
+        assertThat(result.id).isEqualTo(1L)
+    }
+
+    @Test
+    fun 관련없는_사용자가_환불_조회_시_예외가_발생한다() {
+        val refund = createRefund()
+
+        whenever(refundRepository.findById(1L)).thenReturn(Optional.of(refund))
+
+        assertThatThrownBy { service.getRefund(1L, 999L) }
+            .isInstanceOf(RefundAccessDeniedException::class.java)
+    }
+
+    @Test
+    fun 존재하지_않는_환불_조회_시_예외가_발생한다() {
+        whenever(refundRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.getRefund(999L, 1L) }
+            .isInstanceOf(RefundNotFoundException::class.java)
+    }
+
+    @Test
+    fun 내_환불_목록을_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+        val refund = createRefund()
+        val refundItem = createRefundItem()
+
+        whenever(refundRepository.findByBuyerId(1L, pageable))
+            .thenReturn(SliceImpl(listOf(refund), pageable, false))
+        whenever(refundItemRepository.findByRefundIdIn(listOf(1L)))
+            .thenReturn(listOf(refundItem))
+
+        val result = service.getMyRefunds(1L, pageable)
+
+        assertThat(result.content).hasSize(1)
+        assertThat(result.content[0].items).hasSize(1)
+    }
+
+    @Test
+    fun 환불_목록이_비어있으면_빈_슬라이스를_반환한다() {
+        val pageable = PageRequest.of(0, 10)
+
+        whenever(refundRepository.findByBuyerId(1L, pageable))
+            .thenReturn(SliceImpl(emptyList(), pageable, false))
+
+        val result = service.getMyRefunds(1L, pageable)
+
+        assertThat(result.content).isEmpty()
+    }
+
+    @Test
+    fun 판매자_환불_목록을_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+        val refund = createRefund()
+        val refundItem = createRefundItem()
+
+        whenever(refundRepository.findBySellerId(5L, pageable))
+            .thenReturn(SliceImpl(listOf(refund), pageable, false))
+        whenever(refundItemRepository.findByRefundIdIn(listOf(1L)))
+            .thenReturn(listOf(refundItem))
+
+        val result = service.getSellerRefunds(5L, pageable)
+
+        assertThat(result.content).hasSize(1)
+    }
+
+    @Test
+    fun 판매자_환불_목록이_비어있으면_빈_슬라이스를_반환한다() {
+        val pageable = PageRequest.of(0, 10)
+
+        whenever(refundRepository.findBySellerId(5L, pageable))
+            .thenReturn(SliceImpl(emptyList(), pageable, false))
+
+        val result = service.getSellerRefunds(5L, pageable)
+
+        assertThat(result.content).isEmpty()
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/shipping/controller/ShippingControllerTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/shipping/controller/ShippingControllerTest.kt
@@ -1,0 +1,111 @@
+package com.hoppingmall.order.shipping.controller
+
+import com.hoppingmall.common.UserPrincipal
+import com.hoppingmall.order.shipping.dto.request.ShippingCreateRequest
+import com.hoppingmall.order.shipping.dto.request.ShippingStatusUpdateRequest
+import com.hoppingmall.order.shipping.dto.response.ShippingResponse
+import com.hoppingmall.order.shipping.enum.ShippingStatus
+import com.hoppingmall.order.shipping.service.ShippingCommandService
+import com.hoppingmall.order.shipping.service.ShippingQueryService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import java.time.LocalDateTime
+
+@DisplayName("ShippingController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ShippingControllerTest {
+
+    @Mock
+    private lateinit var shippingCommandService: ShippingCommandService
+
+    @Mock
+    private lateinit var shippingQueryService: ShippingQueryService
+
+    @InjectMocks
+    private lateinit var controller: ShippingController
+
+    private val sellerPrincipal = UserPrincipal.of(5L, "SELLER")
+
+    private fun createShippingResponse(
+        id: Long = 1L,
+        status: ShippingStatus = ShippingStatus.PREPARING
+    ): ShippingResponse {
+        return ShippingResponse(
+            id = id,
+            orderId = 10L,
+            buyerId = 1L,
+            status = status,
+            carrierName = "CJ대한통운",
+            trackingNumber = "1234567890",
+            recipientName = "홍길동",
+            recipientPhone = "010-1234-5678",
+            recipientAddress = "서울시 강남구",
+            createdAt = LocalDateTime.now(),
+            updatedAt = null
+        )
+    }
+
+    @Test
+    fun 배송을_생성한다() {
+        val request = ShippingCreateRequest(
+            orderId = 10L, carrierName = "CJ대한통운",
+            trackingNumber = "1234567890", recipientName = "홍길동",
+            recipientPhone = "010-1234-5678", recipientAddress = "서울시 강남구"
+        )
+        val response = createShippingResponse()
+
+        whenever(shippingCommandService.createShipping(5L, request)).thenReturn(response)
+
+        val result = controller.createShipping(sellerPrincipal, request)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.CREATED)
+        assertThat(result.body!!.data!!.id).isEqualTo(1L)
+    }
+
+    @Test
+    fun 배송_상태를_변경한다() {
+        val request = ShippingStatusUpdateRequest(status = ShippingStatus.IN_TRANSIT)
+        val response = createShippingResponse(status = ShippingStatus.IN_TRANSIT)
+
+        whenever(shippingCommandService.updateShippingStatus(5L, 1L, request)).thenReturn(response)
+
+        val result = controller.updateShippingStatus(sellerPrincipal, 1L, request)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data!!.status).isEqualTo(ShippingStatus.IN_TRANSIT)
+    }
+
+    @Test
+    fun 주문ID로_배송을_조회한다() {
+        val response = createShippingResponse()
+
+        whenever(shippingQueryService.getShippingByOrderId(10L)).thenReturn(response)
+
+        val result = controller.getShippingByOrderId(10L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data!!.orderId).isEqualTo(10L)
+    }
+
+    @Test
+    fun 배송ID로_배송을_조회한다() {
+        val response = createShippingResponse()
+
+        whenever(shippingQueryService.getShipping(1L)).thenReturn(response)
+
+        val result = controller.getShipping(1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data!!.id).isEqualTo(1L)
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/shipping/domain/ShippingTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/shipping/domain/ShippingTest.kt
@@ -1,0 +1,116 @@
+package com.hoppingmall.order.shipping.domain
+
+import com.hoppingmall.order.shipping.enum.ShippingStatus
+import com.hoppingmall.order.shipping.exception.ShippingInvalidStatusException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("Shipping")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class ShippingTest {
+
+    private fun createShipping(): Shipping {
+        return Shipping.create(
+            orderId = 1L,
+            buyerId = 10L,
+            carrierName = "CJ대한통운",
+            trackingNumber = "1234567890",
+            recipientName = "홍길동",
+            recipientPhone = "010-1234-5678",
+            recipientAddress = "서울시 강남구"
+        )
+    }
+
+    @Test
+    fun 배송을_생성한다() {
+        val shipping = createShipping()
+
+        assertThat(shipping.orderId).isEqualTo(1L)
+        assertThat(shipping.buyerId).isEqualTo(10L)
+        assertThat(shipping.status).isEqualTo(ShippingStatus.PREPARING)
+        assertThat(shipping.carrierName).isEqualTo("CJ대한통운")
+        assertThat(shipping.trackingNumber).isEqualTo("1234567890")
+        assertThat(shipping.recipientName).isEqualTo("홍길동")
+        assertThat(shipping.recipientPhone).isEqualTo("010-1234-5678")
+        assertThat(shipping.recipientAddress).isEqualTo("서울시 강남구")
+    }
+
+    @Test
+    fun PREPARING에서_IN_TRANSIT으로_상태를_변경한다() {
+        val shipping = createShipping()
+
+        shipping.updateStatus(ShippingStatus.IN_TRANSIT)
+
+        assertThat(shipping.status).isEqualTo(ShippingStatus.IN_TRANSIT)
+    }
+
+    @Test
+    fun PREPARING에서_CANCELLED로_상태를_변경한다() {
+        val shipping = createShipping()
+
+        shipping.updateStatus(ShippingStatus.CANCELLED)
+
+        assertThat(shipping.status).isEqualTo(ShippingStatus.CANCELLED)
+    }
+
+    @Test
+    fun IN_TRANSIT에서_DELIVERED로_상태를_변경한다() {
+        val shipping = createShipping()
+        shipping.updateStatus(ShippingStatus.IN_TRANSIT)
+
+        shipping.updateStatus(ShippingStatus.DELIVERED)
+
+        assertThat(shipping.status).isEqualTo(ShippingStatus.DELIVERED)
+    }
+
+    @Test
+    fun IN_TRANSIT에서_FAILED로_상태를_변경한다() {
+        val shipping = createShipping()
+        shipping.updateStatus(ShippingStatus.IN_TRANSIT)
+
+        shipping.updateStatus(ShippingStatus.FAILED)
+
+        assertThat(shipping.status).isEqualTo(ShippingStatus.FAILED)
+    }
+
+    @Test
+    fun PREPARING에서_DELIVERED로_직접_변경하면_예외가_발생한다() {
+        val shipping = createShipping()
+
+        assertThatThrownBy { shipping.updateStatus(ShippingStatus.DELIVERED) }
+            .isInstanceOf(ShippingInvalidStatusException::class.java)
+    }
+
+    @Test
+    fun DELIVERED에서_상태변경하면_예외가_발생한다() {
+        val shipping = createShipping()
+        shipping.updateStatus(ShippingStatus.IN_TRANSIT)
+        shipping.updateStatus(ShippingStatus.DELIVERED)
+
+        assertThatThrownBy { shipping.updateStatus(ShippingStatus.IN_TRANSIT) }
+            .isInstanceOf(ShippingInvalidStatusException::class.java)
+    }
+
+    @Test
+    fun FAILED에서_상태변경하면_예외가_발생한다() {
+        val shipping = createShipping()
+        shipping.updateStatus(ShippingStatus.IN_TRANSIT)
+        shipping.updateStatus(ShippingStatus.FAILED)
+
+        assertThatThrownBy { shipping.updateStatus(ShippingStatus.PREPARING) }
+            .isInstanceOf(ShippingInvalidStatusException::class.java)
+    }
+
+    @Test
+    fun CANCELLED에서_상태변경하면_예외가_발생한다() {
+        val shipping = createShipping()
+        shipping.updateStatus(ShippingStatus.CANCELLED)
+
+        assertThatThrownBy { shipping.updateStatus(ShippingStatus.PREPARING) }
+            .isInstanceOf(ShippingInvalidStatusException::class.java)
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/shipping/service/ShippingCommandServiceImplTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/shipping/service/ShippingCommandServiceImplTest.kt
@@ -1,0 +1,194 @@
+package com.hoppingmall.order.shipping.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.order.order.domain.Order
+import com.hoppingmall.order.order.domain.OrderItem
+import com.hoppingmall.order.order.domain.repository.OrderItemRepository
+import com.hoppingmall.order.order.domain.repository.OrderRepository
+import com.hoppingmall.order.order.enum.OrderStatus
+import com.hoppingmall.order.order.exception.OrderInvalidStatusException
+import com.hoppingmall.order.order.exception.OrderNotFoundException
+import com.hoppingmall.order.shipping.domain.Shipping
+import com.hoppingmall.order.shipping.domain.repository.ShippingRepository
+import com.hoppingmall.order.shipping.dto.request.ShippingCreateRequest
+import com.hoppingmall.order.shipping.dto.request.ShippingStatusUpdateRequest
+import com.hoppingmall.order.shipping.enum.ShippingStatus
+import com.hoppingmall.order.shipping.exception.ShippingAlreadyExistsException
+import com.hoppingmall.order.shipping.exception.ShippingNotFoundException
+import com.hoppingmall.outbox.service.TransactionalEventPublisher
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.test.util.ReflectionTestUtils
+import java.math.BigDecimal
+import java.util.Optional
+
+@DisplayName("ShippingCommandServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ShippingCommandServiceImplTest {
+
+    @Mock
+    private lateinit var shippingRepository: ShippingRepository
+
+    @Mock
+    private lateinit var orderRepository: OrderRepository
+
+    @Mock
+    private lateinit var orderItemRepository: OrderItemRepository
+
+    @Mock
+    private lateinit var transactionalEventPublisher: TransactionalEventPublisher
+
+    @Mock
+    private lateinit var objectMapper: ObjectMapper
+
+    @InjectMocks
+    private lateinit var service: ShippingCommandServiceImpl
+
+    private val shippingRequest = ShippingCreateRequest(
+        orderId = 10L, carrierName = "CJ대한통운",
+        trackingNumber = "1234567890", recipientName = "홍길동",
+        recipientPhone = "010-1234-5678", recipientAddress = "서울시 강남구"
+    )
+
+    private fun createOrder(status: OrderStatus = OrderStatus.PAID): Order {
+        val order = Order.create(buyerId = 1L, totalAmount = BigDecimal("50000"))
+        order.updateStatus(OrderStatus.PAYING)
+        order.updateStatus(OrderStatus.PAID)
+        if (status == OrderStatus.SHIPPED) {
+            order.updateStatus(OrderStatus.SHIPPED)
+        }
+        ReflectionTestUtils.setField(order, "id", 10L)
+        return order
+    }
+
+    private fun createOrderItem(): OrderItem {
+        val item = OrderItem.create(
+            orderId = 10L, sellerId = 5L, productId = 100L,
+            productName = "테스트 상품", productPrice = BigDecimal("50000"), quantity = 1
+        )
+        ReflectionTestUtils.setField(item, "id", 1L)
+        return item
+    }
+
+    private fun createShipping(id: Long = 1L): Shipping {
+        val shipping = Shipping.create(
+            orderId = 10L, buyerId = 1L, carrierName = "CJ대한통운",
+            trackingNumber = "1234567890", recipientName = "홍길동",
+            recipientPhone = "010-1234-5678", recipientAddress = "서울시 강남구"
+        )
+        ReflectionTestUtils.setField(shipping, "id", id)
+        return shipping
+    }
+
+    @Test
+    fun 배송을_생성한다() {
+        val order = createOrder()
+        val orderItem = createOrderItem()
+        val shipping = createShipping()
+
+        whenever(orderRepository.findById(10L)).thenReturn(Optional.of(order))
+        whenever(shippingRepository.findByOrderId(10L)).thenReturn(null)
+        whenever(orderItemRepository.findByOrderId(10L)).thenReturn(listOf(orderItem))
+        whenever(shippingRepository.save(any<Shipping>())).thenReturn(shipping)
+
+        val result = service.createShipping(5L, shippingRequest)
+
+        assertThat(result.orderId).isEqualTo(10L)
+        assertThat(result.carrierName).isEqualTo("CJ대한통운")
+    }
+
+    @Test
+    fun 존재하지_않는_주문에_배송생성_시_예외가_발생한다() {
+        whenever(orderRepository.findById(10L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.createShipping(5L, shippingRequest) }
+            .isInstanceOf(OrderNotFoundException::class.java)
+    }
+
+    @Test
+    fun PAID가_아닌_주문에_배송생성_시_예외가_발생한다() {
+        val order = Order.create(buyerId = 1L, totalAmount = BigDecimal("50000"))
+        ReflectionTestUtils.setField(order, "id", 10L)
+
+        whenever(orderRepository.findById(10L)).thenReturn(Optional.of(order))
+
+        assertThatThrownBy { service.createShipping(5L, shippingRequest) }
+            .isInstanceOf(OrderInvalidStatusException::class.java)
+    }
+
+    @Test
+    fun 이미_배송이_존재하면_예외가_발생한다() {
+        val order = createOrder()
+        val existingShipping = createShipping()
+
+        whenever(orderRepository.findById(10L)).thenReturn(Optional.of(order))
+        whenever(shippingRepository.findByOrderId(10L)).thenReturn(existingShipping)
+
+        assertThatThrownBy { service.createShipping(5L, shippingRequest) }
+            .isInstanceOf(ShippingAlreadyExistsException::class.java)
+    }
+
+    @Test
+    fun 배송중으로_상태변경_시_주문상태도_SHIPPED로_변경한다() {
+        val request = ShippingStatusUpdateRequest(status = ShippingStatus.IN_TRANSIT)
+        val shipping = createShipping()
+        val order = createOrder()
+
+        whenever(shippingRepository.findById(1L)).thenReturn(Optional.of(shipping))
+        whenever(orderRepository.findById(10L)).thenReturn(Optional.of(order))
+        whenever(objectMapper.writeValueAsString(any())).thenReturn("{}")
+
+        val result = service.updateShippingStatus(5L, 1L, request)
+
+        assertThat(result.status).isEqualTo(ShippingStatus.IN_TRANSIT)
+        assertThat(order.status).isEqualTo(OrderStatus.SHIPPED)
+        verify(transactionalEventPublisher).publishEvent(
+            aggregateType = eq("Shipping"),
+            aggregateId = any(),
+            eventType = any(),
+            eventData = any(),
+            topic = any(),
+            partitionKey = any()
+        )
+    }
+
+    @Test
+    fun 배송완료로_상태변경_시_주문상태도_DELIVERED로_변경한다() {
+        val request = ShippingStatusUpdateRequest(status = ShippingStatus.DELIVERED)
+        val shipping = createShipping()
+        shipping.updateStatus(ShippingStatus.IN_TRANSIT)
+        val order = createOrder(OrderStatus.SHIPPED)
+
+        whenever(shippingRepository.findById(1L)).thenReturn(Optional.of(shipping))
+        whenever(orderRepository.findById(10L)).thenReturn(Optional.of(order))
+        whenever(objectMapper.writeValueAsString(any())).thenReturn("{}")
+
+        val result = service.updateShippingStatus(5L, 1L, request)
+
+        assertThat(result.status).isEqualTo(ShippingStatus.DELIVERED)
+        assertThat(order.status).isEqualTo(OrderStatus.DELIVERED)
+    }
+
+    @Test
+    fun 존재하지_않는_배송_상태변경_시_예외가_발생한다() {
+        val request = ShippingStatusUpdateRequest(status = ShippingStatus.IN_TRANSIT)
+
+        whenever(shippingRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.updateShippingStatus(5L, 999L, request) }
+            .isInstanceOf(ShippingNotFoundException::class.java)
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/shipping/service/ShippingQueryServiceImplTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/shipping/service/ShippingQueryServiceImplTest.kt
@@ -1,0 +1,79 @@
+package com.hoppingmall.order.shipping.service
+
+import com.hoppingmall.order.shipping.domain.Shipping
+import com.hoppingmall.order.shipping.domain.repository.ShippingRepository
+import com.hoppingmall.order.shipping.exception.ShippingNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.test.util.ReflectionTestUtils
+import java.util.Optional
+
+@DisplayName("ShippingQueryServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ShippingQueryServiceImplTest {
+
+    @Mock
+    private lateinit var shippingRepository: ShippingRepository
+
+    @InjectMocks
+    private lateinit var service: ShippingQueryServiceImpl
+
+    private fun createShipping(id: Long = 1L): Shipping {
+        val shipping = Shipping.create(
+            orderId = 10L, buyerId = 1L, carrierName = "CJ대한통운",
+            trackingNumber = "1234567890", recipientName = "홍길동",
+            recipientPhone = "010-1234-5678", recipientAddress = "서울시 강남구"
+        )
+        ReflectionTestUtils.setField(shipping, "id", id)
+        return shipping
+    }
+
+    @Test
+    fun 주문ID로_배송을_조회한다() {
+        val shipping = createShipping()
+
+        whenever(shippingRepository.findByOrderId(10L)).thenReturn(shipping)
+
+        val result = service.getShippingByOrderId(10L)
+
+        assertThat(result.orderId).isEqualTo(10L)
+        assertThat(result.carrierName).isEqualTo("CJ대한통운")
+    }
+
+    @Test
+    fun 주문ID로_배송이_없으면_예외가_발생한다() {
+        whenever(shippingRepository.findByOrderId(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.getShippingByOrderId(999L) }
+            .isInstanceOf(ShippingNotFoundException::class.java)
+    }
+
+    @Test
+    fun 배송ID로_배송을_조회한다() {
+        val shipping = createShipping()
+
+        whenever(shippingRepository.findById(1L)).thenReturn(Optional.of(shipping))
+
+        val result = service.getShipping(1L)
+
+        assertThat(result.id).isEqualTo(1L)
+    }
+
+    @Test
+    fun 배송ID로_배송이_없으면_예외가_발생한다() {
+        whenever(shippingRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.getShipping(999L) }
+            .isInstanceOf(ShippingNotFoundException::class.java)
+    }
+}

--- a/product-service/build.gradle.kts
+++ b/product-service/build.gradle.kts
@@ -99,7 +99,9 @@ val jacocoExcludedDirs = listOf(
 	"**/enums/**",
 	"**/vo/**",
 	"**/exception/**",
-	"**/*Application*"
+	"**/*Application*",
+	"**/grpc/**",
+	"**/BulkImportService\$startImport\$*"
 )
 
 tasks.jacocoTestReport {

--- a/product-service/src/test/kotlin/com/hoppingmall/product/category/controller/CategoryControllerTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/category/controller/CategoryControllerTest.kt
@@ -1,0 +1,115 @@
+package com.hoppingmall.product.category.controller
+
+import com.hoppingmall.product.category.dto.response.CategoryResponse
+import com.hoppingmall.product.category.exception.CategoryNotFoundException
+import com.hoppingmall.product.category.service.CategoryCommandService
+import com.hoppingmall.product.category.service.CategoryQueryService
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import java.time.LocalDateTime
+
+@DisplayName("CategoryController")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class CategoryControllerTest {
+
+    @Mock
+    private lateinit var categoryCommandService: CategoryCommandService
+
+    @Mock
+    private lateinit var categoryQueryService: CategoryQueryService
+
+    @InjectMocks
+    private lateinit var controller: CategoryController
+
+    private fun categoryResponse(id: Long = 1L) = CategoryResponse(
+        id = id,
+        name = "전자기기",
+        parentCategoryId = null,
+        depth = 0,
+        createdAt = LocalDateTime.now(),
+        updatedAt = null
+    )
+
+    @Test
+    fun 카테고리를_생성한다() {
+        whenever(categoryCommandService.createCategory(any())).thenReturn(categoryResponse())
+
+        val result = controller.createCategory(
+            com.hoppingmall.product.category.dto.request.CategoryCreateRequest(name = "전자기기", parentCategoryId = null)
+        )
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.CREATED)
+        assertThat(result.body!!.data!!.name).isEqualTo("전자기기")
+    }
+
+    @Test
+    fun 카테고리를_단건_조회한다() {
+        whenever(categoryQueryService.getCategory(1L)).thenReturn(categoryResponse())
+
+        val result = controller.getCategory(1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data!!.name).isEqualTo("전자기기")
+    }
+
+    @Test
+    fun 존재하지_않는_카테고리_조회_시_예외를_발생시킨다() {
+        whenever(categoryQueryService.getCategory(999L)).thenReturn(null)
+
+        assertThatThrownBy { controller.getCategory(999L) }
+            .isInstanceOf(CategoryNotFoundException::class.java)
+    }
+
+    @Test
+    fun 루트_카테고리_목록을_조회한다() {
+        whenever(categoryQueryService.getRootCategories()).thenReturn(listOf(categoryResponse()))
+
+        val result = controller.getRootCategories()
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data).hasSize(1)
+    }
+
+    @Test
+    fun 하위_카테고리_목록을_조회한다() {
+        whenever(categoryQueryService.getSubCategories(1L)).thenReturn(listOf(categoryResponse(2L)))
+
+        val result = controller.getSubCategories(1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data).hasSize(1)
+    }
+
+    @Test
+    fun 카테고리를_수정한다() {
+        whenever(categoryCommandService.updateCategory(any(), any())).thenReturn(categoryResponse())
+
+        val result = controller.updateCategory(
+            1L,
+            com.hoppingmall.product.category.dto.request.CategoryUpdateRequest(name = "가전제품")
+        )
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun 카테고리를_삭제한다() {
+        val result = controller.deleteCategory(1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
+        verify(categoryCommandService).deleteCategory(1L)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/category/domain/CategoryTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/category/domain/CategoryTest.kt
@@ -1,0 +1,49 @@
+package com.hoppingmall.product.category.domain
+
+import com.hoppingmall.product.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+
+@DisplayName("Category 도메인")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class CategoryTest {
+
+    @Test
+    fun 카테고리를_생성한다() {
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0)
+
+        assertThat(category.name).isEqualTo("전자기기")
+        assertThat(category.parentCategoryId).isNull()
+        assertThat(category.depth).isEqualTo(0)
+    }
+
+    @Test
+    fun 하위_카테고리를_생성한다() {
+        val category = Category.create(name = "노트북", parentCategoryId = 1L, depth = 1)
+
+        assertThat(category.name).isEqualTo("노트북")
+        assertThat(category.parentCategoryId).isEqualTo(1L)
+        assertThat(category.depth).isEqualTo(1)
+    }
+
+    @Test
+    fun 카테고리_이름을_수정한다() {
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0)
+
+        category.update("가전제품")
+
+        assertThat(category.name).isEqualTo("가전제품")
+    }
+
+    @Test
+    fun 루트_카테고리인지_확인한다() {
+        val root = Category.create(name = "전자기기", parentCategoryId = null, depth = 0)
+        val child = Category.create(name = "노트북", parentCategoryId = 1L, depth = 1)
+
+        assertThat(root.isRootCategory()).isTrue()
+        assertThat(child.isRootCategory()).isFalse()
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/category/service/CategoryCommandServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/category/service/CategoryCommandServiceImplTest.kt
@@ -1,0 +1,167 @@
+package com.hoppingmall.product.category.service
+
+import com.hoppingmall.product.category.domain.Category
+import com.hoppingmall.product.category.domain.repository.CategoryRepository
+import com.hoppingmall.product.category.dto.request.CategoryCreateRequest
+import com.hoppingmall.product.category.dto.request.CategoryUpdateRequest
+import com.hoppingmall.product.category.exception.CategoryAlreadyExistsException
+import com.hoppingmall.product.category.exception.CategoryCircularReferenceException
+import com.hoppingmall.product.category.exception.CategoryHasChildrenException
+import com.hoppingmall.product.category.exception.CategoryNotFoundException
+import com.hoppingmall.product.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@DisplayName("CategoryCommandServiceImpl")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class CategoryCommandServiceImplTest {
+
+    @Mock
+    private lateinit var categoryRepository: CategoryRepository
+
+    @InjectMocks
+    private lateinit var service: CategoryCommandServiceImpl
+
+    @Test
+    fun 루트_카테고리를_생성한다() {
+        val request = CategoryCreateRequest(name = "전자기기", parentCategoryId = null)
+        val saved = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+
+        whenever(categoryRepository.existsByName("전자기기")).thenReturn(false)
+        whenever(categoryRepository.save(any<Category>())).thenReturn(saved)
+
+        val result = service.createCategory(request)
+
+        assertThat(result.name).isEqualTo("전자기기")
+        assertThat(result.depth).isEqualTo(0)
+    }
+
+    @Test
+    fun 하위_카테고리를_생성한다() {
+        val parent = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+        val request = CategoryCreateRequest(name = "노트북", parentCategoryId = 1L)
+        val saved = Category.create(name = "노트북", parentCategoryId = 1L, depth = 1).withId(2L)
+
+        whenever(categoryRepository.existsByName("노트북")).thenReturn(false)
+        whenever(categoryRepository.findNullableById(1L)).thenReturn(parent)
+        whenever(categoryRepository.save(any<Category>())).thenReturn(saved)
+
+        val result = service.createCategory(request)
+
+        assertThat(result.name).isEqualTo("노트북")
+        assertThat(result.depth).isEqualTo(1)
+    }
+
+    @Test
+    fun 이미_존재하는_이름으로_카테고리_생성_시_예외를_발생시킨다() {
+        val request = CategoryCreateRequest(name = "전자기기", parentCategoryId = null)
+
+        whenever(categoryRepository.existsByName("전자기기")).thenReturn(true)
+
+        assertThatThrownBy { service.createCategory(request) }
+            .isInstanceOf(CategoryAlreadyExistsException::class.java)
+    }
+
+    @Test
+    fun 존재하지_않는_부모_카테고리로_생성_시_예외를_발생시킨다() {
+        val request = CategoryCreateRequest(name = "노트북", parentCategoryId = 999L)
+
+        whenever(categoryRepository.existsByName("노트북")).thenReturn(false)
+        whenever(categoryRepository.findNullableById(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.createCategory(request) }
+            .isInstanceOf(CategoryNotFoundException::class.java)
+    }
+
+    @Test
+    fun 카테고리를_수정한다() {
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+        val request = CategoryUpdateRequest(name = "가전제품")
+
+        whenever(categoryRepository.findNullableById(1L)).thenReturn(category)
+        whenever(categoryRepository.existsByNameAndIdNot("가전제품", 1L)).thenReturn(false)
+
+        val result = service.updateCategory(1L, request)
+
+        assertThat(result.name).isEqualTo("가전제품")
+    }
+
+    @Test
+    fun 존재하지_않는_카테고리_수정_시_예외를_발생시킨다() {
+        val request = CategoryUpdateRequest(name = "가전제품")
+
+        whenever(categoryRepository.findNullableById(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.updateCategory(999L, request) }
+            .isInstanceOf(CategoryNotFoundException::class.java)
+    }
+
+    @Test
+    fun 중복_이름으로_카테고리_수정_시_예외를_발생시킨다() {
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+        val request = CategoryUpdateRequest(name = "가전제품")
+
+        whenever(categoryRepository.findNullableById(1L)).thenReturn(category)
+        whenever(categoryRepository.existsByNameAndIdNot("가전제품", 1L)).thenReturn(true)
+
+        assertThatThrownBy { service.updateCategory(1L, request) }
+            .isInstanceOf(CategoryAlreadyExistsException::class.java)
+    }
+
+    @Test
+    fun 카테고리를_삭제한다() {
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+
+        whenever(categoryRepository.findNullableById(1L)).thenReturn(category)
+        whenever(categoryRepository.existsByParentCategoryId(1L)).thenReturn(false)
+
+        service.deleteCategory(1L)
+
+        assertThat(category.deletedAt).isNotNull()
+    }
+
+    @Test
+    fun 존재하지_않는_카테고리_삭제_시_예외를_발생시킨다() {
+        whenever(categoryRepository.findNullableById(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.deleteCategory(999L) }
+            .isInstanceOf(CategoryNotFoundException::class.java)
+    }
+
+    @Test
+    fun 하위_카테고리가_있는_카테고리_삭제_시_예외를_발생시킨다() {
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+
+        whenever(categoryRepository.findNullableById(1L)).thenReturn(category)
+        whenever(categoryRepository.existsByParentCategoryId(1L)).thenReturn(true)
+
+        assertThatThrownBy { service.deleteCategory(1L) }
+            .isInstanceOf(CategoryHasChildrenException::class.java)
+    }
+
+    @Test
+    fun 순환_참조가_있는_부모_카테고리로_생성_시_예외를_발생시킨다() {
+        val catA = Category.create(name = "A", parentCategoryId = 2L, depth = 1).withId(1L)
+        val catB = Category.create(name = "B", parentCategoryId = 1L, depth = 1).withId(2L)
+        val request = CategoryCreateRequest(name = "C", parentCategoryId = 1L)
+
+        whenever(categoryRepository.existsByName("C")).thenReturn(false)
+        whenever(categoryRepository.findNullableById(1L)).thenReturn(catA)
+        whenever(categoryRepository.findNullableById(2L)).thenReturn(catB)
+
+        assertThatThrownBy { service.createCategory(request) }
+            .isInstanceOf(CategoryCircularReferenceException::class.java)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/category/service/CategoryQueryServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/category/service/CategoryQueryServiceImplTest.kt
@@ -1,0 +1,76 @@
+package com.hoppingmall.product.category.service
+
+import com.hoppingmall.product.category.domain.Category
+import com.hoppingmall.product.category.domain.repository.CategoryRepository
+import com.hoppingmall.product.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+
+@DisplayName("CategoryQueryServiceImpl")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class CategoryQueryServiceImplTest {
+
+    @Mock
+    private lateinit var categoryRepository: CategoryRepository
+
+    @InjectMocks
+    private lateinit var service: CategoryQueryServiceImpl
+
+    @Test
+    fun 카테고리를_조회한다() {
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+
+        whenever(categoryRepository.findNullableById(1L)).thenReturn(category)
+
+        val result = service.getCategory(1L)
+
+        assertThat(result).isNotNull
+        assertThat(result!!.name).isEqualTo("전자기기")
+    }
+
+    @Test
+    fun 존재하지_않는_카테고리_조회_시_null을_반환한다() {
+        whenever(categoryRepository.findNullableById(999L)).thenReturn(null)
+
+        val result = service.getCategory(999L)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun 루트_카테고리_목록을_조회한다() {
+        val categories = listOf(
+            Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L),
+            Category.create(name = "의류", parentCategoryId = null, depth = 0).withId(2L)
+        )
+
+        whenever(categoryRepository.findByParentCategoryIdIsNull()).thenReturn(categories)
+
+        val result = service.getRootCategories()
+
+        assertThat(result).hasSize(2)
+    }
+
+    @Test
+    fun 하위_카테고리_목록을_조회한다() {
+        val categories = listOf(
+            Category.create(name = "노트북", parentCategoryId = 1L, depth = 1).withId(2L),
+            Category.create(name = "스마트폰", parentCategoryId = 1L, depth = 1).withId(3L)
+        )
+
+        whenever(categoryRepository.findByParentCategoryId(1L)).thenReturn(categories)
+
+        val result = service.getSubCategories(1L)
+
+        assertThat(result).hasSize(2)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/internal/InternalInventoryControllerTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/internal/InternalInventoryControllerTest.kt
@@ -1,0 +1,109 @@
+package com.hoppingmall.product.internal
+
+import com.hoppingmall.product.inventory.exception.ReservationConfirmFailedException
+import com.hoppingmall.product.inventory.service.InventoryCommandService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+
+@DisplayName("InternalInventoryController")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class InternalInventoryControllerTest {
+
+    @Mock
+    private lateinit var inventoryCommandService: InventoryCommandService
+
+    @InjectMocks
+    private lateinit var controller: InternalInventoryController
+
+    @Test
+    fun 재고를_차감한다() {
+        val result = controller.decreaseStock(1L, 5)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        verify(inventoryCommandService).decreaseStock(1L, 5)
+    }
+
+    @Test
+    fun 재고를_증가시킨다() {
+        val result = controller.increaseStock(1L, 5)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        verify(inventoryCommandService).increaseStock(1L, 5)
+    }
+
+    @Test
+    fun 재고를_예약한다() {
+        whenever(inventoryCommandService.reserveStock(1L, 3)).thenReturn("rsv-123")
+
+        val result = controller.reserveStock(1L, 3)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.reservationId).isEqualTo("rsv-123")
+    }
+
+    @Test
+    fun 예약_확정_성공_시_true를_반환한다() {
+        val ids = listOf("rsv-1", "rsv-2")
+        whenever(inventoryCommandService.confirmReservations(ids)).thenReturn(true)
+
+        val result = controller.confirmReservations(ids)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.confirmed).isTrue()
+    }
+
+    @Test
+    fun 예약_확정_실패_시_false를_반환한다() {
+        val ids = listOf("rsv-1", "rsv-2")
+        whenever(inventoryCommandService.confirmReservations(ids)).thenThrow(ReservationConfirmFailedException())
+
+        val result = controller.confirmReservations(ids)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.confirmed).isFalse()
+    }
+
+    @Test
+    fun 단건_예약을_취소한다() {
+        val result = controller.cancelReservation("rsv-1")
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        verify(inventoryCommandService).cancelReservation("rsv-1")
+    }
+
+    @Test
+    fun 배치_예약을_취소한다() {
+        val ids = listOf("rsv-1", "rsv-2")
+
+        val result = controller.cancelReservations(ids)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        verify(inventoryCommandService).cancelReservations(ids)
+    }
+
+    @Test
+    fun 배치_재고_예약을_수행한다() {
+        val items = listOf(
+            InternalInventoryController.ReserveRequest(1L, 3),
+            InternalInventoryController.ReserveRequest(2L, 5)
+        )
+        val expected = mapOf(1L to "rsv-1", 2L to "rsv-2")
+        whenever(inventoryCommandService.batchReserveStock(listOf(1L to 3, 2L to 5))).thenReturn(expected)
+
+        val result = controller.batchReserveStock(items)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body).isEqualTo(expected)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/internal/InternalProductControllerTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/internal/InternalProductControllerTest.kt
@@ -1,0 +1,105 @@
+package com.hoppingmall.product.internal
+
+import com.hoppingmall.product.common.enums.ProductStatus
+import com.hoppingmall.product.product.domain.Product
+import com.hoppingmall.product.product.domain.ProductImage
+import com.hoppingmall.product.product.domain.repository.ProductImageRepository
+import com.hoppingmall.product.product.domain.repository.ProductRepository
+import com.hoppingmall.product.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import java.math.BigDecimal
+
+@DisplayName("InternalProductController")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class InternalProductControllerTest {
+
+    @Mock
+    private lateinit var productRepository: ProductRepository
+
+    @Mock
+    private lateinit var productImageRepository: ProductImageRepository
+
+    @InjectMocks
+    private lateinit var controller: InternalProductController
+
+    @Test
+    fun 상품_단건_조회_성공() {
+        val product = Product.create(
+            sellerId = 1L, categoryId = 1L, name = "테스트상품",
+            description = "설명", price = BigDecimal("10000"), status = ProductStatus.AVAILABLE
+        ).withId(1L)
+        val image = ProductImage.create(productId = 1L, imageUrl = "http://img.jpg", sortOrder = 0).withId(1L)
+
+        whenever(productRepository.findNullableById(1L)).thenReturn(product)
+        whenever(productImageRepository.findByProductIdOrderBySortOrder(1L)).thenReturn(listOf(image))
+
+        val result = controller.getProduct(1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.name).isEqualTo("테스트상품")
+        assertThat(result.body!!.imageUrl).isEqualTo("http://img.jpg")
+    }
+
+    @Test
+    fun 존재하지_않는_상품_조회_시_404를_반환한다() {
+        whenever(productRepository.findNullableById(999L)).thenReturn(null)
+
+        val result = controller.getProduct(999L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    @Test
+    fun 상품_목록을_ID로_조회한다() {
+        val products = listOf(
+            Product.create(
+                sellerId = 1L, categoryId = 1L, name = "상품1",
+                description = "설명", price = BigDecimal("10000"), status = ProductStatus.AVAILABLE
+            ).withId(1L),
+            Product.create(
+                sellerId = 1L, categoryId = 1L, name = "상품2",
+                description = "설명", price = BigDecimal("20000"), status = ProductStatus.AVAILABLE
+            ).withId(2L)
+        )
+
+        whenever(productRepository.findAllById(listOf(1L, 2L))).thenReturn(products)
+
+        val result = controller.getProductsByIds(listOf(1L, 2L))
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body).hasSize(2)
+    }
+
+    @Test
+    fun 상품_이미지_URL을_조회한다() {
+        val image = ProductImage.create(productId = 1L, imageUrl = "http://img.jpg", sortOrder = 0).withId(1L)
+
+        whenever(productImageRepository.findByProductIdOrderBySortOrder(1L)).thenReturn(listOf(image))
+
+        val result = controller.getProductImageUrl(1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body).isEqualTo("http://img.jpg")
+    }
+
+    @Test
+    fun 이미지가_없는_상품의_이미지_URL_조회_시_빈_문자열을_반환한다() {
+        whenever(productImageRepository.findByProductIdOrderBySortOrder(1L)).thenReturn(emptyList())
+
+        val result = controller.getProductImageUrl(1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body).isEmpty()
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImplTest.kt
@@ -1,0 +1,254 @@
+package com.hoppingmall.product.inventory.service
+
+import com.hoppingmall.product.inventory.domain.Inventory
+import com.hoppingmall.product.inventory.domain.InventoryReservation
+import com.hoppingmall.product.inventory.domain.repository.InventoryRepository
+import com.hoppingmall.product.inventory.domain.repository.InventoryReservationRepository
+import com.hoppingmall.product.inventory.enums.ReservationStatus
+import com.hoppingmall.product.inventory.exception.InventoryAlreadyExistsException
+import com.hoppingmall.product.inventory.exception.InventoryNotFoundException
+import com.hoppingmall.product.inventory.exception.ReservationConfirmFailedException
+import com.hoppingmall.product.product.domain.repository.ProductRepository
+import com.hoppingmall.product.product.exception.ProductNotFoundException
+import com.hoppingmall.product.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
+
+@DisplayName("InventoryCommandServiceImpl 추가 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class InventoryCommandServiceImplTest {
+
+    @Mock
+    private lateinit var inventoryRepository: InventoryRepository
+
+    @Mock
+    private lateinit var inventoryReservationRepository: InventoryReservationRepository
+
+    @Mock
+    private lateinit var productRepository: ProductRepository
+
+    @InjectMocks
+    private lateinit var service: InventoryCommandServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        val field = InventoryCommandServiceImpl::class.java.getDeclaredField("ttlMinutes")
+        field.isAccessible = true
+        field.set(service, 10L)
+    }
+
+    @Test
+    fun 재고를_초기화한다() {
+        val inventory = Inventory.create(productId = 1L, stockQuantity = 100).withId(1L)
+        val request = com.hoppingmall.product.inventory.dto.request.InventoryInitRequest(productId = 1L, stockQuantity = 100)
+
+        whenever(productRepository.existsById(1L)).thenReturn(true)
+        whenever(inventoryRepository.existsByProductId(1L)).thenReturn(false)
+        whenever(inventoryRepository.save(any<Inventory>())).thenReturn(inventory)
+
+        val result = service.initStock(request)
+
+        assertThat(result.stockQuantity).isEqualTo(100)
+    }
+
+    @Test
+    fun 존재하지_않는_상품에_재고_초기화_시_예외를_발생시킨다() {
+        val request = com.hoppingmall.product.inventory.dto.request.InventoryInitRequest(productId = 999L, stockQuantity = 100)
+
+        whenever(productRepository.existsById(999L)).thenReturn(false)
+
+        assertThatThrownBy { service.initStock(request) }
+            .isInstanceOf(ProductNotFoundException::class.java)
+    }
+
+    @Test
+    fun 이미_존재하는_상품에_재고_초기화_시_예외를_발생시킨다() {
+        val request = com.hoppingmall.product.inventory.dto.request.InventoryInitRequest(productId = 1L, stockQuantity = 100)
+
+        whenever(productRepository.existsById(1L)).thenReturn(true)
+        whenever(inventoryRepository.existsByProductId(1L)).thenReturn(true)
+
+        assertThatThrownBy { service.initStock(request) }
+            .isInstanceOf(InventoryAlreadyExistsException::class.java)
+    }
+
+    @Test
+    fun 재고를_수정한다() {
+        val inventory = Inventory.create(productId = 1L, stockQuantity = 100).withId(1L)
+        val request = com.hoppingmall.product.inventory.dto.request.InventoryUpdateRequest(stockQuantity = 200)
+
+        whenever(inventoryRepository.findByProductIdForUpdate(1L)).thenReturn(inventory)
+
+        val result = service.updateStock(1L, request)
+
+        assertThat(result.stockQuantity).isEqualTo(200)
+    }
+
+    @Test
+    fun 존재하지_않는_재고_수정_시_예외를_발생시킨다() {
+        val request = com.hoppingmall.product.inventory.dto.request.InventoryUpdateRequest(stockQuantity = 200)
+
+        whenever(inventoryRepository.findByProductIdForUpdate(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.updateStock(999L, request) }
+            .isInstanceOf(InventoryNotFoundException::class.java)
+    }
+
+    @Test
+    fun 재고를_차감한다() {
+        val inventory = Inventory.create(productId = 1L, stockQuantity = 100).withId(1L)
+
+        whenever(inventoryRepository.findByProductIdForUpdate(1L)).thenReturn(inventory)
+
+        service.decreaseStock(1L, 10)
+
+        assertThat(inventory.stockQuantity).isEqualTo(90)
+    }
+
+    @Test
+    fun 존재하지_않는_재고_차감_시_예외를_발생시킨다() {
+        whenever(inventoryRepository.findByProductIdForUpdate(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.decreaseStock(999L, 10) }
+            .isInstanceOf(InventoryNotFoundException::class.java)
+    }
+
+    @Test
+    fun 재고를_증가시킨다() {
+        val inventory = Inventory.create(productId = 1L, stockQuantity = 100).withId(1L)
+
+        whenever(inventoryRepository.findByProductIdForUpdate(1L)).thenReturn(inventory)
+
+        service.increaseStock(1L, 10)
+
+        assertThat(inventory.stockQuantity).isEqualTo(110)
+    }
+
+    @Test
+    fun 존재하지_않는_재고_증가_시_예외를_발생시킨다() {
+        whenever(inventoryRepository.findByProductIdForUpdate(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.increaseStock(999L, 10) }
+            .isInstanceOf(InventoryNotFoundException::class.java)
+    }
+
+    @Test
+    fun 배치_예약_중_실패_시_이전_예약을_모두_취소한다() {
+        val inv1 = Inventory.create(productId = 1L, stockQuantity = 100)
+        val inv2 = Inventory.create(productId = 2L, stockQuantity = 0)
+
+        whenever(inventoryRepository.findByProductIdForUpdate(1L)).thenReturn(inv1)
+        whenever(inventoryReservationRepository.save(any<InventoryReservation>()))
+            .thenAnswer { it.arguments[0] as InventoryReservation }
+        whenever(inventoryRepository.findByProductIdForUpdate(2L)).thenReturn(inv2)
+
+        assertThatThrownBy { service.batchReserveStock(listOf(1L to 3, 2L to 5)) }
+            .isInstanceOf(Exception::class.java)
+    }
+
+    @Test
+    fun 배치_예약_성공() {
+        val inv1 = Inventory.create(productId = 1L, stockQuantity = 100)
+        val inv2 = Inventory.create(productId = 2L, stockQuantity = 100)
+
+        whenever(inventoryRepository.findByProductIdForUpdate(1L)).thenReturn(inv1)
+        whenever(inventoryRepository.findByProductIdForUpdate(2L)).thenReturn(inv2)
+        whenever(inventoryReservationRepository.save(any<InventoryReservation>()))
+            .thenAnswer { it.arguments[0] as InventoryReservation }
+
+        val result = service.batchReserveStock(listOf(2L to 5, 1L to 3))
+
+        assertThat(result).hasSize(2)
+        assertThat(result).containsKeys(1L, 2L)
+    }
+
+    @Test
+    fun 여러_예약을_한번에_취소한다() {
+        whenever(inventoryReservationRepository.findByReservationId("rsv-1")).thenReturn(null)
+        whenever(inventoryReservationRepository.findByReservationId("rsv-2")).thenReturn(null)
+
+        service.cancelReservations(listOf("rsv-1", "rsv-2"))
+
+        verify(inventoryReservationRepository).findByReservationId("rsv-1")
+        verify(inventoryReservationRepository).findByReservationId("rsv-2")
+    }
+
+    @Test
+    fun 확정_시_일부_이미_확정된_예약이_있으면_성공으로_간주한다() {
+        val reservationIds = listOf("rsv-1", "rsv-2")
+        val r1 = InventoryReservation(
+            reservationId = "rsv-1", productId = 1L, quantity = 3,
+            status = ReservationStatus.CONFIRMED, expiresAt = LocalDateTime.now().plusMinutes(10)
+        )
+        val r2 = InventoryReservation(
+            reservationId = "rsv-2", productId = 2L, quantity = 5,
+            status = ReservationStatus.CONFIRMED, expiresAt = LocalDateTime.now().plusMinutes(10)
+        )
+
+        whenever(
+            inventoryReservationRepository.batchUpdateStatusByCas(
+                reservationIds = eq(reservationIds),
+                expectedStatus = eq(ReservationStatus.RESERVED),
+                targetStatus = eq(ReservationStatus.CONFIRMED),
+                updatedAt = any()
+            )
+        ).thenReturn(0)
+        whenever(inventoryReservationRepository.findByReservationIdIn(reservationIds)).thenReturn(listOf(r1, r2))
+
+        val result = service.confirmReservations(reservationIds)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun 확정_실패_시_이미_확정된_예약을_롤백하고_재고를_원복한다() {
+        val reservationIds = listOf("rsv-1", "rsv-2")
+        val r1 = InventoryReservation(
+            reservationId = "rsv-1", productId = 1L, quantity = 3,
+            status = ReservationStatus.CANCELLED, expiresAt = LocalDateTime.now().plusMinutes(10)
+        )
+
+        whenever(
+            inventoryReservationRepository.batchUpdateStatusByCas(
+                reservationIds = eq(reservationIds),
+                expectedStatus = eq(ReservationStatus.RESERVED),
+                targetStatus = eq(ReservationStatus.CONFIRMED),
+                updatedAt = any()
+            )
+        ).thenReturn(1)
+        whenever(inventoryReservationRepository.findByReservationIdIn(reservationIds)).thenReturn(listOf(r1))
+        whenever(
+            inventoryReservationRepository.batchUpdateStatusByCas(
+                reservationIds = eq(reservationIds),
+                expectedStatus = eq(ReservationStatus.CONFIRMED),
+                targetStatus = eq(ReservationStatus.CANCELLED),
+                updatedAt = any()
+            )
+        ).thenReturn(1)
+        whenever(inventoryReservationRepository.findByReservationId("rsv-1")).thenReturn(r1)
+        whenever(inventoryReservationRepository.findByReservationId("rsv-2")).thenReturn(null)
+        val inventory = Inventory.create(productId = 1L, stockQuantity = 0)
+        whenever(inventoryRepository.findByProductIdForUpdate(1L)).thenReturn(inventory)
+
+        assertThatThrownBy { service.confirmReservations(reservationIds) }
+            .isInstanceOf(ReservationConfirmFailedException::class.java)
+
+        assertThat(inventory.stockQuantity).isEqualTo(3)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/inventory/service/InventoryQueryServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/inventory/service/InventoryQueryServiceImplTest.kt
@@ -1,0 +1,48 @@
+package com.hoppingmall.product.inventory.service
+
+import com.hoppingmall.product.inventory.domain.Inventory
+import com.hoppingmall.product.inventory.domain.repository.InventoryRepository
+import com.hoppingmall.product.inventory.exception.InventoryNotFoundException
+import com.hoppingmall.product.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+
+@DisplayName("InventoryQueryServiceImpl")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class InventoryQueryServiceImplTest {
+
+    @Mock
+    private lateinit var inventoryRepository: InventoryRepository
+
+    @InjectMocks
+    private lateinit var service: InventoryQueryServiceImpl
+
+    @Test
+    fun 재고를_조회한다() {
+        val inventory = Inventory.create(productId = 1L, stockQuantity = 100).withId(1L)
+
+        whenever(inventoryRepository.findByProductId(1L)).thenReturn(inventory)
+
+        val result = service.getStock(1L)
+
+        assertThat(result.stockQuantity).isEqualTo(100)
+    }
+
+    @Test
+    fun 존재하지_않는_재고_조회_시_예외를_발생시킨다() {
+        whenever(inventoryRepository.findByProductId(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.getStock(999L) }
+            .isInstanceOf(InventoryNotFoundException::class.java)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/controller/ProductBulkControllerTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/controller/ProductBulkControllerTest.kt
@@ -1,0 +1,89 @@
+package com.hoppingmall.product.product.controller
+
+import com.hoppingmall.common.UserPrincipal
+import com.hoppingmall.product.product.dto.response.BulkImportProgressResponse
+import com.hoppingmall.product.product.dto.response.BulkRowError
+import com.hoppingmall.product.product.dto.response.BulkValidationResponse
+import com.hoppingmall.product.product.enum.BulkImportStatus
+import com.hoppingmall.product.product.service.BulkImportService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.mock.web.MockMultipartFile
+
+@DisplayName("ProductBulkController")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ProductBulkControllerTest {
+
+    @Mock
+    private lateinit var bulkImportService: BulkImportService
+
+    @InjectMocks
+    private lateinit var controller: ProductBulkController
+
+    private val principal = UserPrincipal(1L, "SELLER")
+
+    @Test
+    fun CSV_검증을_수행한다() {
+        val file = MockMultipartFile("file", "test.csv", "text/csv", "data".toByteArray())
+        val response = BulkValidationResponse(
+            totalRows = 1, validRows = 1, invalidRows = 0, errors = emptyList(), preview = emptyList()
+        )
+
+        whenever(bulkImportService.validate(any())).thenReturn(response)
+
+        val result = controller.validateCsv(file)
+
+        assertThat(result.data!!.totalRows).isEqualTo(1)
+    }
+
+    @Test
+    fun CSV_대량_등록을_시작한다() {
+        val file = MockMultipartFile("file", "test.csv", "text/csv", "data".toByteArray())
+        val response = BulkImportProgressResponse(
+            jobId = 1L, status = BulkImportStatus.IMPORTING,
+            totalRows = 10, processedRows = 0, successCount = 0, failCount = 0, completedAt = null
+        )
+
+        whenever(bulkImportService.startImport(eq(1L), any())).thenReturn(response)
+
+        val result = controller.importCsv(file, principal)
+
+        assertThat(result.data!!.jobId).isEqualTo(1L)
+    }
+
+    @Test
+    fun 작업_진행_상태를_조회한다() {
+        val response = BulkImportProgressResponse(
+            jobId = 1L, status = BulkImportStatus.COMPLETED,
+            totalRows = 10, processedRows = 10, successCount = 8, failCount = 2, completedAt = null
+        )
+
+        whenever(bulkImportService.getJobProgress(1L, 1L)).thenReturn(response)
+
+        val result = controller.getJobProgress(1L, principal)
+
+        assertThat(result.data!!.successCount).isEqualTo(8)
+    }
+
+    @Test
+    fun 작업_에러를_조회한다() {
+        val errors = listOf(BulkRowError(1, "name", "에러"))
+
+        whenever(bulkImportService.getJobErrors(1L, 1L)).thenReturn(errors)
+
+        val result = controller.getJobErrors(1L, principal)
+
+        assertThat(result.data).hasSize(1)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/controller/ProductControllerTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/controller/ProductControllerTest.kt
@@ -1,0 +1,168 @@
+package com.hoppingmall.product.product.controller
+
+import com.hoppingmall.product.common.enums.ProductStatus
+import com.hoppingmall.product.product.dto.request.ProductCreateRequest
+import com.hoppingmall.product.product.dto.request.ProductSearchCondition
+import com.hoppingmall.product.product.dto.request.ProductUpdateRequest
+import com.hoppingmall.product.product.dto.response.ProductImageResponse
+import com.hoppingmall.product.product.dto.response.ProductResponse
+import com.hoppingmall.product.product.exception.ProductNotFoundException
+import com.hoppingmall.product.product.service.ProductCommandService
+import com.hoppingmall.product.product.service.ProductImageService
+import com.hoppingmall.product.product.service.ProductQueryService
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import org.springframework.mock.web.MockMultipartFile
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@DisplayName("ProductController")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ProductControllerTest {
+
+    @Mock
+    private lateinit var productQueryService: ProductQueryService
+
+    @Mock
+    private lateinit var productCommandService: ProductCommandService
+
+    @Mock
+    private lateinit var productImageService: ProductImageService
+
+    @InjectMocks
+    private lateinit var controller: ProductController
+
+    private fun productResponse() = ProductResponse(
+        id = 1L, sellerId = 1L, categoryId = 1L, name = "테스트",
+        description = "설명", price = BigDecimal("10000"), status = ProductStatus.AVAILABLE,
+        imageUrls = emptyList(), createdAt = LocalDateTime.now(), updatedAt = null
+    )
+
+    @Test
+    fun 상품_목록을_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+
+        whenever(productQueryService.getProducts(pageable))
+            .thenReturn(SliceImpl(listOf(productResponse()), pageable, false))
+
+        val result = controller.getProducts(pageable)
+
+        assertThat(result.data).isNotNull
+    }
+
+    @Test
+    fun 상품을_단건_조회한다() {
+        whenever(productQueryService.getProductById(1L)).thenReturn(productResponse())
+
+        val result = controller.getProduct(1L)
+
+        assertThat(result.data!!.name).isEqualTo("테스트")
+    }
+
+    @Test
+    fun 존재하지_않는_상품_조회_시_예외를_발생시킨다() {
+        whenever(productQueryService.getProductById(999L)).thenReturn(null)
+
+        assertThatThrownBy { controller.getProduct(999L) }
+            .isInstanceOf(ProductNotFoundException::class.java)
+    }
+
+    @Test
+    fun 판매자별_상품을_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+
+        whenever(productQueryService.getProductsBySellerId(eq(1L), eq(pageable)))
+            .thenReturn(SliceImpl(listOf(productResponse()), pageable, false))
+
+        val result = controller.getProductsBySeller(1L, pageable)
+
+        assertThat(result.data).isNotNull
+    }
+
+    @Test
+    fun 카테고리별_상품을_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+
+        whenever(productQueryService.getProductsByCategoryId(eq(1L), eq(pageable)))
+            .thenReturn(SliceImpl(listOf(productResponse()), pageable, false))
+
+        val result = controller.getProductsByCategory(1L, pageable)
+
+        assertThat(result.data).isNotNull
+    }
+
+    @Test
+    fun 상품을_검색한다() {
+        val pageable = PageRequest.of(0, 10)
+        val condition = ProductSearchCondition(keyword = "테스트")
+
+        whenever(productQueryService.searchProducts(any(), eq(pageable)))
+            .thenReturn(SliceImpl(listOf(productResponse()), pageable, false))
+
+        val result = controller.searchProducts(condition, pageable)
+
+        assertThat(result.data).isNotNull
+    }
+
+    @Test
+    fun 상품을_생성한다() {
+        val request = ProductCreateRequest(
+            sellerId = 1L, categoryId = 1L, name = "테스트",
+            description = "설명", price = BigDecimal("10000")
+        )
+
+        whenever(productCommandService.createProduct(any())).thenReturn(productResponse())
+
+        val result = controller.createProduct(request)
+
+        assertThat(result.data!!.name).isEqualTo("테스트")
+    }
+
+    @Test
+    fun 상품을_수정한다() {
+        val request = ProductUpdateRequest(
+            categoryId = 1L, name = "수정", description = "수정", price = BigDecimal("20000")
+        )
+
+        whenever(productCommandService.updateProduct(eq(1L), any())).thenReturn(productResponse())
+
+        val result = controller.updateProduct(1L, request)
+
+        assertThat(result.data).isNotNull
+    }
+
+    @Test
+    fun 상품을_삭제한다() {
+        val result = controller.deleteProduct(1L)
+
+        verify(productCommandService).deleteProduct(1L)
+        assertThat(result.data).isNotNull
+    }
+
+    @Test
+    fun 상품_이미지를_업로드한다() {
+        val file = MockMultipartFile("image", "test.jpg", "image/jpeg", "test".toByteArray())
+        val imageResponse = ProductImageResponse("http://img.jpg", "test.jpg", 4L)
+
+        whenever(productImageService.uploadProductImage(any())).thenReturn(imageResponse)
+
+        val result = controller.uploadProductImage(file)
+
+        assertThat(result.data!!.imageUrl).isEqualTo("http://img.jpg")
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/controller/ProductStatisticsControllerTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/controller/ProductStatisticsControllerTest.kt
@@ -1,0 +1,187 @@
+package com.hoppingmall.product.product.controller
+
+import com.hoppingmall.product.product.dto.response.*
+import com.hoppingmall.product.product.service.ProductStatisticsQueryService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@DisplayName("ProductStatisticsController")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ProductStatisticsControllerTest {
+
+    @Mock
+    private lateinit var productStatisticsQueryService: ProductStatisticsQueryService
+
+    @InjectMocks
+    private lateinit var controller: ProductStatisticsController
+
+    private fun statsResponse() = ProductStatisticsResponse(
+        productId = 1L, productName = "테스트", sellerId = 1L, categoryId = 1L,
+        totalSalesQuantity = 100, totalSalesAmount = BigDecimal("1000000"),
+        totalRefundQuantity = 5, totalRefundAmount = BigDecimal("50000"),
+        currentCartCount = 10, currentStock = 50, refundRate = BigDecimal("0.05"),
+        stockTurnoverRate = BigDecimal("2.0"), todaySalesQuantity = 10,
+        todaySalesAmount = BigDecimal("100000"), todayOrderCount = 5,
+        todayRefundQuantity = 1, todayRefundAmount = BigDecimal("10000"),
+        last7DaysSalesAmount = BigDecimal("500000"), last30DaysSalesAmount = BigDecimal("2000000"),
+        salesGrowthRate = BigDecimal("10.0"), orderCount = 50,
+        netRevenue = BigDecimal("950000"), averageOrderAmount = BigDecimal("20000"),
+        lastAggregatedAt = java.time.LocalDateTime.now()
+    )
+
+    @Test
+    fun 전체_통계를_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+
+        whenever(productStatisticsQueryService.getAll(pageable))
+            .thenReturn(PageImpl(listOf(statsResponse()), pageable, 1))
+
+        val result = controller.getAll(pageable)
+
+        assertThat(result.data).isNotNull
+    }
+
+    @Test
+    fun 상품ID로_통계를_조회한다() {
+        whenever(productStatisticsQueryService.getByProductId(1L)).thenReturn(statsResponse())
+
+        val result = controller.getByProductId(1L)
+
+        assertThat(result.data!!.productId).isEqualTo(1L)
+    }
+
+    @Test
+    fun 판매자ID로_통계를_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+
+        whenever(productStatisticsQueryService.getBySellerId(1L, pageable))
+            .thenReturn(SliceImpl(listOf(statsResponse()), pageable, false))
+
+        val result = controller.getBySellerId(1L, pageable)
+
+        assertThat(result.data).isNotNull
+    }
+
+    @Test
+    fun 카테고리ID로_통계를_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+
+        whenever(productStatisticsQueryService.getByCategoryId(1L, pageable))
+            .thenReturn(SliceImpl(listOf(statsResponse()), pageable, false))
+
+        val result = controller.getByCategoryId(1L, pageable)
+
+        assertThat(result.data).isNotNull
+    }
+
+    @Test
+    fun 요약을_조회한다() {
+        val summary = ProductStatisticsSummaryResponse(
+            totalProductCount = 100, totalSalesAmount = BigDecimal("10000000"),
+            totalRefundAmount = BigDecimal("500000"), averageRefundRate = BigDecimal("0.05")
+        )
+
+        whenever(productStatisticsQueryService.getSummary()).thenReturn(summary)
+
+        val result = controller.getSummary()
+
+        assertThat(result.data!!.totalProductCount).isEqualTo(100)
+    }
+
+    @Test
+    fun 오늘_요약을_조회한다() {
+        val today = TodaySummaryResponse(
+            todaySalesAmount = BigDecimal("100000"), todayOrderCount = 10,
+            todayRefundAmount = BigDecimal("5000")
+        )
+
+        whenever(productStatisticsQueryService.getTodaySummary()).thenReturn(today)
+
+        val result = controller.getTodaySummary()
+
+        assertThat(result.data!!.todayOrderCount).isEqualTo(10)
+    }
+
+    @Test
+    fun 일별_통계를_조회한다() {
+        val daily = ProductDailyStatisticsResponse(
+            productId = 1L, statisticsDate = LocalDate.now(),
+            dailySalesQuantity = 10, dailySalesAmount = BigDecimal("100000"),
+            dailyOrderCount = 5, dailyRefundQuantity = 0,
+            dailyRefundAmount = BigDecimal.ZERO, endOfDayStock = 90
+        )
+
+        whenever(productStatisticsQueryService.getDailyStatistics(eq(1L), any(), any()))
+            .thenReturn(listOf(daily))
+
+        val result = controller.getDailyStatistics(1L, LocalDate.now().minusDays(7), LocalDate.now())
+
+        assertThat(result.data).hasSize(1)
+    }
+
+    @Test
+    fun 상위_판매_상품을_조회한다() {
+        val top = TopProductResponse(productId = 1L, totalAmount = BigDecimal("1000000"), totalQuantity = 100)
+
+        whenever(productStatisticsQueryService.getTopSellingProducts(7, 10)).thenReturn(listOf(top))
+
+        val result = controller.getTopSellingProducts(7, 10)
+
+        assertThat(result.data).hasSize(1)
+    }
+
+    @Test
+    fun 상위_환불_상품을_조회한다() {
+        val top = TopProductResponse(productId = 1L, totalAmount = BigDecimal("50000"), totalQuantity = 5)
+
+        whenever(productStatisticsQueryService.getTopRefundProducts(7, 10)).thenReturn(listOf(top))
+
+        val result = controller.getTopRefundProducts(7, 10)
+
+        assertThat(result.data).hasSize(1)
+    }
+
+    @Test
+    fun 시간별_통계를_조회한다() {
+        val hourly = ProductHourlyStatisticsResponse(
+            productId = 1L, statisticsDate = LocalDate.now(), hour = 14,
+            hourlySalesQuantity = 10, hourlySalesAmount = BigDecimal("100000"),
+            hourlyOrderCount = 5, hourlyRefundQuantity = 0,
+            hourlyRefundAmount = BigDecimal.ZERO
+        )
+
+        whenever(productStatisticsQueryService.getHourlyStatistics(1L, LocalDate.now()))
+            .thenReturn(listOf(hourly))
+
+        val result = controller.getHourlyStatistics(1L, LocalDate.now())
+
+        assertThat(result.data).hasSize(1)
+    }
+
+    @Test
+    fun 피크_시간을_조회한다() {
+        val peak = PeakHourResponse(hour = 14, totalSalesAmount = BigDecimal("500000"), totalOrderCount = 50)
+
+        whenever(productStatisticsQueryService.getPeakHours(7)).thenReturn(listOf(peak))
+
+        val result = controller.getPeakHours(7)
+
+        assertThat(result.data).hasSize(1)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/controller/SellerDashboardControllerTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/controller/SellerDashboardControllerTest.kt
@@ -1,0 +1,119 @@
+package com.hoppingmall.product.product.controller
+
+import com.hoppingmall.common.UserPrincipal
+import com.hoppingmall.product.product.dto.response.*
+import com.hoppingmall.product.product.service.SellerDashboardService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@DisplayName("SellerDashboardController")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class SellerDashboardControllerTest {
+
+    @Mock
+    private lateinit var sellerDashboardService: SellerDashboardService
+
+    @InjectMocks
+    private lateinit var controller: SellerDashboardController
+
+    private val principal = UserPrincipal(1L, "SELLER")
+
+    private fun statsResponse() = ProductStatisticsResponse(
+        productId = 1L, productName = "테스트", sellerId = 1L, categoryId = 1L,
+        totalSalesQuantity = 100, totalSalesAmount = BigDecimal("1000000"),
+        totalRefundQuantity = 5, totalRefundAmount = BigDecimal("50000"),
+        currentCartCount = 10, currentStock = 50, refundRate = BigDecimal("0.05"),
+        stockTurnoverRate = BigDecimal("2.0"), todaySalesQuantity = 10,
+        todaySalesAmount = BigDecimal("100000"), todayOrderCount = 5,
+        todayRefundQuantity = 1, todayRefundAmount = BigDecimal("10000"),
+        last7DaysSalesAmount = BigDecimal("500000"), last30DaysSalesAmount = BigDecimal("2000000"),
+        salesGrowthRate = BigDecimal("10.0"), orderCount = 50,
+        netRevenue = BigDecimal("950000"), averageOrderAmount = BigDecimal("20000"),
+        lastAggregatedAt = java.time.LocalDateTime.now()
+    )
+
+    @Test
+    fun 판매자_개요를_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+
+        whenever(sellerDashboardService.getOverview(eq(1L), eq(pageable)))
+            .thenReturn(SliceImpl(listOf(statsResponse()), pageable, false))
+
+        val result = controller.getOverview(principal, pageable)
+
+        assertThat(result.data).isNotNull
+    }
+
+    @Test
+    fun 상품_통계를_조회한다() {
+        whenever(sellerDashboardService.getProductStatistics(1L, 1L)).thenReturn(statsResponse())
+
+        val result = controller.getProductStatistics(principal, 1L)
+
+        assertThat(result.data!!.productId).isEqualTo(1L)
+    }
+
+    @Test
+    fun 오늘_요약을_조회한다() {
+        val summary = SellerTodaySummaryResponse(
+            totalProducts = 5, todaySalesAmount = BigDecimal("500000"),
+            todayOrderCount = 10, todayRefundAmount = BigDecimal("10000"),
+            topSellingProductId = 1L, topSellingProductName = "테스트"
+        )
+
+        whenever(sellerDashboardService.getTodaySummary(1L)).thenReturn(summary)
+
+        val result = controller.getTodaySummary(principal)
+
+        assertThat(result.data!!.totalProducts).isEqualTo(5)
+    }
+
+    @Test
+    fun 일별_통계를_조회한다() {
+        val daily = ProductDailyStatisticsResponse(
+            productId = 1L, statisticsDate = LocalDate.now(),
+            dailySalesQuantity = 10, dailySalesAmount = BigDecimal("100000"),
+            dailyOrderCount = 5, dailyRefundQuantity = 0,
+            dailyRefundAmount = BigDecimal.ZERO, endOfDayStock = 90
+        )
+
+        whenever(sellerDashboardService.getDailyStatistics(eq(1L), eq(1L), any(), any()))
+            .thenReturn(listOf(daily))
+
+        val result = controller.getDailyStatistics(principal, 1L, LocalDate.now().minusDays(7), LocalDate.now())
+
+        assertThat(result.data).hasSize(1)
+    }
+
+    @Test
+    fun 시간별_통계를_조회한다() {
+        val hourly = ProductHourlyStatisticsResponse(
+            productId = 1L, statisticsDate = LocalDate.now(), hour = 14,
+            hourlySalesQuantity = 10, hourlySalesAmount = BigDecimal("100000"),
+            hourlyOrderCount = 5, hourlyRefundQuantity = 0,
+            hourlyRefundAmount = BigDecimal.ZERO
+        )
+
+        whenever(sellerDashboardService.getHourlyStatistics(eq(1L), eq(1L), any()))
+            .thenReturn(listOf(hourly))
+
+        val result = controller.getHourlyStatistics(principal, 1L, LocalDate.now())
+
+        assertThat(result.data).hasSize(1)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/domain/BulkImportJobTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/domain/BulkImportJobTest.kt
@@ -1,0 +1,81 @@
+package com.hoppingmall.product.product.domain
+
+import com.hoppingmall.product.product.enum.BulkImportStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+
+@DisplayName("BulkImportJob 도메인")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class BulkImportJobTest {
+
+    @Test
+    fun 대량_등록_작업을_생성한다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 100)
+
+        assertThat(job.sellerId).isEqualTo(1L)
+        assertThat(job.fileName).isEqualTo("test.csv")
+        assertThat(job.totalRows).isEqualTo(100)
+        assertThat(job.status).isEqualTo(BulkImportStatus.VALIDATING)
+    }
+
+    @Test
+    fun 등록_시작_상태로_변경한다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 100)
+
+        job.startImport()
+
+        assertThat(job.status).isEqualTo(BulkImportStatus.IMPORTING)
+    }
+
+    @Test
+    fun 성공_건수를_기록한다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 100)
+
+        job.recordSuccess()
+
+        assertThat(job.processedRows).isEqualTo(1)
+        assertThat(job.successCount).isEqualTo(1)
+    }
+
+    @Test
+    fun 실패_건수를_기록한다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 100)
+
+        job.recordFailure()
+
+        assertThat(job.processedRows).isEqualTo(1)
+        assertThat(job.failCount).isEqualTo(1)
+    }
+
+    @Test
+    fun 완료_상태로_변경한다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 100)
+
+        job.complete()
+
+        assertThat(job.status).isEqualTo(BulkImportStatus.COMPLETED)
+        assertThat(job.completedAt).isNotNull()
+    }
+
+    @Test
+    fun 실패_상태로_변경한다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 100)
+
+        job.fail()
+
+        assertThat(job.status).isEqualTo(BulkImportStatus.FAILED)
+        assertThat(job.completedAt).isNotNull()
+    }
+
+    @Test
+    fun 검증_완료_상태로_변경한다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 100)
+
+        job.validated()
+
+        assertThat(job.status).isEqualTo(BulkImportStatus.VALIDATED)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/domain/ProductDailyStatisticsTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/domain/ProductDailyStatisticsTest.kt
@@ -1,0 +1,57 @@
+package com.hoppingmall.product.product.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@DisplayName("ProductDailyStatistics 도메인")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class ProductDailyStatisticsTest {
+
+    @Test
+    fun 일별_통계를_생성한다() {
+        val daily = ProductDailyStatistics.create(
+            productId = 1L, statisticsDate = LocalDate.of(2026, 1, 1),
+            dailySalesQuantity = 10, dailySalesAmount = BigDecimal("100000"),
+            dailyOrderCount = 5, endOfDayStock = 90
+        )
+
+        assertThat(daily.productId).isEqualTo(1L)
+        assertThat(daily.statisticsDate).isEqualTo(LocalDate.of(2026, 1, 1))
+        assertThat(daily.dailySalesQuantity).isEqualTo(10)
+        assertThat(daily.endOfDayStock).isEqualTo(90)
+    }
+
+    @Test
+    fun 기본값으로_일별_통계를_생성한다() {
+        val daily = ProductDailyStatistics.create(
+            productId = 1L, statisticsDate = LocalDate.of(2026, 1, 1)
+        )
+
+        assertThat(daily.dailySalesQuantity).isEqualTo(0)
+        assertThat(daily.dailySalesAmount).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun ProductStatistics로부터_일별_통계를_업데이트한다() {
+        val daily = ProductDailyStatistics.create(
+            productId = 1L, statisticsDate = LocalDate.of(2026, 1, 1)
+        )
+        val stats = ProductStatistics.create(
+            productId = 1L, productName = "테스트", sellerId = 1L, categoryId = 1L,
+            currentStock = 50
+        )
+        stats.incrementSales(10, BigDecimal("100000"))
+
+        daily.updateFromStatistics(stats)
+
+        assertThat(daily.dailySalesQuantity).isEqualTo(10)
+        assertThat(daily.dailySalesAmount).isEqualByComparingTo(BigDecimal("100000"))
+        assertThat(daily.dailyOrderCount).isEqualTo(1)
+        assertThat(daily.endOfDayStock).isEqualTo(50)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/domain/ProductHourlyStatisticsTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/domain/ProductHourlyStatisticsTest.kt
@@ -1,0 +1,54 @@
+package com.hoppingmall.product.product.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@DisplayName("ProductHourlyStatistics 도메인")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class ProductHourlyStatisticsTest {
+
+    @Test
+    fun 시간별_통계를_생성한다() {
+        val hourly = ProductHourlyStatistics.create(
+            productId = 1L, statisticsDate = LocalDate.of(2026, 1, 1), hour = 14,
+            hourlySalesQuantity = 10, hourlySalesAmount = BigDecimal("100000"),
+            hourlyOrderCount = 5
+        )
+
+        assertThat(hourly.productId).isEqualTo(1L)
+        assertThat(hourly.hour).isEqualTo(14)
+        assertThat(hourly.hourlySalesQuantity).isEqualTo(10)
+    }
+
+    @Test
+    fun 기본값으로_시간별_통계를_생성한다() {
+        val hourly = ProductHourlyStatistics.create(
+            productId = 1L, statisticsDate = LocalDate.of(2026, 1, 1), hour = 0
+        )
+
+        assertThat(hourly.hourlySalesQuantity).isEqualTo(0)
+        assertThat(hourly.hourlySalesAmount).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun ProductStatistics로부터_시간별_통계를_업데이트한다() {
+        val hourly = ProductHourlyStatistics.create(
+            productId = 1L, statisticsDate = LocalDate.of(2026, 1, 1), hour = 14
+        )
+        val stats = ProductStatistics.create(
+            productId = 1L, productName = "테스트", sellerId = 1L, categoryId = 1L
+        )
+        stats.incrementSales(10, BigDecimal("100000"))
+
+        hourly.updateFromStatistics(stats)
+
+        assertThat(hourly.hourlySalesQuantity).isEqualTo(10)
+        assertThat(hourly.hourlySalesAmount).isEqualByComparingTo(BigDecimal("100000"))
+        assertThat(hourly.hourlyOrderCount).isEqualTo(1)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/domain/ProductImageTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/domain/ProductImageTest.kt
@@ -1,0 +1,28 @@
+package com.hoppingmall.product.product.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+
+@DisplayName("ProductImage 도메인")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class ProductImageTest {
+
+    @Test
+    fun 상품_이미지를_생성한다() {
+        val image = ProductImage.create(productId = 1L, imageUrl = "http://img.jpg", sortOrder = 0)
+
+        assertThat(image.productId).isEqualTo(1L)
+        assertThat(image.imageUrl).isEqualTo("http://img.jpg")
+        assertThat(image.sortOrder).isEqualTo(0)
+    }
+
+    @Test
+    fun 기본_정렬순서로_생성한다() {
+        val image = ProductImage.create(productId = 1L, imageUrl = "http://img.jpg")
+
+        assertThat(image.sortOrder).isEqualTo(0)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/domain/ProductStatisticsTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/domain/ProductStatisticsTest.kt
@@ -1,0 +1,176 @@
+package com.hoppingmall.product.product.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("ProductStatistics 도메인")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class ProductStatisticsTest {
+
+    private fun createStats() = ProductStatistics.create(
+        productId = 1L, productName = "테스트상품", sellerId = 1L, categoryId = 1L,
+        totalSalesQuantity = 100, totalSalesAmount = BigDecimal("1000000"),
+        currentStock = 50
+    )
+
+    @Test
+    fun 통계를_생성한다() {
+        val stats = createStats()
+
+        assertThat(stats.productId).isEqualTo(1L)
+        assertThat(stats.productName).isEqualTo("테스트상품")
+        assertThat(stats.totalSalesQuantity).isEqualTo(100)
+    }
+
+    @Test
+    fun 판매_통계를_증가시킨다() {
+        val stats = createStats()
+
+        stats.incrementSales(10, BigDecimal("100000"))
+
+        assertThat(stats.totalSalesQuantity).isEqualTo(110)
+        assertThat(stats.totalSalesAmount).isEqualByComparingTo(BigDecimal("1100000"))
+        assertThat(stats.todaySalesQuantity).isEqualTo(10)
+        assertThat(stats.todayOrderCount).isEqualTo(1)
+        assertThat(stats.orderCount).isEqualTo(1)
+    }
+
+    @Test
+    fun 판매_통계를_감소시킨다() {
+        val stats = createStats()
+        stats.incrementSales(10, BigDecimal("100000"))
+
+        stats.decrementSales(5, BigDecimal("50000"))
+
+        assertThat(stats.totalSalesQuantity).isEqualTo(105)
+        assertThat(stats.todaySalesQuantity).isEqualTo(5)
+    }
+
+    @Test
+    fun 판매_통계_감소_시_0_미만으로_내려가지_않는다() {
+        val stats = ProductStatistics.create(
+            productId = 1L, productName = "테스트상품", sellerId = 1L, categoryId = 1L,
+            totalSalesQuantity = 3, totalSalesAmount = BigDecimal("30000")
+        )
+
+        stats.decrementSales(10, BigDecimal("100000"))
+
+        assertThat(stats.totalSalesQuantity).isEqualTo(0)
+        assertThat(stats.totalSalesAmount).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun 환불_통계를_증가시킨다() {
+        val stats = createStats()
+
+        stats.incrementRefund(5, BigDecimal("50000"))
+
+        assertThat(stats.totalRefundQuantity).isEqualTo(5)
+        assertThat(stats.totalRefundAmount).isEqualByComparingTo(BigDecimal("50000"))
+        assertThat(stats.todayRefundQuantity).isEqualTo(5)
+    }
+
+    @Test
+    fun 오늘_통계를_초기화한다() {
+        val stats = createStats()
+        stats.incrementSales(10, BigDecimal("100000"))
+
+        stats.resetToday()
+
+        assertThat(stats.todaySalesQuantity).isEqualTo(0)
+        assertThat(stats.todaySalesAmount).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(stats.todayOrderCount).isEqualTo(0)
+        assertThat(stats.todayRefundQuantity).isEqualTo(0)
+        assertThat(stats.todayRefundAmount).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun 기간별_지표를_업데이트한다() {
+        val stats = createStats()
+
+        stats.updatePeriodMetrics(
+            last7Days = BigDecimal("500000"),
+            last30Days = BigDecimal("2000000"),
+            previousWeekAmount = BigDecimal("400000")
+        )
+
+        assertThat(stats.last7DaysSalesAmount).isEqualByComparingTo(BigDecimal("500000"))
+        assertThat(stats.last30DaysSalesAmount).isEqualByComparingTo(BigDecimal("2000000"))
+        assertThat(stats.salesGrowthRate).isPositive()
+    }
+
+    @Test
+    fun 이전_주_매출이_0일_때_성장률은_0이다() {
+        val stats = createStats()
+
+        stats.updatePeriodMetrics(
+            last7Days = BigDecimal("500000"),
+            last30Days = BigDecimal("2000000"),
+            previousWeekAmount = BigDecimal.ZERO
+        )
+
+        assertThat(stats.salesGrowthRate).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun 리뷰_통계를_업데이트한다() {
+        val stats = createStats()
+
+        stats.updateReviewStats(BigDecimal("4.50"), 100)
+
+        assertThat(stats.averageRating).isEqualByComparingTo(BigDecimal("4.50"))
+        assertThat(stats.reviewCount).isEqualTo(100)
+    }
+
+    @Test
+    fun 장바구니_및_재고를_업데이트한다() {
+        val stats = createStats()
+
+        stats.updateCartAndInventory(30L, 200)
+
+        assertThat(stats.currentCartCount).isEqualTo(30)
+        assertThat(stats.currentStock).isEqualTo(200)
+    }
+
+    @Test
+    fun update_메서드로_통계를_갱신한다() {
+        val stats = createStats()
+
+        stats.update(
+            productName = "수정상품", categoryId = 2L,
+            totalSalesQuantity = 200, totalSalesAmount = BigDecimal("2000000"),
+            totalRefundQuantity = 10, totalRefundAmount = BigDecimal("100000"),
+            currentCartCount = 50, currentStock = 100
+        )
+
+        assertThat(stats.productName).isEqualTo("수정상품")
+        assertThat(stats.categoryId).isEqualTo(2L)
+        assertThat(stats.totalSalesQuantity).isEqualTo(200)
+        assertThat(stats.netRevenue).isEqualByComparingTo(BigDecimal("1900000"))
+    }
+
+    @Test
+    fun 판매수량이_0이면_환불율은_0이다() {
+        val stats = ProductStatistics.create(
+            productId = 1L, productName = "테스트", sellerId = 1L, categoryId = 1L,
+            totalSalesQuantity = 0, totalSalesAmount = BigDecimal.ZERO
+        )
+
+        assertThat(stats.refundRate).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun 재고가_0이면_재고회전율은_0이다() {
+        val stats = ProductStatistics.create(
+            productId = 1L, productName = "테스트", sellerId = 1L, categoryId = 1L,
+            totalSalesQuantity = 100, totalSalesAmount = BigDecimal("1000000"),
+            currentStock = 0
+        )
+
+        assertThat(stats.stockTurnoverRate).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/domain/ProductTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/domain/ProductTest.kt
@@ -1,0 +1,64 @@
+package com.hoppingmall.product.product.domain
+
+import com.hoppingmall.product.common.enums.ProductStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("Product 도메인")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class ProductTest {
+
+    @Test
+    fun 상품을_생성한다() {
+        val product = Product.create(
+            sellerId = 1L, categoryId = 1L, name = "테스트상품",
+            description = "설명", price = BigDecimal("10000"), status = ProductStatus.AVAILABLE
+        )
+
+        assertThat(product.sellerId).isEqualTo(1L)
+        assertThat(product.categoryId).isEqualTo(1L)
+        assertThat(product.name).isEqualTo("테스트상품")
+        assertThat(product.description).isEqualTo("설명")
+        assertThat(product.price).isEqualByComparingTo(BigDecimal("10000"))
+        assertThat(product.status).isEqualTo(ProductStatus.AVAILABLE)
+    }
+
+    @Test
+    fun 상품을_수정한다() {
+        val product = Product.create(
+            sellerId = 1L, categoryId = 1L, name = "테스트상품",
+            description = "설명", price = BigDecimal("10000"), status = ProductStatus.AVAILABLE
+        )
+
+        product.update(
+            name = "수정상품", description = "수정설명",
+            price = BigDecimal("20000"), categoryId = 2L, status = ProductStatus.SOLD_OUT
+        )
+
+        assertThat(product.name).isEqualTo("수정상품")
+        assertThat(product.description).isEqualTo("수정설명")
+        assertThat(product.price).isEqualByComparingTo(BigDecimal("20000"))
+        assertThat(product.categoryId).isEqualTo(2L)
+        assertThat(product.status).isEqualTo(ProductStatus.SOLD_OUT)
+    }
+
+    @Test
+    fun 가격이_0_이하이면_예외를_발생시킨다() {
+        val product = Product.create(
+            sellerId = 1L, categoryId = 1L, name = "테스트상품",
+            description = "설명", price = BigDecimal("10000"), status = ProductStatus.AVAILABLE
+        )
+
+        assertThatThrownBy {
+            product.update(
+                name = "수정상품", description = "수정설명",
+                price = BigDecimal.ZERO, categoryId = 1L, status = ProductStatus.AVAILABLE
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/domain/StatisticsEventLogTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/domain/StatisticsEventLogTest.kt
@@ -1,0 +1,23 @@
+package com.hoppingmall.product.product.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+
+@DisplayName("StatisticsEventLog 도메인")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class StatisticsEventLogTest {
+
+    @Test
+    fun 통계_이벤트_로그를_생성한다() {
+        val log = StatisticsEventLog(
+            eventId = "evt-123", eventType = "PaymentCompleted", orderId = 1L
+        )
+
+        assertThat(log.eventId).isEqualTo("evt-123")
+        assertThat(log.eventType).isEqualTo("PaymentCompleted")
+        assertThat(log.orderId).isEqualTo(1L)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/domain/repository/ProductSearchRepositoryImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/domain/repository/ProductSearchRepositoryImplTest.kt
@@ -1,0 +1,197 @@
+package com.hoppingmall.product.product.domain.repository
+
+import com.hoppingmall.product.common.enums.ProductStatus
+import com.hoppingmall.product.product.domain.Product
+import jakarta.persistence.EntityManager
+import jakarta.persistence.Query
+import jakarta.persistence.TypedQuery
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import java.math.BigDecimal
+
+@DisplayName("ProductSearchRepositoryImpl")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ProductSearchRepositoryImplTest {
+
+    @Mock
+    private lateinit var entityManager: EntityManager
+
+    @Mock
+    private lateinit var typedQuery: TypedQuery<Product>
+
+    @Mock
+    private lateinit var nativeQuery: Query
+
+    @Nested
+    @DisplayName("LIKE 검색")
+    inner class LikeSearch {
+
+        @Test
+        fun 키워드로_LIKE_검색한다() {
+            val repo = ProductSearchRepositoryImpl(entityManager, "jdbc:h2:mem:test")
+            val pageable = PageRequest.of(0, 10)
+
+            whenever(entityManager.createQuery(any<String>(), eq(Product::class.java))).thenReturn(typedQuery)
+            whenever(typedQuery.resultList).thenReturn(emptyList())
+
+            val result = repo.searchProducts(
+                keyword = "테스트", categoryId = null, status = null,
+                minPrice = null, maxPrice = null, pageable = pageable
+            )
+
+            assertThat(result.content).isEmpty()
+            assertThat(result.hasNext()).isFalse()
+        }
+
+        @Test
+        fun 키워드_없이_검색한다() {
+            val repo = ProductSearchRepositoryImpl(entityManager, "jdbc:h2:mem:test")
+            val pageable = PageRequest.of(0, 10)
+
+            whenever(entityManager.createQuery(any<String>(), eq(Product::class.java))).thenReturn(typedQuery)
+            whenever(typedQuery.resultList).thenReturn(emptyList())
+
+            val result = repo.searchProducts(
+                keyword = null, categoryId = null, status = null,
+                minPrice = null, maxPrice = null, pageable = pageable
+            )
+
+            assertThat(result.content).isEmpty()
+        }
+
+        @Test
+        fun 빈_키워드로_검색한다() {
+            val repo = ProductSearchRepositoryImpl(entityManager, "jdbc:h2:mem:test")
+            val pageable = PageRequest.of(0, 10)
+
+            whenever(entityManager.createQuery(any<String>(), eq(Product::class.java))).thenReturn(typedQuery)
+            whenever(typedQuery.resultList).thenReturn(emptyList())
+
+            val result = repo.searchProducts(
+                keyword = "", categoryId = null, status = null,
+                minPrice = null, maxPrice = null, pageable = pageable
+            )
+
+            assertThat(result.content).isEmpty()
+        }
+
+        @Test
+        fun 모든_조건으로_LIKE_검색한다() {
+            val repo = ProductSearchRepositoryImpl(entityManager, "jdbc:h2:mem:test")
+            val pageable = PageRequest.of(0, 10)
+
+            whenever(entityManager.createQuery(any<String>(), eq(Product::class.java))).thenReturn(typedQuery)
+            whenever(typedQuery.resultList).thenReturn(emptyList())
+
+            val result = repo.searchProducts(
+                keyword = "테스트", categoryId = 1L, status = ProductStatus.AVAILABLE,
+                minPrice = BigDecimal("1000"), maxPrice = BigDecimal("50000"), pageable = pageable
+            )
+
+            assertThat(result.content).isEmpty()
+        }
+
+        @Test
+        fun 결과가_pageSize보다_많으면_hasNext가_true이다() {
+            val repo = ProductSearchRepositoryImpl(entityManager, "jdbc:h2:mem:test")
+            val pageable = PageRequest.of(0, 2)
+            val products = listOf(
+                Product.create(1L, 1L, "A", "d", BigDecimal("1000"), ProductStatus.AVAILABLE),
+                Product.create(1L, 1L, "B", "d", BigDecimal("2000"), ProductStatus.AVAILABLE),
+                Product.create(1L, 1L, "C", "d", BigDecimal("3000"), ProductStatus.AVAILABLE)
+            )
+
+            whenever(entityManager.createQuery(any<String>(), eq(Product::class.java))).thenReturn(typedQuery)
+            whenever(typedQuery.resultList).thenReturn(products)
+
+            val result = repo.searchProducts(
+                keyword = null, categoryId = null, status = null,
+                minPrice = null, maxPrice = null, pageable = pageable
+            )
+
+            assertThat(result.hasNext()).isTrue()
+            assertThat(result.content).hasSize(2)
+        }
+    }
+
+    @Nested
+    @DisplayName("FullText 검색")
+    inner class FullTextSearch {
+
+        @Test
+        fun MySQL에서_키워드로_FullText_검색한다() {
+            val repo = ProductSearchRepositoryImpl(entityManager, "jdbc:mysql://localhost:3306/test")
+            val pageable = PageRequest.of(0, 10)
+
+            whenever(entityManager.createNativeQuery(any<String>(), eq(Product::class.java))).thenReturn(nativeQuery)
+            whenever(nativeQuery.resultList).thenReturn(emptyList<Product>())
+
+            val result = repo.searchProducts(
+                keyword = "테스트", categoryId = null, status = null,
+                minPrice = null, maxPrice = null, pageable = pageable
+            )
+
+            assertThat(result.content).isEmpty()
+        }
+
+        @Test
+        fun MySQL에서_모든_조건으로_FullText_검색한다() {
+            val repo = ProductSearchRepositoryImpl(entityManager, "jdbc:mysql://localhost:3306/test")
+            val pageable = PageRequest.of(0, 10)
+
+            whenever(entityManager.createNativeQuery(any<String>(), eq(Product::class.java))).thenReturn(nativeQuery)
+            whenever(nativeQuery.resultList).thenReturn(emptyList<Product>())
+
+            val result = repo.searchProducts(
+                keyword = "테스트", categoryId = 1L, status = ProductStatus.AVAILABLE,
+                minPrice = BigDecimal("1000"), maxPrice = BigDecimal("50000"), pageable = pageable
+            )
+
+            assertThat(result.content).isEmpty()
+        }
+
+        @Test
+        fun MySQL에서_키워드_없으면_LIKE_검색으로_폴백한다() {
+            val repo = ProductSearchRepositoryImpl(entityManager, "jdbc:mysql://localhost:3306/test")
+            val pageable = PageRequest.of(0, 10)
+
+            whenever(entityManager.createQuery(any<String>(), eq(Product::class.java))).thenReturn(typedQuery)
+            whenever(typedQuery.resultList).thenReturn(emptyList())
+
+            val result = repo.searchProducts(
+                keyword = null, categoryId = null, status = null,
+                minPrice = null, maxPrice = null, pageable = pageable
+            )
+
+            assertThat(result.content).isEmpty()
+        }
+
+        @Test
+        fun MySQL에서_빈_키워드면_LIKE_검색으로_폴백한다() {
+            val repo = ProductSearchRepositoryImpl(entityManager, "jdbc:mysql://localhost:3306/test")
+            val pageable = PageRequest.of(0, 10)
+
+            whenever(entityManager.createQuery(any<String>(), eq(Product::class.java))).thenReturn(typedQuery)
+            whenever(typedQuery.resultList).thenReturn(emptyList())
+
+            val result = repo.searchProducts(
+                keyword = "  ", categoryId = null, status = null,
+                minPrice = null, maxPrice = null, pageable = pageable
+            )
+
+            assertThat(result.content).isEmpty()
+        }
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/BulkImportServiceTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/BulkImportServiceTest.kt
@@ -1,0 +1,339 @@
+package com.hoppingmall.product.product.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.hoppingmall.product.category.domain.Category
+import com.hoppingmall.product.category.domain.repository.CategoryRepository
+import com.hoppingmall.product.common.enums.ProductStatus
+import com.hoppingmall.product.common.file.FileUploadConfig
+import com.hoppingmall.product.inventory.service.InventoryCommandService
+import com.hoppingmall.product.product.domain.BulkImportJob
+import com.hoppingmall.product.product.domain.Product
+import com.hoppingmall.product.product.domain.ProductImage
+import com.hoppingmall.product.product.domain.repository.BulkImportJobRepository
+import com.hoppingmall.product.product.domain.repository.ProductImageRepository
+import com.hoppingmall.product.product.domain.repository.ProductRepository
+import com.hoppingmall.product.product.dto.request.BulkProductRow
+import com.hoppingmall.product.product.dto.response.BulkRowError
+import com.hoppingmall.product.product.enum.BulkImportStatus
+import com.hoppingmall.product.product.exception.ProductException
+import com.hoppingmall.product.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.cache.CacheManager
+import org.springframework.cache.support.NoOpCache
+import org.springframework.mock.web.MockMultipartFile
+import java.math.BigDecimal
+import java.util.Optional
+
+@DisplayName("BulkImportService")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class BulkImportServiceTest {
+
+    @Mock
+    private lateinit var bulkImportValidator: BulkImportValidator
+
+    @Mock
+    private lateinit var csvParsingService: CsvParsingService
+
+    @Mock
+    private lateinit var bulkImportJobRepository: BulkImportJobRepository
+
+    @Mock
+    private lateinit var productRepository: ProductRepository
+
+    @Mock
+    private lateinit var productImageRepository: ProductImageRepository
+
+    @Mock
+    private lateinit var categoryRepository: CategoryRepository
+
+    @Mock
+    private lateinit var inventoryCommandService: InventoryCommandService
+
+    @Mock
+    private lateinit var objectMapper: ObjectMapper
+
+    @Mock
+    private lateinit var cacheManager: CacheManager
+
+    @Mock
+    private lateinit var fileUploadConfig: FileUploadConfig
+
+    @InjectMocks
+    private lateinit var service: BulkImportService
+
+    @Test
+    fun validate를_위임한다() {
+        val file = MockMultipartFile("file", "test.csv", "text/csv", "data".toByteArray())
+        val expected = com.hoppingmall.product.product.dto.response.BulkValidationResponse(
+            totalRows = 1, validRows = 1, invalidRows = 0, errors = emptyList(), preview = emptyList()
+        )
+
+        whenever(bulkImportValidator.validate(any())).thenReturn(expected)
+
+        val result = service.validate(file)
+
+        assertThat(result.totalRows).isEqualTo(1)
+    }
+
+    @Test
+    fun 파싱_실패_시_예외를_발생시킨다() {
+        val file = MockMultipartFile("file", "test.csv", "text/csv", "data".toByteArray())
+        val errors = listOf(BulkRowError(0, "header", "필수 헤더 누락"))
+
+        whenever(csvParsingService.parse(any())).thenReturn(CsvParsingService.ParseResult(emptyList(), errors))
+
+        assertThatThrownBy { service.startImport(1L, file) }
+            .isInstanceOf(ProductException::class.java)
+    }
+
+    @Test
+    fun startImport_트랜잭션_동기화가_활성화된_경우_afterCommit으로_처리한다() {
+        val file = MockMultipartFile("file", "test.csv", "text/csv", "data".toByteArray())
+        val rows = listOf(BulkProductRow(1, "상품A", "설명", 1L, BigDecimal("1000"), 10, emptyList()))
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 1).withId(1L)
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+        val product = Product.create(
+            sellerId = 1L, categoryId = 1L, name = "상품A",
+            description = "설명", price = BigDecimal("1000"), status = ProductStatus.AVAILABLE
+        ).withId(1L)
+
+        whenever(csvParsingService.parse(any())).thenReturn(CsvParsingService.ParseResult(rows, emptyList()))
+        whenever(bulkImportJobRepository.save(any<BulkImportJob>())).thenReturn(job)
+        whenever(bulkImportJobRepository.findById(1L)).thenReturn(Optional.of(job))
+        whenever(categoryRepository.findAllById(any<List<Long>>())).thenReturn(listOf(category))
+        whenever(productRepository.save(any<Product>())).thenReturn(product)
+        whenever(fileUploadConfig.defaultImagePath).thenReturn("/default.jpg")
+        whenever(productImageRepository.saveAll(any<List<ProductImage>>())).thenReturn(emptyList())
+        whenever(cacheManager.getCache("product")).thenReturn(NoOpCache("product"))
+
+        org.springframework.transaction.support.TransactionSynchronizationManager.initSynchronization()
+        try {
+            val result = service.startImport(1L, file)
+            assertThat(result.totalRows).isEqualTo(1)
+
+            val synchronizations = org.springframework.transaction.support.TransactionSynchronizationManager.getSynchronizations()
+            synchronizations.forEach { it.afterCommit() }
+        } finally {
+            org.springframework.transaction.support.TransactionSynchronizationManager.clearSynchronization()
+        }
+    }
+
+    @Test
+    fun startImport로_대량_등록을_시작한다() {
+        val file = MockMultipartFile("file", "test.csv", "text/csv", "data".toByteArray())
+        val rows = listOf(BulkProductRow(1, "상품A", "설명", 1L, BigDecimal("1000"), 10, emptyList()))
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 1).withId(1L)
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+        val product = Product.create(
+            sellerId = 1L, categoryId = 1L, name = "상품A",
+            description = "설명", price = BigDecimal("1000"), status = ProductStatus.AVAILABLE
+        ).withId(1L)
+
+        whenever(csvParsingService.parse(any())).thenReturn(CsvParsingService.ParseResult(rows, emptyList()))
+        whenever(bulkImportJobRepository.save(any<BulkImportJob>())).thenReturn(job)
+        whenever(bulkImportJobRepository.findById(1L)).thenReturn(Optional.of(job))
+        whenever(categoryRepository.findAllById(any<List<Long>>())).thenReturn(listOf(category))
+        whenever(productRepository.save(any<Product>())).thenReturn(product)
+        whenever(fileUploadConfig.defaultImagePath).thenReturn("/default.jpg")
+        whenever(productImageRepository.saveAll(any<List<ProductImage>>())).thenReturn(emptyList())
+        whenever(cacheManager.getCache("product")).thenReturn(NoOpCache("product"))
+
+        val result = service.startImport(1L, file)
+
+        assertThat(result.totalRows).isEqualTo(1)
+    }
+
+    @Test
+    fun processImport에서_상품_저장_시_예외가_발생하면_실패_처리한다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 1).withId(1L)
+        job.startImport()
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+        val rows = listOf(BulkProductRow(1, "상품A", "설명", 1L, BigDecimal("1000"), 10, emptyList()))
+
+        whenever(bulkImportJobRepository.findById(1L)).thenReturn(Optional.of(job))
+        whenever(categoryRepository.findAllById(listOf(1L))).thenReturn(listOf(category))
+        whenever(productRepository.save(any<Product>())).thenThrow(RuntimeException("DB 에러"))
+        whenever(bulkImportJobRepository.save(any<BulkImportJob>())).thenReturn(job)
+        whenever(objectMapper.writeValueAsString(any())).thenReturn("[]")
+        whenever(cacheManager.getCache("product")).thenReturn(NoOpCache("product"))
+
+        service.processImport(1L, 1L, rows, emptyList())
+
+        assertThat(job.failCount).isEqualTo(1)
+    }
+
+    @Test
+    fun processImport에서_캐시_초기화_실패_시에도_정상_완료한다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 0).withId(1L)
+        job.startImport()
+
+        whenever(bulkImportJobRepository.findById(1L)).thenReturn(Optional.of(job))
+        whenever(categoryRepository.findAllById(emptyList())).thenReturn(emptyList())
+        whenever(bulkImportJobRepository.save(any<BulkImportJob>())).thenReturn(job)
+        whenever(cacheManager.getCache("product")).thenThrow(RuntimeException("캐시 에러"))
+
+        service.processImport(1L, 1L, emptyList(), emptyList())
+
+        assertThat(job.status).isEqualTo(com.hoppingmall.product.product.enum.BulkImportStatus.COMPLETED)
+    }
+
+    @Test
+    fun processImport에서_이미지_URL이_있는_행을_처리한다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 1).withId(1L)
+        job.startImport()
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+        val product = Product.create(
+            sellerId = 1L, categoryId = 1L, name = "상품A",
+            description = "설명", price = BigDecimal("1000"), status = ProductStatus.AVAILABLE
+        ).withId(1L)
+        val rows = listOf(BulkProductRow(1, "상품A", "설명", 1L, BigDecimal("1000"), 10, listOf("http://img.jpg")))
+
+        whenever(bulkImportJobRepository.findById(1L)).thenReturn(Optional.of(job))
+        whenever(categoryRepository.findAllById(listOf(1L))).thenReturn(listOf(category))
+        whenever(productRepository.save(any<Product>())).thenReturn(product)
+        whenever(productImageRepository.saveAll(any<List<com.hoppingmall.product.product.domain.ProductImage>>())).thenReturn(emptyList())
+        whenever(bulkImportJobRepository.save(any<BulkImportJob>())).thenReturn(job)
+        whenever(cacheManager.getCache("product")).thenReturn(NoOpCache("product"))
+
+        service.processImport(1L, 1L, rows, emptyList())
+
+        assertThat(job.successCount).isEqualTo(1)
+    }
+
+    @Test
+    fun processImport로_상품을_대량_등록한다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 1).withId(1L)
+        job.startImport()
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+        val product = Product.create(
+            sellerId = 1L, categoryId = 1L, name = "상품A",
+            description = "설명", price = BigDecimal("1000"), status = ProductStatus.AVAILABLE
+        ).withId(1L)
+        val rows = listOf(BulkProductRow(1, "상품A", "설명", 1L, BigDecimal("1000"), 10, emptyList()))
+
+        whenever(bulkImportJobRepository.findById(1L)).thenReturn(Optional.of(job))
+        whenever(categoryRepository.findAllById(listOf(1L))).thenReturn(listOf(category))
+        whenever(productRepository.save(any<Product>())).thenReturn(product)
+        whenever(fileUploadConfig.defaultImagePath).thenReturn("/default.jpg")
+        whenever(productImageRepository.saveAll(any<List<com.hoppingmall.product.product.domain.ProductImage>>())).thenReturn(emptyList())
+        whenever(bulkImportJobRepository.save(any<BulkImportJob>())).thenReturn(job)
+        whenever(cacheManager.getCache("product")).thenReturn(NoOpCache("product"))
+
+        service.processImport(1L, 1L, rows, emptyList())
+
+        assertThat(job.successCount).isEqualTo(1)
+        assertThat(job.status).isEqualTo(BulkImportStatus.COMPLETED)
+    }
+
+    @Test
+    fun 작업_진행_상태를_조회한다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 10).withId(1L)
+
+        whenever(bulkImportJobRepository.findById(1L)).thenReturn(Optional.of(job))
+
+        val result = service.getJobProgress(1L, 1L)
+
+        assertThat(result.totalRows).isEqualTo(10)
+    }
+
+    @Test
+    fun 다른_판매자의_작업_진행_조회_시_예외를_발생시킨다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 10).withId(1L)
+
+        whenever(bulkImportJobRepository.findById(1L)).thenReturn(Optional.of(job))
+
+        assertThatThrownBy { service.getJobProgress(1L, 999L) }
+            .isInstanceOf(ProductException::class.java)
+    }
+
+    @Test
+    fun 존재하지_않는_작업_진행_조회_시_예외를_발생시킨다() {
+        whenever(bulkImportJobRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.getJobProgress(999L, 1L) }
+            .isInstanceOf(ProductException::class.java)
+    }
+
+    @Test
+    fun 작업_에러를_조회한다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 10).withId(1L)
+        job.errorDetails = """[{"rowNumber":1,"field":"name","message":"err"}]"""
+        val errors = listOf(BulkRowError(1, "name", "err"))
+
+        whenever(bulkImportJobRepository.findById(1L)).thenReturn(Optional.of(job))
+        val typeFactory = ObjectMapper().typeFactory
+        whenever(objectMapper.typeFactory).thenReturn(typeFactory)
+        whenever(objectMapper.readValue<List<BulkRowError>>(any<String>(), any<com.fasterxml.jackson.databind.JavaType>())).thenReturn(errors)
+
+        val result = service.getJobErrors(1L, 1L)
+
+        assertThat(result).hasSize(1)
+    }
+
+    @Test
+    fun 에러가_없는_작업의_에러_조회_시_빈_리스트를_반환한다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 10).withId(1L)
+
+        whenever(bulkImportJobRepository.findById(1L)).thenReturn(Optional.of(job))
+
+        val result = service.getJobErrors(1L, 1L)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun 다른_판매자의_에러_조회_시_예외를_발생시킨다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 10).withId(1L)
+
+        whenever(bulkImportJobRepository.findById(1L)).thenReturn(Optional.of(job))
+
+        assertThatThrownBy { service.getJobErrors(1L, 999L) }
+            .isInstanceOf(ProductException::class.java)
+    }
+
+    @Test
+    fun processImport에서_존재하지_않는_카테고리_행을_실패_처리한다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 1).withId(1L)
+        job.startImport()
+        val rows = listOf(BulkProductRow(1, "상품A", "설명", 999L, BigDecimal("1000"), 10, emptyList()))
+
+        whenever(bulkImportJobRepository.findById(1L)).thenReturn(Optional.of(job))
+        whenever(categoryRepository.findAllById(listOf(999L))).thenReturn(emptyList())
+        whenever(bulkImportJobRepository.save(any<BulkImportJob>())).thenReturn(job)
+        whenever(objectMapper.writeValueAsString(any())).thenReturn("[]")
+        whenever(cacheManager.getCache("product")).thenReturn(NoOpCache("product"))
+
+        service.processImport(1L, 1L, rows, emptyList())
+
+        assertThat(job.failCount).isEqualTo(1)
+    }
+
+    @Test
+    fun processImport에서_파싱_에러_행을_실패_처리한다() {
+        val job = BulkImportJob.create(sellerId = 1L, fileName = "test.csv", totalRows = 1).withId(1L)
+        job.startImport()
+        val parseErrors = listOf(BulkRowError(1, "name", "에러"))
+
+        whenever(bulkImportJobRepository.findById(1L)).thenReturn(Optional.of(job))
+        whenever(categoryRepository.findAllById(emptyList())).thenReturn(emptyList())
+        whenever(bulkImportJobRepository.save(any<BulkImportJob>())).thenReturn(job)
+        whenever(objectMapper.writeValueAsString(any())).thenReturn("[]")
+        whenever(cacheManager.getCache("product")).thenReturn(NoOpCache("product"))
+
+        service.processImport(1L, 1L, emptyList(), parseErrors)
+
+        assertThat(job.failCount).isEqualTo(1)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/BulkImportValidatorTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/BulkImportValidatorTest.kt
@@ -1,0 +1,86 @@
+package com.hoppingmall.product.product.service
+
+import com.hoppingmall.product.category.domain.Category
+import com.hoppingmall.product.category.domain.repository.CategoryRepository
+import com.hoppingmall.product.common.file.FileUploadConfig
+import com.hoppingmall.product.product.dto.request.BulkProductRow
+import com.hoppingmall.product.product.dto.response.BulkRowError
+import com.hoppingmall.product.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.mock.web.MockMultipartFile
+import java.math.BigDecimal
+
+@DisplayName("BulkImportValidator")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class BulkImportValidatorTest {
+
+    @Mock
+    private lateinit var csvParsingService: CsvParsingService
+
+    @Mock
+    private lateinit var categoryRepository: CategoryRepository
+
+    @Mock
+    private lateinit var fileUploadConfig: FileUploadConfig
+
+    @InjectMocks
+    private lateinit var validator: BulkImportValidator
+
+    @Test
+    fun 유효한_CSV를_검증한다() {
+        val file = MockMultipartFile("file", "test.csv", "text/csv", "data".toByteArray())
+        val rows = listOf(
+            BulkProductRow(1, "상품A", "설명A", 1L, BigDecimal("1000"), 10, emptyList())
+        )
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+
+        whenever(csvParsingService.parse(any())).thenReturn(CsvParsingService.ParseResult(rows, emptyList()))
+        whenever(categoryRepository.findAllById(listOf(1L))).thenReturn(listOf(category))
+
+        val result = validator.validate(file)
+
+        assertThat(result.totalRows).isEqualTo(1)
+        assertThat(result.validRows).isEqualTo(1)
+        assertThat(result.invalidRows).isEqualTo(0)
+    }
+
+    @Test
+    fun 존재하지_않는_카테고리_행을_에러로_처리한다() {
+        val file = MockMultipartFile("file", "test.csv", "text/csv", "data".toByteArray())
+        val rows = listOf(
+            BulkProductRow(1, "상품A", "설명A", 999L, BigDecimal("1000"), 10, emptyList())
+        )
+
+        whenever(csvParsingService.parse(any())).thenReturn(CsvParsingService.ParseResult(rows, emptyList()))
+        whenever(categoryRepository.findAllById(listOf(999L))).thenReturn(emptyList())
+
+        val result = validator.validate(file)
+
+        assertThat(result.invalidRows).isEqualTo(1)
+        assertThat(result.errors).isNotEmpty()
+    }
+
+    @Test
+    fun 파싱_에러가_있는_CSV를_검증한다() {
+        val file = MockMultipartFile("file", "test.csv", "text/csv", "data".toByteArray())
+        val errors = listOf(BulkRowError(1, "name", "상품명은 필수입니다."))
+
+        whenever(csvParsingService.parse(any())).thenReturn(CsvParsingService.ParseResult(emptyList(), errors))
+        whenever(categoryRepository.findAllById(emptyList())).thenReturn(emptyList())
+
+        val result = validator.validate(file)
+
+        assertThat(result.errors).hasSize(1)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/CsvParsingServiceTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/CsvParsingServiceTest.kt
@@ -1,0 +1,105 @@
+package com.hoppingmall.product.product.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockMultipartFile
+
+@DisplayName("CsvParsingService")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class CsvParsingServiceTest {
+
+    private val service = CsvParsingService()
+
+    @Test
+    fun 정상적인_CSV를_파싱한다() {
+        val csv = "name,description,categoryId,price,stockQuantity\nA,descA,1,1000,10\nB,descB,2,2000,20"
+        val file = MockMultipartFile("file", "test.csv", "text/csv", csv.toByteArray())
+
+        val result = service.parse(file)
+
+        assertThat(result.rows).hasSize(2)
+        assertThat(result.errors).isEmpty()
+        assertThat(result.rows[0].name).isEqualTo("A")
+        assertThat(result.rows[1].price).isEqualByComparingTo(java.math.BigDecimal("2000"))
+    }
+
+    @Test
+    fun 필수_헤더_누락_시_에러를_반환한다() {
+        val csv = "name,price\nA,1000"
+        val file = MockMultipartFile("file", "test.csv", "text/csv", csv.toByteArray())
+
+        val result = service.parse(file)
+
+        assertThat(result.rows).isEmpty()
+        assertThat(result.errors).hasSize(1)
+        assertThat(result.errors[0].field).isEqualTo("header")
+    }
+
+    @Test
+    fun 유효하지_않은_데이터_행을_에러로_처리한다() {
+        val csv = "name,description,categoryId,price,stockQuantity\n,desc,1,1000,10\nB,,abc,-1,-5"
+        val file = MockMultipartFile("file", "test.csv", "text/csv", csv.toByteArray())
+
+        val result = service.parse(file)
+
+        assertThat(result.rows).isEmpty()
+        assertThat(result.errors).isNotEmpty()
+    }
+
+    @Test
+    fun imageUrls_컬럼이_있으면_파싱한다() {
+        val csv = "name,description,categoryId,price,stockQuantity,imageUrls\nA,desc,1,1000,10,http://a.jpg|http://b.jpg"
+        val file = MockMultipartFile("file", "test.csv", "text/csv", csv.toByteArray())
+
+        val result = service.parse(file)
+
+        assertThat(result.rows).hasSize(1)
+        assertThat(result.rows[0].imageUrls).containsExactly("http://a.jpg", "http://b.jpg")
+    }
+
+    @Test
+    fun 빈_imageUrls은_빈_리스트로_파싱한다() {
+        val csv = "name,description,categoryId,price,stockQuantity,imageUrls\nA,desc,1,1000,10,"
+        val file = MockMultipartFile("file", "test.csv", "text/csv", csv.toByteArray())
+
+        val result = service.parse(file)
+
+        assertThat(result.rows).hasSize(1)
+        assertThat(result.rows[0].imageUrls).isEmpty()
+    }
+
+    @Test
+    fun 최대_행_수_초과_시_에러를_추가한다() {
+        val header = "name,description,categoryId,price,stockQuantity"
+        val rows = (1..1001).joinToString("\n") { "name$it,desc$it,1,1000,10" }
+        val csv = "$header\n$rows"
+        val file = MockMultipartFile("file", "test.csv", "text/csv", csv.toByteArray())
+
+        val result = service.parse(file)
+
+        assertThat(result.errors.any { it.field == "row" }).isTrue()
+    }
+
+    @Test
+    fun 가격이_0이면_에러를_반환한다() {
+        val csv = "name,description,categoryId,price,stockQuantity\nA,desc,1,0,10"
+        val file = MockMultipartFile("file", "test.csv", "text/csv", csv.toByteArray())
+
+        val result = service.parse(file)
+
+        assertThat(result.errors).isNotEmpty()
+    }
+
+    @Test
+    fun categoryId가_음수이면_에러를_반환한다() {
+        val csv = "name,description,categoryId,price,stockQuantity\nA,desc,-1,1000,10"
+        val file = MockMultipartFile("file", "test.csv", "text/csv", csv.toByteArray())
+
+        val result = service.parse(file)
+
+        assertThat(result.errors).isNotEmpty()
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductCommandServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductCommandServiceImplTest.kt
@@ -1,0 +1,186 @@
+package com.hoppingmall.product.product.service
+
+import com.hoppingmall.product.category.domain.Category
+import com.hoppingmall.product.category.domain.repository.CategoryRepository
+import com.hoppingmall.product.category.exception.CategoryNotFoundException
+import com.hoppingmall.product.common.enums.ProductStatus
+import com.hoppingmall.product.common.file.FileUploadConfig
+import com.hoppingmall.product.product.domain.Product
+import com.hoppingmall.product.product.domain.ProductImage
+import com.hoppingmall.product.product.domain.repository.ProductImageRepository
+import com.hoppingmall.product.product.domain.repository.ProductRepository
+import com.hoppingmall.product.product.dto.request.ProductCreateRequest
+import com.hoppingmall.product.product.dto.request.ProductUpdateRequest
+import com.hoppingmall.product.product.exception.ProductNotFoundException
+import com.hoppingmall.product.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.util.Optional
+
+@DisplayName("ProductCommandServiceImpl")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ProductCommandServiceImplTest {
+
+    @Mock
+    private lateinit var productRepository: ProductRepository
+
+    @Mock
+    private lateinit var productImageRepository: ProductImageRepository
+
+    @Mock
+    private lateinit var categoryRepository: CategoryRepository
+
+    @Mock
+    private lateinit var fileUploadConfig: FileUploadConfig
+
+    @InjectMocks
+    private lateinit var service: ProductCommandServiceImpl
+
+    @Test
+    fun 상품을_생성한다() {
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+        val product = Product.create(
+            sellerId = 1L, categoryId = 1L, name = "테스트상품",
+            description = "설명", price = BigDecimal("10000"), status = ProductStatus.AVAILABLE
+        ).withId(1L)
+        val image = ProductImage.create(productId = 1L, imageUrl = "/default.jpg", sortOrder = 0).withId(1L)
+        val request = ProductCreateRequest(
+            sellerId = 1L, categoryId = 1L, name = "테스트상품",
+            description = "설명", price = BigDecimal("10000")
+        )
+
+        whenever(categoryRepository.findNullableById(1L)).thenReturn(category)
+        whenever(productRepository.save(any<Product>())).thenReturn(product)
+        whenever(fileUploadConfig.defaultImagePath).thenReturn("/default.jpg")
+        whenever(productImageRepository.saveAll(any<List<ProductImage>>())).thenReturn(listOf(image))
+
+        val result = service.createProduct(request)
+
+        assertThat(result.name).isEqualTo("테스트상품")
+    }
+
+    @Test
+    fun 이미지_URL과_함께_상품을_생성한다() {
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+        val product = Product.create(
+            sellerId = 1L, categoryId = 1L, name = "테스트상품",
+            description = "설명", price = BigDecimal("10000"), status = ProductStatus.AVAILABLE
+        ).withId(1L)
+        val image = ProductImage.create(productId = 1L, imageUrl = "http://img.jpg", sortOrder = 0).withId(1L)
+        val request = ProductCreateRequest(
+            sellerId = 1L, categoryId = 1L, name = "테스트상품",
+            description = "설명", price = BigDecimal("10000"), imageUrls = listOf("http://img.jpg")
+        )
+
+        whenever(categoryRepository.findNullableById(1L)).thenReturn(category)
+        whenever(productRepository.save(any<Product>())).thenReturn(product)
+        whenever(productImageRepository.saveAll(any<List<ProductImage>>())).thenReturn(listOf(image))
+
+        val result = service.createProduct(request)
+
+        assertThat(result.imageUrls).containsExactly("http://img.jpg")
+    }
+
+    @Test
+    fun 존재하지_않는_카테고리로_상품_생성_시_예외를_발생시킨다() {
+        val request = ProductCreateRequest(
+            sellerId = 1L, categoryId = 999L, name = "테스트상품",
+            description = "설명", price = BigDecimal("10000")
+        )
+
+        whenever(categoryRepository.findNullableById(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.createProduct(request) }
+            .isInstanceOf(CategoryNotFoundException::class.java)
+    }
+
+    @Test
+    fun 상품을_수정한다() {
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+        val product = Product.create(
+            sellerId = 1L, categoryId = 1L, name = "테스트상품",
+            description = "설명", price = BigDecimal("10000"), status = ProductStatus.AVAILABLE
+        ).withId(1L)
+        val image = ProductImage.create(productId = 1L, imageUrl = "/default.jpg", sortOrder = 0).withId(1L)
+        val request = ProductUpdateRequest(
+            categoryId = 1L, name = "수정상품",
+            description = "수정설명", price = BigDecimal("20000")
+        )
+
+        whenever(categoryRepository.findNullableById(1L)).thenReturn(category)
+        whenever(productRepository.findById(1L)).thenReturn(Optional.of(product))
+        whenever(productRepository.save(any<Product>())).thenReturn(product)
+        whenever(productImageRepository.findByProductIdOrderBySortOrder(1L)).thenReturn(listOf(image))
+        whenever(fileUploadConfig.defaultImagePath).thenReturn("/default.jpg")
+        whenever(productImageRepository.saveAll(any<List<ProductImage>>())).thenReturn(listOf(image))
+
+        val result = service.updateProduct(1L, request)
+
+        assertThat(result.name).isEqualTo("수정상품")
+    }
+
+    @Test
+    fun 존재하지_않는_상품_수정_시_예외를_발생시킨다() {
+        val category = Category.create(name = "전자기기", parentCategoryId = null, depth = 0).withId(1L)
+        val request = ProductUpdateRequest(
+            categoryId = 1L, name = "수정상품",
+            description = "수정설명", price = BigDecimal("20000")
+        )
+
+        whenever(categoryRepository.findNullableById(1L)).thenReturn(category)
+        whenever(productRepository.findById(1L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.updateProduct(1L, request) }
+            .isInstanceOf(ProductNotFoundException::class.java)
+    }
+
+    @Test
+    fun 존재하지_않는_카테고리로_상품_수정_시_예외를_발생시킨다() {
+        val request = ProductUpdateRequest(
+            categoryId = 999L, name = "수정상품",
+            description = "수정설명", price = BigDecimal("20000")
+        )
+
+        whenever(categoryRepository.findNullableById(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.updateProduct(1L, request) }
+            .isInstanceOf(CategoryNotFoundException::class.java)
+    }
+
+    @Test
+    fun 상품을_삭제한다() {
+        val product = Product.create(
+            sellerId = 1L, categoryId = 1L, name = "테스트상품",
+            description = "설명", price = BigDecimal("10000"), status = ProductStatus.AVAILABLE
+        ).withId(1L)
+        val image = ProductImage.create(productId = 1L, imageUrl = "/img.jpg", sortOrder = 0).withId(1L)
+
+        whenever(productRepository.findById(1L)).thenReturn(Optional.of(product))
+        whenever(productImageRepository.findByProductIdOrderBySortOrder(1L)).thenReturn(listOf(image))
+
+        service.deleteProduct(1L)
+
+        assertThat(product.deletedAt).isNotNull()
+        assertThat(image.deletedAt).isNotNull()
+    }
+
+    @Test
+    fun 존재하지_않는_상품_삭제_시_예외를_발생시킨다() {
+        whenever(productRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.deleteProduct(999L) }
+            .isInstanceOf(ProductNotFoundException::class.java)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductImageServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductImageServiceImplTest.kt
@@ -1,0 +1,45 @@
+package com.hoppingmall.product.product.service
+
+import com.hoppingmall.product.common.file.FileUploadService
+import com.hoppingmall.product.common.file.dto.FileUploadResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.mock.web.MockMultipartFile
+
+@DisplayName("ProductImageServiceImpl")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ProductImageServiceImplTest {
+
+    @Mock
+    private lateinit var fileUploadService: FileUploadService
+
+    @InjectMocks
+    private lateinit var service: ProductImageServiceImpl
+
+    @Test
+    fun 상품_이미지를_업로드한다() {
+        val file = MockMultipartFile("image", "test.jpg", "image/jpeg", "test".toByteArray())
+        val fileResponse = FileUploadResponse(
+            fileUrl = "http://img/test.jpg", fileName = "test.jpg",
+            fileSize = 4L, domain = "product"
+        )
+
+        whenever(fileUploadService.uploadFile(any())).thenReturn(fileResponse)
+
+        val result = service.uploadProductImage(file)
+
+        assertThat(result.imageUrl).isEqualTo("http://img/test.jpg")
+        assertThat(result.fileName).isEqualTo("test.jpg")
+        assertThat(result.fileSize).isEqualTo(4L)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductQueryServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductQueryServiceImplTest.kt
@@ -1,0 +1,133 @@
+package com.hoppingmall.product.product.service
+
+import com.hoppingmall.product.common.enums.ProductStatus
+import com.hoppingmall.product.product.domain.Product
+import com.hoppingmall.product.product.domain.ProductImage
+import com.hoppingmall.product.product.domain.repository.ProductImageRepository
+import com.hoppingmall.product.product.domain.repository.ProductRepository
+import com.hoppingmall.product.product.dto.request.ProductSearchCondition
+import com.hoppingmall.product.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import java.math.BigDecimal
+
+@DisplayName("ProductQueryServiceImpl")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ProductQueryServiceImplTest {
+
+    @Mock
+    private lateinit var productRepository: ProductRepository
+
+    @Mock
+    private lateinit var productImageRepository: ProductImageRepository
+
+    @InjectMocks
+    private lateinit var service: ProductQueryServiceImpl
+
+    private fun createProduct(id: Long = 1L) = Product.create(
+        sellerId = 1L, categoryId = 1L, name = "테스트상품",
+        description = "설명", price = BigDecimal("10000"), status = ProductStatus.AVAILABLE
+    ).withId(id)
+
+    private fun createImage(productId: Long = 1L) = ProductImage.create(
+        productId = productId, imageUrl = "http://img.jpg", sortOrder = 0
+    ).withId(1L)
+
+    @Test
+    fun 전체_상품을_페이지로_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+        val product = createProduct()
+        val slice = SliceImpl(listOf(product), pageable, false)
+
+        whenever(productRepository.findBy(pageable)).thenReturn(slice)
+        whenever(productImageRepository.findByProductIdIn(listOf(1L))).thenReturn(listOf(createImage()))
+
+        val result = service.getProducts(pageable)
+
+        assertThat(result.content).hasSize(1)
+    }
+
+    @Test
+    fun 상품을_ID로_조회한다() {
+        val product = createProduct()
+
+        whenever(productRepository.findNullableById(1L)).thenReturn(product)
+        whenever(productImageRepository.findByProductIdOrderBySortOrder(1L)).thenReturn(listOf(createImage()))
+
+        val result = service.getProductById(1L)
+
+        assertThat(result).isNotNull
+        assertThat(result!!.name).isEqualTo("테스트상품")
+    }
+
+    @Test
+    fun 존재하지_않는_상품_조회_시_null을_반환한다() {
+        whenever(productRepository.findNullableById(999L)).thenReturn(null)
+
+        val result = service.getProductById(999L)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun 판매자_ID로_상품을_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+        val product = createProduct()
+        val slice = SliceImpl(listOf(product), pageable, false)
+
+        whenever(productRepository.findBySellerId(1L, pageable)).thenReturn(slice)
+        whenever(productImageRepository.findByProductIdIn(listOf(1L))).thenReturn(listOf(createImage()))
+
+        val result = service.getProductsBySellerId(1L, pageable)
+
+        assertThat(result.content).hasSize(1)
+    }
+
+    @Test
+    fun 카테고리_ID로_상품을_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+        val product = createProduct()
+        val slice = SliceImpl(listOf(product), pageable, false)
+
+        whenever(productRepository.findByCategoryId(1L, pageable)).thenReturn(slice)
+        whenever(productImageRepository.findByProductIdIn(listOf(1L))).thenReturn(listOf(createImage()))
+
+        val result = service.getProductsByCategoryId(1L, pageable)
+
+        assertThat(result.content).hasSize(1)
+    }
+
+    @Test
+    fun 검색_조건으로_상품을_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+        val product = createProduct()
+        val slice = SliceImpl(listOf(product), pageable, false)
+        val condition = ProductSearchCondition(keyword = "테스트")
+
+        whenever(
+            productRepository.searchProducts(
+                keyword = anyOrNull(), categoryId = anyOrNull(), status = anyOrNull(),
+                minPrice = anyOrNull(), maxPrice = anyOrNull(), pageable = any()
+            )
+        ).thenReturn(slice)
+        whenever(productImageRepository.findByProductIdIn(listOf(1L))).thenReturn(listOf(createImage()))
+
+        val result = service.searchProducts(condition, pageable)
+
+        assertThat(result.content).hasSize(1)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImplTest.kt
@@ -1,0 +1,204 @@
+package com.hoppingmall.product.product.service
+
+import com.hoppingmall.product.common.enums.ProductStatus
+import com.hoppingmall.product.product.domain.Product
+import com.hoppingmall.product.product.domain.ProductDailyStatistics
+import com.hoppingmall.product.product.domain.ProductHourlyStatistics
+import com.hoppingmall.product.product.domain.ProductStatistics
+import com.hoppingmall.product.product.domain.repository.ProductDailyStatisticsRepository
+import com.hoppingmall.product.product.domain.repository.ProductHourlyStatisticsRepository
+import com.hoppingmall.product.product.domain.repository.ProductRepository
+import com.hoppingmall.product.product.domain.repository.ProductStatisticsRepository
+import com.hoppingmall.product.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+@DisplayName("ProductStatisticsCommandServiceImpl")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ProductStatisticsCommandServiceImplTest {
+
+    @Mock
+    private lateinit var productStatisticsRepository: ProductStatisticsRepository
+
+    @Mock
+    private lateinit var productDailyStatisticsRepository: ProductDailyStatisticsRepository
+
+    @Mock
+    private lateinit var productHourlyStatisticsRepository: ProductHourlyStatisticsRepository
+
+    @Mock
+    private lateinit var productRepository: ProductRepository
+
+    @InjectMocks
+    private lateinit var service: ProductStatisticsCommandServiceImpl
+
+    private fun createStats(productId: Long = 1L) = ProductStatistics.create(
+        productId = productId, productName = "테스트", sellerId = 1L, categoryId = 1L
+    ).withId(1L)
+
+    @Test
+    fun 기존_통계에_판매를_증가시킨다() {
+        val stats = createStats()
+
+        whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(stats)
+        whenever(productStatisticsRepository.save(any<ProductStatistics>())).thenReturn(stats)
+
+        service.incrementSalesStats(1L, 5, BigDecimal("50000"))
+
+        assertThat(stats.totalSalesQuantity).isEqualTo(5)
+    }
+
+    @Test
+    fun 통계가_없으면_새로_생성하고_판매를_증가시킨다() {
+        val product = Product.create(
+            sellerId = 1L, categoryId = 1L, name = "테스트",
+            description = "설명", price = BigDecimal("10000"), status = ProductStatus.AVAILABLE
+        ).withId(1L)
+        val stats = createStats()
+
+        whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(null)
+        whenever(productRepository.findById(1L)).thenReturn(Optional.of(product))
+        whenever(productStatisticsRepository.save(any<ProductStatistics>())).thenReturn(stats)
+
+        service.incrementSalesStats(1L, 5, BigDecimal("50000"))
+
+        verify(productStatisticsRepository, org.mockito.kotlin.times(2)).save(any<ProductStatistics>())
+    }
+
+    @Test
+    fun 존재하지_않는_상품의_통계_생성_시_예외를_발생시킨다() {
+        whenever(productStatisticsRepository.findByProductId(999L)).thenReturn(null)
+        whenever(productRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.incrementSalesStats(999L, 5, BigDecimal("50000")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun 판매_통계를_감소시킨다() {
+        val stats = createStats()
+        stats.incrementSales(10, BigDecimal("100000"))
+
+        whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(stats)
+        whenever(productStatisticsRepository.save(any<ProductStatistics>())).thenReturn(stats)
+
+        service.decrementSalesStats(1L, 5, BigDecimal("50000"))
+
+        assertThat(stats.totalSalesQuantity).isEqualTo(5)
+    }
+
+    @Test
+    fun 통계가_없는_상품의_판매_감소는_무시한다() {
+        whenever(productStatisticsRepository.findByProductId(999L)).thenReturn(null)
+
+        service.decrementSalesStats(999L, 5, BigDecimal("50000"))
+
+        verify(productStatisticsRepository).findByProductId(999L)
+    }
+
+    @Test
+    fun 환불_통계를_증가시킨다() {
+        val stats = createStats()
+
+        whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(stats)
+        whenever(productStatisticsRepository.save(any<ProductStatistics>())).thenReturn(stats)
+
+        service.incrementRefundStats(1L, 3, BigDecimal("30000"))
+
+        assertThat(stats.totalRefundQuantity).isEqualTo(3)
+    }
+
+    @Test
+    fun 일별_스냅샷을_저장한다() {
+        val stats = createStats()
+        stats.incrementSales(10, BigDecimal("100000"))
+        val daily = ProductDailyStatistics.create(productId = 1L, statisticsDate = LocalDate.now())
+
+        whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
+        whenever(productDailyStatisticsRepository.findByProductIdAndStatisticsDate(any(), any())).thenReturn(daily)
+        whenever(productDailyStatisticsRepository.save(any<ProductDailyStatistics>())).thenReturn(daily)
+        whenever(productDailyStatisticsRepository.sumSalesAmountByProductIdAndDateRange(any(), any(), any()))
+            .thenReturn(BigDecimal("100000"))
+        whenever(productStatisticsRepository.save(any<ProductStatistics>())).thenReturn(stats)
+
+        service.flushDailySnapshot()
+
+        assertThat(stats.todaySalesQuantity).isEqualTo(0)
+    }
+
+    @Test
+    fun 일별_스냅샷_기존_레코드_없으면_새로_생성한다() {
+        val stats = createStats()
+        stats.incrementSales(10, BigDecimal("100000"))
+
+        whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
+        whenever(productDailyStatisticsRepository.findByProductIdAndStatisticsDate(any(), any())).thenReturn(null)
+        whenever(productDailyStatisticsRepository.save(any<ProductDailyStatistics>())).thenAnswer { it.arguments[0] }
+        whenever(productDailyStatisticsRepository.sumSalesAmountByProductIdAndDateRange(any(), any(), any()))
+            .thenReturn(BigDecimal.ZERO)
+        whenever(productStatisticsRepository.save(any<ProductStatistics>())).thenReturn(stats)
+
+        service.flushDailySnapshot()
+
+        verify(productDailyStatisticsRepository).save(any<ProductDailyStatistics>())
+    }
+
+    @Test
+    fun 시간별_스냅샷을_저장한다() {
+        val stats = createStats()
+        stats.incrementSales(10, BigDecimal("100000"))
+
+        whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
+        whenever(productHourlyStatisticsRepository.findByProductIdAndStatisticsDateAndHour(any(), any(), any()))
+            .thenReturn(null)
+        whenever(productHourlyStatisticsRepository.save(any<ProductHourlyStatistics>())).thenAnswer { it.arguments[0] }
+
+        service.flushHourlySnapshot()
+
+        verify(productHourlyStatisticsRepository).save(any<ProductHourlyStatistics>())
+    }
+
+    @Test
+    fun 오늘_활동이_없는_통계는_시간별_스냅샷에서_건너뛴다() {
+        val stats = createStats()
+
+        whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
+
+        service.flushHourlySnapshot()
+
+        verify(productHourlyStatisticsRepository, org.mockito.kotlin.never()).save(any<ProductHourlyStatistics>())
+    }
+
+    @Test
+    fun 기존_시간별_스냅샷이_있으면_업데이트한다() {
+        val stats = createStats()
+        stats.incrementSales(10, BigDecimal("100000"))
+        val hourly = ProductHourlyStatistics.create(
+            productId = 1L, statisticsDate = LocalDate.now(), hour = java.time.LocalDateTime.now().hour
+        )
+
+        whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
+        whenever(productHourlyStatisticsRepository.findByProductIdAndStatisticsDateAndHour(any(), any(), any()))
+            .thenReturn(hourly)
+        whenever(productHourlyStatisticsRepository.save(any<ProductHourlyStatistics>())).thenReturn(hourly)
+
+        service.flushHourlySnapshot()
+
+        assertThat(hourly.hourlySalesQuantity).isEqualTo(10)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsQueryServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsQueryServiceImplTest.kt
@@ -1,0 +1,209 @@
+package com.hoppingmall.product.product.service
+
+import com.hoppingmall.product.product.domain.ProductDailyStatistics
+import com.hoppingmall.product.product.domain.ProductHourlyStatistics
+import com.hoppingmall.product.product.domain.ProductStatistics
+import com.hoppingmall.product.product.domain.repository.ProductDailyStatisticsRepository
+import com.hoppingmall.product.product.domain.repository.ProductHourlyStatisticsRepository
+import com.hoppingmall.product.product.domain.repository.ProductStatisticsRepository
+import com.hoppingmall.product.product.dto.HourlyAggregationProjection
+import com.hoppingmall.product.product.dto.TopProductProjection
+import com.hoppingmall.product.product.exception.ProductStatisticsNotFoundException
+import com.hoppingmall.product.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@DisplayName("ProductStatisticsQueryServiceImpl")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ProductStatisticsQueryServiceImplTest {
+
+    @Mock
+    private lateinit var productStatisticsRepository: ProductStatisticsRepository
+
+    @Mock
+    private lateinit var productDailyStatisticsRepository: ProductDailyStatisticsRepository
+
+    @Mock
+    private lateinit var productHourlyStatisticsRepository: ProductHourlyStatisticsRepository
+
+    @InjectMocks
+    private lateinit var service: ProductStatisticsQueryServiceImpl
+
+    private fun createStats() = ProductStatistics.create(
+        productId = 1L, productName = "테스트", sellerId = 1L, categoryId = 1L
+    ).withId(1L)
+
+    @Test
+    fun 전체_통계를_페이지로_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+        val stats = createStats()
+        val page = PageImpl(listOf(stats), pageable, 1)
+
+        whenever(productStatisticsRepository.findAll(pageable)).thenReturn(page)
+
+        val result = service.getAll(pageable)
+
+        assertThat(result.content).hasSize(1)
+    }
+
+    @Test
+    fun 상품ID로_통계를_조회한다() {
+        val stats = createStats()
+
+        whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(stats)
+
+        val result = service.getByProductId(1L)
+
+        assertThat(result.productId).isEqualTo(1L)
+    }
+
+    @Test
+    fun 존재하지_않는_상품_통계_조회_시_예외를_발생시킨다() {
+        whenever(productStatisticsRepository.findByProductId(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.getByProductId(999L) }
+            .isInstanceOf(ProductStatisticsNotFoundException::class.java)
+    }
+
+    @Test
+    fun 판매자ID로_통계를_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+        val stats = createStats()
+
+        whenever(productStatisticsRepository.findBySellerId(1L, pageable))
+            .thenReturn(SliceImpl(listOf(stats), pageable, false))
+
+        val result = service.getBySellerId(1L, pageable)
+
+        assertThat(result.content).hasSize(1)
+    }
+
+    @Test
+    fun 카테고리ID로_통계를_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+        val stats = createStats()
+
+        whenever(productStatisticsRepository.findByCategoryId(1L, pageable))
+            .thenReturn(SliceImpl(listOf(stats), pageable, false))
+
+        val result = service.getByCategoryId(1L, pageable)
+
+        assertThat(result.content).hasSize(1)
+    }
+
+    @Test
+    fun 요약_통계를_조회한다() {
+        whenever(productStatisticsRepository.countAllProducts()).thenReturn(100)
+        whenever(productStatisticsRepository.sumTotalSalesAmount()).thenReturn(BigDecimal("10000000"))
+        whenever(productStatisticsRepository.sumTotalRefundAmount()).thenReturn(BigDecimal("500000"))
+        whenever(productStatisticsRepository.avgRefundRate()).thenReturn(BigDecimal("0.05"))
+
+        val result = service.getSummary()
+
+        assertThat(result.totalProductCount).isEqualTo(100)
+    }
+
+    @Test
+    fun 오늘_요약을_조회한다() {
+        whenever(productStatisticsRepository.sumTodaySalesAmount()).thenReturn(BigDecimal("100000"))
+        whenever(productStatisticsRepository.sumTodayOrderCount()).thenReturn(10)
+        whenever(productStatisticsRepository.sumTodayRefundAmount()).thenReturn(BigDecimal("5000"))
+
+        val result = service.getTodaySummary()
+
+        assertThat(result.todayOrderCount).isEqualTo(10)
+    }
+
+    @Test
+    fun 일별_통계를_조회한다() {
+        val daily = ProductDailyStatistics.create(productId = 1L, statisticsDate = LocalDate.now()).withId(1L)
+
+        whenever(productDailyStatisticsRepository
+            .findByProductIdAndStatisticsDateBetweenOrderByStatisticsDateAsc(any(), any(), any()))
+            .thenReturn(listOf(daily))
+
+        val result = service.getDailyStatistics(1L, LocalDate.now().minusDays(7), LocalDate.now())
+
+        assertThat(result).hasSize(1)
+    }
+
+    @Test
+    fun 상위_판매_상품을_조회한다() {
+        val projection = object : TopProductProjection {
+            override fun getProductId() = 1L
+            override fun getTotalAmount() = BigDecimal("1000000")
+            override fun getTotalQuantity() = 100L
+        }
+
+        whenever(productDailyStatisticsRepository.findTopSellingProducts(any(), any(), eq(10)))
+            .thenReturn(listOf(projection))
+
+        val result = service.getTopSellingProducts(7, 10)
+
+        assertThat(result).hasSize(1)
+    }
+
+    @Test
+    fun 상위_환불_상품을_조회한다() {
+        val projection = object : TopProductProjection {
+            override fun getProductId() = 1L
+            override fun getTotalAmount() = BigDecimal("50000")
+            override fun getTotalQuantity() = 5L
+        }
+
+        whenever(productDailyStatisticsRepository.findTopRefundProducts(any(), any(), eq(10)))
+            .thenReturn(listOf(projection))
+
+        val result = service.getTopRefundProducts(7, 10)
+
+        assertThat(result).hasSize(1)
+    }
+
+    @Test
+    fun 시간별_통계를_조회한다() {
+        val hourly = ProductHourlyStatistics.create(
+            productId = 1L, statisticsDate = LocalDate.now(), hour = 14
+        ).withId(1L)
+
+        whenever(productHourlyStatisticsRepository
+            .findByProductIdAndStatisticsDateOrderByHourAsc(1L, LocalDate.now()))
+            .thenReturn(listOf(hourly))
+
+        val result = service.getHourlyStatistics(1L, LocalDate.now())
+
+        assertThat(result).hasSize(1)
+    }
+
+    @Test
+    fun 피크_시간을_조회한다() {
+        val projection = object : HourlyAggregationProjection {
+            override fun getHour() = 14
+            override fun getTotalAmount() = BigDecimal("500000")
+            override fun getTotalOrders() = 50L
+        }
+
+        whenever(productHourlyStatisticsRepository.findPeakHours(any(), any()))
+            .thenReturn(listOf(projection))
+
+        val result = service.getPeakHours(7)
+
+        assertThat(result).hasSize(1)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/SellerDashboardServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/SellerDashboardServiceImplTest.kt
@@ -1,0 +1,174 @@
+package com.hoppingmall.product.product.service
+
+import com.hoppingmall.product.product.domain.ProductDailyStatistics
+import com.hoppingmall.product.product.domain.ProductHourlyStatistics
+import com.hoppingmall.product.product.domain.ProductStatistics
+import com.hoppingmall.product.product.domain.repository.ProductDailyStatisticsRepository
+import com.hoppingmall.product.product.domain.repository.ProductHourlyStatisticsRepository
+import com.hoppingmall.product.product.domain.repository.ProductStatisticsRepository
+import com.hoppingmall.product.product.exception.ProductException
+import com.hoppingmall.product.product.exception.ProductStatisticsNotFoundException
+import com.hoppingmall.product.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@DisplayName("SellerDashboardServiceImpl")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class SellerDashboardServiceImplTest {
+
+    @Mock
+    private lateinit var productStatisticsRepository: ProductStatisticsRepository
+
+    @Mock
+    private lateinit var productDailyStatisticsRepository: ProductDailyStatisticsRepository
+
+    @Mock
+    private lateinit var productHourlyStatisticsRepository: ProductHourlyStatisticsRepository
+
+    @InjectMocks
+    private lateinit var service: SellerDashboardServiceImpl
+
+    private fun createStats(sellerId: Long = 1L) = ProductStatistics.create(
+        productId = 1L, productName = "테스트", sellerId = sellerId, categoryId = 1L
+    ).withId(1L)
+
+    @Test
+    fun 판매자_개요를_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+        val stats = createStats()
+
+        whenever(productStatisticsRepository.findBySellerId(1L, pageable))
+            .thenReturn(SliceImpl(listOf(stats), pageable, false))
+
+        val result = service.getOverview(1L, pageable)
+
+        assertThat(result.content).hasSize(1)
+    }
+
+    @Test
+    fun 상품_통계를_조회한다() {
+        val stats = createStats()
+
+        whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(stats)
+
+        val result = service.getProductStatistics(1L, 1L)
+
+        assertThat(result.productId).isEqualTo(1L)
+    }
+
+    @Test
+    fun 존재하지_않는_상품_통계_조회_시_예외를_발생시킨다() {
+        whenever(productStatisticsRepository.findByProductId(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.getProductStatistics(1L, 999L) }
+            .isInstanceOf(ProductStatisticsNotFoundException::class.java)
+    }
+
+    @Test
+    fun 다른_판매자의_상품_통계_조회_시_예외를_발생시킨다() {
+        val stats = createStats(sellerId = 2L)
+
+        whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(stats)
+
+        assertThatThrownBy { service.getProductStatistics(1L, 1L) }
+            .isInstanceOf(ProductException::class.java)
+    }
+
+    @Test
+    fun 오늘_요약을_조회한다() {
+        val topSelling = createStats()
+
+        whenever(productStatisticsRepository.countBySellerId(1L)).thenReturn(5)
+        whenever(productStatisticsRepository.sumTodaySalesAmountBySellerId(1L)).thenReturn(BigDecimal("500000"))
+        whenever(productStatisticsRepository.sumTodayOrderCountBySellerId(1L)).thenReturn(10)
+        whenever(productStatisticsRepository.sumTodayRefundAmountBySellerId(1L)).thenReturn(BigDecimal("10000"))
+        whenever(productStatisticsRepository.findTopSellingBySellerId(1L)).thenReturn(topSelling)
+
+        val result = service.getTodaySummary(1L)
+
+        assertThat(result.totalProducts).isEqualTo(5)
+        assertThat(result.todayOrderCount).isEqualTo(10)
+        assertThat(result.topSellingProductId).isEqualTo(1L)
+    }
+
+    @Test
+    fun 상위_판매_상품이_없을_때_오늘_요약을_조회한다() {
+        whenever(productStatisticsRepository.countBySellerId(1L)).thenReturn(0)
+        whenever(productStatisticsRepository.sumTodaySalesAmountBySellerId(1L)).thenReturn(BigDecimal.ZERO)
+        whenever(productStatisticsRepository.sumTodayOrderCountBySellerId(1L)).thenReturn(0)
+        whenever(productStatisticsRepository.sumTodayRefundAmountBySellerId(1L)).thenReturn(BigDecimal.ZERO)
+        whenever(productStatisticsRepository.findTopSellingBySellerId(1L)).thenReturn(null)
+
+        val result = service.getTodaySummary(1L)
+
+        assertThat(result.topSellingProductId).isNull()
+        assertThat(result.topSellingProductName).isNull()
+    }
+
+    @Test
+    fun 일별_통계를_조회한다() {
+        val stats = createStats()
+        val daily = ProductDailyStatistics.create(productId = 1L, statisticsDate = LocalDate.now()).withId(1L)
+
+        whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(stats)
+        whenever(productDailyStatisticsRepository
+            .findByProductIdAndStatisticsDateBetweenOrderByStatisticsDateAsc(any(), any(), any()))
+            .thenReturn(listOf(daily))
+
+        val result = service.getDailyStatistics(1L, 1L, LocalDate.now().minusDays(7), LocalDate.now())
+
+        assertThat(result).hasSize(1)
+    }
+
+    @Test
+    fun 다른_판매자의_일별_통계_조회_시_예외를_발생시킨다() {
+        val stats = createStats(sellerId = 2L)
+
+        whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(stats)
+
+        assertThatThrownBy { service.getDailyStatistics(1L, 1L, LocalDate.now().minusDays(7), LocalDate.now()) }
+            .isInstanceOf(ProductException::class.java)
+    }
+
+    @Test
+    fun 시간별_통계를_조회한다() {
+        val stats = createStats()
+        val hourly = ProductHourlyStatistics.create(
+            productId = 1L, statisticsDate = LocalDate.now(), hour = 14
+        ).withId(1L)
+
+        whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(stats)
+        whenever(productHourlyStatisticsRepository
+            .findByProductIdAndStatisticsDateOrderByHourAsc(any(), any()))
+            .thenReturn(listOf(hourly))
+
+        val result = service.getHourlyStatistics(1L, 1L, LocalDate.now())
+
+        assertThat(result).hasSize(1)
+    }
+
+    @Test
+    fun 다른_판매자의_시간별_통계_조회_시_예외를_발생시킨다() {
+        val stats = createStats(sellerId = 2L)
+
+        whenever(productStatisticsRepository.findByProductId(1L)).thenReturn(stats)
+
+        assertThatThrownBy { service.getHourlyStatistics(1L, 1L, LocalDate.now()) }
+            .isInstanceOf(ProductException::class.java)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/review/controller/ReviewControllerTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/review/controller/ReviewControllerTest.kt
@@ -1,0 +1,113 @@
+package com.hoppingmall.product.review.controller
+
+import com.hoppingmall.common.UserPrincipal
+import com.hoppingmall.product.review.dto.request.ReviewCreateRequest
+import com.hoppingmall.product.review.dto.request.ReviewUpdateRequest
+import com.hoppingmall.product.review.dto.response.ReviewResponse
+import com.hoppingmall.product.review.service.ReviewCommandService
+import com.hoppingmall.product.review.service.ReviewQueryService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import org.springframework.http.HttpStatus
+import java.time.LocalDateTime
+
+@DisplayName("ReviewController")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ReviewControllerTest {
+
+    @Mock
+    private lateinit var reviewCommandService: ReviewCommandService
+
+    @Mock
+    private lateinit var reviewQueryService: ReviewQueryService
+
+    @InjectMocks
+    private lateinit var controller: ReviewController
+
+    private val principal = UserPrincipal(1L, "BUYER")
+    private val now = LocalDateTime.now()
+
+    private fun reviewResponse() = ReviewResponse(
+        id = 1L, buyerId = 1L, orderItemId = 100L, productId = 1L,
+        rating = 5, content = "좋아요", imageUrl = null,
+        createdAt = now, updatedAt = now
+    )
+
+    @Test
+    fun 리뷰를_생성한다() {
+        val request = ReviewCreateRequest(orderItemId = 100L, rating = 5, content = "좋아요")
+
+        whenever(reviewCommandService.createReview(eq(1L), any())).thenReturn(reviewResponse())
+
+        val result = controller.createReview(principal, request)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.CREATED)
+        assertThat(result.body!!.data!!.rating).isEqualTo(5)
+    }
+
+    @Test
+    fun 리뷰를_단건_조회한다() {
+        whenever(reviewQueryService.getReview(1L)).thenReturn(reviewResponse())
+
+        val result = controller.getReview(1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun 상품별_리뷰를_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+
+        whenever(reviewQueryService.getReviewsByProductId(1L, pageable))
+            .thenReturn(SliceImpl(listOf(reviewResponse()), pageable, false))
+
+        val result = controller.getProductReviews(1L, pageable)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun 내_리뷰를_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+
+        whenever(reviewQueryService.getMyReviews(1L, pageable))
+            .thenReturn(SliceImpl(listOf(reviewResponse()), pageable, false))
+
+        val result = controller.getMyReviews(principal, pageable)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun 리뷰를_수정한다() {
+        val request = ReviewUpdateRequest(rating = 3, content = "보통", imageUrl = null)
+
+        whenever(reviewCommandService.updateReview(eq(1L), eq(1L), any())).thenReturn(reviewResponse())
+
+        val result = controller.updateReview(principal, 1L, request)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun 리뷰를_삭제한다() {
+        val result = controller.deleteReview(principal, 1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        verify(reviewCommandService).deleteReview(1L, 1L)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/review/domain/ReviewTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/review/domain/ReviewTest.kt
@@ -1,0 +1,51 @@
+package com.hoppingmall.product.review.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+
+@DisplayName("Review 도메인")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class ReviewTest {
+
+    @Test
+    fun 리뷰를_생성한다() {
+        val review = Review.create(
+            buyerId = 1L, orderItemId = 100L, productId = 10L,
+            rating = 5, content = "좋아요", imageUrl = "http://img.jpg"
+        )
+
+        assertThat(review.buyerId).isEqualTo(1L)
+        assertThat(review.orderItemId).isEqualTo(100L)
+        assertThat(review.productId).isEqualTo(10L)
+        assertThat(review.rating).isEqualTo(5)
+        assertThat(review.content).isEqualTo("좋아요")
+        assertThat(review.imageUrl).isEqualTo("http://img.jpg")
+    }
+
+    @Test
+    fun 이미지_없이_리뷰를_생성한다() {
+        val review = Review.create(
+            buyerId = 1L, orderItemId = 100L, productId = 10L,
+            rating = 4, content = "괜찮아요"
+        )
+
+        assertThat(review.imageUrl).isNull()
+    }
+
+    @Test
+    fun 리뷰를_수정한다() {
+        val review = Review.create(
+            buyerId = 1L, orderItemId = 100L, productId = 10L,
+            rating = 5, content = "좋아요"
+        )
+
+        review.update(rating = 3, content = "보통이에요", imageUrl = "http://new.jpg")
+
+        assertThat(review.rating).isEqualTo(3)
+        assertThat(review.content).isEqualTo("보통이에요")
+        assertThat(review.imageUrl).isEqualTo("http://new.jpg")
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/review/port/HttpOrderQueryAdapterTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/review/port/HttpOrderQueryAdapterTest.kt
@@ -1,0 +1,175 @@
+package com.hoppingmall.product.review.port
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.client.RestClientException
+import java.math.BigDecimal
+import java.time.Duration
+
+@DisplayName("HttpOrderQueryAdapter")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class HttpOrderQueryAdapterTest {
+
+    @Mock
+    private lateinit var restTemplate: RestTemplate
+
+    private lateinit var adapter: HttpOrderQueryAdapter
+
+    @BeforeEach
+    fun setUp() {
+        val restTemplateBuilder = object : RestTemplateBuilder() {
+            override fun connectTimeout(connectTimeout: Duration): RestTemplateBuilder = this
+            override fun readTimeout(readTimeout: Duration): RestTemplateBuilder = this
+            override fun build(): RestTemplate = restTemplate
+        }
+        adapter = HttpOrderQueryAdapter("http://localhost:8084", restTemplateBuilder)
+    }
+
+    @Test
+    fun 주문_상품을_조회한다() {
+        val info = OrderItemInfo(
+            id = 1L, orderId = 10L, sellerId = 1L, productId = 1L,
+            productName = "테스트", productPrice = BigDecimal("10000"),
+            quantity = 1, totalPrice = BigDecimal("10000")
+        )
+
+        whenever(
+            restTemplate.getForObject(
+                "http://localhost:8084/internal/api/v1/order-items/1",
+                OrderItemInfo::class.java
+            )
+        ).thenReturn(info)
+
+        val result = adapter.findOrderItemById(1L)
+
+        assertThat(result).isNotNull
+        assertThat(result!!.productId).isEqualTo(1L)
+    }
+
+    @Test
+    fun 배송_완료_여부를_조회한다() {
+        whenever(
+            restTemplate.getForObject(
+                "http://localhost:8084/internal/api/v1/orders/10/delivered?buyerId=1",
+                Boolean::class.java
+            )
+        ).thenReturn(true)
+
+        val result = adapter.isDelivered(10L, 1L)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun 배송_완료_여부_null_응답_시_false를_반환한다() {
+        whenever(
+            restTemplate.getForObject(
+                "http://localhost:8084/internal/api/v1/orders/10/delivered?buyerId=1",
+                Boolean::class.java
+            )
+        ).thenReturn(null)
+
+        val result = adapter.isDelivered(10L, 1L)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun 주문별_상품_목록을_조회한다() {
+        val items = arrayOf(
+            OrderItemInfo(
+                id = 1L, orderId = 10L, sellerId = 1L, productId = 1L,
+                productName = "테스트", productPrice = BigDecimal("10000"),
+                quantity = 1, totalPrice = BigDecimal("10000")
+            )
+        )
+
+        whenever(
+            restTemplate.getForObject(
+                "http://localhost:8084/internal/api/v1/orders/10/items",
+                Array<OrderItemInfo>::class.java
+            )
+        ).thenReturn(items)
+
+        val result = adapter.findOrderItemsByOrderId(10L)
+
+        assertThat(result).hasSize(1)
+    }
+
+    @Test
+    fun 주문별_상품_목록_null_응답_시_빈_리스트를_반환한다() {
+        whenever(
+            restTemplate.getForObject(
+                "http://localhost:8084/internal/api/v1/orders/10/items",
+                Array<OrderItemInfo>::class.java
+            )
+        ).thenReturn(null)
+
+        val result = adapter.findOrderItemsByOrderId(10L)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun findOrderItemById_폴백_메서드가_null을_반환한다() {
+        val method = HttpOrderQueryAdapter::class.java.getDeclaredMethod(
+            "findOrderItemByIdFallback", Long::class.java, Exception::class.java
+        )
+        method.isAccessible = true
+
+        val result = method.invoke(adapter, 1L, RuntimeException("fail"))
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun isDelivered_폴백_메서드가_false를_반환한다() {
+        val method = HttpOrderQueryAdapter::class.java.getDeclaredMethod(
+            "isDeliveredFallback", Long::class.java, Long::class.java, Exception::class.java
+        )
+        method.isAccessible = true
+
+        val result = method.invoke(adapter, 10L, 1L, RuntimeException("fail"))
+
+        assertThat(result).isEqualTo(false)
+    }
+
+    @Test
+    fun findOrderItemsByOrderId_폴백_메서드가_빈_리스트를_반환한다() {
+        val method = HttpOrderQueryAdapter::class.java.getDeclaredMethod(
+            "findOrderItemsByOrderIdFallback", Long::class.java, Exception::class.java
+        )
+        method.isAccessible = true
+
+        @Suppress("UNCHECKED_CAST")
+        val result = method.invoke(adapter, 10L, RuntimeException("fail")) as List<OrderItemInfo>
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun OrderItemInfo를_생성한다() {
+        val info = OrderItemInfo(
+            id = 1L, orderId = 10L, sellerId = 1L, productId = 1L,
+            productName = "테스트", productPrice = BigDecimal("10000"),
+            quantity = 1, totalPrice = BigDecimal("10000")
+        )
+
+        assertThat(info.id).isEqualTo(1L)
+        assertThat(info.orderId).isEqualTo(10L)
+        assertThat(info.sellerId).isEqualTo(1L)
+        assertThat(info.productName).isEqualTo("테스트")
+        assertThat(info.quantity).isEqualTo(1)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/review/service/ReviewCommandServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/review/service/ReviewCommandServiceImplTest.kt
@@ -1,0 +1,206 @@
+package com.hoppingmall.product.review.service
+
+import com.hoppingmall.product.product.domain.ProductStatistics
+import com.hoppingmall.product.product.domain.repository.ProductStatisticsRepository
+import com.hoppingmall.product.review.domain.Review
+import com.hoppingmall.product.review.domain.repository.ReviewRepository
+import com.hoppingmall.product.review.dto.request.ReviewCreateRequest
+import com.hoppingmall.product.review.dto.request.ReviewUpdateRequest
+import com.hoppingmall.product.review.exception.ReviewAccessDeniedException
+import com.hoppingmall.product.review.exception.ReviewAlreadyExistsException
+import com.hoppingmall.product.review.exception.ReviewException
+import com.hoppingmall.product.review.exception.ReviewNotFoundException
+import com.hoppingmall.product.review.port.OrderItemInfo
+import com.hoppingmall.product.review.port.OrderQueryPort
+import com.hoppingmall.product.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+
+@DisplayName("ReviewCommandServiceImpl")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ReviewCommandServiceImplTest {
+
+    @Mock
+    private lateinit var reviewRepository: ReviewRepository
+
+    @Mock
+    private lateinit var orderQueryPort: OrderQueryPort
+
+    @Mock
+    private lateinit var productStatisticsRepository: ProductStatisticsRepository
+
+    @InjectMocks
+    private lateinit var service: ReviewCommandServiceImpl
+
+    private val orderItemInfo = OrderItemInfo(
+        id = 100L, orderId = 10L, sellerId = 1L, productId = 1L,
+        productName = "테스트", productPrice = BigDecimal("10000"),
+        quantity = 1, totalPrice = BigDecimal("10000")
+    )
+
+    @Test
+    fun 리뷰를_생성한다() {
+        val request = ReviewCreateRequest(orderItemId = 100L, rating = 5, content = "좋아요")
+        val review = Review.create(
+            buyerId = 1L, orderItemId = 100L, productId = 1L,
+            rating = 5, content = "좋아요"
+        ).withId(1L)
+
+        whenever(orderQueryPort.findOrderItemById(100L)).thenReturn(orderItemInfo)
+        whenever(orderQueryPort.isDelivered(10L, 1L)).thenReturn(true)
+        whenever(reviewRepository.existsByOrderItemId(100L)).thenReturn(false)
+        whenever(reviewRepository.save(any<Review>())).thenReturn(review)
+        whenever(productStatisticsRepository.findByProductIdForUpdate(1L)).thenReturn(null)
+
+        val result = service.createReview(1L, request)
+
+        assertThat(result.rating).isEqualTo(5)
+    }
+
+    @Test
+    fun 주문_상품이_없으면_리뷰_생성_시_예외를_발생시킨다() {
+        val request = ReviewCreateRequest(orderItemId = 999L, rating = 5, content = "좋아요")
+
+        whenever(orderQueryPort.findOrderItemById(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.createReview(1L, request) }
+            .isInstanceOf(ReviewException::class.java)
+    }
+
+    @Test
+    fun 배송_미완료_시_리뷰_생성_예외를_발생시킨다() {
+        val request = ReviewCreateRequest(orderItemId = 100L, rating = 5, content = "좋아요")
+
+        whenever(orderQueryPort.findOrderItemById(100L)).thenReturn(orderItemInfo)
+        whenever(orderQueryPort.isDelivered(10L, 1L)).thenReturn(false)
+
+        assertThatThrownBy { service.createReview(1L, request) }
+            .isInstanceOf(ReviewException::class.java)
+    }
+
+    @Test
+    fun 이미_리뷰가_존재하면_예외를_발생시킨다() {
+        val request = ReviewCreateRequest(orderItemId = 100L, rating = 5, content = "좋아요")
+
+        whenever(orderQueryPort.findOrderItemById(100L)).thenReturn(orderItemInfo)
+        whenever(orderQueryPort.isDelivered(10L, 1L)).thenReturn(true)
+        whenever(reviewRepository.existsByOrderItemId(100L)).thenReturn(true)
+
+        assertThatThrownBy { service.createReview(1L, request) }
+            .isInstanceOf(ReviewAlreadyExistsException::class.java)
+    }
+
+    @Test
+    fun 리뷰를_수정한다() {
+        val review = Review.create(
+            buyerId = 1L, orderItemId = 100L, productId = 1L,
+            rating = 5, content = "좋아요"
+        ).withId(1L)
+        val request = ReviewUpdateRequest(rating = 3, content = "보통", imageUrl = null)
+
+        whenever(reviewRepository.findNullableById(1L)).thenReturn(review)
+        whenever(productStatisticsRepository.findByProductIdForUpdate(1L)).thenReturn(null)
+
+        val result = service.updateReview(1L, 1L, request)
+
+        assertThat(result.rating).isEqualTo(3)
+    }
+
+    @Test
+    fun 존재하지_않는_리뷰_수정_시_예외를_발생시킨다() {
+        val request = ReviewUpdateRequest(rating = 3, content = "보통", imageUrl = null)
+
+        whenever(reviewRepository.findNullableById(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.updateReview(999L, 1L, request) }
+            .isInstanceOf(ReviewNotFoundException::class.java)
+    }
+
+    @Test
+    fun 다른_사용자의_리뷰_수정_시_예외를_발생시킨다() {
+        val review = Review.create(
+            buyerId = 1L, orderItemId = 100L, productId = 1L,
+            rating = 5, content = "좋아요"
+        ).withId(1L)
+        val request = ReviewUpdateRequest(rating = 3, content = "보통", imageUrl = null)
+
+        whenever(reviewRepository.findNullableById(1L)).thenReturn(review)
+
+        assertThatThrownBy { service.updateReview(1L, 999L, request) }
+            .isInstanceOf(ReviewAccessDeniedException::class.java)
+    }
+
+    @Test
+    fun 리뷰를_삭제한다() {
+        val review = Review.create(
+            buyerId = 1L, orderItemId = 100L, productId = 1L,
+            rating = 5, content = "좋아요"
+        ).withId(1L)
+
+        whenever(reviewRepository.findNullableById(1L)).thenReturn(review)
+        whenever(productStatisticsRepository.findByProductIdForUpdate(1L)).thenReturn(null)
+
+        service.deleteReview(1L, 1L)
+
+        assertThat(review.deletedAt).isNotNull()
+    }
+
+    @Test
+    fun 존재하지_않는_리뷰_삭제_시_예외를_발생시킨다() {
+        whenever(reviewRepository.findNullableById(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.deleteReview(999L, 1L) }
+            .isInstanceOf(ReviewNotFoundException::class.java)
+    }
+
+    @Test
+    fun 다른_사용자의_리뷰_삭제_시_예외를_발생시킨다() {
+        val review = Review.create(
+            buyerId = 1L, orderItemId = 100L, productId = 1L,
+            rating = 5, content = "좋아요"
+        ).withId(1L)
+
+        whenever(reviewRepository.findNullableById(1L)).thenReturn(review)
+
+        assertThatThrownBy { service.deleteReview(1L, 999L) }
+            .isInstanceOf(ReviewAccessDeniedException::class.java)
+    }
+
+    @Test
+    fun 리뷰_생성_후_통계를_업데이트한다() {
+        val request = ReviewCreateRequest(orderItemId = 100L, rating = 5, content = "좋아요")
+        val review = Review.create(
+            buyerId = 1L, orderItemId = 100L, productId = 1L,
+            rating = 5, content = "좋아요"
+        ).withId(1L)
+        val stats = ProductStatistics.create(
+            productId = 1L, productName = "테스트", sellerId = 1L, categoryId = 1L
+        ).withId(1L)
+
+        whenever(orderQueryPort.findOrderItemById(100L)).thenReturn(orderItemInfo)
+        whenever(orderQueryPort.isDelivered(10L, 1L)).thenReturn(true)
+        whenever(reviewRepository.existsByOrderItemId(100L)).thenReturn(false)
+        whenever(reviewRepository.save(any<Review>())).thenReturn(review)
+        whenever(productStatisticsRepository.findByProductIdForUpdate(1L)).thenReturn(stats)
+        whenever(reviewRepository.averageRatingByProductId(1L)).thenReturn(4.5)
+        whenever(reviewRepository.countByProductId(1L)).thenReturn(10)
+
+        service.createReview(1L, request)
+
+        assertThat(stats.averageRating).isEqualByComparingTo(BigDecimal("4.50"))
+        assertThat(stats.reviewCount).isEqualTo(10)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/review/service/ReviewQueryServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/review/service/ReviewQueryServiceImplTest.kt
@@ -1,0 +1,79 @@
+package com.hoppingmall.product.review.service
+
+import com.hoppingmall.product.review.domain.Review
+import com.hoppingmall.product.review.domain.repository.ReviewRepository
+import com.hoppingmall.product.review.exception.ReviewNotFoundException
+import com.hoppingmall.product.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+
+@DisplayName("ReviewQueryServiceImpl")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ReviewQueryServiceImplTest {
+
+    @Mock
+    private lateinit var reviewRepository: ReviewRepository
+
+    @InjectMocks
+    private lateinit var service: ReviewQueryServiceImpl
+
+    private fun createReview() = Review.create(
+        buyerId = 1L, orderItemId = 100L, productId = 1L,
+        rating = 5, content = "좋아요"
+    ).withId(1L)
+
+    @Test
+    fun 리뷰를_단건_조회한다() {
+        whenever(reviewRepository.findNullableById(1L)).thenReturn(createReview())
+
+        val result = service.getReview(1L)
+
+        assertThat(result.rating).isEqualTo(5)
+    }
+
+    @Test
+    fun 존재하지_않는_리뷰_조회_시_예외를_발생시킨다() {
+        whenever(reviewRepository.findNullableById(999L)).thenReturn(null)
+
+        assertThatThrownBy { service.getReview(999L) }
+            .isInstanceOf(ReviewNotFoundException::class.java)
+    }
+
+    @Test
+    fun 상품별_리뷰를_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+        val review = createReview()
+
+        whenever(reviewRepository.findByProductId(1L, pageable))
+            .thenReturn(SliceImpl(listOf(review), pageable, false))
+
+        val result = service.getReviewsByProductId(1L, pageable)
+
+        assertThat(result.content).hasSize(1)
+    }
+
+    @Test
+    fun 내_리뷰를_조회한다() {
+        val pageable = PageRequest.of(0, 10)
+        val review = createReview()
+
+        whenever(reviewRepository.findByBuyerId(1L, pageable))
+            .thenReturn(SliceImpl(listOf(review), pageable, false))
+
+        val result = service.getMyReviews(1L, pageable)
+
+        assertThat(result.content).hasSize(1)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/statistics/port/HttpCartItemQueryAdapterTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/statistics/port/HttpCartItemQueryAdapterTest.kt
@@ -1,0 +1,78 @@
+package com.hoppingmall.product.statistics.port
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.web.client.RestTemplate
+import java.time.Duration
+
+@DisplayName("HttpCartItemQueryAdapter")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class HttpCartItemQueryAdapterTest {
+
+    @Mock
+    private lateinit var restTemplate: RestTemplate
+
+    private lateinit var adapter: HttpCartItemQueryAdapter
+
+    @BeforeEach
+    fun setUp() {
+        val restTemplateBuilder = object : RestTemplateBuilder() {
+            override fun connectTimeout(connectTimeout: Duration): RestTemplateBuilder = this
+            override fun readTimeout(readTimeout: Duration): RestTemplateBuilder = this
+            override fun build(): RestTemplate = restTemplate
+        }
+        adapter = HttpCartItemQueryAdapter("http://localhost:8084", restTemplateBuilder)
+    }
+
+    @Test
+    fun 장바구니_집계를_조회한다() {
+        val aggregations = arrayOf(
+            CartAggregation(productId = 1L, buyerCount = 10),
+            CartAggregation(productId = 2L, buyerCount = 5)
+        )
+
+        whenever(
+            restTemplate.getForObject(
+                "http://localhost:8084/internal/api/v1/cart-items/aggregate",
+                Array<CartAggregation>::class.java
+            )
+        ).thenReturn(aggregations)
+
+        val result = adapter.aggregateCartByProduct()
+
+        assertThat(result).hasSize(2)
+        assertThat(result[0].productId).isEqualTo(1L)
+    }
+
+    @Test
+    fun 장바구니_집계_null_응답_시_빈_리스트를_반환한다() {
+        whenever(
+            restTemplate.getForObject(
+                "http://localhost:8084/internal/api/v1/cart-items/aggregate",
+                Array<CartAggregation>::class.java
+            )
+        ).thenReturn(null)
+
+        val result = adapter.aggregateCartByProduct()
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun CartAggregation을_생성한다() {
+        val agg = CartAggregation(productId = 1L, buyerCount = 10)
+
+        assertThat(agg.productId).isEqualTo(1L)
+        assertThat(agg.buyerCount).isEqualTo(10)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/statistics/port/HttpOrderItemQueryAdapterTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/statistics/port/HttpOrderItemQueryAdapterTest.kt
@@ -1,0 +1,84 @@
+package com.hoppingmall.product.statistics.port
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.web.client.RestTemplate
+import java.math.BigDecimal
+import java.time.Duration
+
+@DisplayName("HttpOrderItemQueryAdapter")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class HttpOrderItemQueryAdapterTest {
+
+    @Mock
+    private lateinit var restTemplate: RestTemplate
+
+    private lateinit var adapter: HttpOrderItemQueryAdapter
+
+    @BeforeEach
+    fun setUp() {
+        val restTemplateBuilder = object : RestTemplateBuilder() {
+            override fun connectTimeout(connectTimeout: Duration): RestTemplateBuilder = this
+            override fun readTimeout(readTimeout: Duration): RestTemplateBuilder = this
+            override fun build(): RestTemplate = restTemplate
+        }
+        adapter = HttpOrderItemQueryAdapter("http://localhost:8084", restTemplateBuilder)
+    }
+
+    @Test
+    fun 주문별_상품_목록을_조회한다() {
+        val items = arrayOf(
+            OrderItemInfo(id = 1L, orderId = 10L, productId = 1L, quantity = 2, totalPrice = BigDecimal("20000")),
+            OrderItemInfo(id = 2L, orderId = 10L, productId = 2L, quantity = 1, totalPrice = BigDecimal("15000"))
+        )
+
+        whenever(
+            restTemplate.getForObject(
+                "http://localhost:8084/internal/api/v1/orders/10/items",
+                Array<OrderItemInfo>::class.java
+            )
+        ).thenReturn(items)
+
+        val result = adapter.findByOrderId(10L)
+
+        assertThat(result).hasSize(2)
+        assertThat(result[0].productId).isEqualTo(1L)
+    }
+
+    @Test
+    fun 주문별_상품_목록_null_응답_시_빈_리스트를_반환한다() {
+        whenever(
+            restTemplate.getForObject(
+                "http://localhost:8084/internal/api/v1/orders/10/items",
+                Array<OrderItemInfo>::class.java
+            )
+        ).thenReturn(null)
+
+        val result = adapter.findByOrderId(10L)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun OrderItemInfo를_생성한다() {
+        val info = OrderItemInfo(
+            id = 1L, orderId = 10L, productId = 1L, quantity = 2, totalPrice = BigDecimal("20000")
+        )
+
+        assertThat(info.id).isEqualTo(1L)
+        assertThat(info.orderId).isEqualTo(10L)
+        assertThat(info.productId).isEqualTo(1L)
+        assertThat(info.quantity).isEqualTo(2)
+        assertThat(info.totalPrice).isEqualByComparingTo(BigDecimal("20000"))
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/statistics/service/ProductStatisticsSchedulerTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/statistics/service/ProductStatisticsSchedulerTest.kt
@@ -1,0 +1,92 @@
+package com.hoppingmall.product.statistics.service
+
+import com.hoppingmall.product.inventory.domain.Inventory
+import com.hoppingmall.product.inventory.domain.repository.InventoryRepository
+import com.hoppingmall.product.product.domain.ProductStatistics
+import com.hoppingmall.product.product.domain.repository.ProductStatisticsRepository
+import com.hoppingmall.product.product.service.ProductStatisticsCommandService
+import com.hoppingmall.product.statistics.port.CartAggregation
+import com.hoppingmall.product.statistics.port.CartItemQueryPort
+import com.hoppingmall.product.support.withId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.transaction.TransactionStatus
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
+
+@DisplayName("ProductStatisticsScheduler")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class ProductStatisticsSchedulerTest {
+
+    @Mock
+    private lateinit var productStatisticsRepository: ProductStatisticsRepository
+
+    @Mock
+    private lateinit var cartItemQueryPort: CartItemQueryPort
+
+    @Mock
+    private lateinit var inventoryRepository: InventoryRepository
+
+    @Mock
+    private lateinit var productStatisticsCommandService: ProductStatisticsCommandService
+
+    @Mock
+    private lateinit var transactionTemplate: TransactionTemplate
+
+    @Mock
+    private lateinit var transactionStatus: TransactionStatus
+
+    @Test
+    fun 장바구니_및_재고를_동기화한다() {
+        val scheduler = ProductStatisticsScheduler(
+            productStatisticsRepository, cartItemQueryPort,
+            inventoryRepository, productStatisticsCommandService, transactionTemplate
+        )
+        val stats = ProductStatistics.create(
+            productId = 1L, productName = "테스트", sellerId = 1L, categoryId = 1L
+        ).withId(1L)
+        val cartAggregations = listOf(CartAggregation(productId = 1L, buyerCount = 5))
+        val inventory = Inventory.create(productId = 1L, stockQuantity = 100).withId(1L)
+        val page = PageImpl(listOf(stats), PageRequest.of(0, 500), 1)
+
+        whenever(cartItemQueryPort.aggregateCartByProduct()).thenReturn(cartAggregations)
+        whenever(transactionTemplate.execute(any<TransactionCallback<Pair<Boolean, Int>>>()))
+            .thenAnswer { invocation ->
+                @Suppress("UNCHECKED_CAST")
+                val callback = invocation.arguments[0] as TransactionCallback<Pair<Boolean, Int>>
+                callback.doInTransaction(transactionStatus)
+            }
+        whenever(productStatisticsRepository.findAll(any<PageRequest>())).thenReturn(page)
+        whenever(inventoryRepository.findAllByProductIdIn(listOf(1L))).thenReturn(listOf(inventory))
+
+        scheduler.syncCartAndInventory()
+
+        assertThat(stats.currentCartCount).isEqualTo(5)
+        assertThat(stats.currentStock).isEqualTo(100)
+        verify(productStatisticsCommandService).flushHourlySnapshot()
+    }
+
+    @Test
+    fun 일별_통계_마감을_수행한다() {
+        val scheduler = ProductStatisticsScheduler(
+            productStatisticsRepository, cartItemQueryPort,
+            inventoryRepository, productStatisticsCommandService, transactionTemplate
+        )
+
+        scheduler.flushDailyStatistics()
+
+        verify(productStatisticsCommandService).flushDailySnapshot()
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/statistics/service/StatisticsEventConsumerTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/statistics/service/StatisticsEventConsumerTest.kt
@@ -1,0 +1,140 @@
+package com.hoppingmall.product.statistics.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.hoppingmall.product.product.domain.StatisticsEventLog
+import com.hoppingmall.product.product.domain.repository.StatisticsEventLogRepository
+import com.hoppingmall.product.product.service.ProductStatisticsCommandService
+import com.hoppingmall.product.statistics.port.OrderItemInfo
+import com.hoppingmall.product.statistics.port.OrderItemQueryPort
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Spy
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+
+@DisplayName("StatisticsEventConsumer")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class StatisticsEventConsumerTest {
+
+    @Mock
+    private lateinit var statisticsEventLogRepository: StatisticsEventLogRepository
+
+    @Mock
+    private lateinit var orderItemQueryPort: OrderItemQueryPort
+
+    @Mock
+    private lateinit var productStatisticsCommandService: ProductStatisticsCommandService
+
+    @Spy
+    private var objectMapper: ObjectMapper = ObjectMapper().registerModule(JavaTimeModule())
+
+    @InjectMocks
+    private lateinit var consumer: StatisticsEventConsumer
+
+    @Test
+    fun 결제_완료_이벤트를_처리한다() {
+        val message = """{"paymentId":1,"orderId":10,"userId":1,"amount":10000,"pointAmount":0,"transactionId":"txn-1","completedAt":"2026-01-01T00:00:00"}"""
+        val items = listOf(
+            OrderItemInfo(id = 1L, orderId = 10L, productId = 1L, quantity = 2, totalPrice = BigDecimal("20000"))
+        )
+
+        whenever(statisticsEventLogRepository.existsByEventId("txn-1")).thenReturn(false)
+        whenever(orderItemQueryPort.findByOrderId(10L)).thenReturn(items)
+        whenever(statisticsEventLogRepository.save(any<StatisticsEventLog>())).thenAnswer { it.arguments[0] }
+
+        consumer.handlePaymentCompleted(message)
+
+        verify(productStatisticsCommandService).incrementSalesStats(1L, 2L, BigDecimal("20000"))
+    }
+
+    @Test
+    fun 이미_처리된_결제_완료_이벤트를_무시한다() {
+        val message = """{"paymentId":1,"orderId":10,"userId":1,"amount":10000,"pointAmount":0,"transactionId":"txn-1","completedAt":"2026-01-01T00:00:00"}"""
+
+        whenever(statisticsEventLogRepository.existsByEventId("txn-1")).thenReturn(true)
+
+        consumer.handlePaymentCompleted(message)
+
+        verify(productStatisticsCommandService, never()).incrementSalesStats(any(), any(), any())
+    }
+
+    @Test
+    fun 결제_취소_보상_이벤트를_처리한다() {
+        val message = """{"eventType":"PaymentCancelled","eventId":"evt-1","paymentId":1,"orderId":10,"userId":1,"amount":10000,"transactionId":"txn-1"}"""
+        val items = listOf(
+            OrderItemInfo(id = 1L, orderId = 10L, productId = 1L, quantity = 2, totalPrice = BigDecimal("20000"))
+        )
+
+        whenever(statisticsEventLogRepository.existsByEventId("evt-1")).thenReturn(false)
+        whenever(orderItemQueryPort.findByOrderId(10L)).thenReturn(items)
+        whenever(statisticsEventLogRepository.save(any<StatisticsEventLog>())).thenAnswer { it.arguments[0] }
+
+        consumer.handleCompensationEvent(message)
+
+        verify(productStatisticsCommandService).decrementSalesStats(1L, 2L, BigDecimal("20000"))
+    }
+
+    @Test
+    fun PaymentCancelled가_아닌_보상_이벤트는_무시한다() {
+        val message = """{"eventType":"Other","eventId":"evt-1","orderId":10}"""
+
+        consumer.handleCompensationEvent(message)
+
+        verify(productStatisticsCommandService, never()).decrementSalesStats(any(), any(), any())
+    }
+
+    @Test
+    fun 결제_역보상_이벤트를_처리한다() {
+        val message = """{"eventType":"PaymentReversalRequested","eventId":"rev-1","orderId":10}"""
+        val items = listOf(
+            OrderItemInfo(id = 1L, orderId = 10L, productId = 1L, quantity = 1, totalPrice = BigDecimal("10000"))
+        )
+
+        whenever(statisticsEventLogRepository.existsByEventId("rev-1")).thenReturn(false)
+        whenever(orderItemQueryPort.findByOrderId(10L)).thenReturn(items)
+        whenever(statisticsEventLogRepository.save(any<StatisticsEventLog>())).thenAnswer { it.arguments[0] }
+
+        consumer.handlePaymentReversal(message)
+
+        verify(productStatisticsCommandService).decrementSalesStats(1L, 1L, BigDecimal("10000"))
+    }
+
+    @Test
+    fun PaymentReversalRequested가_아닌_역보상_이벤트는_무시한다() {
+        val message = """{"eventType":"Other","eventId":"rev-1","orderId":10}"""
+
+        consumer.handlePaymentReversal(message)
+
+        verify(productStatisticsCommandService, never()).decrementSalesStats(any(), any(), any())
+    }
+
+    @Test
+    fun eventId가_없는_역보상_이벤트는_무시한다() {
+        val message = """{"eventType":"PaymentReversalRequested","orderId":10}"""
+
+        consumer.handlePaymentReversal(message)
+
+        verify(productStatisticsCommandService, never()).decrementSalesStats(any(), any(), any())
+    }
+
+    @Test
+    fun orderId가_없는_역보상_이벤트는_무시한다() {
+        val message = """{"eventType":"PaymentReversalRequested","eventId":"rev-1"}"""
+
+        consumer.handlePaymentReversal(message)
+
+        verify(productStatisticsCommandService, never()).decrementSalesStats(any(), any(), any())
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/support/TestEntityUtil.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/support/TestEntityUtil.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.product.support
+
+import com.hoppingmall.common.BaseEntity
+
+fun <T : BaseEntity> T.withId(id: Long): T {
+    val field = BaseEntity::class.java.getDeclaredField("id")
+    field.isAccessible = true
+    field.set(this, id)
+    return this
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/wishlist/controller/WishlistControllerTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/wishlist/controller/WishlistControllerTest.kt
@@ -1,0 +1,86 @@
+package com.hoppingmall.product.wishlist.controller
+
+import com.hoppingmall.common.UserPrincipal
+import com.hoppingmall.product.wishlist.dto.request.WishlistCreateRequest
+import com.hoppingmall.product.wishlist.dto.response.WishlistResponse
+import com.hoppingmall.product.wishlist.service.WishlistCommandService
+import com.hoppingmall.product.wishlist.service.WishlistQueryService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import org.springframework.http.HttpStatus
+import java.time.LocalDateTime
+
+@DisplayName("WishlistController")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class WishlistControllerTest {
+
+    @Mock
+    private lateinit var wishlistCommandService: WishlistCommandService
+
+    @Mock
+    private lateinit var wishlistQueryService: WishlistQueryService
+
+    @InjectMocks
+    private lateinit var controller: WishlistController
+
+    private val principal = UserPrincipal(1L, "BUYER")
+
+    private fun wishlistResponse() = WishlistResponse(
+        id = 1L, productId = 10L, createdAt = LocalDateTime.now()
+    )
+
+    @Test
+    fun 위시리스트에_추가한다() {
+        val request = WishlistCreateRequest(productId = 10L)
+
+        whenever(wishlistCommandService.addWishlist(eq(1L), any())).thenReturn(wishlistResponse())
+
+        val result = controller.addWishlist(principal, request)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.CREATED)
+    }
+
+    @Test
+    fun 위시리스트에서_제거한다() {
+        val result = controller.removeWishlist(principal, 1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        verify(wishlistCommandService).removeWishlist(1L, 1L)
+    }
+
+    @Test
+    fun 위시리스트_목록을_조회한다() {
+        val pageable = PageRequest.of(0, 20)
+
+        whenever(wishlistQueryService.getWishlists(1L, pageable))
+            .thenReturn(SliceImpl(listOf(wishlistResponse()), pageable, false))
+
+        val result = controller.getWishlists(principal, pageable)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun 위시리스트_여부를_확인한다() {
+        whenever(wishlistQueryService.isWishlisted(1L, 10L)).thenReturn(true)
+
+        val result = controller.isWishlisted(principal, 10L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data).isTrue()
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/wishlist/domain/WishlistTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/wishlist/domain/WishlistTest.kt
@@ -1,0 +1,20 @@
+package com.hoppingmall.product.wishlist.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+
+@DisplayName("Wishlist 도메인")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class WishlistTest {
+
+    @Test
+    fun 위시리스트를_생성한다() {
+        val wishlist = Wishlist.create(buyerId = 1L, productId = 10L)
+
+        assertThat(wishlist.buyerId).isEqualTo(1L)
+        assertThat(wishlist.productId).isEqualTo(10L)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/wishlist/service/WishlistCommandServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/wishlist/service/WishlistCommandServiceImplTest.kt
@@ -1,0 +1,113 @@
+package com.hoppingmall.product.wishlist.service
+
+import com.hoppingmall.product.common.enums.ProductStatus
+import com.hoppingmall.product.product.domain.Product
+import com.hoppingmall.product.product.domain.repository.ProductRepository
+import com.hoppingmall.product.product.exception.ProductNotFoundException
+import com.hoppingmall.product.support.withId
+import com.hoppingmall.product.wishlist.domain.Wishlist
+import com.hoppingmall.product.wishlist.domain.repository.WishlistRepository
+import com.hoppingmall.product.wishlist.dto.request.WishlistCreateRequest
+import com.hoppingmall.product.wishlist.exception.WishlistAlreadyExistsException
+import com.hoppingmall.product.wishlist.exception.WishlistNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.util.Optional
+
+@DisplayName("WishlistCommandServiceImpl")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class WishlistCommandServiceImplTest {
+
+    @Mock
+    private lateinit var wishlistRepository: WishlistRepository
+
+    @Mock
+    private lateinit var productRepository: ProductRepository
+
+    @InjectMocks
+    private lateinit var service: WishlistCommandServiceImpl
+
+    @Test
+    fun 위시리스트에_추가한다() {
+        val product = Product.create(
+            sellerId = 1L, categoryId = 1L, name = "테스트",
+            description = "설명", price = BigDecimal("10000"), status = ProductStatus.AVAILABLE
+        ).withId(10L)
+        val wishlist = Wishlist.create(buyerId = 1L, productId = 10L).withId(1L)
+        val request = WishlistCreateRequest(productId = 10L)
+
+        whenever(productRepository.findById(10L)).thenReturn(Optional.of(product))
+        whenever(wishlistRepository.existsByBuyerIdAndProductId(1L, 10L)).thenReturn(false)
+        whenever(wishlistRepository.save(any<Wishlist>())).thenReturn(wishlist)
+
+        val result = service.addWishlist(1L, request)
+
+        assertThat(result.productId).isEqualTo(10L)
+    }
+
+    @Test
+    fun 존재하지_않는_상품을_위시리스트에_추가_시_예외를_발생시킨다() {
+        val request = WishlistCreateRequest(productId = 999L)
+
+        whenever(productRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.addWishlist(1L, request) }
+            .isInstanceOf(ProductNotFoundException::class.java)
+    }
+
+    @Test
+    fun 이미_위시리스트에_있는_상품_추가_시_예외를_발생시킨다() {
+        val product = Product.create(
+            sellerId = 1L, categoryId = 1L, name = "테스트",
+            description = "설명", price = BigDecimal("10000"), status = ProductStatus.AVAILABLE
+        ).withId(10L)
+        val request = WishlistCreateRequest(productId = 10L)
+
+        whenever(productRepository.findById(10L)).thenReturn(Optional.of(product))
+        whenever(wishlistRepository.existsByBuyerIdAndProductId(1L, 10L)).thenReturn(true)
+
+        assertThatThrownBy { service.addWishlist(1L, request) }
+            .isInstanceOf(WishlistAlreadyExistsException::class.java)
+    }
+
+    @Test
+    fun 위시리스트에서_제거한다() {
+        val wishlist = Wishlist.create(buyerId = 1L, productId = 10L).withId(1L)
+
+        whenever(wishlistRepository.findById(1L)).thenReturn(Optional.of(wishlist))
+
+        service.removeWishlist(1L, 1L)
+
+        assertThat(wishlist.deletedAt).isNotNull()
+    }
+
+    @Test
+    fun 존재하지_않는_위시리스트_제거_시_예외를_발생시킨다() {
+        whenever(wishlistRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.removeWishlist(1L, 999L) }
+            .isInstanceOf(WishlistNotFoundException::class.java)
+    }
+
+    @Test
+    fun 다른_사용자의_위시리스트_제거_시_예외를_발생시킨다() {
+        val wishlist = Wishlist.create(buyerId = 1L, productId = 10L).withId(1L)
+
+        whenever(wishlistRepository.findById(1L)).thenReturn(Optional.of(wishlist))
+
+        assertThatThrownBy { service.removeWishlist(999L, 1L) }
+            .isInstanceOf(WishlistNotFoundException::class.java)
+    }
+}

--- a/product-service/src/test/kotlin/com/hoppingmall/product/wishlist/service/WishlistQueryServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/wishlist/service/WishlistQueryServiceImplTest.kt
@@ -1,0 +1,60 @@
+package com.hoppingmall.product.wishlist.service
+
+import com.hoppingmall.product.support.withId
+import com.hoppingmall.product.wishlist.domain.Wishlist
+import com.hoppingmall.product.wishlist.domain.repository.WishlistRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+
+@DisplayName("WishlistQueryServiceImpl")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class WishlistQueryServiceImplTest {
+
+    @Mock
+    private lateinit var wishlistRepository: WishlistRepository
+
+    @InjectMocks
+    private lateinit var service: WishlistQueryServiceImpl
+
+    @Test
+    fun 위시리스트를_조회한다() {
+        val pageable = PageRequest.of(0, 20)
+        val wishlist = Wishlist.create(buyerId = 1L, productId = 10L).withId(1L)
+
+        whenever(wishlistRepository.findByBuyerId(1L, pageable))
+            .thenReturn(SliceImpl(listOf(wishlist), pageable, false))
+
+        val result = service.getWishlists(1L, pageable)
+
+        assertThat(result.content).hasSize(1)
+    }
+
+    @Test
+    fun 위시리스트_여부를_확인한다_존재하는_경우() {
+        whenever(wishlistRepository.existsByBuyerIdAndProductId(1L, 10L)).thenReturn(true)
+
+        val result = service.isWishlisted(1L, 10L)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun 위시리스트_여부를_확인한다_존재하지_않는_경우() {
+        whenever(wishlistRepository.existsByBuyerIdAndProductId(1L, 10L)).thenReturn(false)
+
+        val result = service.isWishlisted(1L, 10L)
+
+        assertThat(result).isFalse()
+    }
+}

--- a/settlement-service/src/test/kotlin/com/hoppingmall/settlement/controller/SettlementControllerTest.kt
+++ b/settlement-service/src/test/kotlin/com/hoppingmall/settlement/controller/SettlementControllerTest.kt
@@ -1,0 +1,186 @@
+package com.hoppingmall.settlement.controller
+
+import com.hoppingmall.common.UserPrincipal
+import com.hoppingmall.settlement.dto.response.SettlementDetailResponse
+import com.hoppingmall.settlement.dto.response.SettlementItemResponse
+import com.hoppingmall.settlement.dto.response.SettlementResponse
+import com.hoppingmall.settlement.dto.request.CreateSettlementRequest
+import com.hoppingmall.settlement.enums.SettlementStatus
+import com.hoppingmall.settlement.exception.SettlementSellerNotFoundException
+import com.hoppingmall.settlement.port.SellerInfo
+import com.hoppingmall.settlement.port.SellerQueryPort
+import com.hoppingmall.settlement.service.SettlementCommandService
+import com.hoppingmall.settlement.service.SettlementQueryService
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.http.HttpStatus
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("SettlementController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class SettlementControllerTest {
+
+    @Mock
+    private lateinit var settlementCommandService: SettlementCommandService
+
+    @Mock
+    private lateinit var settlementQueryService: SettlementQueryService
+
+    @Mock
+    private lateinit var sellerQueryPort: SellerQueryPort
+
+    private lateinit var controller: SettlementController
+
+    @BeforeEach
+    fun setUp() {
+        controller = SettlementController(settlementCommandService, settlementQueryService, sellerQueryPort)
+    }
+
+    private fun createSettlementResponse(id: Long = 1L): SettlementResponse {
+        return SettlementResponse(
+            id = id,
+            sellerId = 1L,
+            periodStart = LocalDate.of(2026, 1, 1),
+            periodEnd = LocalDate.of(2026, 1, 31),
+            totalSalesAmount = BigDecimal("1000000"),
+            totalRefundAmount = BigDecimal("50000"),
+            commissionRate = BigDecimal("0.1000"),
+            commissionAmount = BigDecimal("95000"),
+            settlementAmount = BigDecimal("855000"),
+            status = SettlementStatus.CALCULATED,
+            confirmedAt = null,
+            paidAt = null,
+            createdAt = LocalDateTime.now()
+        )
+    }
+
+    @Test
+    fun 정산을_생성한다() {
+        val request = CreateSettlementRequest(
+            sellerId = 1L,
+            periodStart = LocalDate.of(2026, 1, 1),
+            periodEnd = LocalDate.of(2026, 1, 31),
+            commissionRate = BigDecimal("0.1000")
+        )
+        whenever(settlementCommandService.createSettlement(request)).thenReturn(createSettlementResponse())
+
+        val result = controller.createSettlement(request)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data!!.id).isEqualTo(1L)
+    }
+
+    @Test
+    fun 정산을_확정한다() {
+        whenever(settlementCommandService.confirmSettlement(1L)).thenReturn(createSettlementResponse())
+
+        val result = controller.confirmSettlement(1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun 정산을_지급_처리한다() {
+        whenever(settlementCommandService.paySettlement(1L)).thenReturn(createSettlementResponse())
+
+        val result = controller.paySettlement(1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun 관리자가_정산_목록을_조회한다() {
+        val pageable = PageRequest.of(0, 20)
+        whenever(settlementQueryService.getSettlements(null, null, pageable))
+            .thenReturn(PageImpl(listOf(createSettlementResponse())))
+
+        val result = controller.getSettlementsForAdmin(null, null, pageable)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body!!.data!!.content).hasSize(1)
+    }
+
+    @Test
+    fun 관리자가_정산_상세를_조회한다() {
+        val detail = SettlementDetailResponse(
+            id = 1L, sellerId = 1L,
+            periodStart = LocalDate.of(2026, 1, 1), periodEnd = LocalDate.of(2026, 1, 31),
+            totalSalesAmount = BigDecimal("1000000"), totalRefundAmount = BigDecimal("50000"),
+            commissionRate = BigDecimal("0.1000"), commissionAmount = BigDecimal("95000"),
+            settlementAmount = BigDecimal("855000"), status = SettlementStatus.CALCULATED,
+            confirmedAt = null, paidAt = null, createdAt = LocalDateTime.now(),
+            items = emptyList()
+        )
+        whenever(settlementQueryService.getSettlementDetail(1L, null)).thenReturn(detail)
+
+        val result = controller.getSettlementDetailForAdmin(1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun 판매자가_정산_목록을_조회한다() {
+        val userPrincipal = UserPrincipal.of(10L, "SELLER")
+        val pageable = PageRequest.of(0, 20)
+        whenever(sellerQueryPort.findByUserId(10L)).thenReturn(SellerInfo(id = 5L, userId = 10L))
+        whenever(settlementQueryService.getSettlements(5L, null, pageable))
+            .thenReturn(PageImpl(listOf(createSettlementResponse())))
+
+        val result = controller.getSettlementsForSeller(userPrincipal, null, pageable)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun 판매자가_정산_상세를_조회한다() {
+        val userPrincipal = UserPrincipal.of(10L, "SELLER")
+        val detail = SettlementDetailResponse(
+            id = 1L, sellerId = 5L,
+            periodStart = LocalDate.of(2026, 1, 1), periodEnd = LocalDate.of(2026, 1, 31),
+            totalSalesAmount = BigDecimal("1000000"), totalRefundAmount = BigDecimal("50000"),
+            commissionRate = BigDecimal("0.1000"), commissionAmount = BigDecimal("95000"),
+            settlementAmount = BigDecimal("855000"), status = SettlementStatus.CALCULATED,
+            confirmedAt = null, paidAt = null, createdAt = LocalDateTime.now(),
+            items = emptyList()
+        )
+        whenever(sellerQueryPort.findByUserId(10L)).thenReturn(SellerInfo(id = 5L, userId = 10L))
+        whenever(settlementQueryService.getSettlementDetail(1L, 5L)).thenReturn(detail)
+
+        val result = controller.getSettlementDetailForSeller(userPrincipal, 1L)
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun 판매자_정보가_없으면_목록_조회시_예외가_발생한다() {
+        val userPrincipal = UserPrincipal.of(10L, "SELLER")
+        val pageable = PageRequest.of(0, 20)
+        whenever(sellerQueryPort.findByUserId(10L)).thenReturn(null)
+
+        assertThatThrownBy { controller.getSettlementsForSeller(userPrincipal, null, pageable) }
+            .isInstanceOf(SettlementSellerNotFoundException::class.java)
+    }
+
+    @Test
+    fun 판매자_정보가_없으면_상세_조회시_예외가_발생한다() {
+        val userPrincipal = UserPrincipal.of(10L, "SELLER")
+        whenever(sellerQueryPort.findByUserId(10L)).thenReturn(null)
+
+        assertThatThrownBy { controller.getSettlementDetailForSeller(userPrincipal, 1L) }
+            .isInstanceOf(SettlementSellerNotFoundException::class.java)
+    }
+}

--- a/settlement-service/src/test/kotlin/com/hoppingmall/settlement/domain/SettlementItemTest.kt
+++ b/settlement-service/src/test/kotlin/com/hoppingmall/settlement/domain/SettlementItemTest.kt
@@ -1,0 +1,32 @@
+package com.hoppingmall.settlement.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("SettlementItem")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class SettlementItemTest {
+
+    @Test
+    fun 정산_항목을_생성한다() {
+        val item = SettlementItem.create(
+            settlementId = 1L,
+            orderId = 100L,
+            orderItemId = 200L,
+            productName = "테스트 상품",
+            quantity = 3,
+            salesAmount = BigDecimal("30000")
+        )
+
+        assertThat(item.settlementId).isEqualTo(1L)
+        assertThat(item.orderId).isEqualTo(100L)
+        assertThat(item.orderItemId).isEqualTo(200L)
+        assertThat(item.productName).isEqualTo("테스트 상품")
+        assertThat(item.quantity).isEqualTo(3)
+        assertThat(item.salesAmount).isEqualByComparingTo(BigDecimal("30000"))
+    }
+}

--- a/user-service/build.gradle.kts
+++ b/user-service/build.gradle.kts
@@ -98,7 +98,14 @@ val jacocoExcludedDirs = listOf(
 	"**/enums/**",
 	"**/vo/**",
 	"**/exception/**",
-	"**/*Application*"
+	"**/*Application*",
+	"**/grpc/MembershipQueryServiceGrpc*",
+	"**/grpc/MembershipQueryServiceGrpcKt*",
+	"**/grpc/MembershipQuery*",
+	"**/grpc/UserIdRequest*",
+	"**/grpc/EarningRateResponse*",
+	"**/grpc/UserIdRequestKt*",
+	"**/grpc/EarningRateResponseKt*"
 )
 
 tasks.jacocoTestReport {

--- a/user-service/src/test/kotlin/com/hoppingmall/user/auth/TokenProviderImplTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/auth/TokenProviderImplTest.kt
@@ -1,0 +1,111 @@
+package com.hoppingmall.user.auth
+
+import com.hoppingmall.user.auth.exception.InvalidTokenException
+import com.hoppingmall.user.common.enums.Role
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("TokenProviderImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class TokenProviderImplTest {
+
+    private lateinit var tokenProvider: TokenProviderImpl
+
+    @BeforeEach
+    fun setUp() {
+        val jwtProperties = JwtProperties().apply {
+            secret = "test-secret-key-that-is-at-least-32-bytes-long-for-hs256"
+            accessExpirationMs = 3600000
+            refreshExpirationMs = 86400000
+        }
+        tokenProvider = TokenProviderImpl(jwtProperties)
+    }
+
+    @Test
+    fun 액세스_토큰을_생성한다() {
+        val token = tokenProvider.generateAccessToken(1L, Role.BUYER)
+
+        assertThat(token).isNotBlank()
+    }
+
+    @Test
+    fun 리프레시_토큰을_생성한다() {
+        val token = tokenProvider.generateRefreshToken(1L)
+
+        assertThat(token).isNotBlank()
+    }
+
+    @Test
+    fun 액세스_토큰에서_사용자_ID를_파싱한다() {
+        val token = tokenProvider.generateAccessToken(42L, Role.SELLER)
+
+        val userId = tokenProvider.parseAccessToken(token)
+
+        assertThat(userId).isEqualTo(42L)
+    }
+
+    @Test
+    fun 리프레시_토큰에서_사용자_ID를_파싱한다() {
+        val token = tokenProvider.generateRefreshToken(42L)
+
+        val userId = tokenProvider.parseRefreshToken(token)
+
+        assertThat(userId).isEqualTo(42L)
+    }
+
+    @Test
+    fun 유효한_토큰을_검증한다() {
+        val token = tokenProvider.generateAccessToken(1L, Role.BUYER)
+
+        val result = tokenProvider.validateToken(token)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun 잘못된_토큰을_검증하면_예외가_발생한다() {
+        assertThatThrownBy { tokenProvider.validateToken("invalid-token") }
+            .isInstanceOf(InvalidTokenException::class.java)
+    }
+
+    @Test
+    fun 토큰에서_사용자_ID를_가져온다() {
+        val token = tokenProvider.generateAccessToken(10L, Role.ADMIN)
+
+        val userId = tokenProvider.getUserIdFromToken(token)
+
+        assertThat(userId).isEqualTo(10L)
+    }
+
+    @Test
+    fun 토큰에서_사용자_역할을_가져온다() {
+        val token = tokenProvider.generateAccessToken(1L, Role.SELLER)
+
+        val role = tokenProvider.getUserRoleFromToken(token)
+
+        assertThat(role).isEqualTo(Role.SELLER)
+    }
+
+    @Test
+    fun 토큰에서_UserPrincipal을_가져온다() {
+        val token = tokenProvider.generateAccessToken(5L, Role.BUYER)
+
+        val principal = tokenProvider.getUserPrincipal(token)
+
+        assertThat(principal.getUserId()).isEqualTo(5L)
+    }
+
+    @Test
+    fun 토큰의_남은_만료_시간을_가져온다() {
+        val token = tokenProvider.generateAccessToken(1L, Role.BUYER)
+
+        val remaining = tokenProvider.getRemainingExpirationMs(token)
+
+        assertThat(remaining).isPositive()
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/auth/domain/repository/AccessTokenBlacklistRepositoryTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/auth/domain/repository/AccessTokenBlacklistRepositoryTest.kt
@@ -1,0 +1,68 @@
+package com.hoppingmall.user.auth.domain.repository
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.util.concurrent.TimeUnit
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("AccessTokenBlacklistRepository")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class AccessTokenBlacklistRepositoryTest {
+
+    @Mock
+    private lateinit var customStringRedisTemplate: RedisTemplate<String, String>
+
+    @Mock
+    private lateinit var valueOperations: ValueOperations<String, String>
+
+    @InjectMocks
+    private lateinit var repository: AccessTokenBlacklistRepository
+
+    @Test
+    fun 토큰을_블랙리스트에_추가한다() {
+        whenever(customStringRedisTemplate.opsForValue()).thenReturn(valueOperations)
+
+        repository.add("test-token", 3600000L)
+
+        verify(valueOperations).set(eq("blacklist:test-token"), eq("blacklisted"), eq(3600000L), eq(TimeUnit.MILLISECONDS))
+    }
+
+    @Test
+    fun TTL이_0이하이면_블랙리스트에_추가하지_않는다() {
+        repository.add("test-token", 0L)
+
+        verify(customStringRedisTemplate, never()).opsForValue()
+    }
+
+    @Test
+    fun 블랙리스트에_토큰이_존재하는지_확인한다() {
+        whenever(customStringRedisTemplate.hasKey("blacklist:test-token")).thenReturn(true)
+
+        val result = repository.exists("test-token")
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun 블랙리스트에_토큰이_존재하지_않으면_false를_반환한다() {
+        whenever(customStringRedisTemplate.hasKey("blacklist:test-token")).thenReturn(false)
+
+        val result = repository.exists("test-token")
+
+        assertThat(result).isFalse()
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/auth/domain/repository/RefreshTokenRepositoryTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/auth/domain/repository/RefreshTokenRepositoryTest.kt
@@ -1,0 +1,70 @@
+package com.hoppingmall.user.auth.domain.repository
+
+import com.hoppingmall.user.auth.domain.RefreshToken
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.util.concurrent.TimeUnit
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("RefreshTokenRepository")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class RefreshTokenRepositoryTest {
+
+    @Mock
+    private lateinit var stringRedisTemplate: RedisTemplate<String, String>
+
+    @Mock
+    private lateinit var valueOperations: ValueOperations<String, String>
+
+    @InjectMocks
+    private lateinit var repository: RefreshTokenRepository
+
+    @Test
+    fun 리프레시_토큰을_저장한다() {
+        val refreshToken = RefreshToken(userId = 1L, token = "test-token", ttl = 86400000L)
+        whenever(stringRedisTemplate.opsForValue()).thenReturn(valueOperations)
+
+        repository.save(refreshToken)
+
+        verify(valueOperations).set(eq("refreshToken:1"), eq("test-token"), eq(86400000L), eq(TimeUnit.MILLISECONDS))
+    }
+
+    @Test
+    fun 사용자_ID로_리프레시_토큰을_조회한다() {
+        whenever(stringRedisTemplate.opsForValue()).thenReturn(valueOperations)
+        whenever(valueOperations.get("refreshToken:1")).thenReturn("stored-token")
+
+        val result = repository.findByUserId(1L)
+
+        assertThat(result).isEqualTo("stored-token")
+    }
+
+    @Test
+    fun 존재하지_않는_사용자의_리프레시_토큰_조회시_null을_반환한다() {
+        whenever(stringRedisTemplate.opsForValue()).thenReturn(valueOperations)
+        whenever(valueOperations.get("refreshToken:999")).thenReturn(null)
+
+        val result = repository.findByUserId(999L)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun 사용자_ID로_리프레시_토큰을_삭제한다() {
+        repository.deleteByUserId(1L)
+
+        verify(stringRedisTemplate).delete("refreshToken:1")
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/domain/MembershipEventLogTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/domain/MembershipEventLogTest.kt
@@ -1,0 +1,25 @@
+package com.hoppingmall.user.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("MembershipEventLog")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class MembershipEventLogTest {
+
+    @Test
+    fun 멤버십_이벤트_로그를_생성한다() {
+        val log = MembershipEventLog(
+            eventId = "evt-001",
+            paymentId = 100L,
+            orderId = 200L
+        )
+
+        assertThat(log.eventId).isEqualTo("evt-001")
+        assertThat(log.paymentId).isEqualTo(100L)
+        assertThat(log.orderId).isEqualTo(200L)
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/grpc/BusinessContextServerInterceptorTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/grpc/BusinessContextServerInterceptorTest.kt
@@ -1,0 +1,81 @@
+package com.hoppingmall.user.grpc
+
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.slf4j.MDC
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("BusinessContextServerInterceptor")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class BusinessContextServerInterceptorTest {
+
+    @Mock
+    private lateinit var serverCall: ServerCall<Any, Any>
+
+    @Mock
+    private lateinit var next: ServerCallHandler<Any, Any>
+
+    @Mock
+    private lateinit var delegate: ServerCall.Listener<Any>
+
+    @Test
+    fun userId_헤더가_있으면_MDC에_설정한다() {
+        val interceptor = BusinessContextServerInterceptor()
+        val headers = Metadata()
+        headers.put(BusinessContextServerInterceptor.USER_ID_KEY, "42")
+        whenever(next.startCall(any(), any())).thenReturn(delegate)
+
+        interceptor.interceptCall(serverCall, headers, next)
+
+        assertThat(MDC.get("userId")).isEqualTo("42")
+        MDC.remove("userId")
+    }
+
+    @Test
+    fun userId_헤더가_없어도_정상_동작한다() {
+        val interceptor = BusinessContextServerInterceptor()
+        val headers = Metadata()
+        whenever(next.startCall(any(), any())).thenReturn(delegate)
+
+        interceptor.interceptCall(serverCall, headers, next)
+
+        assertThat(MDC.get("userId")).isNull()
+    }
+
+    @Test
+    fun onComplete_호출시_MDC를_정리한다() {
+        val interceptor = BusinessContextServerInterceptor()
+        val headers = Metadata()
+        headers.put(BusinessContextServerInterceptor.USER_ID_KEY, "42")
+        whenever(next.startCall(any(), any())).thenReturn(delegate)
+
+        val listener = interceptor.interceptCall(serverCall, headers, next)
+        listener.onComplete()
+
+        assertThat(MDC.get("userId")).isNull()
+    }
+
+    @Test
+    fun onCancel_호출시_MDC를_정리한다() {
+        val interceptor = BusinessContextServerInterceptor()
+        val headers = Metadata()
+        headers.put(BusinessContextServerInterceptor.USER_ID_KEY, "42")
+        whenever(next.startCall(any(), any())).thenReturn(delegate)
+
+        val listener = interceptor.interceptCall(serverCall, headers, next)
+        listener.onCancel()
+
+        assertThat(MDC.get("userId")).isNull()
+    }
+}

--- a/user-service/src/test/kotlin/com/hoppingmall/user/grpc/InternalTokenServerInterceptorTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/grpc/InternalTokenServerInterceptorTest.kt
@@ -1,0 +1,69 @@
+package com.hoppingmall.user.grpc
+
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.Status
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("InternalTokenServerInterceptor")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class InternalTokenServerInterceptorTest {
+
+    @Mock
+    private lateinit var serverCall: ServerCall<Any, Any>
+
+    @Mock
+    private lateinit var next: ServerCallHandler<Any, Any>
+
+    @Mock
+    private lateinit var listener: ServerCall.Listener<Any>
+
+    @Test
+    fun 유효한_토큰이면_요청을_통과시킨다() {
+        val interceptor = InternalTokenServerInterceptor("valid-token")
+        val headers = Metadata()
+        headers.put(InternalTokenServerInterceptor.INTERNAL_TOKEN_KEY, "valid-token")
+        whenever(next.startCall(serverCall, headers)).thenReturn(listener)
+
+        interceptor.interceptCall(serverCall, headers, next)
+
+        verify(next).startCall(serverCall, headers)
+    }
+
+    @Test
+    fun 잘못된_토큰이면_요청을_거부한다() {
+        val interceptor = InternalTokenServerInterceptor("valid-token")
+        val headers = Metadata()
+        headers.put(InternalTokenServerInterceptor.INTERNAL_TOKEN_KEY, "wrong-token")
+
+        interceptor.interceptCall(serverCall, headers, next)
+
+        verify(serverCall).close(argThat { code == Status.UNAUTHENTICATED.code }, any())
+        verify(next, never()).startCall(any(), any())
+    }
+
+    @Test
+    fun 토큰이_없으면_요청을_거부한다() {
+        val interceptor = InternalTokenServerInterceptor("valid-token")
+        val headers = Metadata()
+
+        interceptor.interceptCall(serverCall, headers, next)
+
+        verify(serverCall).close(argThat { code == Status.UNAUTHENTICATED.code }, any())
+        verify(next, never()).startCall(any(), any())
+    }
+}


### PR DESCRIPTION
Closes #336

### 📌 작업 개요
CI에서 Jacoco 커버리지 80% 미달 시 빌드가 실패하도록 검증 단계를 추가하고,
MSA 전환 과정에서 누락된 라이브러리 모듈의 Jacoco 설정과 테스트 의존성을 보강합니다.

---

### ✅ 주요 변경 사항

- `.github/workflows/ci.yml`
  - `jacocoTestVerification` 단계 추가 (80% LINE 커버리지 게이트)

- `hoppingmall-cache/build.gradle.kts`
  - jacoco 플러그인, 제외 설정, verification task, redis/redisson 테스트 의존성 추가

- `hoppingmall-outbox/build.gradle.kts`
  - jacoco 플러그인, 제외 설정, verification task 추가

- `hoppingmall-dlq/build.gradle.kts`
  - `micrometer-core`, `spring-kafka` 테스트 의존성 추가

- `hoppingmall-idempotency/build.gradle.kts`
  - 테스트 의존성 추가, `useJUnitPlatform()` 설정

- `api-gateway/build.gradle.kts`
  - `mockito-kotlin` 테스트 의존성 추가

- `order-service/build.gradle.kts`, `product-service/build.gradle.kts`, `user-service/build.gradle.kts`
  - gRPC 자동 생성 클래스 jacoco 제외 대상 추가

---

### 📎 관련 이슈
- #336
