### PR TITLE
fix: Soft Delete 전략을 @FilterDef에서 @SQLRestriction으로 전환

### DIFF
--- a/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/BaseEntity.kt
+++ b/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/BaseEntity.kt
@@ -1,17 +1,13 @@
 package com.hoppingmall.common
 
 import jakarta.persistence.*
-import org.hibernate.annotations.FilterDef
+import org.hibernate.annotations.SQLRestriction
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
 
-@FilterDef(
-    name = "softDeleteFilter",
-    autoEnabled = true,
-    defaultCondition = "deleted_at IS NULL"
-)
+@SQLRestriction("deleted_at IS NULL")
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
 abstract class BaseEntity {

--- a/order-service/src/main/kotlin/com/hoppingmall/order/cartItem/domain/CartItem.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/cartItem/domain/CartItem.kt
@@ -5,10 +5,8 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Index
 import jakarta.persistence.Table
-import org.hibernate.annotations.Filter
 import java.math.BigDecimal
 
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 @Entity
 @Table(
     name = "cart_items",

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/Order.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/Order.kt
@@ -4,7 +4,6 @@ import com.hoppingmall.common.BaseEntity
 import com.hoppingmall.order.order.enum.OrderStatus
 import com.hoppingmall.order.order.exception.OrderInvalidStatusException
 import jakarta.persistence.*
-import org.hibernate.annotations.Filter
 import java.math.BigDecimal
 
 @Entity
@@ -12,7 +11,6 @@ import java.math.BigDecimal
     name = "orders",
     indexes = [Index(name = "idx_orders_buyer_id", columnList = "buyerId")]
 )
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class Order private constructor(
     @Column(nullable = false)
     val buyerId: Long,

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/OrderItem.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/OrderItem.kt
@@ -5,7 +5,6 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Index
 import jakarta.persistence.Table
-import org.hibernate.annotations.Filter
 import java.math.BigDecimal
 
 @Entity
@@ -16,7 +15,6 @@ import java.math.BigDecimal
         Index(name = "idx_order_items_product_id", columnList = "productId")
     ]
 )
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class OrderItem private constructor(
     @Column(nullable = false)
     val orderId: Long,

--- a/order-service/src/main/kotlin/com/hoppingmall/order/refund/domain/Refund.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/refund/domain/Refund.kt
@@ -5,7 +5,6 @@ import com.hoppingmall.order.refund.enum.RefundReason
 import com.hoppingmall.order.refund.enum.RefundStatus
 import com.hoppingmall.order.refund.exception.RefundInvalidStatusException
 import jakarta.persistence.*
-import org.hibernate.annotations.Filter
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
@@ -19,7 +18,6 @@ import java.time.LocalDateTime
         Index(name = "idx_refunds_seller_id", columnList = "sellerId")
     ]
 )
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class Refund private constructor(
     @Column(nullable = false)
     val orderId: Long,

--- a/order-service/src/main/kotlin/com/hoppingmall/order/refund/domain/RefundItem.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/refund/domain/RefundItem.kt
@@ -5,7 +5,6 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Index
 import jakarta.persistence.Table
-import org.hibernate.annotations.Filter
 import java.math.BigDecimal
 
 @Entity
@@ -13,7 +12,6 @@ import java.math.BigDecimal
     name = "refund_items",
     indexes = [Index(name = "idx_refund_items_refund_id", columnList = "refundId")]
 )
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class RefundItem private constructor(
     @Column(nullable = false)
     val refundId: Long,

--- a/order-service/src/main/kotlin/com/hoppingmall/order/shipping/domain/Shipping.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/shipping/domain/Shipping.kt
@@ -4,7 +4,6 @@ import com.hoppingmall.common.BaseEntity
 import com.hoppingmall.order.shipping.enum.ShippingStatus
 import com.hoppingmall.order.shipping.exception.ShippingInvalidStatusException
 import jakarta.persistence.*
-import org.hibernate.annotations.Filter
 
 @Entity
 @Table(
@@ -15,7 +14,6 @@ import org.hibernate.annotations.Filter
         Index(name = "idx_shippings_tracking_number", columnList = "trackingNumber")
     ]
 )
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class Shipping private constructor(
     @Column(nullable = false)
     val orderId: Long,

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/domain/Coupon.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/domain/Coupon.kt
@@ -4,14 +4,12 @@ import com.hoppingmall.payment.coupon.enum.CouponStatus
 import com.hoppingmall.payment.coupon.enum.DiscountType
 import com.hoppingmall.common.BaseEntity
 import jakarta.persistence.*
-import org.hibernate.annotations.Filter
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDateTime
 
 @Entity
 @Table(name = "coupons")
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class Coupon private constructor(
     @Column(nullable = false)
     val name: String,

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/domain/UserCoupon.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/domain/UserCoupon.kt
@@ -3,7 +3,6 @@ package com.hoppingmall.payment.coupon.domain
 import com.hoppingmall.payment.coupon.enum.UserCouponStatus
 import com.hoppingmall.common.BaseEntity
 import jakarta.persistence.*
-import org.hibernate.annotations.Filter
 import java.time.LocalDateTime
 
 @Entity
@@ -12,7 +11,6 @@ import java.time.LocalDateTime
     uniqueConstraints = [UniqueConstraint(columnNames = ["user_id", "coupon_id"])],
     indexes = [Index(name = "idx_user_coupons_user_id", columnList = "userId")]
 )
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class UserCoupon private constructor(
     @Column(nullable = false)
     val userId: Long,

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/domain/repository/CouponRepository.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/domain/repository/CouponRepository.kt
@@ -11,18 +11,18 @@ import java.time.LocalDateTime
 @Repository
 interface CouponRepository : JpaRepository<Coupon, Long> {
 
-    @Query("SELECT c FROM Coupon c WHERE c.id = :id AND c.deletedAt IS NULL")
+    @Query("SELECT c FROM Coupon c WHERE c.id = :id")
     fun findActiveById(@Param("id") id: Long): Coupon?
 
     @Query(
         "SELECT c FROM Coupon c WHERE c.status = :status AND c.validFrom <= :now AND c.validTo > :now " +
-            "AND c.issuedQuantity < c.totalQuantity AND c.deletedAt IS NULL"
+            "AND c.issuedQuantity < c.totalQuantity"
     )
     fun findAvailableCoupons(
         @Param("status") status: CouponStatus = CouponStatus.ACTIVE,
         @Param("now") now: LocalDateTime = LocalDateTime.now()
     ): List<Coupon>
 
-    @Query("SELECT c FROM Coupon c WHERE c.deletedAt IS NULL")
+    @Query("SELECT c FROM Coupon c")
     fun findAllActive(): List<Coupon>
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/domain/Payment.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/domain/Payment.kt
@@ -4,7 +4,6 @@ import com.hoppingmall.common.BaseEntity
 import com.hoppingmall.payment.payment.enum.PaymentMethod
 import com.hoppingmall.payment.payment.enum.PaymentStatus
 import jakarta.persistence.*
-import org.hibernate.annotations.Filter
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
@@ -16,7 +15,6 @@ import java.time.LocalDateTime
         Index(name = "idx_payments_user_id", columnList = "userId")
     ]
 )
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class Payment private constructor(
     @Column(nullable = false)
     val orderId: Long,

--- a/product-service/src/main/kotlin/com/hoppingmall/product/category/domain/Category.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/category/domain/Category.kt
@@ -5,9 +5,6 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Index
 import jakarta.persistence.Table
-import org.hibernate.annotations.Filter
-
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 @Entity
 @Table(
     name = "categories",

--- a/product-service/src/main/kotlin/com/hoppingmall/product/inventory/domain/Inventory.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/inventory/domain/Inventory.kt
@@ -5,9 +5,6 @@ import com.hoppingmall.product.inventory.exception.InventoryInsufficientStockExc
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
-import org.hibernate.annotations.Filter
-
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 @Entity
 @Table(name = "inventories")
 class Inventory private constructor(

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/BulkImportJob.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/BulkImportJob.kt
@@ -3,7 +3,6 @@ package com.hoppingmall.product.product.domain
 import com.hoppingmall.common.BaseEntity
 import com.hoppingmall.product.product.enum.BulkImportStatus
 import jakarta.persistence.*
-import org.hibernate.annotations.Filter
 import java.time.LocalDateTime
 
 @Entity
@@ -11,7 +10,6 @@ import java.time.LocalDateTime
     name = "bulk_import_jobs",
     indexes = [Index(name = "idx_bulk_import_jobs_seller_id", columnList = "sellerId")]
 )
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class BulkImportJob private constructor(
     @Column(nullable = false)
     val sellerId: Long,

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/Product.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/Product.kt
@@ -3,7 +3,6 @@ package com.hoppingmall.product.product.domain
 import com.hoppingmall.common.BaseEntity
 import com.hoppingmall.product.common.enums.ProductStatus
 import jakarta.persistence.*
-import org.hibernate.annotations.Filter
 import java.math.BigDecimal
 
 @Entity
@@ -14,7 +13,6 @@ import java.math.BigDecimal
         Index(name = "idx_products_category_id", columnList = "categoryId")
     ]
 )
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class Product private constructor(
 
     @Column(nullable = false)

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/ProductImage.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/ProductImage.kt
@@ -5,14 +5,11 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Index
 import jakarta.persistence.Table
-import org.hibernate.annotations.Filter
-
 @Entity
 @Table(
     name = "product_images",
     indexes = [Index(name = "idx_product_images_product_id", columnList = "productId")]
 )
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class ProductImage private constructor(
 
     @Column(nullable = false)

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductSearchRepositoryImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductSearchRepositoryImpl.kt
@@ -67,7 +67,7 @@ class ProductSearchRepositoryImpl(
         maxPrice: BigDecimal?,
         pageable: Pageable
     ): Slice<Product> {
-        val sb = StringBuilder("SELECT p FROM Product p WHERE p.deletedAt IS NULL")
+        val sb = StringBuilder("SELECT p FROM Product p WHERE 1=1")
 
         if (!keyword.isNullOrBlank()) {
             sb.append(" AND (p.name LIKE :keyword OR p.description LIKE :keyword)")

--- a/product-service/src/main/kotlin/com/hoppingmall/product/review/domain/Review.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/review/domain/Review.kt
@@ -2,7 +2,6 @@ package com.hoppingmall.product.review.domain
 
 import com.hoppingmall.common.BaseEntity
 import jakarta.persistence.*
-import org.hibernate.annotations.Filter
 
 @Entity
 @Table(
@@ -13,7 +12,6 @@ import org.hibernate.annotations.Filter
         Index(name = "idx_reviews_buyer_id", columnList = "buyerId")
     ]
 )
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class Review private constructor(
     @Column(nullable = false)
     val buyerId: Long,

--- a/product-service/src/main/kotlin/com/hoppingmall/product/review/domain/repository/ReviewRepository.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/review/domain/repository/ReviewRepository.kt
@@ -15,9 +15,9 @@ interface ReviewRepository : JpaRepository<Review, Long> {
     fun existsByOrderItemId(orderItemId: Long): Boolean
     fun findNullableById(id: Long): Review?
 
-    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.productId = :productId AND r.deletedAt IS NULL")
+    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.productId = :productId")
     fun averageRatingByProductId(@Param("productId") productId: Long): Double?
 
-    @Query("SELECT COUNT(r) FROM Review r WHERE r.productId = :productId AND r.deletedAt IS NULL")
+    @Query("SELECT COUNT(r) FROM Review r WHERE r.productId = :productId")
     fun countByProductId(@Param("productId") productId: Long): Long
 }

--- a/user-service/src/main/kotlin/com/hoppingmall/user/domain/Buyer.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/domain/Buyer.kt
@@ -2,9 +2,7 @@ package com.hoppingmall.user.domain
 
 import com.hoppingmall.common.BaseEntity
 import jakarta.persistence.*
-import org.hibernate.annotations.Filter
 
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 @Entity
 @Table(name = "buyers")
 class Buyer private constructor(

--- a/user-service/src/main/kotlin/com/hoppingmall/user/domain/Seller.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/domain/Seller.kt
@@ -2,9 +2,7 @@ package com.hoppingmall.user.domain
 
 import com.hoppingmall.common.BaseEntity
 import jakarta.persistence.*
-import org.hibernate.annotations.Filter
 
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 @Entity
 @Table(name = "sellers")
 class Seller private constructor(

--- a/user-service/src/main/kotlin/com/hoppingmall/user/domain/User.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/domain/User.kt
@@ -5,11 +5,9 @@ import com.hoppingmall.user.common.enums.Role
 import com.hoppingmall.user.common.vo.Email
 import com.hoppingmall.user.common.vo.Password
 import jakarta.persistence.*
-import org.hibernate.annotations.Filter
 
 @Entity
 @Table(name = "users")
-@Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL")
 class User private constructor(
     @Embedded
     val email: Email,


### PR DESCRIPTION
Closes #341

### 📌 작업 개요
`@FilterDef(autoEnabled=true)` 기반 Soft Delete 전략을 `@SQLRestriction`으로 전환하여,
`findById()` 호출 시 soft-deleted 레코드가 반환되는 정합성 버그를 수정했습니다.

---

### ✅ 주요 변경 사항

- `hoppingmall-common.BaseEntity`
  - `@FilterDef` 제거, `@SQLRestriction("deleted_at IS NULL")` 적용

- `order-service`, `payment-service`, `product-service`, `user-service` 엔티티 (18개)
  - 각 엔티티의 `@Filter` 어노테이션 및 import 제거
  - `@SQLRestriction`은 `@MappedSuperclass`를 통해 자동 상속

- `CouponRepository`, `ReviewRepository`, `ProductSearchRepositoryImpl`
  - JPQL 쿼리에서 중복 `deletedAt IS NULL` 조건 제거 (자동 적용됨)
  - Native SQL 쿼리의 `deleted_at IS NULL`은 유지 (자동 적용 대상 아님)

---

### 🧪 테스트

- user-service, order-service, payment-service, product-service 전체 테스트 통과

---

### 📎 관련 이슈
- #341
