### PR TITLE
perf: Kafka Consumer 튜닝

### DIFF
--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/config/KafkaConsumerConfig.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/config/KafkaConsumerConfig.kt
@@ -45,6 +45,8 @@ class KafkaConsumerConfig(
             ConsumerConfig.MAX_POLL_RECORDS_CONFIG to 100,
             ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG to 30_000,
             ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG to 10_000,
+            ConsumerConfig.FETCH_MIN_BYTES_CONFIG to 1024,
+            ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG to 500,
             "schema.registry.url" to schemaRegistryUrl
         )
         return DefaultKafkaConsumerFactory(props)
@@ -54,6 +56,7 @@ class KafkaConsumerConfig(
     fun kafkaListenerContainerFactory(): ConcurrentKafkaListenerContainerFactory<String, Any> {
         val factory = ConcurrentKafkaListenerContainerFactory<String, Any>()
         factory.consumerFactory = consumerFactory()
+        factory.setConcurrency(4)
         factory.setRecordInterceptor(BusinessContextConsumerInterceptor())
 
         val errorHandler = DefaultErrorHandler(

--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/KafkaConfig.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/KafkaConfig.kt
@@ -116,6 +116,8 @@ class KafkaConfig(
         configProps[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = 100
         configProps[ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG] = 30_000
         configProps[ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG] = 10_000
+        configProps[ConsumerConfig.FETCH_MIN_BYTES_CONFIG] = 1024
+        configProps[ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG] = 500
 
         return DefaultKafkaConsumerFactory(configProps)
     }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/KafkaConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/KafkaConfig.kt
@@ -110,6 +110,8 @@ class KafkaConfig(
         configProps[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = 100
         configProps[ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG] = 30_000
         configProps[ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG] = 10_000
+        configProps[ConsumerConfig.FETCH_MIN_BYTES_CONFIG] = 1024
+        configProps[ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG] = 500
 
         return DefaultKafkaConsumerFactory(configProps)
     }

--- a/user-service/src/main/kotlin/com/hoppingmall/user/config/KafkaConsumerConfig.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/config/KafkaConsumerConfig.kt
@@ -45,6 +45,8 @@ class KafkaConsumerConfig(
             ConsumerConfig.MAX_POLL_RECORDS_CONFIG to 100,
             ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG to 30_000,
             ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG to 10_000,
+            ConsumerConfig.FETCH_MIN_BYTES_CONFIG to 1024,
+            ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG to 500,
             "schema.registry.url" to schemaRegistryUrl
         )
         return DefaultKafkaConsumerFactory(props)
@@ -54,6 +56,7 @@ class KafkaConsumerConfig(
     fun kafkaListenerContainerFactory(): ConcurrentKafkaListenerContainerFactory<String, Any> {
         val factory = ConcurrentKafkaListenerContainerFactory<String, Any>()
         factory.consumerFactory = consumerFactory()
+        factory.setConcurrency(4)
         factory.setRecordInterceptor(BusinessContextConsumerInterceptor())
 
         val errorHandler = DefaultErrorHandler(


### PR DESCRIPTION
Closes #376

### 📌 작업 개요
Kafka Consumer 성능을 개선했습니다.
빈 폴링 감소와 병렬 처리 일관성을 위해 설정을 표준화합니다.

---

### ✅ 주요 변경 사항

- `user.config.KafkaConsumerConfig`
  - `setConcurrency(4)` 추가
  - `fetch.min.bytes=1024`, `fetch.max.wait.ms=500` 추가

- `notification.config.KafkaConsumerConfig`
  - `setConcurrency(4)` 추가
  - `fetch.min.bytes=1024`, `fetch.max.wait.ms=500` 추가

- `payment.config.KafkaConfig`
  - `fetch.min.bytes=1024`, `fetch.max.wait.ms=500` 추가

- `order.config.KafkaConfig`
  - `fetch.min.bytes=1024`, `fetch.max.wait.ms=500` 추가

---

### 🧪 테스트

- 4개 서비스 전체 jacocoTestVerification 통과

---

### 📎 관련 이슈
- #376
