### PR TITLE
perf: 트랜잭션 범위 최적화 — 외부 호출 분리

### DIFF
--- a/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/scheduler/OutboxEventPublisher.kt
+++ b/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/scheduler/OutboxEventPublisher.kt
@@ -10,7 +10,8 @@ import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.support.SendResult
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
 
@@ -19,35 +20,40 @@ class OutboxEventPublisher(
     private val outboxEventRepository: OutboxEventRepository,
     private val kafkaTemplate: KafkaTemplate<String, Any>,
     private val outboxMetrics: OutboxMetrics,
-    private val avroEventConverter: AvroEventConverter
+    private val avroEventConverter: AvroEventConverter,
+    transactionManager: PlatformTransactionManager
 ) {
 
     private val logger = LoggerFactory.getLogger(OutboxEventPublisher::class.java)
     private val maxRetries = 3
+    private val transactionTemplate = TransactionTemplate(transactionManager)
 
     @Scheduled(fixedDelayString = "\${outbox.publish.interval-ms:5000}")
-    @Transactional
     fun publishPendingEvents() {
-        val pendingEvents = outboxEventRepository.findUnprocessedEvents(
-            status = OutboxStatus.PENDING,
-            retryStatus = OutboxStatus.FAILED,
-            maxRetries = maxRetries,
-            limit = 100
-        )
+        val pendingEvents = transactionTemplate.execute {
+            outboxEventRepository.findUnprocessedEvents(
+                status = OutboxStatus.PENDING,
+                retryStatus = OutboxStatus.FAILED,
+                maxRetries = maxRetries,
+                limit = 100
+            )
+        } ?: return
 
         if (pendingEvents.isNotEmpty()) {
             logger.info("Processing ${pendingEvents.size} pending outbox events")
 
             pendingEvents.forEach { event ->
                 val eventId = event.id ?: return@forEach
-                val claimed = outboxEventRepository.claimEventForPublish(
-                    id = eventId,
-                    nextStatus = OutboxStatus.RETRYING,
-                    updatedAt = LocalDateTime.now(),
-                    pendingStatus = OutboxStatus.PENDING,
-                    failedStatus = OutboxStatus.FAILED,
-                    maxRetries = maxRetries
-                )
+                val claimed = transactionTemplate.execute {
+                    outboxEventRepository.claimEventForPublish(
+                        id = eventId,
+                        nextStatus = OutboxStatus.RETRYING,
+                        updatedAt = LocalDateTime.now(),
+                        pendingStatus = OutboxStatus.PENDING,
+                        failedStatus = OutboxStatus.FAILED,
+                        maxRetries = maxRetries
+                    )
+                } ?: 0
                 if (claimed > 0) {
                     publishEvent(eventId)
                 }
@@ -55,15 +61,16 @@ class OutboxEventPublisher(
         }
     }
 
-    @Transactional
     fun publishEvent(eventId: Long) {
-        var event: OutboxEvent? = null
-        try {
-            event = outboxEventRepository.findById(eventId).orElse(null) ?: return
-            if (event.processed || event.status != OutboxStatus.RETRYING) {
-                return
-            }
+        val event = transactionTemplate.execute {
+            outboxEventRepository.findById(eventId).orElse(null)
+        } ?: return
 
+        if (event.processed || event.status != OutboxStatus.RETRYING) {
+            return
+        }
+
+        try {
             val avroRecord = avroEventConverter.convertJsonToAvro(event.eventType, event.eventData)
 
             val result = kafkaTemplate.executeInTransaction { template ->
@@ -74,15 +81,14 @@ class OutboxEventPublisher(
                 ).get(10, TimeUnit.SECONDS)
             }
 
-            handlePublishSuccess(event, result)
+            transactionTemplate.executeWithoutResult {
+                handlePublishSuccess(event, result)
+            }
 
         } catch (e: Exception) {
-            val failedEvent = event
-            if (failedEvent != null) {
-                logger.error("Failed to publish outbox event: ${failedEvent.id}", e)
-                handlePublishFailure(failedEvent, e)
-            } else {
-                logger.error("Failed to publish outbox event: $eventId", e)
+            logger.error("Failed to publish outbox event: ${event.id}", e)
+            transactionTemplate.executeWithoutResult {
+                handlePublishFailure(event, e)
             }
         }
     }

--- a/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/scheduler/OutboxEventPublisherTest.kt
+++ b/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/scheduler/OutboxEventPublisherTest.kt
@@ -10,12 +10,12 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
@@ -28,6 +28,8 @@ import org.springframework.kafka.core.KafkaOperations
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.support.SendResult
 import org.springframework.test.util.ReflectionTestUtils
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.SimpleTransactionStatus
 import java.time.LocalDateTime
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
@@ -49,8 +51,18 @@ class OutboxEventPublisherTest {
     @Mock
     private lateinit var avroEventConverter: AvroEventConverter
 
-    @InjectMocks
+    @Mock
+    private lateinit var transactionManager: PlatformTransactionManager
+
     private lateinit var outboxEventPublisher: OutboxEventPublisher
+
+    @BeforeEach
+    fun setUp() {
+        whenever(transactionManager.getTransaction(any())).thenReturn(SimpleTransactionStatus())
+        outboxEventPublisher = OutboxEventPublisher(
+            outboxEventRepository, kafkaTemplate, outboxMetrics, avroEventConverter, transactionManager
+        )
+    }
 
     private fun createOutboxEvent(
         id: Long = 1L,

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/PaymentCommandServiceImpl.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/PaymentCommandServiceImpl.kt
@@ -11,6 +11,7 @@ import com.hoppingmall.payment.payment.dto.response.PaymentResponse
 import com.hoppingmall.payment.payment.exception.PaymentAccessDeniedException
 import com.hoppingmall.payment.payment.exception.PaymentInvalidStateException
 import com.hoppingmall.payment.payment.exception.PaymentNotFoundException
+import com.hoppingmall.payment.point.service.strategy.PointEarnRateStrategy
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.PlatformTransactionManager
@@ -26,6 +27,7 @@ class PaymentCommandServiceImpl(
     private val paymentNotificationService: PaymentNotificationService,
     private val couponCommandService: CouponCommandService,
     private val paymentMetrics: PaymentMetrics,
+    private val pointEarnRateStrategy: PointEarnRateStrategy,
     transactionManager: PlatformTransactionManager
 ) : PaymentCommandService {
 
@@ -63,6 +65,10 @@ class PaymentCommandServiceImpl(
 
         val paymentResult = paymentService.processPayment(savedPayment)
 
+        val earnRate = if (savedPayment.amount > BigDecimal.ZERO) {
+            pointEarnRateStrategy.getEarnRate(savedPayment.userId)
+        } else null
+
         val finalPayment = transactionTemplate.execute {
             val updatedPayment = updatePaymentWithResult(savedPayment, paymentResult)
             val saved = paymentRepository.save(updatedPayment)
@@ -70,7 +76,7 @@ class PaymentCommandServiceImpl(
             if (saved.status == PaymentStatus.SUCCESS) {
                 log.info("결제 성공: paymentId={}, orderId={}, userId={}, amount={}", saved.id, saved.orderId, userId, saved.amount)
                 paymentMetrics.recordPaymentCompleted(saved.amount, saved.method.name)
-                publishPaymentEvents(saved)
+                publishPaymentEvents(saved, earnRate)
             }
 
             if (saved.status == PaymentStatus.FAILED) {
@@ -138,11 +144,11 @@ class PaymentCommandServiceImpl(
         }
     }
 
-    private fun publishPaymentEvents(payment: Payment) {
+    private fun publishPaymentEvents(payment: Payment, earnRate: BigDecimal? = null) {
         paymentEventService.publishPaymentCompletedEvent(payment)
 
-        if (payment.amount > BigDecimal.ZERO) {
-            paymentEventService.publishPointEarnRequestEvent(payment)
+        if (payment.amount > BigDecimal.ZERO && earnRate != null) {
+            paymentEventService.publishPointEarnRequestEvent(payment, earnRate)
             paymentEventService.publishMembershipUpdateEvent(payment)
         }
         paymentNotificationService.publishPaymentCompletedNotification(payment)

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/PaymentEventService.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/PaymentEventService.kt
@@ -6,14 +6,13 @@ import com.hoppingmall.payment.payment.dto.event.PaymentCancelledEvent
 import com.hoppingmall.payment.payment.dto.event.PaymentCompletedEvent
 import com.hoppingmall.payment.payment.dto.event.PaymentFailedEvent
 import com.hoppingmall.payment.payment.dto.event.PointEarnRequestEvent
-import com.hoppingmall.payment.point.service.strategy.PointEarnRateStrategy
 import org.springframework.stereotype.Service
+import java.math.BigDecimal
 import java.time.LocalDateTime
 
 @Service
 class PaymentEventService(
-    private val paymentEventPublisher: PaymentEventPublisher,
-    private val pointEarnRateStrategy: PointEarnRateStrategy
+    private val paymentEventPublisher: PaymentEventPublisher
 ) {
 
     fun publishPaymentCompletedEvent(payment: Payment) {
@@ -31,8 +30,7 @@ class PaymentEventService(
         paymentEventPublisher.publishPaymentCompletedEvent(event)
     }
 
-    fun publishPointEarnRequestEvent(payment: Payment) {
-        val earnRate = pointEarnRateStrategy.getEarnRate(payment.userId)
+    fun publishPointEarnRequestEvent(payment: Payment, earnRate: BigDecimal) {
         val earnAmount = payment.amount.multiply(earnRate)
         val eventId = payment.transactionId ?: "payment-${payment.id}"
 

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointDomainService.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointDomainService.kt
@@ -4,24 +4,32 @@ import com.hoppingmall.payment.point.domain.Point
 import com.hoppingmall.payment.point.domain.PointRepository
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 
 @Service
 class PointDomainService(
-    private val pointRepository: PointRepository
+    private val pointRepository: PointRepository,
+    private val txManager: PlatformTransactionManager
 ) {
 
     @Transactional
     fun findOrCreatePoint(userId: Long): Point {
-        return try {
-            pointRepository.findByUserIdForUpdate(userId)
-                ?: run {
-                    val newPoint = Point(userId = userId)
-                    pointRepository.save(newPoint)
-                }
-        } catch (e: DataIntegrityViolationException) {
-            pointRepository.findByUserIdForUpdate(userId)
-                ?: throw IllegalStateException("포인트 생성 실패: 사용자 $userId")
+        pointRepository.findByUserIdForUpdate(userId)?.let { return it }
+
+        val newTx = TransactionTemplate(txManager).apply {
+            propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
         }
+        newTx.execute {
+            try {
+                pointRepository.save(Point(userId = userId))
+            } catch (_: DataIntegrityViolationException) {
+            }
+        }
+
+        return pointRepository.findByUserIdForUpdate(userId)
+            ?: throw IllegalStateException("포인트 생성 실패: 사용자 $userId")
     }
 }

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/payment/service/PaymentCommandServiceImplTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/payment/service/PaymentCommandServiceImplTest.kt
@@ -9,6 +9,7 @@ import com.hoppingmall.payment.payment.enum.PaymentStatus
 import com.hoppingmall.payment.payment.exception.PaymentAccessDeniedException
 import com.hoppingmall.payment.payment.exception.PaymentInvalidStateException
 import com.hoppingmall.payment.payment.exception.PaymentNotFoundException
+import com.hoppingmall.payment.point.service.strategy.PointEarnRateStrategy
 import com.hoppingmall.common.BaseEntity
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -50,6 +51,9 @@ class PaymentCommandServiceImplTest {
     private lateinit var paymentMetrics: PaymentMetrics
 
     @Mock
+    private lateinit var pointEarnRateStrategy: PointEarnRateStrategy
+
+    @Mock
     private lateinit var transactionManager: PlatformTransactionManager
 
     private fun createService() = PaymentCommandServiceImpl(
@@ -59,6 +63,7 @@ class PaymentCommandServiceImplTest {
         paymentNotificationService,
         couponCommandService,
         paymentMetrics,
+        pointEarnRateStrategy,
         transactionManager
     )
 

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/point/service/PointDomainServiceTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/point/service/PointDomainServiceTest.kt
@@ -16,10 +16,12 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.transaction.PlatformTransactionManager
 import java.math.BigDecimal
 
 @ExtendWith(MockitoExtension::class)
@@ -29,6 +31,9 @@ class PointDomainServiceTest {
 
     @Mock
     private lateinit var pointRepository: PointRepository
+
+    @Mock
+    private lateinit var txManager: PlatformTransactionManager
 
     @InjectMocks
     private lateinit var pointDomainService: PointDomainService
@@ -51,7 +56,10 @@ class PointDomainServiceTest {
         val idField = BaseEntity::class.java.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(newPoint, 1L)
-        whenever(pointRepository.findByUserIdForUpdate(1L)).thenReturn(null)
+        whenever(pointRepository.findByUserIdForUpdate(1L))
+            .thenReturn(null)
+            .thenReturn(newPoint)
+        whenever(txManager.getTransaction(any())).thenReturn(mock())
         doAnswer { newPoint }.whenever(pointRepository).save(any())
 
         val result = pointDomainService.findOrCreatePoint(1L)
@@ -69,6 +77,7 @@ class PointDomainServiceTest {
         whenever(pointRepository.findByUserIdForUpdate(1L))
             .thenReturn(null)
             .thenReturn(existing)
+        whenever(txManager.getTransaction(any())).thenReturn(mock())
         doThrow(DataIntegrityViolationException("duplicate")).whenever(pointRepository).save(any())
 
         val result = pointDomainService.findOrCreatePoint(1L)
@@ -81,6 +90,7 @@ class PointDomainServiceTest {
         whenever(pointRepository.findByUserIdForUpdate(1L))
             .thenReturn(null)
             .thenReturn(null)
+        whenever(txManager.getTransaction(any())).thenReturn(mock())
         doThrow(DataIntegrityViolationException("duplicate")).whenever(pointRepository).save(any())
 
         assertThatThrownBy { pointDomainService.findOrCreatePoint(1L) }

--- a/settlement-service/src/main/kotlin/com/hoppingmall/settlement/service/SettlementCommandServiceImpl.kt
+++ b/settlement-service/src/main/kotlin/com/hoppingmall/settlement/service/SettlementCommandServiceImpl.kt
@@ -13,29 +13,25 @@ import com.hoppingmall.settlement.exception.SettlementNotFoundException
 import com.hoppingmall.settlement.port.OrderItemQueryPort
 import com.hoppingmall.settlement.port.RefundQueryPort
 import org.springframework.stereotype.Service
+import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.annotation.Transactional
-import java.math.BigDecimal
+import org.springframework.transaction.support.TransactionTemplate
 import java.math.RoundingMode
 
 @Service
-@Transactional
 class SettlementCommandServiceImpl(
     private val settlementRepository: SettlementRepository,
     private val settlementItemRepository: SettlementItemRepository,
     private val orderItemQueryPort: OrderItemQueryPort,
-    private val refundQueryPort: RefundQueryPort
+    private val refundQueryPort: RefundQueryPort,
+    transactionManager: PlatformTransactionManager
 ) : SettlementCommandService {
+
+    private val transactionTemplate = TransactionTemplate(transactionManager)
 
     override fun createSettlement(request: CreateSettlementRequest): SettlementResponse {
         if (request.periodEnd.isBefore(request.periodStart)) {
             throw SettlementInvalidPeriodException()
-        }
-
-        if (settlementRepository.existsBySellerIdAndPeriodStartAndPeriodEnd(
-                request.sellerId, request.periodStart, request.periodEnd
-            )
-        ) {
-            throw SettlementAlreadyExistsException()
         }
 
         val startDateTime = request.periodStart.atStartOfDay()
@@ -60,34 +56,44 @@ class SettlementCommandServiceImpl(
             .setScale(2, RoundingMode.HALF_UP)
         val settlementAmount = totalSalesAmount.subtract(totalRefundAmount).subtract(commissionAmount)
 
-        val settlement = settlementRepository.save(
-            Settlement.create(
-                sellerId = request.sellerId,
-                periodStart = request.periodStart,
-                periodEnd = request.periodEnd,
-                totalSalesAmount = totalSalesAmount,
-                totalRefundAmount = totalRefundAmount,
-                commissionRate = request.commissionRate,
-                commissionAmount = commissionAmount,
-                settlementAmount = settlementAmount
-            )
-        )
+        return transactionTemplate.execute {
+            if (settlementRepository.existsBySellerIdAndPeriodStartAndPeriodEnd(
+                    request.sellerId, request.periodStart, request.periodEnd
+                )
+            ) {
+                throw SettlementAlreadyExistsException()
+            }
 
-        val settlementItems = orderItems.map { orderItem ->
-            SettlementItem.create(
-                settlementId = settlement.id!!,
-                orderId = orderItem.orderId,
-                orderItemId = orderItem.id,
-                productName = orderItem.productName,
-                quantity = orderItem.quantity,
-                salesAmount = orderItem.totalPrice
+            val settlement = settlementRepository.save(
+                Settlement.create(
+                    sellerId = request.sellerId,
+                    periodStart = request.periodStart,
+                    periodEnd = request.periodEnd,
+                    totalSalesAmount = totalSalesAmount,
+                    totalRefundAmount = totalRefundAmount,
+                    commissionRate = request.commissionRate,
+                    commissionAmount = commissionAmount,
+                    settlementAmount = settlementAmount
+                )
             )
-        }
-        settlementItemRepository.saveAll(settlementItems)
 
-        return SettlementResponse.from(settlement)
+            val settlementItems = orderItems.map { orderItem ->
+                SettlementItem.create(
+                    settlementId = settlement.id!!,
+                    orderId = orderItem.orderId,
+                    orderItemId = orderItem.id,
+                    productName = orderItem.productName,
+                    quantity = orderItem.quantity,
+                    salesAmount = orderItem.totalPrice
+                )
+            }
+            settlementItemRepository.saveAll(settlementItems)
+
+            SettlementResponse.from(settlement)
+        }!!
     }
 
+    @Transactional
     override fun confirmSettlement(settlementId: Long): SettlementResponse {
         val settlement = settlementRepository.findById(settlementId)
             .orElseThrow { SettlementNotFoundException() }
@@ -95,6 +101,7 @@ class SettlementCommandServiceImpl(
         return SettlementResponse.from(settlement)
     }
 
+    @Transactional
     override fun paySettlement(settlementId: Long): SettlementResponse {
         val settlement = settlementRepository.findById(settlementId)
             .orElseThrow { SettlementNotFoundException() }

--- a/settlement-service/src/test/kotlin/com/hoppingmall/settlement/service/SettlementCommandServiceImplTest.kt
+++ b/settlement-service/src/test/kotlin/com/hoppingmall/settlement/service/SettlementCommandServiceImplTest.kt
@@ -15,24 +15,29 @@ import com.hoppingmall.settlement.port.RefundInfo
 import com.hoppingmall.settlement.port.RefundQueryPort
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
 import org.springframework.test.util.ReflectionTestUtils
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.SimpleTransactionStatus
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 @DisplayName("SettlementCommandServiceImpl")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
 class SettlementCommandServiceImplTest {
@@ -49,8 +54,18 @@ class SettlementCommandServiceImplTest {
     @Mock
     private lateinit var refundQueryPort: RefundQueryPort
 
-    @InjectMocks
+    @Mock
+    private lateinit var transactionManager: PlatformTransactionManager
+
     private lateinit var settlementCommandServiceImpl: SettlementCommandServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        whenever(transactionManager.getTransaction(any())).thenReturn(SimpleTransactionStatus())
+        settlementCommandServiceImpl = SettlementCommandServiceImpl(
+            settlementRepository, settlementItemRepository, orderItemQueryPort, refundQueryPort, transactionManager
+        )
+    }
 
     @Test
     fun 정산_생성_시_매출과_환불을_조회하고_정산을_생성한다() {
@@ -127,6 +142,21 @@ class SettlementCommandServiceImplTest {
             commissionRate = BigDecimal("0.05")
         )
 
+        val orderItems = listOf(
+            OrderItemInfo(
+                id = 10L,
+                orderId = 100L,
+                sellerId = 1L,
+                productId = 1L,
+                productName = "상품A",
+                productPrice = BigDecimal("50000"),
+                quantity = 2,
+                totalPrice = BigDecimal("100000")
+            )
+        )
+
+        whenever(orderItemQueryPort.findDeliveredItemsBySellerAndPeriod(any(), any<LocalDateTime>(), any<LocalDateTime>())).thenReturn(orderItems)
+        whenever(refundQueryPort.findCompletedBySellerAndPeriod(any(), any<LocalDateTime>(), any<LocalDateTime>())).thenReturn(emptyList())
         whenever(settlementRepository.existsBySellerIdAndPeriodStartAndPeriodEnd(any(), any(), any())).thenReturn(true)
 
         assertThatThrownBy { settlementCommandServiceImpl.createSettlement(request) }
@@ -142,7 +172,6 @@ class SettlementCommandServiceImplTest {
             commissionRate = BigDecimal("0.05")
         )
 
-        whenever(settlementRepository.existsBySellerIdAndPeriodStartAndPeriodEnd(any(), any(), any())).thenReturn(false)
         whenever(orderItemQueryPort.findDeliveredItemsBySellerAndPeriod(any(), any<LocalDateTime>(), any<LocalDateTime>())).thenReturn(emptyList())
 
         assertThatThrownBy { settlementCommandServiceImpl.createSettlement(request) }


### PR DESCRIPTION
Closes #370

### 📌 작업 개요
DB 트랜잭션 내부에서 외부 서비스 호출(Kafka 전송, HTTP)을 수행하여 커넥션 장기 점유 및 타임아웃 위험이 있는 3건의 트랜잭션 범위 문제를 수정했습니다.
TransactionTemplate을 활용하여 외부 호출을 트랜잭션 밖으로 분리하고, DB 쓰기만 최소 범위로 트랜잭션 처리합니다.

---

### ✅ 주요 변경 사항

- `outbox.scheduler`
  - `OutboxEventPublisher`: @Transactional 제거, TransactionTemplate으로 이벤트별 독립 트랜잭션 분리. Kafka 전송이 DB 트랜잭션 밖에서 실행

- `payment.service`
  - `PaymentEventService`: getEarnRate() 호출 책임을 PaymentCommandServiceImpl로 이동
  - `PaymentCommandServiceImpl`: earnRate를 트랜잭션 진입 전에 미리 조회, PointEarnRateStrategy 의존성 추가

- `settlement.service`
  - `SettlementCommandServiceImpl`: 클래스 레벨 @Transactional 제거, 외부 포트 호출(orderItemQueryPort, refundQueryPort)을 트랜잭션 밖으로 분리, DB 쓰기만 TransactionTemplate으로 처리

---

### 🧪 테스트

- `OutboxEventPublisherTest`: TransactionTemplate 기반으로 테스트 리팩토링, 전체 10건 통과
- `PaymentCommandServiceImplTest`: PointEarnRateStrategy mock 추가, 전체 8건 통과
- `SettlementCommandServiceImplTest`: TransactionTemplate 기반으로 테스트 리팩토링, 전체 7건 통과

---

### 📎 관련 이슈
- #370
