### PR TITLE
perf: 정산 스냅샷 N+1 쿼리 제거

### DIFF
--- a/settlement-service/src/main/kotlin/com/hoppingmall/settlement/domain/repository/SettlementSummaryRepository.kt
+++ b/settlement-service/src/main/kotlin/com/hoppingmall/settlement/domain/repository/SettlementSummaryRepository.kt
@@ -11,6 +11,7 @@ interface SettlementSummaryRepository : JpaRepository<SettlementSummary, Long> {
     fun findBySellerIdOrderByPeriodStartDesc(sellerId: Long, pageable: Pageable): Page<SettlementSummary>
     fun findBySellerIdAndPeriodStartAndPeriodEnd(sellerId: Long, periodStart: LocalDate, periodEnd: LocalDate): SettlementSummary?
     fun findBySettlementId(settlementId: Long): SettlementSummary?
+    fun findBySettlementIdIn(settlementIds: List<Long>): List<SettlementSummary>
     fun findBySellerIdAndStatus(sellerId: Long, status: SettlementStatus, pageable: Pageable): Page<SettlementSummary>
     fun findByStatus(status: SettlementStatus, pageable: Pageable): Page<SettlementSummary>
     fun findBySellerId(sellerId: Long, pageable: Pageable): Page<SettlementSummary>

--- a/settlement-service/src/main/kotlin/com/hoppingmall/settlement/service/SettlementSnapshotService.kt
+++ b/settlement-service/src/main/kotlin/com/hoppingmall/settlement/service/SettlementSnapshotService.kt
@@ -22,19 +22,27 @@ class SettlementSnapshotService(
         log.info("Settlement snapshot job started")
 
         val settlements = settlementRepository.findAll()
-        var created = 0
-        var updated = 0
+        val summaryMap = settlementSummaryRepository
+            .findBySettlementIdIn(settlements.map { it.id!! })
+            .associateBy { it.settlementId }
+
+        val newSummaries = mutableListOf<SettlementSummary>()
 
         settlements.forEach { settlement ->
-            val existing = settlementSummaryRepository.findBySettlementId(settlement.id!!)
+            val existing = summaryMap[settlement.id!!]
             if (existing != null) {
                 existing.updateFrom(settlement)
-                updated++
             } else {
-                settlementSummaryRepository.save(SettlementSummary.from(settlement))
-                created++
+                newSummaries.add(SettlementSummary.from(settlement))
             }
         }
+
+        if (newSummaries.isNotEmpty()) {
+            settlementSummaryRepository.saveAll(newSummaries)
+        }
+
+        val created = newSummaries.size
+        val updated = settlements.size - created
 
         log.info("Settlement snapshot job completed: created=$created, updated=$updated")
     }

--- a/settlement-service/src/test/kotlin/com/hoppingmall/settlement/service/SettlementSnapshotServiceTest.kt
+++ b/settlement-service/src/test/kotlin/com/hoppingmall/settlement/service/SettlementSnapshotServiceTest.kt
@@ -54,12 +54,12 @@ class SettlementSnapshotServiceTest {
         val settlement = createSettlement(1L)
 
         whenever(settlementRepository.findAll()).thenReturn(listOf(settlement))
-        whenever(settlementSummaryRepository.findBySettlementId(1L)).thenReturn(null)
-        whenever(settlementSummaryRepository.save(any<SettlementSummary>())).thenAnswer { it.arguments[0] }
+        whenever(settlementSummaryRepository.findBySettlementIdIn(listOf(1L))).thenReturn(emptyList())
+        whenever(settlementSummaryRepository.saveAll(any<List<SettlementSummary>>())).thenAnswer { it.arguments[0] }
 
         settlementSnapshotService.createSnapshot()
 
-        verify(settlementSummaryRepository).save(any<SettlementSummary>())
+        verify(settlementSummaryRepository).saveAll(any<List<SettlementSummary>>())
     }
 
     @Test
@@ -68,10 +68,10 @@ class SettlementSnapshotServiceTest {
         val existingSummary = SettlementSummary.from(settlement)
 
         whenever(settlementRepository.findAll()).thenReturn(listOf(settlement))
-        whenever(settlementSummaryRepository.findBySettlementId(1L)).thenReturn(existingSummary)
+        whenever(settlementSummaryRepository.findBySettlementIdIn(listOf(1L))).thenReturn(listOf(existingSummary))
 
         settlementSnapshotService.createSnapshot()
 
-        verify(settlementSummaryRepository, never()).save(any<SettlementSummary>())
+        verify(settlementSummaryRepository, never()).saveAll(any<List<SettlementSummary>>())
     }
 }


### PR DESCRIPTION
Closes #349

### 📌 작업 개요
`SettlementSnapshotService.createSnapshot()`에서 Settlement별 개별 Summary 조회(N+1)를 배치 조회로 전환하여 쿼리 수를 대폭 줄였습니다.

---

### ✅ 주요 변경 사항

- `settlement.domain.repository`
  - `SettlementSummaryRepository`: `findBySettlementIdIn()` 배치 조회 메서드 추가

- `settlement.service`
  - `SettlementSnapshotService`: 개별 `findBySettlementId()` → `findBySettlementIdIn()` + Map 룩업, 개별 `save()` → `saveAll()` 전환

---

### 🧪 테스트

- `SettlementSnapshotServiceTest`: 배치 조회/저장 방식에 맞게 Mock 수정

---

### 📎 관련 이슈
- #349
