### PR TITLE
perf: 인프라/Docker 설정 개선

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -9,7 +9,7 @@ RUN sed -i "s/\r$//" gradlew && chmod +x gradlew && ./gradlew bootJar --no-daemo
 FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
-ENV JAVA_OPTS="-Xms128m -Xmx256m"
+ENV JAVA_OPTS="-Xms256m -Xmx512m"
 ENV SPRING_PROFILES_ACTIVE="docker"
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=3s \

--- a/api-gateway/src/main/resources/logback-spring.xml
+++ b/api-gateway/src/main/resources/logback-spring.xml
@@ -23,8 +23,15 @@
             </encoder>
         </appender>
 
-        <root level="INFO">
+        <appender name="ASYNC_JSON" class="ch.qos.logback.classic.AsyncAppender">
+            <queueSize>1024</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+            <neverBlock>true</neverBlock>
             <appender-ref ref="JSON_CONSOLE"/>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_JSON"/>
         </root>
     </springProfile>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,13 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+      KAFKA_NUM_PARTITIONS: 4
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   schema-registry:
     image: confluentinc/cp-schema-registry:7.6.0
@@ -293,11 +300,12 @@ services:
       context: .
       dockerfile: notification-service/Dockerfile
     container_name: notification-service
+    restart: unless-stopped
     depends_on:
       mysql:
         condition: service_healthy
       kafka:
-        condition: service_started
+        condition: service_healthy
       redis-cluster-init:
         condition: service_started
     environment:
@@ -317,6 +325,7 @@ services:
       context: .
       dockerfile: user-service/Dockerfile
     container_name: user-service
+    restart: unless-stopped
     depends_on:
       mysql:
         condition: service_healthy
@@ -341,6 +350,7 @@ services:
       context: .
       dockerfile: product-service/Dockerfile
     container_name: product-service
+    restart: unless-stopped
     depends_on:
       mysql:
         condition: service_healthy
@@ -365,11 +375,12 @@ services:
       context: .
       dockerfile: order-service/Dockerfile
     container_name: order-service
+    restart: unless-stopped
     depends_on:
       mysql:
         condition: service_healthy
       kafka:
-        condition: service_started
+        condition: service_healthy
       redis-cluster-init:
         condition: service_started
     environment:
@@ -391,11 +402,12 @@ services:
       context: .
       dockerfile: payment-service/Dockerfile
     container_name: payment-service
+    restart: unless-stopped
     depends_on:
       mysql:
         condition: service_healthy
       kafka:
-        condition: service_started
+        condition: service_healthy
       redis-cluster-init:
         condition: service_started
     environment:
@@ -417,6 +429,7 @@ services:
       context: .
       dockerfile: settlement-service/Dockerfile
     container_name: settlement-service
+    restart: unless-stopped
     depends_on:
       mysql:
         condition: service_healthy
@@ -438,6 +451,7 @@ services:
       context: .
       dockerfile: api-gateway/Dockerfile
     container_name: api-gateway
+    restart: unless-stopped
     depends_on:
       redis-cluster-init:
         condition: service_started

--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -12,7 +12,7 @@ RUN sed -i "s/\r$//" gradlew && chmod +x gradlew && ./gradlew bootJar --no-daemo
 FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
-ENV JAVA_OPTS="-Xms128m -Xmx256m"
+ENV JAVA_OPTS="-Xms256m -Xmx512m"
 ENV SPRING_PROFILES_ACTIVE="docker"
 EXPOSE 8081
 HEALTHCHECK --interval=30s --timeout=3s \

--- a/notification-service/src/main/resources/logback-spring.xml
+++ b/notification-service/src/main/resources/logback-spring.xml
@@ -24,8 +24,15 @@
             </encoder>
         </appender>
 
-        <root level="INFO">
+        <appender name="ASYNC_JSON" class="ch.qos.logback.classic.AsyncAppender">
+            <queueSize>1024</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+            <neverBlock>true</neverBlock>
             <appender-ref ref="JSON_CONSOLE"/>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_JSON"/>
         </root>
     </springProfile>
 

--- a/order-service/Dockerfile
+++ b/order-service/Dockerfile
@@ -14,7 +14,7 @@ RUN sed -i "s/\r$//" gradlew && chmod +x gradlew && ./gradlew bootJar --no-daemo
 FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
-ENV JAVA_OPTS="-Xms128m -Xmx256m"
+ENV JAVA_OPTS="-Xms256m -Xmx512m"
 ENV SPRING_PROFILES_ACTIVE="docker"
 EXPOSE 8084
 HEALTHCHECK --interval=30s --timeout=3s \

--- a/order-service/src/main/resources/logback-spring.xml
+++ b/order-service/src/main/resources/logback-spring.xml
@@ -24,8 +24,15 @@
             </encoder>
         </appender>
 
-        <root level="INFO">
+        <appender name="ASYNC_JSON" class="ch.qos.logback.classic.AsyncAppender">
+            <queueSize>1024</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+            <neverBlock>true</neverBlock>
             <appender-ref ref="JSON_CONSOLE"/>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_JSON"/>
         </root>
     </springProfile>
 

--- a/payment-service/Dockerfile
+++ b/payment-service/Dockerfile
@@ -14,7 +14,7 @@ RUN sed -i "s/\r$//" gradlew && chmod +x gradlew && ./gradlew bootJar --no-daemo
 FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
