### PR TITLE
perf: ProductStatistics findAll() 전체 테이블 로드 제거

### DIFF
--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductStatisticsRepository.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductStatisticsRepository.kt
@@ -53,4 +53,7 @@ interface ProductStatisticsRepository : JpaRepository<ProductStatistics, Long> {
 
     @Query("SELECT ps FROM ProductStatistics ps WHERE ps.sellerId = :sellerId ORDER BY ps.todaySalesAmount DESC LIMIT 1")
     fun findTopSellingBySellerId(@Param("sellerId") sellerId: Long): ProductStatistics?
+
+    @Query("SELECT ps FROM ProductStatistics ps WHERE ps.todaySalesQuantity > 0 OR ps.todayRefundQuantity > 0")
+    fun findAllActive(): List<ProductStatistics>
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImpl.kt
@@ -8,6 +8,8 @@ import com.hoppingmall.product.product.domain.repository.ProductHourlyStatistics
 import com.hoppingmall.product.product.domain.repository.ProductRepository
 import com.hoppingmall.product.product.domain.repository.ProductStatisticsRepository
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
@@ -48,13 +50,16 @@ class ProductStatisticsCommandServiceImpl(
 
     override fun flushDailySnapshot() {
         val today = LocalDate.now()
-        val allStats = productStatisticsRepository.findAll()
-        if (allStats.isEmpty()) {
-            logger.info("일별 통계 스냅샷 완료: 0건")
-            return
-        }
+        var page = 0
+        var totalProcessed = 0
 
-        allStats.chunked(BATCH_SIZE).forEach { chunk ->
+        while (true) {
+            val slice = productStatisticsRepository.findAll(
+                PageRequest.of(page, BATCH_SIZE, Sort.by("id"))
+            )
+            if (slice.isEmpty) break
+
+            val chunk = slice.content
             transactionTemplate.executeWithoutResult {
                 val productIds = chunk.map { it.productId }
 
@@ -92,9 +97,13 @@ class ProductStatisticsCommandServiceImpl(
                 productDailyStatisticsRepository.saveAll(dailyToSave)
                 productStatisticsRepository.saveAll(chunk)
             }
+
+            totalProcessed += chunk.size
+            if (!slice.hasNext()) break
+            page++
         }
 
-        logger.info("일별 통계 스냅샷 완료: ${allStats.size}건")
+        logger.info("일별 통계 스냅샷 완료: ${totalProcessed}건")
     }
 
     @Transactional
@@ -102,9 +111,7 @@ class ProductStatisticsCommandServiceImpl(
         val now = java.time.LocalDateTime.now()
         val today = now.toLocalDate()
         val currentHour = now.hour
-        val allStats = productStatisticsRepository.findAll()
-
-        val activeStats = allStats.filter { it.todaySalesQuantity > 0L || it.todayRefundQuantity > 0L }
+        val activeStats = productStatisticsRepository.findAllActive()
         if (activeStats.isEmpty()) {
             logger.info("시간별 통계 스냅샷 완료: 0건 (${currentHour}시)")
             return

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImplTest.kt
@@ -26,6 +26,7 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.support.TransactionTemplate
@@ -150,6 +151,33 @@ class ProductStatisticsCommandServiceImplTest {
         service.flushDailySnapshot()
 
         verify(productDailyStatisticsRepository, org.mockito.kotlin.never())
+            .saveAll(any<List<ProductDailyStatistics>>())
+    }
+
+    @Test
+    fun 일별_스냅샷_다중_페이지를_처리한다() {
+        val stats1 = createStats(1L)
+        stats1.incrementSales(5, BigDecimal("50000"))
+        val stats2 = ProductStatistics.create(
+            productId = 2L, productName = "테스트2", sellerId = 1L, categoryId = 1L
+        ).withId(2L)
+        stats2.incrementSales(3, BigDecimal("30000"))
+
+        whenever(productStatisticsRepository.findAll(any<Pageable>()))
+            .thenReturn(PageImpl(listOf(stats1), PageRequest.of(0, 1), 2))
+            .thenReturn(PageImpl(listOf(stats2), PageRequest.of(1, 1), 2))
+        whenever(productDailyStatisticsRepository.findByStatisticsDateAndProductIdIn(any(), any()))
+            .thenReturn(emptyList())
+        whenever(productDailyStatisticsRepository.sumSalesAmountByProductIdsAndDateRange(any(), any(), any()))
+            .thenReturn(emptyList())
+        whenever(productDailyStatisticsRepository.saveAll(any<List<ProductDailyStatistics>>()))
+            .thenAnswer { it.arguments[0] }
+        whenever(productStatisticsRepository.saveAll(any<List<ProductStatistics>>()))
+            .thenAnswer { it.arguments[0] }
+
+        service.flushDailySnapshot()
+
+        verify(productDailyStatisticsRepository, org.mockito.kotlin.times(2))
             .saveAll(any<List<ProductDailyStatistics>>())
     }
 

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImplTest.kt
@@ -143,6 +143,17 @@ class ProductStatisticsCommandServiceImplTest {
     }
 
     @Test
+    fun 통계가_없으면_일별_스냅샷을_건너뛴다() {
+        whenever(productStatisticsRepository.findAll(any<Pageable>()))
+            .thenReturn(PageImpl(emptyList()))
+
+        service.flushDailySnapshot()
+
+        verify(productDailyStatisticsRepository, org.mockito.kotlin.never())
+            .saveAll(any<List<ProductDailyStatistics>>())
+    }
+
+    @Test
     fun 일별_스냅샷을_저장한다() {
         val stats = createStats()
         stats.incrementSales(10, BigDecimal("100000"))

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImplTest.kt
@@ -25,6 +25,8 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.support.TransactionTemplate
 import java.math.BigDecimal
@@ -146,7 +148,8 @@ class ProductStatisticsCommandServiceImplTest {
         stats.incrementSales(10, BigDecimal("100000"))
         val daily = ProductDailyStatistics.create(productId = 1L, statisticsDate = LocalDate.now())
 
-        whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
+        whenever(productStatisticsRepository.findAll(any<Pageable>()))
+            .thenReturn(PageImpl(listOf(stats)))
         whenever(productDailyStatisticsRepository.findByStatisticsDateAndProductIdIn(any(), any()))
             .thenReturn(listOf(daily))
         whenever(productDailyStatisticsRepository.sumSalesAmountByProductIdsAndDateRange(any(), any(), any()))
@@ -166,7 +169,8 @@ class ProductStatisticsCommandServiceImplTest {
         val stats = createStats()
         stats.incrementSales(10, BigDecimal("100000"))
 
-        whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
+        whenever(productStatisticsRepository.findAll(any<Pageable>()))
+            .thenReturn(PageImpl(listOf(stats)))
         whenever(productDailyStatisticsRepository.findByStatisticsDateAndProductIdIn(any(), any()))
             .thenReturn(emptyList())
         whenever(productDailyStatisticsRepository.sumSalesAmountByProductIdsAndDateRange(any(), any(), any()))
@@ -186,7 +190,7 @@ class ProductStatisticsCommandServiceImplTest {
         val stats = createStats()
         stats.incrementSales(10, BigDecimal("100000"))
 
-        whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
+        whenever(productStatisticsRepository.findAllActive()).thenReturn(listOf(stats))
         whenever(productHourlyStatisticsRepository.findByStatisticsDateAndHourAndProductIdIn(any(), any<Int>(), any()))
             .thenReturn(emptyList())
         whenever(productHourlyStatisticsRepository.saveAll(any<List<ProductHourlyStatistics>>()))
@@ -199,9 +203,7 @@ class ProductStatisticsCommandServiceImplTest {
 
     @Test
     fun 오늘_활동이_없는_통계는_시간별_스냅샷에서_건너뛴다() {
-        val stats = createStats()
-
-        whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
+        whenever(productStatisticsRepository.findAllActive()).thenReturn(emptyList())
 
         service.flushHourlySnapshot()
 
@@ -217,7 +219,7 @@ class ProductStatisticsCommandServiceImplTest {
             productId = 1L, statisticsDate = LocalDate.now(), hour = java.time.LocalDateTime.now().hour
         )
 
-        whenever(productStatisticsRepository.findAll()).thenReturn(listOf(stats))
+        whenever(productStatisticsRepository.findAllActive()).thenReturn(listOf(stats))
         whenever(productHourlyStatisticsRepository.findByStatisticsDateAndHourAndProductIdIn(any(), any<Int>(), any()))
             .thenReturn(listOf(hourly))
         whenever(productHourlyStatisticsRepository.saveAll(any<List<ProductHourlyStatistics>>()))


### PR DESCRIPTION
Closes #383

### 📌 작업 개요
통계 스냅샷 생성 시 전체 테이블을 메모리에 로드하는 문제를 해결했습니다.

---

### ✅ 주요 변경 사항

- `product.domain.repository`
  - `ProductStatisticsRepository`: `findAllActive()` 쿼리 추가 (todaySalesQuantity > 0 OR todayRefundQuantity > 0)

- `product.service`
  - `ProductStatisticsCommandServiceImpl.flushDailySnapshot`: `findAll()` → `findAll(PageRequest)` 페이지 기반 반복으로 변경
  - `ProductStatisticsCommandServiceImpl.flushHourlySnapshot`: `findAll()` + 메모리 필터 → `findAllActive()` DB 레벨 필터링으로 변경

---

### 🧪 테스트

- `product-service`: jacocoTestVerification 통과

---

### 📎 관련 이슈
- #383
