### PR TITLE
perf: 일별 스냅샷 대규모 트랜잭션 배치 분할

### DIFF
--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImpl.kt
@@ -10,32 +10,36 @@ import com.hoppingmall.product.product.domain.repository.ProductStatisticsReposi
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 import java.math.BigDecimal
 import java.time.LocalDate
 
 @Service
-@Transactional
 class ProductStatisticsCommandServiceImpl(
     private val productStatisticsRepository: ProductStatisticsRepository,
     private val productDailyStatisticsRepository: ProductDailyStatisticsRepository,
     private val productHourlyStatisticsRepository: ProductHourlyStatisticsRepository,
-    private val productRepository: ProductRepository
+    private val productRepository: ProductRepository,
+    private val transactionTemplate: TransactionTemplate
 ) : ProductStatisticsCommandService {
 
     private val logger = LoggerFactory.getLogger(ProductStatisticsCommandServiceImpl::class.java)
 
+    @Transactional
     override fun incrementSalesStats(productId: Long, quantity: Long, amount: BigDecimal) {
         val stats = getOrCreateStatistics(productId)
         stats.incrementSales(quantity, amount)
         productStatisticsRepository.save(stats)
     }
 
+    @Transactional
     override fun decrementSalesStats(productId: Long, quantity: Long, amount: BigDecimal) {
         val stats = productStatisticsRepository.findByProductId(productId) ?: return
         stats.decrementSales(quantity, amount)
         productStatisticsRepository.save(stats)
     }
 
+    @Transactional
     override fun incrementRefundStats(productId: Long, quantity: Long, amount: BigDecimal) {
         val stats = getOrCreateStatistics(productId)
         stats.incrementRefund(quantity, amount)
@@ -50,45 +54,50 @@ class ProductStatisticsCommandServiceImpl(
             return
         }
 
-        val productIds = allStats.map { it.productId }
+        allStats.chunked(BATCH_SIZE).forEach { chunk ->
+            transactionTemplate.executeWithoutResult {
+                val productIds = chunk.map { it.productId }
 
-        val existingDailyMap = productDailyStatisticsRepository
-            .findByStatisticsDateAndProductIdIn(today, productIds)
-            .associateBy { it.productId }
+                val existingDailyMap = productDailyStatisticsRepository
+                    .findByStatisticsDateAndProductIdIn(today, productIds)
+                    .associateBy { it.productId }
 
-        val last7DaysMap = toSalesAmountMap(
-            productDailyStatisticsRepository.sumSalesAmountByProductIdsAndDateRange(productIds, today.minusDays(6), today)
-        )
-        val last30DaysMap = toSalesAmountMap(
-            productDailyStatisticsRepository.sumSalesAmountByProductIdsAndDateRange(productIds, today.minusDays(29), today)
-        )
-        val previousWeekMap = toSalesAmountMap(
-            productDailyStatisticsRepository.sumSalesAmountByProductIdsAndDateRange(productIds, today.minusDays(13), today.minusDays(7))
-        )
+                val last7DaysMap = toSalesAmountMap(
+                    productDailyStatisticsRepository.sumSalesAmountByProductIdsAndDateRange(productIds, today.minusDays(6), today)
+                )
+                val last30DaysMap = toSalesAmountMap(
+                    productDailyStatisticsRepository.sumSalesAmountByProductIdsAndDateRange(productIds, today.minusDays(29), today)
+                )
+                val previousWeekMap = toSalesAmountMap(
+                    productDailyStatisticsRepository.sumSalesAmountByProductIdsAndDateRange(productIds, today.minusDays(13), today.minusDays(7))
+                )
 
-        val dailyToSave = mutableListOf<ProductDailyStatistics>()
-        for (stats in allStats) {
-            val daily = existingDailyMap[stats.productId] ?: ProductDailyStatistics.create(
-                productId = stats.productId,
-                statisticsDate = today
-            )
-            daily.updateFromStatistics(stats)
-            dailyToSave.add(daily)
+                val dailyToSave = mutableListOf<ProductDailyStatistics>()
+                for (stats in chunk) {
+                    val daily = existingDailyMap[stats.productId] ?: ProductDailyStatistics.create(
+                        productId = stats.productId,
+                        statisticsDate = today
+                    )
+                    daily.updateFromStatistics(stats)
+                    dailyToSave.add(daily)
 
-            stats.updatePeriodMetrics(
-                last7DaysMap[stats.productId] ?: BigDecimal.ZERO,
-                last30DaysMap[stats.productId] ?: BigDecimal.ZERO,
-                previousWeekMap[stats.productId] ?: BigDecimal.ZERO
-            )
-            stats.resetToday()
+                    stats.updatePeriodMetrics(
+                        last7DaysMap[stats.productId] ?: BigDecimal.ZERO,
+                        last30DaysMap[stats.productId] ?: BigDecimal.ZERO,
+                        previousWeekMap[stats.productId] ?: BigDecimal.ZERO
+                    )
+                    stats.resetToday()
+                }
+
+                productDailyStatisticsRepository.saveAll(dailyToSave)
+                productStatisticsRepository.saveAll(chunk)
+            }
         }
-
-        productDailyStatisticsRepository.saveAll(dailyToSave)
-        productStatisticsRepository.saveAll(allStats)
 
         logger.info("일별 통계 스냅샷 완료: ${allStats.size}건")
     }
 
+    @Transactional
     override fun flushHourlySnapshot() {
         val now = java.time.LocalDateTime.now()
         val today = now.toLocalDate()
@@ -124,6 +133,10 @@ class ProductStatisticsCommandServiceImpl(
 
     private fun toSalesAmountMap(rows: List<Array<Any>>): Map<Long, BigDecimal> {
         return rows.associate { (it[0] as Long) to (it[1] as BigDecimal) }
+    }
+
+    companion object {
+        private const val BATCH_SIZE = 100
     }
 
     private fun getOrCreateStatistics(productId: Long): ProductStatistics {

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImplTest.kt
@@ -12,6 +12,7 @@ import com.hoppingmall.product.product.domain.repository.ProductStatisticsReposi
 import com.hoppingmall.product.support.withId
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator
@@ -21,11 +22,15 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.transaction.TransactionStatus
+import org.springframework.transaction.support.TransactionTemplate
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.Optional
+import java.util.function.Consumer
 
 @DisplayName("ProductStatisticsCommandServiceImpl")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
@@ -44,8 +49,20 @@ class ProductStatisticsCommandServiceImplTest {
     @Mock
     private lateinit var productRepository: ProductRepository
 
+    @Mock
+    private lateinit var transactionTemplate: TransactionTemplate
+
     @InjectMocks
     private lateinit var service: ProductStatisticsCommandServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        org.mockito.Mockito.lenient().doAnswer { invocation ->
+            val callback = invocation.getArgument<Consumer<TransactionStatus>>(0)
+            callback.accept(org.mockito.kotlin.mock())
+            null
+        }.`when`(transactionTemplate).executeWithoutResult(any())
+    }
 
     private fun createStats(productId: Long = 1L) = ProductStatistics.create(
         productId = productId, productName = "테스트", sellerId = 1L, categoryId = 1L


### PR DESCRIPTION
Closes #351

### 📌 작업 개요
`flushDailySnapshot()`이 전체 상품 통계를 단일 트랜잭션으로 처리하던 구조를 100건 단위 배치로 분할하여 트랜잭션 지속 시간과 DB 락 점유를 줄였습니다.

---

### ✅ 주요 변경 사항

- `product.service`
  - `ProductStatisticsCommandServiceImpl`: 클래스 레벨 `@Transactional` 제거, 메서드별 `@Transactional` 적용
  - `flushDailySnapshot()`: `TransactionTemplate` 기반 100건 단위 청크 처리로 전환

---

### 🧪 테스트

- `ProductStatisticsCommandServiceImplTest`: `TransactionTemplate` Mock 설정 추가, 기존 11개 테스트 모두 통과

---

### 📎 관련 이슈
- #351
