### PR TITLE
perf: 주문 서비스 트랜잭션 범위 최적화

### DIFF
--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImpl.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImpl.kt
@@ -24,10 +24,10 @@ import com.hoppingmall.outbox.service.TransactionalEventPublisher
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 import java.math.BigDecimal
 
 @Service
-@Transactional
 class OrderCommandServiceImpl(
     private val orderRepository: OrderRepository,
     private val orderItemRepository: OrderItemRepository,
@@ -36,7 +36,8 @@ class OrderCommandServiceImpl(
     private val inventoryCommandPort: InventoryCommandPort,
     private val paymentCommandPort: PaymentCommandPort,
     private val transactionalEventPublisher: TransactionalEventPublisher,
-    private val orderMetrics: OrderMetrics
+    private val orderMetrics: OrderMetrics,
+    private val transactionTemplate: TransactionTemplate
 ) : OrderCommandService {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -64,27 +65,29 @@ class OrderCommandServiceImpl(
 
         val totalAmount = cartItems.fold(BigDecimal.ZERO) { acc, it -> acc.add(it.productPrice.multiply(BigDecimal(it.quantity))) }
 
-        val order = orderRepository.save(Order.create(buyerId = buyerId, totalAmount = totalAmount))
+        return transactionTemplate.execute {
+            val order = orderRepository.save(Order.create(buyerId = buyerId, totalAmount = totalAmount))
 
-        val orderItems = cartItems.map { cartItem ->
-            OrderItem.create(
-                orderId = order.id!!,
-                sellerId = productMap[cartItem.productId]!!.sellerId,
-                productId = cartItem.productId,
-                productName = cartItem.productName,
-                productPrice = cartItem.productPrice,
-                quantity = cartItem.quantity,
-                reservationId = reservationMap[cartItem.productId]
-            )
-        }
-        val savedOrderItems = orderItemRepository.saveAll(orderItems)
-        order.updateStatus(OrderStatus.PAYING)
+            val orderItems = cartItems.map { cartItem ->
+                OrderItem.create(
+                    orderId = order.id!!,
+                    sellerId = productMap[cartItem.productId]!!.sellerId,
+                    productId = cartItem.productId,
+                    productName = cartItem.productName,
+                    productPrice = cartItem.productPrice,
+                    quantity = cartItem.quantity,
+                    reservationId = reservationMap[cartItem.productId]
+                )
+            }
+            val savedOrderItems = orderItemRepository.saveAll(orderItems)
+            order.updateStatus(OrderStatus.PAYING)
 
-        cartItemRepository.deleteAllById(request.cartItemIds)
+            cartItemRepository.deleteAllById(request.cartItemIds)
 
-        orderMetrics.recordOrderCreated(totalAmount)
-        log.info("주문 생성: orderId={}, buyerId={}, totalAmount={}, itemCount={}", order.id, buyerId, totalAmount, orderItems.size)
-        return OrderResponse.from(order, savedOrderItems)
+            orderMetrics.recordOrderCreated(totalAmount)
+            log.info("주문 생성: orderId={}, buyerId={}, totalAmount={}, itemCount={}", order.id, buyerId, totalAmount, orderItems.size)
+            OrderResponse.from(order, savedOrderItems)
+        }!!
     }
 
     override fun cancelOrder(buyerId: Long, orderId: Long): OrderResponse {
@@ -103,37 +106,51 @@ class OrderCommandServiceImpl(
 
         when (order.status) {
             OrderStatus.PAYING -> {
-                order.updateStatus(OrderStatus.CANCELLED)
                 if (!paymentCommandPort.cancelPayment(orderId)) {
                     throw OrderPaymentCancellationFailedException()
+                }
+                transactionTemplate.execute {
+                    val target = orderRepository.findById(orderId)
+                        .orElseThrow { OrderNotFoundException() }
+                    target.updateStatus(OrderStatus.CANCELLED)
                 }
                 restoreInventory(orderItems)
             }
             OrderStatus.CREATED -> {
-                order.updateStatus(OrderStatus.CANCELLED)
+                transactionTemplate.execute {
+                    val target = orderRepository.findById(orderId)
+                        .orElseThrow { OrderNotFoundException() }
+                    target.updateStatus(OrderStatus.CANCELLED)
+                }
                 restoreInventory(orderItems)
             }
             OrderStatus.PAID -> {
-                order.updateStatus(OrderStatus.CANCEL_REQUESTED)
-                transactionalEventPublisher.publishEvent(
-                    aggregateType = "Order",
-                    aggregateId = orderId.toString(),
-                    eventType = "PaymentCancellationRequested",
-                    eventData = mapOf(
-                        "eventType" to "PaymentCancellationRequested",
-                        "eventId" to "cancel-$orderId-${System.currentTimeMillis()}",
-                        "orderId" to orderId
-                    ),
-                    topic = KafkaTopics.PAYMENT_COMPENSATION,
-                    partitionKey = orderId.toString()
-                )
+                transactionTemplate.execute {
+                    val target = orderRepository.findById(orderId)
+                        .orElseThrow { OrderNotFoundException() }
+                    target.updateStatus(OrderStatus.CANCEL_REQUESTED)
+                    transactionalEventPublisher.publishEvent(
+                        aggregateType = "Order",
+                        aggregateId = orderId.toString(),
+                        eventType = "PaymentCancellationRequested",
+                        eventData = mapOf(
+                            "eventType" to "PaymentCancellationRequested",
+                            "eventId" to "cancel-$orderId-${System.currentTimeMillis()}",
+                            "orderId" to orderId
+                        ),
+                        topic = KafkaTopics.PAYMENT_COMPENSATION,
+                        partitionKey = orderId.toString()
+                    )
+                }
             }
             else -> throw OrderInvalidStatusException()
         }
 
+        val updatedOrder = orderRepository.findById(orderId)
+            .orElseThrow { OrderNotFoundException() }
         orderMetrics.recordOrderCancelled()
-        log.info("주문 취소: orderId={}, buyerId={}, status={}", orderId, buyerId, order.status)
-        return OrderResponse.from(order, orderItems)
+        log.info("주문 취소: orderId={}, buyerId={}, status={}", orderId, buyerId, updatedOrder.status)
+        return OrderResponse.from(updatedOrder, orderItems)
     }
 
     private fun restoreInventory(orderItems: List<OrderItem>) {
@@ -147,6 +164,7 @@ class OrderCommandServiceImpl(
         }
     }
 
+    @Transactional
     override fun updateOrderStatus(orderId: Long, request: OrderStatusUpdateRequest, userId: Long, isAdmin: Boolean): OrderResponse {
         val order = orderRepository.findById(orderId)
             .orElseThrow { OrderNotFoundException() }

--- a/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImplTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImplTest.kt
@@ -22,17 +22,21 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.test.util.ReflectionTestUtils
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
 import java.math.BigDecimal
 import java.util.Optional
 
@@ -65,8 +69,24 @@ class OrderCommandServiceImplTest {
     @Mock
     private lateinit var orderMetrics: OrderMetrics
 
-    @InjectMocks
+    @Mock
+    private lateinit var transactionTemplate: TransactionTemplate
+
     private lateinit var service: OrderCommandServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        Mockito.lenient().`when`(transactionTemplate.execute(any<TransactionCallback<Any>>())).thenAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            val callback = invocation.arguments[0] as TransactionCallback<Any?>
+            callback.doInTransaction(mock())
+        }
+        service = OrderCommandServiceImpl(
+            orderRepository, orderItemRepository, cartItemRepository,
+            productQueryPort, inventoryCommandPort, paymentCommandPort,
+            transactionalEventPublisher, orderMetrics, transactionTemplate
+        )
+    }
 
     @Test
     fun 주문_생성_시_재고_예약을_수행한다() {


### PR DESCRIPTION
Closes #347

### 📌 작업 개요
OrderCommandServiceImpl의 클래스 레벨 @Transactional을 제거하고,
Remote HTTP 호출을 트랜잭션 밖으로 분리하여 DB 커넥션 점유 시간을 최소화했습니다.
기존 RefundCommandServiceImpl, OrderSagaConsumer의 TransactionTemplate 패턴을 따릅니다.

---

### ✅ 주요 변경 사항

- `order.service`
  - `OrderCommandServiceImpl`: 클래스 레벨 @Transactional 제거, TransactionTemplate 주입
    - createOrder(): Remote 호출(상품조회, 재고예약) → 트랜잭션 밖, DB 쓰기 → transactionTemplate.execute
    - cancelOrder(): Remote 호출(결제취소, 재고복원) → 트랜잭션 밖, 상태변경 → transactionTemplate.execute
    - updateOrderStatus(): 메서드 레벨 @Transactional (순수 DB 작업)

---

### 🧪 테스트

- `OrderCommandServiceImplTest`: TransactionTemplate Mock 적용, 전체 테스트 통과
- `OrderTransactionalRollbackTest`: 기존 트랜잭션 롤백 통합 테스트 통과

---

### 📎 관련 이슈
- #347
