### PR TITLE
fix: 미사용 unbounded findByUserId() 메서드 제거

### DIFF
--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/domain/NotificationRepository.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/domain/NotificationRepository.kt
@@ -14,8 +14,6 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
 
     fun existsByEventId(eventId: String): Boolean
 
-    fun findByUserId(userId: Long): List<Notification>
-
     fun findByUserId(userId: Long, pageable: Pageable): Slice<Notification>
 
     fun findByUserIdAndType(userId: Long, type: NotificationType, pageable: Pageable): Slice<Notification>

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/domain/repository/PaymentRepository.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/domain/repository/PaymentRepository.kt
@@ -19,8 +19,6 @@ interface PaymentRepository : JpaRepository<Payment, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     fun findByIdForUpdate(@Param("id") id: Long): Payment?
 
-    fun findByUserId(userId: Long): List<Payment>
-
     fun findByUserId(userId: Long, pageable: Pageable): Slice<Payment>
 
     fun findByTransactionId(transactionId: String): Payment?

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/domain/PointHistoryRepository.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/domain/PointHistoryRepository.kt
@@ -10,8 +10,6 @@ import org.springframework.stereotype.Repository
 interface PointHistoryRepository : JpaRepository<PointHistory, Long> {
     fun existsByEventId(eventId: String): Boolean
 
-    fun findByUserIdOrderByCreatedAtDesc(userId: Long): List<PointHistory>
-
     fun findByUserId(userId: Long, pageable: Pageable): Slice<PointHistory>
 
     fun findByPaymentIdAndType(paymentId: Long, type: PointType): PointHistory?


### PR DESCRIPTION
Closes #357

### 📌 작업 개요
3개 Repository에서 미사용 unbounded `findByUserId()` 메서드를 제거했습니다. 각 Repository에 pageable 버전이 이미 존재하며, unbounded 버전은 호출처가 없어 데이터 증가 시 OOM 위험만 남기는 상태였습니다.

---

### ✅ 주요 변경 사항

- `payment.domain.repository`
  - `PaymentRepository`: `findByUserId(userId): List<Payment>` 제거

- `point.domain`
  - `PointHistoryRepository`: `findByUserIdOrderByCreatedAtDesc(userId): List<PointHistory>` 제거

- `notification.domain`
  - `NotificationRepository`: `findByUserId(userId): List<Notification>` 제거

---

### 📎 관련 이슈
- #357
