### PR TITLE
fix: 쿠폰 발급 트랜잭션 원자성 보장

### DIFF
--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/service/CouponCommandServiceImpl.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/service/CouponCommandServiceImpl.kt
@@ -16,7 +16,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Caching
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 
@@ -62,7 +61,6 @@ class CouponCommandServiceImpl(
     }
 
     @CacheEvict(cacheNames = ["coupon:available"], allEntries = true)
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     override fun issueCoupon(userId: Long, couponId: Long): UserCouponResponse {
         return distributedLockExecutor.withLock("coupon:issue:$couponId") {
             try {

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/internal/DistributedLockExecutor.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/internal/DistributedLockExecutor.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.payment.internal
 import org.redisson.api.RedissonClient
 import org.springframework.stereotype.Component
 import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.Duration
 import java.util.concurrent.TimeUnit
@@ -12,6 +13,12 @@ class DistributedLockExecutor(
     private val redissonClient: RedissonClient,
     private val transactionManager: PlatformTransactionManager
 ) {
+
+    private fun newTransactionTemplate(): TransactionTemplate {
+        return TransactionTemplate(transactionManager).apply {
+            propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
+        }
+    }
 
     fun <T : Any> withLock(
         key: String,
@@ -24,7 +31,7 @@ class DistributedLockExecutor(
             throw DistributedLockException()
         }
         try {
-            return TransactionTemplate(transactionManager).execute { action() }
+            return newTransactionTemplate().execute { action() }
                 ?: throw IllegalStateException("Transaction returned null for lock key: $key")
         } finally {
             if (lock.isHeldByCurrentThread) {
@@ -44,7 +51,7 @@ class DistributedLockExecutor(
             throw DistributedLockException()
         }
         try {
-            TransactionTemplate(transactionManager).executeWithoutResult { action() }
+            newTransactionTemplate().executeWithoutResult { action() }
         } finally {
             if (lock.isHeldByCurrentThread) {
                 lock.unlock()


### PR DESCRIPTION
Closes #345

### 📌 작업 개요
issueCoupon()의 NOT_SUPPORTED 전파 전략을 제거하고,
DistributedLockExecutor의 TransactionTemplate을 REQUIRES_NEW로 전환하여
분산 락 내부 트랜잭션이 락 해제 전에 커밋되도록 보장했습니다.

---

### ✅ 주요 변경 사항

- `internal`
  - `DistributedLockExecutor`: TransactionTemplate 전파를 REQUIRES_NEW로 변경, newTransactionTemplate() 헬퍼 추출

- `coupon.service`
  - `CouponCommandServiceImpl`: issueCoupon()에서 @Transactional(propagation = NOT_SUPPORTED) 제거

---

### 🧪 테스트

- `DistributedLockExecutorTest`: 전체 테스트 통과
- `CouponCommandServiceImplTest`: 전체 테스트 통과
- `PaymentCommandServiceImplTest`: 전체 테스트 통과

---

### 📎 관련 이슈
- #345
