### PR TITLE
perf: Seller, Buyer user_id 인덱스 추가

### DIFF
--- a/user-service/src/main/kotlin/com/hoppingmall/user/domain/Buyer.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/domain/Buyer.kt
@@ -4,7 +4,10 @@ import com.hoppingmall.common.BaseEntity
 import jakarta.persistence.*
 
 @Entity
-@Table(name = "buyers")
+@Table(
+    name = "buyers",
+    indexes = [Index(name = "idx_buyers_user_id", columnList = "user_id")]
+)
 class Buyer private constructor(
 
     @Column(name = "user_id", nullable = false)

--- a/user-service/src/main/kotlin/com/hoppingmall/user/domain/Seller.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/domain/Seller.kt
@@ -4,7 +4,10 @@ import com.hoppingmall.common.BaseEntity
 import jakarta.persistence.*
 
 @Entity
-@Table(name = "sellers")
+@Table(
+    name = "sellers",
+    indexes = [Index(name = "idx_sellers_user_id", columnList = "user_id")]
+)
 class Seller private constructor(
     @Column(name = "user_id", nullable = false)
     val userId: Long,


### PR DESCRIPTION
Closes #359

### 📌 작업 개요
`sellers`, `buyers` 테이블의 `user_id` 컬럼에 인덱스가 없어 userId 기반 조회 시 풀 테이블 스캔이 발생하는 문제를 해결했습니다.

---

### ✅ 주요 변경 사항

- `user.domain`
  - `Seller`: `@Table(indexes)` 속성에 `idx_sellers_user_id` 인덱스 추가
  - `Buyer`: `@Table(indexes)` 속성에 `idx_buyers_user_id` 인덱스 추가

---

### 📎 관련 이슈
- #359
