### PR TITLE
perf: 통계 스냅샷 N+1 쿼리 제거

### DIFF
--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductDailyStatisticsRepository.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductDailyStatisticsRepository.kt
@@ -14,6 +14,11 @@ interface ProductDailyStatisticsRepository : JpaRepository<ProductDailyStatistic
 
     fun findByProductIdAndStatisticsDate(productId: Long, statisticsDate: LocalDate): ProductDailyStatistics?
 
+    fun findByStatisticsDateAndProductIdIn(
+        statisticsDate: LocalDate,
+        productIds: Collection<Long>
+    ): List<ProductDailyStatistics>
+
     fun findByProductIdAndStatisticsDateBetweenOrderByStatisticsDateAsc(
         productId: Long,
         startDate: LocalDate,
@@ -33,6 +38,21 @@ interface ProductDailyStatisticsRepository : JpaRepository<ProductDailyStatistic
         @Param("startDate") startDate: LocalDate,
         @Param("endDate") endDate: LocalDate
     ): BigDecimal
+
+    @Query(
+        """
+        SELECT d.productId, COALESCE(SUM(d.dailySalesAmount), 0)
+        FROM ProductDailyStatistics d
+        WHERE d.productId IN :productIds
+          AND d.statisticsDate BETWEEN :startDate AND :endDate
+        GROUP BY d.productId
+        """
+    )
+    fun sumSalesAmountByProductIdsAndDateRange(
+        @Param("productIds") productIds: Collection<Long>,
+        @Param("startDate") startDate: LocalDate,
+        @Param("endDate") endDate: LocalDate
+    ): List<Array<Any>>
 
     @Query(
         """

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductHourlyStatisticsRepository.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductHourlyStatisticsRepository.kt
@@ -17,6 +17,12 @@ interface ProductHourlyStatisticsRepository : JpaRepository<ProductHourlyStatist
         hour: Int
     ): ProductHourlyStatistics?
 
+    fun findByStatisticsDateAndHourAndProductIdIn(
+        statisticsDate: LocalDate,
+        hour: Int,
+        productIds: Collection<Long>
+    ): List<ProductHourlyStatistics>
+
     fun findByProductIdAndStatisticsDateOrderByHourAsc(
         productId: Long,
         statisticsDate: LocalDate

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImpl.kt
@@ -45,32 +45,46 @@ class ProductStatisticsCommandServiceImpl(
     override fun flushDailySnapshot() {
         val today = LocalDate.now()
         val allStats = productStatisticsRepository.findAll()
+        if (allStats.isEmpty()) {
+            logger.info("일별 통계 스냅샷 완료: 0건")
+            return
+        }
 
+        val productIds = allStats.map { it.productId }
+
+        val existingDailyMap = productDailyStatisticsRepository
+            .findByStatisticsDateAndProductIdIn(today, productIds)
+            .associateBy { it.productId }
+
+        val last7DaysMap = toSalesAmountMap(
+            productDailyStatisticsRepository.sumSalesAmountByProductIdsAndDateRange(productIds, today.minusDays(6), today)
+        )
+        val last30DaysMap = toSalesAmountMap(
+            productDailyStatisticsRepository.sumSalesAmountByProductIdsAndDateRange(productIds, today.minusDays(29), today)
+        )
+        val previousWeekMap = toSalesAmountMap(
+            productDailyStatisticsRepository.sumSalesAmountByProductIdsAndDateRange(productIds, today.minusDays(13), today.minusDays(7))
+        )
+
+        val dailyToSave = mutableListOf<ProductDailyStatistics>()
         for (stats in allStats) {
-            val existing = productDailyStatisticsRepository
-                .findByProductIdAndStatisticsDate(stats.productId, today)
-
-            val daily = existing ?: ProductDailyStatistics.create(
+            val daily = existingDailyMap[stats.productId] ?: ProductDailyStatistics.create(
                 productId = stats.productId,
                 statisticsDate = today
             )
             daily.updateFromStatistics(stats)
-            productDailyStatisticsRepository.save(daily)
+            dailyToSave.add(daily)
 
-            val last7Days = productDailyStatisticsRepository.sumSalesAmountByProductIdAndDateRange(
-                stats.productId, today.minusDays(6), today
+            stats.updatePeriodMetrics(
+                last7DaysMap[stats.productId] ?: BigDecimal.ZERO,
+                last30DaysMap[stats.productId] ?: BigDecimal.ZERO,
+                previousWeekMap[stats.productId] ?: BigDecimal.ZERO
             )
-            val last30Days = productDailyStatisticsRepository.sumSalesAmountByProductIdAndDateRange(
-                stats.productId, today.minusDays(29), today
-            )
-            val previousWeek = productDailyStatisticsRepository.sumSalesAmountByProductIdAndDateRange(
-                stats.productId, today.minusDays(13), today.minusDays(7)
-            )
-
-            stats.updatePeriodMetrics(last7Days, last30Days, previousWeek)
             stats.resetToday()
-            productStatisticsRepository.save(stats)
         }
+
+        productDailyStatisticsRepository.saveAll(dailyToSave)
+        productStatisticsRepository.saveAll(allStats)
 
         logger.info("일별 통계 스냅샷 완료: ${allStats.size}건")
     }
@@ -81,24 +95,35 @@ class ProductStatisticsCommandServiceImpl(
         val currentHour = now.hour
         val allStats = productStatisticsRepository.findAll()
 
-        var flushedCount = 0
-        for (stats in allStats) {
-            if (stats.todaySalesQuantity == 0L && stats.todayRefundQuantity == 0L) continue
+        val activeStats = allStats.filter { it.todaySalesQuantity > 0L || it.todayRefundQuantity > 0L }
+        if (activeStats.isEmpty()) {
+            logger.info("시간별 통계 스냅샷 완료: 0건 (${currentHour}시)")
+            return
+        }
 
-            val existing = productHourlyStatisticsRepository
-                .findByProductIdAndStatisticsDateAndHour(stats.productId, today, currentHour)
+        val productIds = activeStats.map { it.productId }
+        val existingHourlyMap = productHourlyStatisticsRepository
+            .findByStatisticsDateAndHourAndProductIdIn(today, currentHour, productIds)
+            .associateBy { it.productId }
 
-            val hourly = existing ?: ProductHourlyStatistics.create(
+        val hourlyToSave = mutableListOf<ProductHourlyStatistics>()
+        for (stats in activeStats) {
+            val hourly = existingHourlyMap[stats.productId] ?: ProductHourlyStatistics.create(
                 productId = stats.productId,
                 statisticsDate = today,
                 hour = currentHour
             )
             hourly.updateFromStatistics(stats)
-            productHourlyStatisticsRepository.save(hourly)
-            flushedCount++
+            hourlyToSave.add(hourly)
         }
 
-        logger.info("시간별 통계 스냅샷 완료: ${flushedCount}건 (${currentHour}시)")
+        productHourlyStatisticsRepository.saveAll(hourlyToSave)
+
+        logger.info("시간별 통계 스냅샷 완료: ${hourlyToSave.size}건 (${currentHour}시)")
+    }
+
+    private fun toSalesAmountMap(rows: List<Array<Any>>): Map<Long, BigDecimal> {
+        return rows.associate { (it[0] as Long) to (it[1] as BigDecimal) }
     }
 
     private fun getOrCreateStatistics(productId: Long): ProductStatistics {

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImplTest.kt
@@ -130,11 +130,14 @@ class ProductStatisticsCommandServiceImplTest {
         val daily = ProductDailyStatistics.create(productId = 1L, statisticsDate = LocalDate.now())
 
         whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
-        whenever(productDailyStatisticsRepository.findByProductIdAndStatisticsDate(any(), any())).thenReturn(daily)
-        whenever(productDailyStatisticsRepository.save(any<ProductDailyStatistics>())).thenReturn(daily)
-        whenever(productDailyStatisticsRepository.sumSalesAmountByProductIdAndDateRange(any(), any(), any()))
-            .thenReturn(BigDecimal("100000"))
-        whenever(productStatisticsRepository.save(any<ProductStatistics>())).thenReturn(stats)
+        whenever(productDailyStatisticsRepository.findByStatisticsDateAndProductIdIn(any(), any()))
+            .thenReturn(listOf(daily))
+        whenever(productDailyStatisticsRepository.sumSalesAmountByProductIdsAndDateRange(any(), any(), any()))
+            .thenReturn(listOf(arrayOf<Any>(1L, BigDecimal("100000"))))
+        whenever(productDailyStatisticsRepository.saveAll(any<List<ProductDailyStatistics>>()))
+            .thenAnswer { it.arguments[0] }
+        whenever(productStatisticsRepository.saveAll(any<List<ProductStatistics>>()))
+            .thenAnswer { it.arguments[0] }
 
         service.flushDailySnapshot()
 
@@ -147,15 +150,18 @@ class ProductStatisticsCommandServiceImplTest {
         stats.incrementSales(10, BigDecimal("100000"))
 
         whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
-        whenever(productDailyStatisticsRepository.findByProductIdAndStatisticsDate(any(), any())).thenReturn(null)
-        whenever(productDailyStatisticsRepository.save(any<ProductDailyStatistics>())).thenAnswer { it.arguments[0] }
-        whenever(productDailyStatisticsRepository.sumSalesAmountByProductIdAndDateRange(any(), any(), any()))
-            .thenReturn(BigDecimal.ZERO)
-        whenever(productStatisticsRepository.save(any<ProductStatistics>())).thenReturn(stats)
+        whenever(productDailyStatisticsRepository.findByStatisticsDateAndProductIdIn(any(), any()))
+            .thenReturn(emptyList())
+        whenever(productDailyStatisticsRepository.sumSalesAmountByProductIdsAndDateRange(any(), any(), any()))
+            .thenReturn(emptyList())
+        whenever(productDailyStatisticsRepository.saveAll(any<List<ProductDailyStatistics>>()))
+            .thenAnswer { it.arguments[0] }
+        whenever(productStatisticsRepository.saveAll(any<List<ProductStatistics>>()))
+            .thenAnswer { it.arguments[0] }
 
         service.flushDailySnapshot()
 
-        verify(productDailyStatisticsRepository).save(any<ProductDailyStatistics>())
+        verify(productDailyStatisticsRepository).saveAll(any<List<ProductDailyStatistics>>())
     }
 
     @Test
@@ -164,13 +170,14 @@ class ProductStatisticsCommandServiceImplTest {
         stats.incrementSales(10, BigDecimal("100000"))
 
         whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
-        whenever(productHourlyStatisticsRepository.findByProductIdAndStatisticsDateAndHour(any(), any(), any()))
-            .thenReturn(null)
-        whenever(productHourlyStatisticsRepository.save(any<ProductHourlyStatistics>())).thenAnswer { it.arguments[0] }
+        whenever(productHourlyStatisticsRepository.findByStatisticsDateAndHourAndProductIdIn(any(), any<Int>(), any()))
+            .thenReturn(emptyList())
+        whenever(productHourlyStatisticsRepository.saveAll(any<List<ProductHourlyStatistics>>()))
+            .thenAnswer { it.arguments[0] }
 
         service.flushHourlySnapshot()
 
-        verify(productHourlyStatisticsRepository).save(any<ProductHourlyStatistics>())
+        verify(productHourlyStatisticsRepository).saveAll(any<List<ProductHourlyStatistics>>())
     }
 
     @Test
@@ -181,7 +188,8 @@ class ProductStatisticsCommandServiceImplTest {
 
         service.flushHourlySnapshot()
 
-        verify(productHourlyStatisticsRepository, org.mockito.kotlin.never()).save(any<ProductHourlyStatistics>())
+        verify(productHourlyStatisticsRepository, org.mockito.kotlin.never())
+            .saveAll(any<List<ProductHourlyStatistics>>())
     }
 
     @Test
@@ -193,9 +201,10 @@ class ProductStatisticsCommandServiceImplTest {
         )
 
         whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
-        whenever(productHourlyStatisticsRepository.findByProductIdAndStatisticsDateAndHour(any(), any(), any()))
-            .thenReturn(hourly)
-        whenever(productHourlyStatisticsRepository.save(any<ProductHourlyStatistics>())).thenReturn(hourly)
+        whenever(productHourlyStatisticsRepository.findByStatisticsDateAndHourAndProductIdIn(any(), any<Int>(), any()))
+            .thenReturn(listOf(hourly))
+        whenever(productHourlyStatisticsRepository.saveAll(any<List<ProductHourlyStatistics>>()))
+            .thenAnswer { it.arguments[0] }
 
         service.flushHourlySnapshot()
 


### PR DESCRIPTION
Closes #343

### 📌 작업 개요

flushDailySnapshot()과 flushHourlySnapshot()에서 상품 수(N)에 비례하여 쿼리가 증가하는 N+1 문제를 배치 조회와 saveAll()로 해결했습니다.

---

### ✅ 주요 변경 사항

- `product.domain.repository`
  - `ProductDailyStatisticsRepository`: `findByStatisticsDateAndProductIdIn`, `sumSalesAmountByProductIdsAndDateRange` 배치 메서드 추가
  - `ProductHourlyStatisticsRepository`: `findByStatisticsDateAndHourAndProductIdIn` 배치 메서드 추가

- `product.service`
  - `ProductStatisticsCommandServiceImpl`: 개별 조회/저장 루프를 배치 pre-fetch + saveAll()로 전환
  - flushDailySnapshot: 1+5N → 6 쿼리, flushHourlySnapshot: 1+2N → 3 쿼리

---

### 🧪 테스트

- `ProductStatisticsCommandServiceImplTest`: 배치 Repository 메서드에 맞춰 Mock 수정, 전체 10건 통과

---

### 📎 관련 이슈
- #343