### PR TITLE
perf: 서비스 설정 표준화

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -260,4 +260,4 @@ jwt:
 
 logging:
   level:
-    org.springframework.cloud.gateway: DEBUG
+    org.springframework.cloud.gateway: INFO

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -7,6 +7,12 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      idle-timeout: 300000
+      max-lifetime: 600000
+      connection-timeout: 30000
 
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -7,6 +7,12 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      idle-timeout: 300000
+      max-lifetime: 600000
+      connection-timeout: 30000
 
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
@@ -19,6 +25,9 @@ spring:
         use_sql_comments: true
         legacy_id_generator_strategy: true
         default_batch_fetch_size: 100
+
+  jackson:
+    property-naming-strategy: SNAKE_CASE
 
   data:
     redis:

--- a/product-service/src/main/resources/application-docker.yml
+++ b/product-service/src/main/resources/application-docker.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         format_sql: true

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -7,6 +7,12 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      idle-timeout: 300000
+      max-lifetime: 600000
+      connection-timeout: 30000
 
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect

--- a/settlement-service/src/main/resources/application.yml
+++ b/settlement-service/src/main/resources/application.yml
@@ -10,6 +10,12 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      idle-timeout: 300000
+      max-lifetime: 600000
+      connection-timeout: 30000
 
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
@@ -20,7 +26,7 @@ spring:
       hibernate:
         format_sql: true
         use_sql_comments: true
-        show_sql: true
+        default_batch_fetch_size: 100
 
 server:
   port: 8086

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -10,6 +10,12 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      idle-timeout: 300000
+      max-lifetime: 600000
+      connection-timeout: 30000
 
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
@@ -20,7 +26,7 @@ spring:
       hibernate:
         format_sql: true
         use_sql_comments: true
-        show_sql: true
+        default_batch_fetch_size: 100
 
   kafka:
     bootstrap-servers: ${spring.embedded.kafka.brokers:localhost:9092}


### PR DESCRIPTION
Closes #367

### 📌 작업 개요
서비스별 누락되거나 불일치하는 설정을 표준화했습니다.
HikariCP 커넥션 풀, Jackson 직렬화, Hibernate 배치 페치, 로그 레벨 등을 정리합니다.

---

### ✅ 주요 변경 사항

- `payment, product, user, order, settlement`
  - HikariCP 커넥션 풀 설정 추가 (maximum-pool-size: 20, minimum-idle: 5)

- `user-service`, `settlement-service`
  - `show_sql: true` 제거 (불필요한 SQL 로깅 비활성화)
  - `default_batch_fetch_size: 100` 추가 (N+1 방지)

- `product-service` (docker 프로필)
  - `show-sql: true` → `false` 변경

- `payment-service`
  - `jackson.property-naming-strategy: SNAKE_CASE` 추가 (다른 서비스와 통일)

- `api-gateway`
  - `org.springframework.cloud.gateway` 로그 레벨 `DEBUG` → `INFO` 변경

---

### 🧪 테스트

- 6개 서비스 전체 jacocoTestVerification / test 통과

---

### 📎 관련 이슈
- #367