-ENV JAVA_OPTS="-Xms128m -Xmx256m"
+ENV JAVA_OPTS="-Xms256m -Xmx512m"
 ENV SPRING_PROFILES_ACTIVE="docker"
 EXPOSE 8085
 HEALTHCHECK --interval=30s --timeout=3s \

--- a/payment-service/src/main/resources/logback-spring.xml
+++ b/payment-service/src/main/resources/logback-spring.xml
@@ -24,8 +24,15 @@
             </encoder>
         </appender>
 
-        <root level="INFO">
+        <appender name="ASYNC_JSON" class="ch.qos.logback.classic.AsyncAppender">
+            <queueSize>1024</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+            <neverBlock>true</neverBlock>
             <appender-ref ref="JSON_CONSOLE"/>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_JSON"/>
         </root>
     </springProfile>
 

--- a/product-service/Dockerfile
+++ b/product-service/Dockerfile
@@ -14,7 +14,7 @@ RUN sed -i "s/\r$//" gradlew && chmod +x gradlew && ./gradlew bootJar --no-daemo
 FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
-ENV JAVA_OPTS="-Xms128m -Xmx256m"
+ENV JAVA_OPTS="-Xms256m -Xmx512m"
 ENV SPRING_PROFILES_ACTIVE="docker"
 EXPOSE 8083
 HEALTHCHECK --interval=30s --timeout=3s \

--- a/product-service/src/main/resources/logback-spring.xml
+++ b/product-service/src/main/resources/logback-spring.xml
@@ -24,8 +24,15 @@
             </encoder>
         </appender>
 
-        <root level="INFO">
+        <appender name="ASYNC_JSON" class="ch.qos.logback.classic.AsyncAppender">
+            <queueSize>1024</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+            <neverBlock>true</neverBlock>
             <appender-ref ref="JSON_CONSOLE"/>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_JSON"/>
         </root>
     </springProfile>
 

--- a/settlement-service/Dockerfile
+++ b/settlement-service/Dockerfile
@@ -10,7 +10,7 @@ RUN sed -i "s/\r$//" gradlew && chmod +x gradlew && ./gradlew bootJar --no-daemo
 FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
-ENV JAVA_OPTS="-Xms128m -Xmx256m"
+ENV JAVA_OPTS="-Xms256m -Xmx512m"
 ENV SPRING_PROFILES_ACTIVE="docker"
 EXPOSE 8086
 HEALTHCHECK --interval=30s --timeout=3s \

--- a/settlement-service/src/main/resources/logback-spring.xml
+++ b/settlement-service/src/main/resources/logback-spring.xml
@@ -24,8 +24,15 @@
             </encoder>
         </appender>
 
-        <root level="INFO">
+        <appender name="ASYNC_JSON" class="ch.qos.logback.classic.AsyncAppender">
+            <queueSize>1024</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+            <neverBlock>true</neverBlock>
             <appender-ref ref="JSON_CONSOLE"/>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_JSON"/>
         </root>
     </springProfile>
 

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -12,7 +12,7 @@ RUN sed -i "s/\r$//" gradlew && chmod +x gradlew && ./gradlew bootJar --no-daemo
 FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
-ENV JAVA_OPTS="-Xms128m -Xmx256m"
+ENV JAVA_OPTS="-Xms256m -Xmx512m"
 ENV SPRING_PROFILES_ACTIVE="docker"
 EXPOSE 8082 9082
 HEALTHCHECK --interval=30s --timeout=3s \

--- a/user-service/src/main/resources/logback-spring.xml
+++ b/user-service/src/main/resources/logback-spring.xml
@@ -24,8 +24,15 @@
             </encoder>
         </appender>
 
-        <root level="INFO">
+        <appender name="ASYNC_JSON" class="ch.qos.logback.classic.AsyncAppender">
+            <queueSize>1024</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+            <neverBlock>true</neverBlock>
             <appender-ref ref="JSON_CONSOLE"/>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_JSON"/>
         </root>
     </springProfile>
 


### PR DESCRIPTION
Closes #369

### 📌 작업 개요
Docker 환경 안정성 및 성능을 위한 인프라 설정을 개선했습니다.
JVM 힙 사이징, 서비스 재시작 정책, Kafka 의존성/파티션, 비동기 로깅을 적용합니다.

---

### ✅ 주요 변경 사항

- `Dockerfile` (7개 서비스)
  - JVM 힙 메모리 `-Xms128m -Xmx256m` → `-Xms256m -Xmx512m` 상향

- `docker-compose.yml`
  - 7개 애플리케이션 서비스에 `restart: unless-stopped` 추가
  - Kafka healthcheck 추가 (`kafka-broker-api-versions`)
  - Kafka 의존 서비스 3개 `service_started` → `service_healthy` 변경
  - `KAFKA_NUM_PARTITIONS: 4` 추가 (consumer concurrency=4에 맞춤)

- `logback-spring.xml` (7개 서비스)
  - docker 프로필에 `AsyncAppender` 적용 (queueSize=1024, neverBlock=true)

---

### 🧪 테스트

- 7개 서비스 전체 jacocoTestVerification 통과

---

### 📎 관련 이슈
- #369
