### PR TITLE
perf: 예약 취소 배치 처리 및 데드락 방지

### DIFF
--- a/product-service/src/main/kotlin/com/hoppingmall/product/inventory/domain/repository/InventoryRepository.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/inventory/domain/repository/InventoryRepository.kt
@@ -19,4 +19,8 @@ interface InventoryRepository : JpaRepository<Inventory, Long> {
     fun existsByProductId(productId: Long): Boolean
 
     fun findAllByProductIdIn(productIds: List<Long>): List<Inventory>
+
+    @Query("SELECT i FROM Inventory i WHERE i.productId IN :productIds ORDER BY i.productId")
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    fun findByProductIdInForUpdate(@Param("productIds") productIds: List<Long>): List<Inventory>
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImpl.kt
@@ -145,7 +145,30 @@ class InventoryCommandServiceImpl(
     }
 
     override fun cancelReservations(reservationIds: List<String>) {
-        reservationIds.forEach { cancelReservation(it) }
+        if (reservationIds.isEmpty()) return
+
+        val reservations = inventoryReservationRepository.findByReservationIdIn(reservationIds)
+            .filter { it.status == ReservationStatus.RESERVED }
+        if (reservations.isEmpty()) return
+
+        inventoryReservationRepository.batchUpdateStatusByCas(
+            reservationIds = reservations.map { it.reservationId },
+            expectedStatus = ReservationStatus.RESERVED,
+            targetStatus = ReservationStatus.CANCELLED,
+            updatedAt = LocalDateTime.now()
+        )
+
+        val stockToRestore = reservations
+            .groupBy { it.productId }
+            .mapValues { (_, rsv) -> rsv.sumOf { it.quantity } }
+            .toSortedMap()
+
+        val inventories = inventoryRepository.findByProductIdInForUpdate(stockToRestore.keys.toList())
+            .associateBy { it.productId }
+
+        stockToRestore.forEach { (productId, quantity) ->
+            inventories[productId]?.increaseStock(quantity)
+        }
     }
 
     override fun batchReserveStock(items: List<Pair<Long, Int>>): Map<Long, String> {

--- a/product-service/src/test/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImplTest.kt
@@ -180,13 +180,42 @@ class InventoryCommandServiceImplTest {
 
     @Test
     fun 여러_예약을_한번에_취소한다() {
-        whenever(inventoryReservationRepository.findByReservationId("rsv-1")).thenReturn(null)
-        whenever(inventoryReservationRepository.findByReservationId("rsv-2")).thenReturn(null)
+        val r1 = InventoryReservation(
+            reservationId = "rsv-1", productId = 1L, quantity = 3,
+            status = ReservationStatus.RESERVED, expiresAt = LocalDateTime.now().plusMinutes(10)
+        )
+        val r2 = InventoryReservation(
+            reservationId = "rsv-2", productId = 2L, quantity = 5,
+            status = ReservationStatus.RESERVED, expiresAt = LocalDateTime.now().plusMinutes(10)
+        )
+        val inv1 = Inventory.create(productId = 1L, stockQuantity = 0)
+        val inv2 = Inventory.create(productId = 2L, stockQuantity = 0)
+
+        whenever(inventoryReservationRepository.findByReservationIdIn(listOf("rsv-1", "rsv-2")))
+            .thenReturn(listOf(r1, r2))
+        whenever(inventoryReservationRepository.batchUpdateStatusByCas(
+            reservationIds = eq(listOf("rsv-1", "rsv-2")),
+            expectedStatus = eq(ReservationStatus.RESERVED),
+            targetStatus = eq(ReservationStatus.CANCELLED),
+            updatedAt = any()
+        )).thenReturn(2)
+        whenever(inventoryRepository.findByProductIdInForUpdate(listOf(1L, 2L)))
+            .thenReturn(listOf(inv1, inv2))
 
         service.cancelReservations(listOf("rsv-1", "rsv-2"))
 
-        verify(inventoryReservationRepository).findByReservationId("rsv-1")
-        verify(inventoryReservationRepository).findByReservationId("rsv-2")
+        assertThat(inv1.stockQuantity).isEqualTo(3)
+        assertThat(inv2.stockQuantity).isEqualTo(5)
+    }
+
+    @Test
+    fun 예약이_없으면_취소를_건너뛴다() {
+        whenever(inventoryReservationRepository.findByReservationIdIn(listOf("rsv-1", "rsv-2")))
+            .thenReturn(emptyList())
+
+        service.cancelReservations(listOf("rsv-1", "rsv-2"))
+
+        verify(inventoryReservationRepository, never()).batchUpdateStatusByCas(any(), any(), any(), any())
     }
 
     @Test

--- a/product-service/src/test/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImplTest.kt
@@ -219,6 +219,28 @@ class InventoryCommandServiceImplTest {
     }
 
     @Test
+    fun 빈_예약_목록이면_취소를_건너뛴다() {
+        service.cancelReservations(emptyList())
+
+        verify(inventoryReservationRepository, never()).findByReservationIdIn(any())
+    }
+
+    @Test
+    fun RESERVED_상태가_아닌_예약만_있으면_취소를_건너뛴다() {
+        val confirmed = InventoryReservation(
+            reservationId = "rsv-1", productId = 1L, quantity = 3,
+            status = ReservationStatus.CONFIRMED, expiresAt = LocalDateTime.now().plusMinutes(10)
+        )
+
+        whenever(inventoryReservationRepository.findByReservationIdIn(listOf("rsv-1")))
+            .thenReturn(listOf(confirmed))
+
+        service.cancelReservations(listOf("rsv-1"))
+
+        verify(inventoryReservationRepository, never()).batchUpdateStatusByCas(any(), any(), any(), any())
+    }
+
+    @Test
     fun 확정_시_일부_이미_확정된_예약이_있으면_성공으로_간주한다() {
         val reservationIds = listOf("rsv-1", "rsv-2")
         val r1 = InventoryReservation(


### PR DESCRIPTION
Closes #353

### 📌 작업 개요
`cancelReservations()`가 예약별 개별 조회/CAS/락을 수행하던 구조를 배치 조회 + 일괄 CAS + 정렬된 락 획득으로 전환하여 쿼리 수를 줄이고 데드락을 방지합니다.

---

### ✅ 주요 변경 사항

- `inventory.domain.repository`
  - `InventoryRepository`: `findByProductIdInForUpdate()` 배치 락 메서드 추가 (productId ORDER BY로 데드락 방지)

- `inventory.service`
  - `InventoryCommandServiceImpl`: `cancelReservations()` 배치 처리로 전환
    - `findByReservationIdIn()` 일괄 조회
    - `batchUpdateStatusByCas()` 일괄 상태 변경
    - productId 기준 정렬 후 일괄 락 + 재고 원복

---

### 🧪 테스트

- `InventoryCommandServiceImplTest`: 배치 취소 테스트 재작성, 예약 없는 경우 건너뛰기 테스트 추가

---

### 📎 관련 이슈
- #353
