### PR TITLE
perf: 캐싱 및 페치 전략 개선

### DIFF
--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/SagaEventLog.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/SagaEventLog.kt
@@ -23,7 +23,7 @@ class SagaEventLog(
     @Column(nullable = false)
     val createdAt: LocalDateTime = LocalDateTime.now(),
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "saga_event_log_steps", joinColumns = [JoinColumn(name = "saga_event_log_id")])
     @Column(name = "step")
     val completedSteps: MutableSet<String> = mutableSetOf()

--- a/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderTransactionalRollbackTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderTransactionalRollbackTest.kt
@@ -68,6 +68,9 @@ class OrderTransactionalRollbackTest {
     @Autowired
     private lateinit var sagaEventLogRepository: SagaEventLogRepository
 
+    @Autowired
+    private lateinit var txTemplate: TransactionTemplate
+
     @MockitoBean
     private lateinit var cartItemRepository: CartItemRepository
 
@@ -128,10 +131,12 @@ class OrderTransactionalRollbackTest {
         assertThat(propagatedMessages).contains("outbox publish failed")
 
         val reloadedOrder = orderRepository.findById(order.id!!).orElseThrow()
-        val reloadedLog = sagaEventLogRepository.findByEventId("payment-completed-txn-123")!!
-
         assertThat(reloadedOrder.status).isEqualTo(OrderStatus.PAID)
-        assertThat(reloadedLog.isStepCompleted(SagaEventLog.REMOTE_COMPLETED)).isFalse()
+
+        txTemplate.execute {
+            val reloadedLog = sagaEventLogRepository.findByEventId("payment-completed-txn-123")!!
+            assertThat(reloadedLog.isStepCompleted(SagaEventLog.REMOTE_COMPLETED)).isFalse()
+        }
     }
 
     @Test

--- a/user-service/build.gradle.kts
+++ b/user-service/build.gradle.kts
@@ -44,6 +44,8 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
+	implementation("org.springframework.boot:spring-boot-starter-cache")
+	implementation("com.github.ben-manes.caffeine:caffeine")
 
 	implementation("org.springframework.boot:spring-boot-starter-data-redis") {
 		exclude(group = "io.lettuce", module = "lettuce-core")

--- a/user-service/src/main/kotlin/com/hoppingmall/user/auth/domain/repository/AccessTokenBlacklistRepository.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/auth/domain/repository/AccessTokenBlacklistRepository.kt
@@ -7,19 +7,19 @@ import java.util.concurrent.TimeUnit
 
 @Repository
 class AccessTokenBlacklistRepository(
-    @Qualifier("customStringRedisTemplate")
-    private val customStringRedisTemplate: RedisTemplate<String, String>
+    @Qualifier("stringRedisTemplate")
+    private val stringRedisTemplate: RedisTemplate<String, String>
 ) {
     private val prefix = "blacklist:"
 
     fun add(token: String, remainingTtlMs: Long) {
         if (remainingTtlMs <= 0) return
-        customStringRedisTemplate.opsForValue()
+        stringRedisTemplate.opsForValue()
             .set(getKey(token), "blacklisted", remainingTtlMs, TimeUnit.MILLISECONDS)
     }
 
     fun exists(token: String): Boolean {
-        return customStringRedisTemplate.hasKey(getKey(token))
+        return stringRedisTemplate.hasKey(getKey(token))
     }
 
     private fun getKey(token: String) = "$prefix$token"

--- a/user-service/src/main/kotlin/com/hoppingmall/user/config/CacheConfig.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/config/CacheConfig.kt
@@ -1,0 +1,25 @@
+package com.hoppingmall.user.config
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.util.concurrent.TimeUnit
+
+@Configuration
+@EnableCaching
+class CacheConfig {
+
+    @Bean
+    fun cacheManager(): CacheManager {
+        val cacheManager = CaffeineCacheManager()
+        cacheManager.setCaffeine(
+            Caffeine.newBuilder()
+                .maximumSize(1000)
+                .expireAfterWrite(10, TimeUnit.MINUTES)
+        )
+        return cacheManager
+    }
+}

--- a/user-service/src/main/kotlin/com/hoppingmall/user/config/RedisConfig.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/config/RedisConfig.kt
@@ -20,14 +20,4 @@ class RedisConfig {
         return template
     }
 
-    @Bean
-    fun customStringRedisTemplate(redisConnectionFactory: RedisConnectionFactory): RedisTemplate<String, String> {
-        val template = RedisTemplate<String, String>()
-        template.connectionFactory = redisConnectionFactory
-        template.keySerializer = StringRedisSerializer()
-        template.valueSerializer = StringRedisSerializer()
-        template.hashKeySerializer = StringRedisSerializer()
-        template.hashValueSerializer = StringRedisSerializer()
-        return template
-    }
 }

--- a/user-service/src/test/kotlin/com/hoppingmall/user/UserServiceApplicationTests.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/UserServiceApplicationTests.kt
@@ -40,14 +40,6 @@ class UserServiceApplicationTests {
             return template
         }
 
-        @Bean
-        fun customStringRedisTemplate(redisConnectionFactory: RedisConnectionFactory): RedisTemplate<String, String> {
-            val template = RedisTemplate<String, String>()
-            template.connectionFactory = redisConnectionFactory
-            template.keySerializer = StringRedisSerializer()
-            template.valueSerializer = StringRedisSerializer()
-            return template
-        }
     }
 
     @Test

--- a/user-service/src/test/kotlin/com/hoppingmall/user/auth/domain/repository/AccessTokenBlacklistRepositoryTest.kt
+++ b/user-service/src/test/kotlin/com/hoppingmall/user/auth/domain/repository/AccessTokenBlacklistRepositoryTest.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit
 class AccessTokenBlacklistRepositoryTest {
 
     @Mock
-    private lateinit var customStringRedisTemplate: RedisTemplate<String, String>
+    private lateinit var stringRedisTemplate: RedisTemplate<String, String>
 
     @Mock
     private lateinit var valueOperations: ValueOperations<String, String>
@@ -34,7 +34,7 @@ class AccessTokenBlacklistRepositoryTest {
 
     @Test
     fun 토큰을_블랙리스트에_추가한다() {
-        whenever(customStringRedisTemplate.opsForValue()).thenReturn(valueOperations)
+        whenever(stringRedisTemplate.opsForValue()).thenReturn(valueOperations)
 
         repository.add("test-token", 3600000L)
 
@@ -45,12 +45,12 @@ class AccessTokenBlacklistRepositoryTest {
     fun TTL이_0이하이면_블랙리스트에_추가하지_않는다() {
         repository.add("test-token", 0L)
 
-        verify(customStringRedisTemplate, never()).opsForValue()
+        verify(stringRedisTemplate, never()).opsForValue()
     }
 
     @Test
     fun 블랙리스트에_토큰이_존재하는지_확인한다() {
-        whenever(customStringRedisTemplate.hasKey("blacklist:test-token")).thenReturn(true)
+        whenever(stringRedisTemplate.hasKey("blacklist:test-token")).thenReturn(true)
 
         val result = repository.exists("test-token")
 
@@ -59,7 +59,7 @@ class AccessTokenBlacklistRepositoryTest {
 
     @Test
     fun 블랙리스트에_토큰이_존재하지_않으면_false를_반환한다() {
-        whenever(customStringRedisTemplate.hasKey("blacklist:test-token")).thenReturn(false)
+        whenever(stringRedisTemplate.hasKey("blacklist:test-token")).thenReturn(false)
 
         val result = repository.exists("test-token")
 


### PR DESCRIPTION
Closes #373

### 📌 작업 개요
user-service 캐시 메모리 무한 증가 위험을 해결하고 중복 빈을 제거했습니다.
order-service SagaEventLog의 불필요한 EAGER 로딩을 LAZY로 변경했습니다.

---

### ✅ 주요 변경 사항

- `user.config`
  - `CacheConfig`: Caffeine 기반 CacheConfig 신규 추가 (maximumSize=1000, TTL=10분)
  - `RedisConfig`: 중복 `customStringRedisTemplate` 빈 제거

- `user.auth.domain.repository`
  - `AccessTokenBlacklistRepository`: `customStringRedisTemplate` → `stringRedisTemplate`로 통합

- `order.order.domain`
  - `SagaEventLog`: `completedSteps` 페치 전략 `EAGER` → `LAZY` 변경

---

### 🧪 테스트

- `user-service`: jacocoTestVerification 통과
- `order-service`: jacocoTestVerification 통과

---

### 📎 관련 이슈
- #373
