### PR TITLE
perf: getTodaySummary 집계 쿼리 통합

### DIFF
--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductStatisticsRepository.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductStatisticsRepository.kt
@@ -42,16 +42,14 @@ interface ProductStatisticsRepository : JpaRepository<ProductStatistics, Long> {
     @Query("SELECT COALESCE(SUM(ps.todayRefundAmount), 0) FROM ProductStatistics ps")
     fun sumTodayRefundAmount(): BigDecimal
 
-    fun countBySellerId(sellerId: Long): Long
-
-    @Query("SELECT COALESCE(SUM(ps.todaySalesAmount), 0) FROM ProductStatistics ps WHERE ps.sellerId = :sellerId")
-    fun sumTodaySalesAmountBySellerId(@Param("sellerId") sellerId: Long): BigDecimal
-
-    @Query("SELECT COALESCE(SUM(ps.todayOrderCount), 0) FROM ProductStatistics ps WHERE ps.sellerId = :sellerId")
-    fun sumTodayOrderCountBySellerId(@Param("sellerId") sellerId: Long): Long
-
-    @Query("SELECT COALESCE(SUM(ps.todayRefundAmount), 0) FROM ProductStatistics ps WHERE ps.sellerId = :sellerId")
-    fun sumTodayRefundAmountBySellerId(@Param("sellerId") sellerId: Long): BigDecimal
+    @Query("""
+        SELECT COUNT(ps) AS totalProducts,
+               COALESCE(SUM(ps.todaySalesAmount), 0) AS todaySalesAmount,
+               COALESCE(SUM(ps.todayOrderCount), 0) AS todayOrderCount,
+               COALESCE(SUM(ps.todayRefundAmount), 0) AS todayRefundAmount
+        FROM ProductStatistics ps WHERE ps.sellerId = :sellerId
+    """)
+    fun findSellerTodaySummary(@Param("sellerId") sellerId: Long): SellerTodaySummaryProjection
 
     @Query("SELECT ps FROM ProductStatistics ps WHERE ps.sellerId = :sellerId ORDER BY ps.todaySalesAmount DESC LIMIT 1")
     fun findTopSellingBySellerId(@Param("sellerId") sellerId: Long): ProductStatistics?

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/SellerTodaySummaryProjection.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/SellerTodaySummaryProjection.kt
@@ -1,0 +1,10 @@
+package com.hoppingmall.product.product.domain.repository
+
+import java.math.BigDecimal
+
+interface SellerTodaySummaryProjection {
+    fun getTotalProducts(): Long
+    fun getTodaySalesAmount(): BigDecimal
+    fun getTodayOrderCount(): Long
+    fun getTodayRefundAmount(): BigDecimal
+}

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/SellerDashboardServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/SellerDashboardServiceImpl.kt
@@ -39,12 +39,13 @@ class SellerDashboardServiceImpl(
     }
 
     override fun getTodaySummary(sellerId: Long): SellerTodaySummaryResponse {
+        val summary = productStatisticsRepository.findSellerTodaySummary(sellerId)
         val topSelling = productStatisticsRepository.findTopSellingBySellerId(sellerId)
         return SellerTodaySummaryResponse(
-            totalProducts = productStatisticsRepository.countBySellerId(sellerId),
-            todaySalesAmount = productStatisticsRepository.sumTodaySalesAmountBySellerId(sellerId),
-            todayOrderCount = productStatisticsRepository.sumTodayOrderCountBySellerId(sellerId),
-            todayRefundAmount = productStatisticsRepository.sumTodayRefundAmountBySellerId(sellerId),
+            totalProducts = summary.getTotalProducts(),
+            todaySalesAmount = summary.getTodaySalesAmount(),
+            todayOrderCount = summary.getTodayOrderCount(),
+            todayRefundAmount = summary.getTodayRefundAmount(),
             topSellingProductId = topSelling?.productId,
             topSellingProductName = topSelling?.productName
         )

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/SellerDashboardServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/SellerDashboardServiceImplTest.kt
@@ -6,6 +6,7 @@ import com.hoppingmall.product.product.domain.ProductStatistics
 import com.hoppingmall.product.product.domain.repository.ProductDailyStatisticsRepository
 import com.hoppingmall.product.product.domain.repository.ProductHourlyStatisticsRepository
 import com.hoppingmall.product.product.domain.repository.ProductStatisticsRepository
+import com.hoppingmall.product.product.domain.repository.SellerTodaySummaryProjection
 import com.hoppingmall.product.product.exception.ProductException
 import com.hoppingmall.product.product.exception.ProductStatisticsNotFoundException
 import com.hoppingmall.product.support.withId
@@ -92,11 +93,9 @@ class SellerDashboardServiceImplTest {
     @Test
     fun 오늘_요약을_조회한다() {
         val topSelling = createStats()
+        val summary = mockSummaryProjection(5L, BigDecimal("500000"), 10L, BigDecimal("10000"))
 
-        whenever(productStatisticsRepository.countBySellerId(1L)).thenReturn(5)
-        whenever(productStatisticsRepository.sumTodaySalesAmountBySellerId(1L)).thenReturn(BigDecimal("500000"))
-        whenever(productStatisticsRepository.sumTodayOrderCountBySellerId(1L)).thenReturn(10)
-        whenever(productStatisticsRepository.sumTodayRefundAmountBySellerId(1L)).thenReturn(BigDecimal("10000"))
+        whenever(productStatisticsRepository.findSellerTodaySummary(1L)).thenReturn(summary)
         whenever(productStatisticsRepository.findTopSellingBySellerId(1L)).thenReturn(topSelling)
 
         val result = service.getTodaySummary(1L)
@@ -108,16 +107,29 @@ class SellerDashboardServiceImplTest {
 
     @Test
     fun 상위_판매_상품이_없을_때_오늘_요약을_조회한다() {
-        whenever(productStatisticsRepository.countBySellerId(1L)).thenReturn(0)
-        whenever(productStatisticsRepository.sumTodaySalesAmountBySellerId(1L)).thenReturn(BigDecimal.ZERO)
-        whenever(productStatisticsRepository.sumTodayOrderCountBySellerId(1L)).thenReturn(0)
-        whenever(productStatisticsRepository.sumTodayRefundAmountBySellerId(1L)).thenReturn(BigDecimal.ZERO)
+        val summary = mockSummaryProjection(0L, BigDecimal.ZERO, 0L, BigDecimal.ZERO)
+
+        whenever(productStatisticsRepository.findSellerTodaySummary(1L)).thenReturn(summary)
         whenever(productStatisticsRepository.findTopSellingBySellerId(1L)).thenReturn(null)
 
         val result = service.getTodaySummary(1L)
 
         assertThat(result.topSellingProductId).isNull()
         assertThat(result.topSellingProductName).isNull()
+    }
+
+    private fun mockSummaryProjection(
+        totalProducts: Long,
+        todaySalesAmount: BigDecimal,
+        todayOrderCount: Long,
+        todayRefundAmount: BigDecimal
+    ): SellerTodaySummaryProjection {
+        val projection = org.mockito.Mockito.mock(SellerTodaySummaryProjection::class.java)
+        whenever(projection.getTotalProducts()).thenReturn(totalProducts)
+        whenever(projection.getTodaySalesAmount()).thenReturn(todaySalesAmount)
+        whenever(projection.getTodayOrderCount()).thenReturn(todayOrderCount)
+        whenever(projection.getTodayRefundAmount()).thenReturn(todayRefundAmount)
+        return projection
     }
 
     @Test


### PR DESCRIPTION
Closes #363

### 📌 작업 개요
`getTodaySummary()`에서 5개의 개별 집계 쿼리를 2개로 통합하여 DB 부하를 줄입니다.
4개의 집계 쿼리(count, sumSalesAmount, sumOrderCount, sumRefundAmount)를 단일 JPQL 프로젝션 쿼리로 병합하고, topSelling 조회는 별도 쿼리로 유지합니다.

---

### ✅ 주요 변경 사항

- `product.domain.repository`
  - `SellerTodaySummaryProjection`: 집계 결과를 담는 Spring Data 프로젝션 인터페이스 추가
  - `ProductStatisticsRepository`: `countBySellerId`, `sumTodaySalesAmountBySellerId`, `sumTodayOrderCountBySellerId`, `sumTodayRefundAmountBySellerId` 4개 메서드를 `findSellerTodaySummary` 단일 프로젝션 쿼리로 대체

- `product.service`
  - `SellerDashboardServiceImpl`: `getTodaySummary()`에서 프로젝션 쿼리 사용으로 변경

---

### 🧪 테스트

- `SellerDashboardServiceImplTest`: 프로젝션 Mock으로 전환하여 기존 테스트 유지

---

### 📎 관련 이슈
- #363
