### PR TITLE
fix: PaymentEventLog 중복 unique 제약조건 제거

### DIFF
--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/domain/PaymentEventLog.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/domain/PaymentEventLog.kt
@@ -12,7 +12,7 @@ import jakarta.persistence.UniqueConstraint
     uniqueConstraints = [UniqueConstraint(columnNames = ["transaction_id"])]
 )
 class PaymentEventLog(
-    @Column(name = "transaction_id", nullable = false, unique = true)
+    @Column(name = "transaction_id", nullable = false)
     val transactionId: String,
 
     @Column(nullable = false)


### PR DESCRIPTION
Closes #355

### 📌 작업 개요
`PaymentEventLog.transaction_id`에 `@Table(uniqueConstraints)`와 `@Column(unique = true)`가 동시에 선언되어 중복 인덱스가 생성되는 문제를 정리했습니다.

---

### ✅ 주요 변경 사항

- `payment.domain`
  - `PaymentEventLog`: `@Column`의 `unique = true` 제거, `@Table` 레벨 `UniqueConstraint`만 유지

---

### 📎 관련 이슈
- #355
