### PR TITLE
perf: 위시리스트 응답에 상품 정보 포함

### DIFF
--- a/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/dto/response/WishlistResponse.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/dto/response/WishlistResponse.kt
@@ -1,18 +1,27 @@
 package com.hoppingmall.product.wishlist.dto.response
 
+import com.hoppingmall.product.common.enums.ProductStatus
+import com.hoppingmall.product.product.domain.Product
 import com.hoppingmall.product.wishlist.domain.Wishlist
+import java.math.BigDecimal
 import java.time.LocalDateTime
 
 data class WishlistResponse(
     val id: Long,
     val productId: Long,
+    val productName: String?,
+    val productPrice: BigDecimal?,
+    val productStatus: ProductStatus?,
     val createdAt: LocalDateTime
 ) {
     companion object {
-        fun from(wishlist: Wishlist): WishlistResponse {
+        fun from(wishlist: Wishlist, product: Product?): WishlistResponse {
             return WishlistResponse(
                 id = wishlist.id!!,
                 productId = wishlist.productId,
+                productName = product?.name,
+                productPrice = product?.price,
+                productStatus = product?.status,
                 createdAt = wishlist.createdAt
             )
         }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/service/WishlistCommandServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/service/WishlistCommandServiceImpl.kt
@@ -19,7 +19,7 @@ class WishlistCommandServiceImpl(
 ) : WishlistCommandService {
 
     override fun addWishlist(buyerId: Long, request: WishlistCreateRequest): WishlistResponse {
-        productRepository.findById(request.productId)
+        val product = productRepository.findById(request.productId)
             .orElseThrow { ProductNotFoundException() }
 
         if (wishlistRepository.existsByBuyerIdAndProductId(buyerId, request.productId)) {
@@ -29,7 +29,7 @@ class WishlistCommandServiceImpl(
         val wishlist = Wishlist.create(buyerId, request.productId)
         val savedWishlist = wishlistRepository.save(wishlist)
 
-        return WishlistResponse.from(savedWishlist)
+        return WishlistResponse.from(savedWishlist, product)
     }
 
     override fun removeWishlist(buyerId: Long, wishlistId: Long) {

--- a/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/service/WishlistQueryServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/service/WishlistQueryServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.product.wishlist.service
 
+import com.hoppingmall.product.product.domain.repository.ProductRepository
 import com.hoppingmall.product.wishlist.domain.repository.WishlistRepository
 import com.hoppingmall.product.wishlist.dto.response.WishlistResponse
 import org.springframework.data.domain.Pageable
@@ -10,12 +11,16 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(readOnly = true)
 class WishlistQueryServiceImpl(
-    private val wishlistRepository: WishlistRepository
+    private val wishlistRepository: WishlistRepository,
+    private val productRepository: ProductRepository
 ) : WishlistQueryService {
 
     override fun getWishlists(buyerId: Long, pageable: Pageable): Slice<WishlistResponse> {
-        return wishlistRepository.findByBuyerId(buyerId, pageable)
-            .map { WishlistResponse.from(it) }
+        val wishlists = wishlistRepository.findByBuyerId(buyerId, pageable)
+        val productIds = wishlists.content.map { it.productId }
+        val productMap = productRepository.findAllById(productIds).associateBy { it.id!! }
+
+        return wishlists.map { WishlistResponse.from(it, productMap[it.productId]) }
     }
 
     override fun isWishlisted(buyerId: Long, productId: Long): Boolean {

--- a/product-service/src/test/kotlin/com/hoppingmall/product/wishlist/controller/WishlistControllerTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/wishlist/controller/WishlistControllerTest.kt
@@ -18,9 +18,11 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import com.hoppingmall.product.common.enums.ProductStatus
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.SliceImpl
 import org.springframework.http.HttpStatus
+import java.math.BigDecimal
 import java.time.LocalDateTime
 
 @DisplayName("WishlistController")
@@ -40,7 +42,9 @@ class WishlistControllerTest {
     private val principal = UserPrincipal(1L, "BUYER")
 
     private fun wishlistResponse() = WishlistResponse(
-        id = 1L, productId = 10L, createdAt = LocalDateTime.now()
+        id = 1L, productId = 10L,
+        productName = "테스트 상품", productPrice = BigDecimal("10000"),
+        productStatus = ProductStatus.AVAILABLE, createdAt = LocalDateTime.now()
     )
 
     @Test

--- a/product-service/src/test/kotlin/com/hoppingmall/product/wishlist/service/WishlistQueryServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/wishlist/service/WishlistQueryServiceImplTest.kt
@@ -1,5 +1,8 @@
 package com.hoppingmall.product.wishlist.service
 
+import com.hoppingmall.product.common.enums.ProductStatus
+import com.hoppingmall.product.product.domain.Product
+import com.hoppingmall.product.product.domain.repository.ProductRepository
 import com.hoppingmall.product.support.withId
 import com.hoppingmall.product.wishlist.domain.Wishlist
 import com.hoppingmall.product.wishlist.domain.repository.WishlistRepository
@@ -15,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.SliceImpl
+import java.math.BigDecimal
 
 @DisplayName("WishlistQueryServiceImpl")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
@@ -24,20 +28,32 @@ class WishlistQueryServiceImplTest {
     @Mock
     private lateinit var wishlistRepository: WishlistRepository
 
+    @Mock
+    private lateinit var productRepository: ProductRepository
+
     @InjectMocks
     private lateinit var service: WishlistQueryServiceImpl
 
     @Test
-    fun 위시리스트를_조회한다() {
+    fun 위시리스트를_조회하면_상품_정보가_포함된다() {
         val pageable = PageRequest.of(0, 20)
         val wishlist = Wishlist.create(buyerId = 1L, productId = 10L).withId(1L)
+        val product = Product.create(
+            sellerId = 2L, categoryId = 1L, name = "테스트 상품",
+            description = "설명", price = BigDecimal("10000"),
+            status = ProductStatus.AVAILABLE
+        ).withId(10L)
 
         whenever(wishlistRepository.findByBuyerId(1L, pageable))
             .thenReturn(SliceImpl(listOf(wishlist), pageable, false))
+        whenever(productRepository.findAllById(listOf(10L)))
+            .thenReturn(listOf(product))
 
         val result = service.getWishlists(1L, pageable)
 
         assertThat(result.content).hasSize(1)
+        assertThat(result.content[0].productName).isEqualTo("테스트 상품")
+        assertThat(result.content[0].productPrice).isEqualByComparingTo(BigDecimal("10000"))
     }
 
     @Test


### PR DESCRIPTION
Closes #381

### 📌 작업 개요
위시리스트 조회 시 상품 상세 정보를 함께 반환하여 클라이언트의 N+1 API 호출을 제거했습니다.

---

### ✅ 주요 변경 사항

- `wishlist.dto.response`
  - `WishlistResponse`: `productName`, `productPrice`, `productStatus` 필드 추가

- `wishlist.service`
  - `WishlistQueryServiceImpl`: 상품 ID 배치 조회(`findAllById`) 후 매핑하여 N+1 제거
  - `WishlistCommandServiceImpl`: 위시리스트 추가 시 상품 정보 함께 반환

---

### 🧪 테스트

- `product-service`: jacocoTestVerification 통과
- `WishlistQueryServiceImplTest`: 상품 정보 포함 검증 추가
- `WishlistControllerTest`: 변경된 응답 구조 반영

---

### 📎 관련 이슈
- #381
