### PR TITLE
perf: API 응답 및 압축 개선

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -241,6 +241,10 @@ spring:
 
 server:
   port: 8000
+  compression:
+    enabled: true
+    mime-types: application/json,application/xml,text/html,text/xml,text/plain
+    min-response-size: 1024
 
 management:
   endpoints:

--- a/order-service/src/main/kotlin/com/hoppingmall/order/refund/controller/RefundController.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/refund/controller/RefundController.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.order.refund.controller
 
+import com.hoppingmall.common.ApiResponse
 import com.hoppingmall.common.UserPrincipal
 import com.hoppingmall.idempotency.Idempotent
 import com.hoppingmall.order.refund.dto.request.RefundApprovalRequest
@@ -10,7 +11,6 @@ import com.hoppingmall.order.refund.service.RefundQueryService
 import jakarta.validation.Valid
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Slice
-import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
@@ -28,20 +28,18 @@ class RefundController(
     fun requestRefund(
         @Valid @RequestBody request: RefundCreateRequest,
         @AuthenticationPrincipal principal: UserPrincipal
-    ): ResponseEntity<RefundResponse> {
+    ): ApiResponse<RefundResponse> {
         val buyerId = principal.getUserId()
-        val response = refundCommandService.requestRefund(buyerId, request)
-        return ResponseEntity.ok(response)
+        return ApiResponse.success(refundCommandService.requestRefund(buyerId, request))
     }
 
     @GetMapping("/{refundId}")
     fun getRefund(
         @PathVariable refundId: Long,
         @AuthenticationPrincipal principal: UserPrincipal
-    ): ResponseEntity<RefundResponse> {
+    ): ApiResponse<RefundResponse> {
         val userId = principal.getUserId()
-        val response = refundQueryService.getRefund(refundId, userId)
-        return ResponseEntity.ok(response)
+        return ApiResponse.success(refundQueryService.getRefund(refundId, userId))
     }
 
     @GetMapping("/my")
@@ -49,11 +47,10 @@ class RefundController(
         @AuthenticationPrincipal principal: UserPrincipal,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int
-    ): ResponseEntity<Slice<RefundResponse>> {
+    ): ApiResponse<Slice<RefundResponse>> {
         val buyerId = principal.getUserId()
         val pageable = PageRequest.of(page, size)
-        val refunds = refundQueryService.getMyRefunds(buyerId, pageable)
-        return ResponseEntity.ok(refunds)
+        return ApiResponse.success(refundQueryService.getMyRefunds(buyerId, pageable))
     }
 
     @GetMapping("/seller")
@@ -61,11 +58,10 @@ class RefundController(
         @AuthenticationPrincipal principal: UserPrincipal,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int
-    ): ResponseEntity<Slice<RefundResponse>> {
+    ): ApiResponse<Slice<RefundResponse>> {
         val sellerId = principal.getUserId()
         val pageable = PageRequest.of(page, size)
-        val refunds = refundQueryService.getSellerRefunds(sellerId, pageable)
-        return ResponseEntity.ok(refunds)
+        return ApiResponse.success(refundQueryService.getSellerRefunds(sellerId, pageable))
     }
 
     @Idempotent(ttlHours = 24)
@@ -73,10 +69,9 @@ class RefundController(
     fun approveRefund(
         @PathVariable refundId: Long,
         @AuthenticationPrincipal principal: UserPrincipal
-    ): ResponseEntity<RefundResponse> {
+    ): ApiResponse<RefundResponse> {
         val approverId = principal.getUserId()
-        val response = refundCommandService.approveRefund(refundId, approverId)
-        return ResponseEntity.ok(response)
+        return ApiResponse.success(refundCommandService.approveRefund(refundId, approverId))
     }
 
     @Idempotent(ttlHours = 24)
@@ -85,9 +80,8 @@ class RefundController(
         @PathVariable refundId: Long,
         @RequestBody request: RefundApprovalRequest,
         @AuthenticationPrincipal principal: UserPrincipal
-    ): ResponseEntity<RefundResponse> {
+    ): ApiResponse<RefundResponse> {
         val approverId = principal.getUserId()
-        val response = refundCommandService.rejectRefund(refundId, approverId, request)
-        return ResponseEntity.ok(response)
+        return ApiResponse.success(refundCommandService.rejectRefund(refundId, approverId, request))
     }
 }

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -50,6 +50,10 @@ spring:
 
 server:
   port: 8084
+  compression:
+    enabled: true
+    mime-types: application/json,application/xml,text/html,text/xml,text/plain
+    min-response-size: 1024
 
 management:
   endpoints:

--- a/order-service/src/test/kotlin/com/hoppingmall/order/refund/controller/RefundControllerTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/refund/controller/RefundControllerTest.kt
@@ -21,7 +21,6 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.SliceImpl
-import org.springframework.http.HttpStatus
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
@@ -80,8 +79,7 @@ class RefundControllerTest {
 
         val result = controller.requestRefund(request, buyerPrincipal)
 
-        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(result.body!!.id).isEqualTo(1L)
+        assertThat(result.data!!.id).isEqualTo(1L)
     }
 
     @Test
@@ -92,8 +90,7 @@ class RefundControllerTest {
 
         val result = controller.getRefund(1L, buyerPrincipal)
 
-        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(result.body!!.id).isEqualTo(1L)
+        assertThat(result.data!!.id).isEqualTo(1L)
     }
 
     @Test
@@ -106,8 +103,7 @@ class RefundControllerTest {
 
         val result = controller.getMyRefunds(buyerPrincipal, 0, 10)
 
-        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(result.body!!.content).hasSize(1)
+        assertThat(result.data!!.content).hasSize(1)
     }
 
     @Test
@@ -120,8 +116,7 @@ class RefundControllerTest {
 
         val result = controller.getSellerRefunds(sellerPrincipal, 0, 10)
 
-        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(result.body!!.content).hasSize(1)
+        assertThat(result.data!!.content).hasSize(1)
     }
 
     @Test
@@ -132,8 +127,7 @@ class RefundControllerTest {
 
         val result = controller.approveRefund(1L, sellerPrincipal)
 
-        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(result.body!!.status).isEqualTo(RefundStatus.COMPLETED)
+        assertThat(result.data!!.status).isEqualTo(RefundStatus.COMPLETED)
     }
 
     @Test
@@ -145,7 +139,6 @@ class RefundControllerTest {
 
         val result = controller.rejectRefund(1L, request, sellerPrincipal)
 
-        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(result.body!!.status).isEqualTo(RefundStatus.REJECTED)
+        assertThat(result.data!!.status).isEqualTo(RefundStatus.REJECTED)
     }
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/controller/PointPolicyController.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/controller/PointPolicyController.kt
@@ -1,10 +1,10 @@
 package com.hoppingmall.payment.point.controller
 
+import com.hoppingmall.common.ApiResponse
 import com.hoppingmall.payment.point.dto.request.PointPolicyRequest
 import com.hoppingmall.payment.point.dto.response.PointPolicyResponse
 import com.hoppingmall.payment.point.service.PointPolicyService
 import jakarta.validation.Valid
-import org.springframework.http.ResponseEntity
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 
@@ -18,47 +18,41 @@ class PointPolicyController(
     @PostMapping
     fun createPolicy(
         @Valid @RequestBody request: PointPolicyRequest
-    ): ResponseEntity<PointPolicyResponse> {
-        val policy = pointPolicyService.createPolicy(request)
-        return ResponseEntity.ok(policy)
+    ): ApiResponse<PointPolicyResponse> {
+        return ApiResponse.success(pointPolicyService.createPolicy(request))
     }
 
     @PutMapping("/{policyId}")
     fun updatePolicy(
         @PathVariable policyId: Long,
         @Valid @RequestBody request: PointPolicyRequest
-    ): ResponseEntity<PointPolicyResponse> {
-        val policy = pointPolicyService.updatePolicy(policyId, request)
-        return ResponseEntity.ok(policy)
+    ): ApiResponse<PointPolicyResponse> {
+        return ApiResponse.success(pointPolicyService.updatePolicy(policyId, request))
     }
 
     @PostMapping("/{policyId}/activate")
     fun activatePolicy(
         @PathVariable policyId: Long
-    ): ResponseEntity<PointPolicyResponse> {
-        val policy = pointPolicyService.activatePolicy(policyId)
-        return ResponseEntity.ok(policy)
+    ): ApiResponse<PointPolicyResponse> {
+        return ApiResponse.success(pointPolicyService.activatePolicy(policyId))
     }
 
     @PostMapping("/{policyId}/deactivate")
     fun deactivatePolicy(
         @PathVariable policyId: Long
-    ): ResponseEntity<PointPolicyResponse> {
-        val policy = pointPolicyService.deactivatePolicy(policyId)
-        return ResponseEntity.ok(policy)
+    ): ApiResponse<PointPolicyResponse> {
+        return ApiResponse.success(pointPolicyService.deactivatePolicy(policyId))
     }
 
     @GetMapping("/current")
-    fun getCurrentPolicy(): ResponseEntity<PointPolicyResponse?> {
-        val policy = pointPolicyService.getCurrentPolicy()
-        return ResponseEntity.ok(policy)
+    fun getCurrentPolicy(): ApiResponse<PointPolicyResponse?> {
+        return ApiResponse.success(pointPolicyService.getCurrentPolicy())
     }
 
     @GetMapping("/{policyId}")
     fun getPolicyById(
         @PathVariable policyId: Long
-    ): ResponseEntity<PointPolicyResponse> {
-        val policy = pointPolicyService.getPolicyById(policyId)
-        return ResponseEntity.ok(policy)
+    ): ApiResponse<PointPolicyResponse> {
+        return ApiResponse.success(pointPolicyService.getPolicyById(policyId))
     }
 }

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -45,6 +45,10 @@ spring:
 
 server:
   port: 8085
+  compression:
+    enabled: true
+    mime-types: application/json,application/xml,text/html,text/xml,text/plain
+    min-response-size: 1024
 
 management:
   endpoints:

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/controller/ProductStatisticsController.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/controller/ProductStatisticsController.kt
@@ -10,6 +10,7 @@ import org.springframework.format.annotation.DateTimeFormat
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 
 @RestController
 @RequestMapping("/api/v1/admin/product-statistics")
@@ -59,6 +60,12 @@ class ProductStatisticsController(
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate
     ): ApiResponse<List<ProductDailyStatisticsResponse>> {
+        require(ChronoUnit.DAYS.between(startDate, endDate) <= 90) {
+            "조회 기간은 최대 90일까지 가능합니다."
+        }
+        require(!startDate.isAfter(endDate)) {
+            "시작일은 종료일보다 이전이어야 합니다."
+        }
         return ApiResponse.success(productStatisticsQueryService.getDailyStatistics(productId, startDate, endDate))
     }
 

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -45,6 +45,10 @@ spring:
 
 server:
   port: 8083
+  compression:
+    enabled: true
+    mime-types: application/json,application/xml,text/html,text/xml,text/plain
+    min-response-size: 1024
 
 management:
   endpoints:

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/controller/ProductStatisticsControllerTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/controller/ProductStatisticsControllerTest.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.product.product.controller
 import com.hoppingmall.product.product.dto.response.*
 import com.hoppingmall.product.product.service.ProductStatisticsQueryService
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator
@@ -133,6 +134,20 @@ class ProductStatisticsControllerTest {
         val result = controller.getDailyStatistics(1L, LocalDate.now().minusDays(7), LocalDate.now())
 
         assertThat(result.data).hasSize(1)
+    }
+
+    @Test
+    fun 일별_통계_조회_시_90일_초과하면_예외가_발생한다() {
+        assertThatThrownBy {
+            controller.getDailyStatistics(1L, LocalDate.now().minusDays(91), LocalDate.now())
+        }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun 일별_통계_조회_시_시작일이_종료일보다_이후면_예외가_발생한다() {
+        assertThatThrownBy {
+            controller.getDailyStatistics(1L, LocalDate.now(), LocalDate.now().minusDays(1))
+        }.isInstanceOf(IllegalArgumentException::class.java)
     }
 
     @Test

--- a/settlement-service/src/main/resources/application.yml
+++ b/settlement-service/src/main/resources/application.yml
@@ -24,6 +24,10 @@ spring:
 
 server:
   port: 8086
+  compression:
+    enabled: true
+    mime-types: application/json,application/xml,text/html,text/xml,text/plain
+    min-response-size: 1024
 
 management:
   endpoints:

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -45,6 +45,10 @@ spring:
 
 server:
   port: 8082
+  compression:
+    enabled: true
+    mime-types: application/json,application/xml,text/html,text/xml,text/plain
+    min-response-size: 1024
 
 management:
   endpoints:


### PR DESCRIPTION
Closes #375

### 📌 작업 개요
API 응답 일관성 및 네트워크 성능을 개선했습니다.
gzip 압축 활성화, 컨트롤러 ApiResponse 래핑 통일, 날짜 범위 검증을 적용합니다.

---

### ✅ 주요 변경 사항

- `application.yml` (6개 서비스)
  - `server.compression` gzip 응답 압축 활성화 (min-response-size: 1024)

- `order.refund.controller`
  - `RefundController`: `ResponseEntity<T>` → `ApiResponse<T>` 래핑 변경

- `payment.point.controller`
  - `PointPolicyController`: `ResponseEntity<T>` → `ApiResponse<T>` 래핑 변경

- `product.product.controller`
  - `ProductStatisticsController`: `getDailyStatistics` 날짜 범위 최대 90일 제한 추가

---

### 🧪 테스트

- `order-service`: jacocoTestVerification 통과
- `payment-service`: jacocoTestVerification 통과
- `product-service`: jacocoTestVerification 통과

---

### 📎 관련 이슈
- #375
