### PR TITLE
perf: 누락된 DB 인덱스 추가

### DIFF
--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/Order.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/Order.kt
@@ -9,7 +9,10 @@ import java.math.BigDecimal
 @Entity
 @Table(
     name = "orders",
-    indexes = [Index(name = "idx_orders_buyer_id", columnList = "buyerId")]
+    indexes = [
+        Index(name = "idx_orders_buyer_id", columnList = "buyerId"),
+        Index(name = "idx_orders_status_updated_at", columnList = "status, updatedAt")
+    ]
 )
 class Order private constructor(
     @Column(nullable = false)

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/OrderItem.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/OrderItem.kt
@@ -12,7 +12,8 @@ import java.math.BigDecimal
     name = "order_items",
     indexes = [
         Index(name = "idx_order_items_order_id", columnList = "orderId"),
-        Index(name = "idx_order_items_product_id", columnList = "productId")
+        Index(name = "idx_order_items_product_id", columnList = "productId"),
+        Index(name = "idx_order_items_seller_id", columnList = "sellerId")
     ]
 )
 class OrderItem private constructor(

--- a/order-service/src/main/kotlin/com/hoppingmall/order/refund/domain/Refund.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/refund/domain/Refund.kt
@@ -15,7 +15,8 @@ import java.time.LocalDateTime
         Index(name = "idx_refunds_order_id", columnList = "orderId"),
         Index(name = "idx_refunds_payment_id", columnList = "paymentId"),
         Index(name = "idx_refunds_buyer_id", columnList = "buyerId"),
-        Index(name = "idx_refunds_seller_id", columnList = "sellerId")
+        Index(name = "idx_refunds_seller_id", columnList = "sellerId"),
+        Index(name = "idx_refunds_seller_status_completed", columnList = "sellerId, status, completedAt")
     ]
 )
 class Refund private constructor(

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/domain/UserCoupon.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/domain/UserCoupon.kt
@@ -9,7 +9,10 @@ import java.time.LocalDateTime
 @Table(
     name = "user_coupons",
     uniqueConstraints = [UniqueConstraint(columnNames = ["user_id", "coupon_id"])],
-    indexes = [Index(name = "idx_user_coupons_user_id", columnList = "userId")]
+    indexes = [
+        Index(name = "idx_user_coupons_user_id", columnList = "userId"),
+        Index(name = "idx_user_coupons_order_id", columnList = "orderId")
+    ]
 )
 class UserCoupon private constructor(
     @Column(nullable = false)

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/ProductDailyStatistics.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/ProductDailyStatistics.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.product.product.domain
 import com.hoppingmall.common.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.Index
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
 import java.math.BigDecimal
@@ -11,7 +12,8 @@ import java.time.LocalDate
 @Entity
 @Table(
     name = "product_daily_statistics",
-    uniqueConstraints = [UniqueConstraint(columnNames = ["product_id", "statistics_date"])]
+    uniqueConstraints = [UniqueConstraint(columnNames = ["product_id", "statistics_date"])],
+    indexes = [Index(name = "idx_daily_stats_date", columnList = "statistics_date")]
 )
 class ProductDailyStatistics private constructor(
     @Column(name = "product_id", nullable = false)

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/ProductHourlyStatistics.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/ProductHourlyStatistics.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.product.product.domain
 import com.hoppingmall.common.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.Index
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
 import java.math.BigDecimal
@@ -11,7 +12,8 @@ import java.time.LocalDate
 @Entity
 @Table(
     name = "product_hourly_statistics",
-    uniqueConstraints = [UniqueConstraint(columnNames = ["product_id", "statistics_date", "\"hour\""])]
+    uniqueConstraints = [UniqueConstraint(columnNames = ["product_id", "statistics_date", "\"hour\""])],
+    indexes = [Index(name = "idx_hourly_stats_date_hour", columnList = "statistics_date, \"hour\"")]
 )
 class ProductHourlyStatistics(
     @Column(name = "product_id", nullable = false)


### PR DESCRIPTION
Closes #365

### 📌 작업 개요
쿼리 성능 향상을 위해 누락된 DB 인덱스 6건을 JPA @Table 어노테이션에 추가했습니다.
기존 쿼리에서 full table scan이 발생하는 컬럼에 인덱스를 추가하여 조회 성능을 개선합니다.

---

### ✅ 주요 변경 사항

- `order.order.domain`
  - `Order`: `idx_orders_status_updated_at(status, updatedAt)` 인덱스 추가
  - `OrderItem`: `idx_order_items_seller_id(sellerId)` 인덱스 추가

- `order.refund.domain`
  - `Refund`: `idx_refunds_seller_status_completed(sellerId, status, completedAt)` 복합 인덱스 추가

- `payment.coupon.domain`
  - `UserCoupon`: `idx_user_coupons_order_id(orderId)` 인덱스 추가

- `product.product.domain`
  - `ProductDailyStatistics`: `idx_daily_stats_date(statistics_date)` 인덱스 추가
  - `ProductHourlyStatistics`: `idx_hourly_stats_date_hour(statistics_date, hour)` 복합 인덱스 추가

---

### 🧪 테스트

- `order-service`: jacocoTestVerification 통과
- `payment-service`: jacocoTestVerification 통과
- `product-service`: jacocoTestVerification 통과

---

### 📎 관련 이슈
- #365
