### PR TITLE
refactor: findById().orElseThrow() → findByIdOrNull() 전환

### DIFF
--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/service/NotificationCommandServiceImpl.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/service/NotificationCommandServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.notification.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.notification.domain.NotificationRepository
 import com.hoppingmall.notification.exception.NotificationAccessDeniedException
 import com.hoppingmall.notification.exception.NotificationNotFoundException
@@ -15,8 +16,7 @@ class NotificationCommandServiceImpl(
 
     @CacheEvict(cacheNames = ["unread-count"], key = "#userId")
     override fun markAsRead(notificationId: Long, userId: Long) {
-        val notification = notificationRepository.findById(notificationId)
-            .orElseThrow { NotificationNotFoundException() }
+        val notification = notificationRepository.findByIdOrNull(notificationId) ?: throw NotificationNotFoundException() 
 
         if (notification.userId != userId) {
             throw NotificationAccessDeniedException()

--- a/order-service/src/main/kotlin/com/hoppingmall/order/cartItem/service/CartItemCommandServiceImpl.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/cartItem/service/CartItemCommandServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.order.cartItem.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.order.cartItem.domain.CartItem
 import com.hoppingmall.order.cartItem.domain.repository.CartItemRepository
 import com.hoppingmall.order.cartItem.dto.request.CartItemCreateRequest
@@ -58,8 +59,7 @@ class CartItemCommandServiceImpl(
     }
 
     override fun updateCartItemQuantity(buyerId: Long, cartItemId: Long, request: CartItemUpdateRequest): CartItemResponse {
-        val cartItem = cartItemRepository.findById(cartItemId)
-            .orElseThrow { CartItemNotFoundException() }
+        val cartItem = cartItemRepository.findByIdOrNull(cartItemId) ?: throw CartItemNotFoundException() 
 
         if (cartItem.buyerId != buyerId) {
             throw CartItemAccessDeniedException()
@@ -71,8 +71,7 @@ class CartItemCommandServiceImpl(
     }
 
     override fun removeCartItem(buyerId: Long, cartItemId: Long) {
-        val cartItem = cartItemRepository.findById(cartItemId)
-            .orElseThrow { CartItemNotFoundException() }
+        val cartItem = cartItemRepository.findByIdOrNull(cartItemId) ?: throw CartItemNotFoundException() 
 
         if (cartItem.buyerId != buyerId) {
             throw CartItemAccessDeniedException()

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImpl.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.order.order.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.order.cartItem.domain.repository.CartItemRepository
 import com.hoppingmall.order.order.domain.Order
 import com.hoppingmall.order.order.domain.OrderItem
@@ -91,8 +92,7 @@ class OrderCommandServiceImpl(
     }
 
     override fun cancelOrder(buyerId: Long, orderId: Long): OrderResponse {
-        val order = orderRepository.findById(orderId)
-            .orElseThrow { OrderNotFoundException() }
+        val order = orderRepository.findByIdOrNull(orderId) ?: throw OrderNotFoundException() 
 
         if (order.buyerId != buyerId) {
             throw OrderAccessDeniedException()
@@ -110,24 +110,21 @@ class OrderCommandServiceImpl(
                     throw OrderPaymentCancellationFailedException()
                 }
                 transactionTemplate.execute {
-                    val target = orderRepository.findById(orderId)
-                        .orElseThrow { OrderNotFoundException() }
+                    val target = orderRepository.findByIdOrNull(orderId) ?: throw OrderNotFoundException() 
                     target.updateStatus(OrderStatus.CANCELLED)
                 }
                 restoreInventory(orderItems)
             }
             OrderStatus.CREATED -> {
                 transactionTemplate.execute {
-                    val target = orderRepository.findById(orderId)
-                        .orElseThrow { OrderNotFoundException() }
+                    val target = orderRepository.findByIdOrNull(orderId) ?: throw OrderNotFoundException() 
                     target.updateStatus(OrderStatus.CANCELLED)
                 }
                 restoreInventory(orderItems)
             }
             OrderStatus.PAID -> {
                 transactionTemplate.execute {
-                    val target = orderRepository.findById(orderId)
-                        .orElseThrow { OrderNotFoundException() }
+                    val target = orderRepository.findByIdOrNull(orderId) ?: throw OrderNotFoundException() 
                     target.updateStatus(OrderStatus.CANCEL_REQUESTED)
                     transactionalEventPublisher.publishEvent(
                         aggregateType = "Order",
@@ -146,8 +143,7 @@ class OrderCommandServiceImpl(
             else -> throw OrderInvalidStatusException()
         }
 
-        val updatedOrder = orderRepository.findById(orderId)
-            .orElseThrow { OrderNotFoundException() }
+        val updatedOrder = orderRepository.findByIdOrNull(orderId) ?: throw OrderNotFoundException() 
         orderMetrics.recordOrderCancelled()
         log.info("주문 취소: orderId={}, buyerId={}, status={}", orderId, buyerId, updatedOrder.status)
         return OrderResponse.from(updatedOrder, orderItems)
@@ -166,8 +162,7 @@ class OrderCommandServiceImpl(
 
     @Transactional
     override fun updateOrderStatus(orderId: Long, request: OrderStatusUpdateRequest, userId: Long, isAdmin: Boolean): OrderResponse {
-        val order = orderRepository.findById(orderId)
-            .orElseThrow { OrderNotFoundException() }
+        val order = orderRepository.findByIdOrNull(orderId) ?: throw OrderNotFoundException() 
 
         if (order.buyerId != userId && !isAdmin) {
             throw OrderAccessDeniedException()

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderQueryServiceImpl.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderQueryServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.order.order.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.order.order.domain.repository.OrderItemRepository
 import com.hoppingmall.order.order.domain.repository.OrderRepository
 import com.hoppingmall.order.order.dto.response.OrderResponse
@@ -18,8 +19,7 @@ class OrderQueryServiceImpl(
 ) : OrderQueryService {
 
     override fun getOrder(orderId: Long, buyerId: Long): OrderResponse {
-        val order = orderRepository.findById(orderId)
-            .orElseThrow { OrderNotFoundException() }
+        val order = orderRepository.findByIdOrNull(orderId) ?: throw OrderNotFoundException() 
 
         if (order.buyerId != buyerId) {
             throw OrderAccessDeniedException()

--- a/order-service/src/main/kotlin/com/hoppingmall/order/refund/service/RefundCommandServiceImpl.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/refund/service/RefundCommandServiceImpl.kt
@@ -134,8 +134,8 @@ class RefundCommandServiceImpl(
     }
 
     override fun approveRefund(refundId: Long, approverId: Long): RefundResponse {
-        val payment = paymentQueryPort.findByIdOrNull(
-            refundRepository.findById(refundId) ?: throw RefundNotFoundException() .paymentId
+        val payment = paymentQueryPort.findById(
+            (refundRepository.findByIdOrNull(refundId) ?: throw RefundNotFoundException()).paymentId
         ) ?: throw RefundPaymentNotFoundException()
 
         return transactionTemplate.execute { _ ->

--- a/order-service/src/main/kotlin/com/hoppingmall/order/refund/service/RefundCommandServiceImpl.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/refund/service/RefundCommandServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.order.refund.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.order.order.domain.repository.OrderItemRepository
 import com.hoppingmall.order.order.domain.repository.OrderRepository
 import com.hoppingmall.order.order.enum.OrderStatus
@@ -52,8 +53,7 @@ class RefundCommandServiceImpl(
         }
 
         return transactionTemplate.execute { _ ->
-            val order = orderRepository.findById(request.orderId)
-                .orElseThrow { OrderNotFoundException() }
+            val order = orderRepository.findByIdOrNull(request.orderId) ?: throw OrderNotFoundException() 
 
             if (order.buyerId != buyerId) {
                 throw RefundAccessDeniedException()
@@ -134,14 +134,12 @@ class RefundCommandServiceImpl(
     }
 
     override fun approveRefund(refundId: Long, approverId: Long): RefundResponse {
-        val payment = paymentQueryPort.findById(
-            refundRepository.findById(refundId)
-                .orElseThrow { RefundNotFoundException() }.paymentId
+        val payment = paymentQueryPort.findByIdOrNull(
+            refundRepository.findById(refundId) ?: throw RefundNotFoundException() .paymentId
         ) ?: throw RefundPaymentNotFoundException()
 
         return transactionTemplate.execute { _ ->
-            val refund = refundRepository.findById(refundId)
-                .orElseThrow { RefundNotFoundException() }
+            val refund = refundRepository.findByIdOrNull(refundId) ?: throw RefundNotFoundException() 
 
             if (refund.sellerId != approverId) {
                 throw RefundAccessDeniedException()
@@ -161,8 +159,7 @@ class RefundCommandServiceImpl(
 
     @Transactional
     override fun rejectRefund(refundId: Long, approverId: Long, request: RefundApprovalRequest): RefundResponse {
-        val refund = refundRepository.findById(refundId)
-            .orElseThrow { RefundNotFoundException() }
+        val refund = refundRepository.findByIdOrNull(refundId) ?: throw RefundNotFoundException() 
 
         if (refund.sellerId != approverId) {
             throw RefundAccessDeniedException()

--- a/order-service/src/main/kotlin/com/hoppingmall/order/refund/service/RefundQueryServiceImpl.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/refund/service/RefundQueryServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.order.refund.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.order.refund.domain.repository.RefundItemRepository
 import com.hoppingmall.order.refund.domain.repository.RefundRepository
 import com.hoppingmall.order.refund.dto.response.RefundResponse
@@ -18,8 +19,7 @@ class RefundQueryServiceImpl(
 ) : RefundQueryService {
 
     override fun getRefund(refundId: Long, userId: Long): RefundResponse {
-        val refund = refundRepository.findById(refundId)
-            .orElseThrow { RefundNotFoundException() }
+        val refund = refundRepository.findByIdOrNull(refundId) ?: throw RefundNotFoundException() 
         if (refund.buyerId != userId && refund.sellerId != userId) {
             throw RefundAccessDeniedException()
         }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/shipping/service/ShippingCommandServiceImpl.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/shipping/service/ShippingCommandServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.order.shipping.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.hoppingmall.order.common.NotificationType
 import com.hoppingmall.common.KafkaTopics
@@ -31,8 +32,7 @@ class ShippingCommandServiceImpl(
 ) : ShippingCommandService {
 
     override fun createShipping(sellerId: Long, request: ShippingCreateRequest): ShippingResponse {
-        val order = orderRepository.findById(request.orderId)
-            .orElseThrow { OrderNotFoundException() }
+        val order = orderRepository.findByIdOrNull(request.orderId) ?: throw OrderNotFoundException() 
 
         if (order.status != OrderStatus.PAID) {
             throw OrderInvalidStatusException()
@@ -67,13 +67,11 @@ class ShippingCommandServiceImpl(
         shippingId: Long,
         request: ShippingStatusUpdateRequest
     ): ShippingResponse {
-        val shipping = shippingRepository.findById(shippingId)
-            .orElseThrow { ShippingNotFoundException() }
+        val shipping = shippingRepository.findByIdOrNull(shippingId) ?: throw ShippingNotFoundException() 
 
         shipping.updateStatus(request.status)
 
-        val order = orderRepository.findById(shipping.orderId)
-            .orElseThrow { OrderNotFoundException() }
+        val order = orderRepository.findByIdOrNull(shipping.orderId) ?: throw OrderNotFoundException() 
 
         when (request.status) {
             ShippingStatus.IN_TRANSIT -> {

--- a/order-service/src/main/kotlin/com/hoppingmall/order/shipping/service/ShippingQueryServiceImpl.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/shipping/service/ShippingQueryServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.order.shipping.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.order.shipping.domain.repository.ShippingRepository
 import com.hoppingmall.order.shipping.dto.response.ShippingResponse
 import com.hoppingmall.order.shipping.exception.ShippingNotFoundException
@@ -19,8 +20,7 @@ class ShippingQueryServiceImpl(
     }
 
     override fun getShipping(shippingId: Long): ShippingResponse {
-        val shipping = shippingRepository.findById(shippingId)
-            .orElseThrow { ShippingNotFoundException() }
+        val shipping = shippingRepository.findByIdOrNull(shippingId) ?: throw ShippingNotFoundException() 
         return ShippingResponse.from(shipping)
     }
 }

--- a/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImplTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImplTest.kt
@@ -391,6 +391,73 @@ class OrderCommandServiceImplTest {
     }
 
     @Test
+    fun PAYING_상태_주문_취소_시_트랜잭션_내부_조회_실패하면_예외가_발생한다() {
+        val order = Order.create(buyerId = 10L, totalAmount = BigDecimal("50000"))
+        setEntityId(order, 1L)
+        order.updateStatus(OrderStatus.PAYING)
+
+        val orderItem = OrderItem.create(
+            orderId = 1L, sellerId = 5L, productId = 100L,
+            productName = "상품A", productPrice = BigDecimal("50000"),
+            quantity = 1, reservationId = "rsv-1"
+        )
+        setEntityId(orderItem, 10L)
+
+        Mockito.`when`(orderRepository.findById(1L))
+            .thenReturn(Optional.of(order))
+            .thenReturn(Optional.empty())
+        whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(orderItem))
+        whenever(paymentCommandPort.cancelPayment(1L)).thenReturn(true)
+
+        assertThatThrownBy { service.cancelOrder(10L, 1L) }
+            .isInstanceOf(OrderNotFoundException::class.java)
+    }
+
+    @Test
+    fun CREATED_상태_주문_취소_시_트랜잭션_내부_조회_실패하면_예외가_발생한다() {
+        val order = Order.create(buyerId = 10L, totalAmount = BigDecimal("50000"))
+        setEntityId(order, 1L)
+
+        val orderItem = OrderItem.create(
+            orderId = 1L, sellerId = 5L, productId = 100L,
+            productName = "상품A", productPrice = BigDecimal("50000"),
+            quantity = 1, reservationId = "rsv-1"
+        )
+        setEntityId(orderItem, 10L)
+
+        Mockito.`when`(orderRepository.findById(1L))
+            .thenReturn(Optional.of(order))
+            .thenReturn(Optional.empty())
+        whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(orderItem))
+
+        assertThatThrownBy { service.cancelOrder(10L, 1L) }
+            .isInstanceOf(OrderNotFoundException::class.java)
+    }
+
+    @Test
+    fun PAID_상태_주문_취소_시_트랜잭션_내부_조회_실패하면_예외가_발생한다() {
+        val order = Order.create(buyerId = 10L, totalAmount = BigDecimal("50000"))
+        setEntityId(order, 1L)
+        order.updateStatus(OrderStatus.PAYING)
+        order.updateStatus(OrderStatus.PAID)
+
+        val orderItem = OrderItem.create(
+            orderId = 1L, sellerId = 5L, productId = 100L,
+            productName = "상품A", productPrice = BigDecimal("50000"),
+            quantity = 1, reservationId = "rsv-1"
+        )
+        setEntityId(orderItem, 10L)
+
+        Mockito.`when`(orderRepository.findById(1L))
+            .thenReturn(Optional.of(order))
+            .thenReturn(Optional.empty())
+        whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(orderItem))
+
+        assertThatThrownBy { service.cancelOrder(10L, 1L) }
+            .isInstanceOf(OrderNotFoundException::class.java)
+    }
+
+    @Test
     fun CREATED_상태_주문_취소_후_최종_조회_시_주문이_없으면_예외가_발생한다() {
         val order = Order.create(buyerId = 10L, totalAmount = BigDecimal("50000"))
         setEntityId(order, 1L)

--- a/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImplTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderCommandServiceImplTest.kt
@@ -390,6 +390,28 @@ class OrderCommandServiceImplTest {
             .isInstanceOf(com.hoppingmall.order.order.exception.OrderProductNotFoundException::class.java)
     }
 
+    @Test
+    fun CREATED_상태_주문_취소_후_최종_조회_시_주문이_없으면_예외가_발생한다() {
+        val order = Order.create(buyerId = 10L, totalAmount = BigDecimal("50000"))
+        setEntityId(order, 1L)
+
+        val orderItem = OrderItem.create(
+            orderId = 1L, sellerId = 5L, productId = 100L,
+            productName = "상품A", productPrice = BigDecimal("50000"),
+            quantity = 1, reservationId = "rsv-1"
+        )
+        setEntityId(orderItem, 10L)
+
+        Mockito.`when`(orderRepository.findById(1L))
+            .thenReturn(Optional.of(order))
+            .thenReturn(Optional.of(order))
+            .thenReturn(Optional.empty())
+        whenever(orderItemRepository.findByOrderId(1L)).thenReturn(listOf(orderItem))
+
+        assertThatThrownBy { service.cancelOrder(10L, 1L) }
+            .isInstanceOf(OrderNotFoundException::class.java)
+    }
+
     private fun setEntityId(entity: Any, id: Long) {
         ReflectionTestUtils.setField(entity, "id", id)
     }

--- a/order-service/src/test/kotlin/com/hoppingmall/order/refund/service/RefundCommandServiceImplTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/refund/service/RefundCommandServiceImplTest.kt
@@ -248,6 +248,19 @@ class RefundCommandServiceImplTest {
     }
 
     @Test
+    fun 환불_승인_시_트랜잭션_내부_조회_실패하면_예외가_발생한다() {
+        val refund = createRefund()
+
+        Mockito.`when`(refundRepository.findById(1L))
+            .thenReturn(Optional.of(refund))
+            .thenReturn(Optional.empty())
+        whenever(paymentQueryPort.findById(20L)).thenReturn(payment)
+
+        assertThatThrownBy { service.approveRefund(1L, 5L) }
+            .isInstanceOf(RefundNotFoundException::class.java)
+    }
+
+    @Test
     fun 환불을_거절한다() {
         val refund = createRefund()
         val refundItem = RefundItem.create(

--- a/order-service/src/test/kotlin/com/hoppingmall/order/refund/service/RefundCommandServiceImplTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/refund/service/RefundCommandServiceImplTest.kt
@@ -286,4 +286,18 @@ class RefundCommandServiceImplTest {
         assertThatThrownBy { service.rejectRefund(999L, 5L, request) }
             .isInstanceOf(RefundNotFoundException::class.java)
     }
+
+    @Test
+    fun 환불_요청_시_주문이_존재하지_않으면_예외가_발생한다() {
+        val request = RefundCreateRequest(
+            orderId = 10L, reason = RefundReason.CHANGE_OF_MIND, reasonDetail = null,
+            items = listOf(RefundItemRequest(orderItemId = 1L, quantity = 1))
+        )
+
+        whenever(paymentQueryPort.findByOrderId(10L)).thenReturn(payment)
+        whenever(orderRepository.findById(10L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.requestRefund(1L, request) }
+            .isInstanceOf(OrderNotFoundException::class.java)
+    }
 }

--- a/order-service/src/test/kotlin/com/hoppingmall/order/shipping/service/ShippingCommandServiceImplTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/shipping/service/ShippingCommandServiceImplTest.kt
@@ -191,4 +191,16 @@ class ShippingCommandServiceImplTest {
         assertThatThrownBy { service.updateShippingStatus(5L, 999L, request) }
             .isInstanceOf(ShippingNotFoundException::class.java)
     }
+
+    @Test
+    fun 배송_상태변경_시_주문이_존재하지_않으면_예외가_발생한다() {
+        val request = ShippingStatusUpdateRequest(status = ShippingStatus.IN_TRANSIT)
+        val shipping = createShipping()
+
+        whenever(shippingRepository.findById(1L)).thenReturn(Optional.of(shipping))
+        whenever(orderRepository.findById(10L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.updateShippingStatus(5L, 1L, request) }
+            .isInstanceOf(OrderNotFoundException::class.java)
+    }
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/service/CouponCommandServiceImpl.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/service/CouponCommandServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.payment.coupon.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.payment.coupon.domain.Coupon
 import com.hoppingmall.payment.coupon.domain.UserCoupon
 import com.hoppingmall.payment.coupon.domain.repository.CouponRepository
@@ -54,8 +55,7 @@ class CouponCommandServiceImpl(
         CacheEvict(cacheNames = ["coupon:all"], allEntries = true)
     ])
     override fun changeCouponStatus(couponId: Long, status: CouponStatus): CouponResponse {
-        val coupon = couponRepository.findById(couponId)
-            .orElseThrow { CouponNotFoundException() }
+        val coupon = couponRepository.findByIdOrNull(couponId) ?: throw CouponNotFoundException() 
         coupon.changeStatus(status)
         return CouponResponse.from(couponRepository.save(coupon))
     }
@@ -106,8 +106,7 @@ class CouponCommandServiceImpl(
             throw CouponNotAvailableException()
         }
 
-        val coupon = couponRepository.findById(couponId)
-            .orElseThrow { CouponNotFoundException() }
+        val coupon = couponRepository.findByIdOrNull(couponId) ?: throw CouponNotFoundException() 
 
         if (!coupon.isValid()) {
             throw CouponExpiredException()

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/PaymentQueryServiceImpl.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/PaymentQueryServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.payment.payment.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.payment.payment.domain.repository.PaymentRepository
 import com.hoppingmall.payment.payment.dto.response.PaymentResponse
 import com.hoppingmall.payment.payment.exception.PaymentAccessDeniedException
@@ -16,8 +17,7 @@ class PaymentQueryServiceImpl(
 ) : PaymentQueryService {
 
     override fun getPaymentById(paymentId: Long, userId: Long): PaymentResponse {
-        val payment = paymentRepository.findById(paymentId)
-            .orElseThrow { PaymentNotFoundException() }
+        val payment = paymentRepository.findByIdOrNull(paymentId) ?: throw PaymentNotFoundException() 
         if (payment.userId != userId) {
             throw PaymentAccessDeniedException()
         }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointPolicyServiceImpl.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointPolicyServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.payment.point.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.payment.point.domain.PointPolicy
 import com.hoppingmall.payment.point.domain.PointPolicyRepository
 import com.hoppingmall.payment.point.dto.request.PointPolicyRequest
@@ -40,8 +41,7 @@ class PointPolicyServiceImpl(
     override fun updatePolicy(policyId: Long, request: PointPolicyRequest): PointPolicyResponse {
         validatePolicyRequest(request)
 
-        val policy = pointPolicyRepository.findById(policyId)
-            .orElseThrow { PointPolicyNotFoundException() }
+        val policy = pointPolicyRepository.findByIdOrNull(policyId) ?: throw PointPolicyNotFoundException() 
 
         val updatedPolicy = policy.update(
             policyName = request.policyName,
@@ -58,8 +58,7 @@ class PointPolicyServiceImpl(
 
     @CacheEvict(cacheNames = ["point-policy"], allEntries = true)
     override fun activatePolicy(policyId: Long): PointPolicyResponse {
-        val policy = pointPolicyRepository.findById(policyId)
-            .orElseThrow { PointPolicyNotFoundException() }
+        val policy = pointPolicyRepository.findByIdOrNull(policyId) ?: throw PointPolicyNotFoundException() 
 
         deactivateAllPolicies()
 
@@ -70,8 +69,7 @@ class PointPolicyServiceImpl(
 
     @CacheEvict(cacheNames = ["point-policy"], allEntries = true)
     override fun deactivatePolicy(policyId: Long): PointPolicyResponse {
-        val policy = pointPolicyRepository.findById(policyId)
-            .orElseThrow { PointPolicyNotFoundException() }
+        val policy = pointPolicyRepository.findByIdOrNull(policyId) ?: throw PointPolicyNotFoundException() 
 
         val deactivatedPolicy = policy.deactivate()
         val savedPolicy = pointPolicyRepository.save(deactivatedPolicy)
@@ -85,8 +83,7 @@ class PointPolicyServiceImpl(
     }
 
     override fun getPolicyById(policyId: Long): PointPolicyResponse {
-        val policy = pointPolicyRepository.findById(policyId)
-            .orElseThrow { PointPolicyNotFoundException() }
+        val policy = pointPolicyRepository.findByIdOrNull(policyId) ?: throw PointPolicyNotFoundException() 
         return PointPolicyResponse.from(policy)
     }
 

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/coupon/service/CouponCommandServiceImplTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/coupon/service/CouponCommandServiceImplTest.kt
@@ -235,4 +235,14 @@ class CouponCommandServiceImplTest {
 
         verify(userCouponRepository).findByUserIdAndCouponId(10L, 1L)
     }
+
+    @Test
+    fun 쿠폰_사용_시_쿠폰이_존재하지_않으면_예외를_던진다() {
+        val userCoupon = createUserCoupon(id = 1L, userId = 10L, couponId = 1L)
+        whenever(userCouponRepository.findByUserIdAndCouponId(10L, 1L)).thenReturn(userCoupon)
+        whenever(couponRepository.findById(1L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.useCoupon(10L, 1L, BigDecimal("30000"), 100L) }
+            .isInstanceOf(CouponNotFoundException::class.java)
+    }
 }

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/point/service/PointPolicyServiceImplTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/point/service/PointPolicyServiceImplTest.kt
@@ -154,4 +154,36 @@ class PointPolicyServiceImplTest {
 
         assertThat(result).isNotNull
     }
+
+    @Test
+    fun 존재하지_않는_정책_업데이트_시_예외가_발생한다() {
+        whenever(pointPolicyRepository.findById(999L)).thenReturn(Optional.empty())
+
+        val request = PointPolicyRequest(
+            policyName = "수정 정책",
+            earnRate = BigDecimal("0.02"),
+            maxEarnRate = BigDecimal("0.10"),
+            minUseAmount = BigDecimal("200"),
+            maxUseAmount = BigDecimal("50000")
+        )
+
+        assertThatThrownBy { pointPolicyService.updatePolicy(999L, request) }
+            .isInstanceOf(PointPolicyNotFoundException::class.java)
+    }
+
+    @Test
+    fun 존재하지_않는_정책_활성화_시_예외가_발생한다() {
+        whenever(pointPolicyRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { pointPolicyService.activatePolicy(999L) }
+            .isInstanceOf(PointPolicyNotFoundException::class.java)
+    }
+
+    @Test
+    fun 존재하지_않는_정책_비활성화_시_예외가_발생한다() {
+        whenever(pointPolicyRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { pointPolicyService.deactivatePolicy(999L) }
+            .isInstanceOf(PointPolicyNotFoundException::class.java)
+    }
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/BulkImportService.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/BulkImportService.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.product.product.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.product.category.domain.repository.CategoryRepository
 import com.hoppingmall.product.common.enums.ProductStatus
 import com.hoppingmall.product.common.file.FileUploadConfig
@@ -89,9 +90,8 @@ class BulkImportService(
 
     @Transactional
     fun processImport(jobId: Long, sellerId: Long, rows: List<BulkProductRow>, parseErrors: List<BulkRowError>) {
-        val job = bulkImportJobRepository.findById(jobId).orElseThrow {
-            ProductException(ProductErrorCode.BULK_IMPORT_JOB_NOT_FOUND)
-        }
+        val job = bulkImportJobRepository.findByIdOrNull(jobId)
+            ?: throw ProductException(ProductErrorCode.BULK_IMPORT_JOB_NOT_FOUND)
 
         val allErrors = parseErrors.toMutableList()
         val categoryIds = rows.map { it.categoryId }.distinct()
@@ -168,9 +168,8 @@ class BulkImportService(
 
     @Transactional(readOnly = true)
     fun getJobProgress(jobId: Long, sellerId: Long): BulkImportProgressResponse {
-        val job = bulkImportJobRepository.findById(jobId).orElseThrow {
-            ProductException(ProductErrorCode.BULK_IMPORT_JOB_NOT_FOUND)
-        }
+        val job = bulkImportJobRepository.findByIdOrNull(jobId)
+            ?: throw ProductException(ProductErrorCode.BULK_IMPORT_JOB_NOT_FOUND)
         if (job.sellerId != sellerId) {
             throw ProductException(ProductErrorCode.BULK_IMPORT_ACCESS_DENIED)
         }
@@ -179,9 +178,8 @@ class BulkImportService(
 
     @Transactional(readOnly = true)
     fun getJobErrors(jobId: Long, sellerId: Long): List<BulkRowError> {
-        val job = bulkImportJobRepository.findById(jobId).orElseThrow {
-            ProductException(ProductErrorCode.BULK_IMPORT_JOB_NOT_FOUND)
-        }
+        val job = bulkImportJobRepository.findByIdOrNull(jobId)
+            ?: throw ProductException(ProductErrorCode.BULK_IMPORT_JOB_NOT_FOUND)
         if (job.sellerId != sellerId) {
             throw ProductException(ProductErrorCode.BULK_IMPORT_ACCESS_DENIED)
         }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductCommandServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductCommandServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.product.product.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.product.category.domain.repository.CategoryRepository
 import com.hoppingmall.product.category.exception.CategoryNotFoundException
 import com.hoppingmall.product.common.file.FileUploadConfig
@@ -58,8 +59,7 @@ class ProductCommandServiceImpl(
             throw CategoryNotFoundException()
         }
 
-        val product = productRepository.findById(productId)
-            .orElseThrow { ProductNotFoundException() }
+        val product = productRepository.findByIdOrNull(productId) ?: throw ProductNotFoundException() 
 
         product.update(
             name = request.name,
@@ -89,8 +89,7 @@ class ProductCommandServiceImpl(
 
     @CacheEvict(cacheNames = ["product"], key = "#productId")
     override fun deleteProduct(productId: Long) {
-        val product = productRepository.findById(productId)
-            .orElseThrow { ProductNotFoundException() }
+        val product = productRepository.findByIdOrNull(productId) ?: throw ProductNotFoundException() 
 
         val productImages = productImageRepository.findByProductIdOrderBySortOrder(productId)
         productImages.forEach { it.softDelete() }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/service/WishlistCommandServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/service/WishlistCommandServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.product.wishlist.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.product.product.domain.repository.ProductRepository
 import com.hoppingmall.product.product.exception.ProductNotFoundException
 import com.hoppingmall.product.wishlist.domain.Wishlist
@@ -19,8 +20,7 @@ class WishlistCommandServiceImpl(
 ) : WishlistCommandService {
 
     override fun addWishlist(buyerId: Long, request: WishlistCreateRequest): WishlistResponse {
-        productRepository.findById(request.productId)
-            .orElseThrow { ProductNotFoundException() }
+        productRepository.findByIdOrNull(request.productId) ?: throw ProductNotFoundException() 
 
         if (wishlistRepository.existsByBuyerIdAndProductId(buyerId, request.productId)) {
             throw WishlistAlreadyExistsException()
@@ -33,8 +33,7 @@ class WishlistCommandServiceImpl(
     }
 
     override fun removeWishlist(buyerId: Long, wishlistId: Long) {
-        val wishlist = wishlistRepository.findById(wishlistId)
-            .orElseThrow { WishlistNotFoundException() }
+        val wishlist = wishlistRepository.findByIdOrNull(wishlistId) ?: throw WishlistNotFoundException() 
 
         if (wishlist.buyerId != buyerId) {
             throw WishlistNotFoundException()

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/BulkImportServiceTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/BulkImportServiceTest.kt
@@ -336,4 +336,20 @@ class BulkImportServiceTest {
 
         assertThat(job.failCount).isEqualTo(1)
     }
+
+    @Test
+    fun 존재하지_않는_작업으로_processImport_호출_시_예외를_발생시킨다() {
+        whenever(bulkImportJobRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.processImport(999L, 1L, emptyList(), emptyList()) }
+            .isInstanceOf(ProductException::class.java)
+    }
+
+    @Test
+    fun 존재하지_않는_작업_에러_조회_시_예외를_발생시킨다() {
+        whenever(bulkImportJobRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.getJobErrors(999L, 1L) }
+            .isInstanceOf(ProductException::class.java)
+    }
 }

--- a/settlement-service/src/main/kotlin/com/hoppingmall/settlement/service/SettlementCommandServiceImpl.kt
+++ b/settlement-service/src/main/kotlin/com/hoppingmall/settlement/service/SettlementCommandServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.settlement.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.settlement.domain.Settlement
 import com.hoppingmall.settlement.domain.SettlementItem
 import com.hoppingmall.settlement.domain.repository.SettlementItemRepository
@@ -95,16 +96,14 @@ class SettlementCommandServiceImpl(
 
     @Transactional
     override fun confirmSettlement(settlementId: Long): SettlementResponse {
-        val settlement = settlementRepository.findById(settlementId)
-            .orElseThrow { SettlementNotFoundException() }
+        val settlement = settlementRepository.findByIdOrNull(settlementId) ?: throw SettlementNotFoundException() 
         settlement.confirm()
         return SettlementResponse.from(settlement)
     }
 
     @Transactional
     override fun paySettlement(settlementId: Long): SettlementResponse {
-        val settlement = settlementRepository.findById(settlementId)
-            .orElseThrow { SettlementNotFoundException() }
+        val settlement = settlementRepository.findByIdOrNull(settlementId) ?: throw SettlementNotFoundException() 
         settlement.pay()
         return SettlementResponse.from(settlement)
     }

--- a/settlement-service/src/main/kotlin/com/hoppingmall/settlement/service/SettlementQueryServiceImpl.kt
+++ b/settlement-service/src/main/kotlin/com/hoppingmall/settlement/service/SettlementQueryServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.settlement.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.settlement.domain.SettlementSummary
 import com.hoppingmall.settlement.domain.repository.SettlementItemRepository
 import com.hoppingmall.settlement.domain.repository.SettlementRepository
@@ -35,8 +36,7 @@ class SettlementQueryServiceImpl(
     }
 
     override fun getSettlementDetail(settlementId: Long, sellerId: Long?): SettlementDetailResponse {
-        val settlement = settlementRepository.findById(settlementId)
-            .orElseThrow { SettlementNotFoundException() }
+        val settlement = settlementRepository.findByIdOrNull(settlementId) ?: throw SettlementNotFoundException() 
 
         if (sellerId != null && settlement.sellerId != sellerId) {
             throw SettlementAccessDeniedException()

--- a/settlement-service/src/test/kotlin/com/hoppingmall/settlement/service/SettlementCommandServiceImplTest.kt
+++ b/settlement-service/src/test/kotlin/com/hoppingmall/settlement/service/SettlementCommandServiceImplTest.kt
@@ -228,4 +228,12 @@ class SettlementCommandServiceImplTest {
         assertThatThrownBy { settlementCommandServiceImpl.confirmSettlement(999L) }
             .isInstanceOf(SettlementNotFoundException::class.java)
     }
+
+    @Test
+    fun 존재하지_않는_정산_지급_시_예외가_발생한다() {
+        whenever(settlementRepository.findById(any())).thenReturn(Optional.empty())
+
+        assertThatThrownBy { settlementCommandServiceImpl.paySettlement(999L) }
+            .isInstanceOf(SettlementNotFoundException::class.java)
+    }
 }

--- a/settlement-service/src/test/kotlin/com/hoppingmall/settlement/service/SettlementQueryServiceImplTest.kt
+++ b/settlement-service/src/test/kotlin/com/hoppingmall/settlement/service/SettlementQueryServiceImplTest.kt
@@ -7,6 +7,7 @@ import com.hoppingmall.settlement.domain.repository.SettlementRepository
 import com.hoppingmall.settlement.domain.repository.SettlementSummaryRepository
 import com.hoppingmall.settlement.enums.SettlementStatus
 import com.hoppingmall.settlement.exception.SettlementAccessDeniedException
+import com.hoppingmall.settlement.exception.SettlementNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
@@ -129,5 +130,13 @@ class SettlementQueryServiceImplTest {
 
         assertThatThrownBy { settlementQueryServiceImpl.getSettlementDetail(1L, 99L) }
             .isInstanceOf(SettlementAccessDeniedException::class.java)
+    }
+
+    @Test
+    fun 존재하지_않는_정산_상세_조회_시_예외가_발생한다() {
+        whenever(settlementRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { settlementQueryServiceImpl.getSettlementDetail(999L, 1L) }
+            .isInstanceOf(SettlementNotFoundException::class.java)
     }
 }

--- a/user-service/src/main/kotlin/com/hoppingmall/user/auth/service/AuthServiceImpl.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/auth/service/AuthServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.user.auth.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.user.auth.JwtProperties
 import com.hoppingmall.user.auth.TokenProvider
 import com.hoppingmall.user.auth.domain.repository.AccessTokenBlacklistRepository
@@ -47,8 +48,7 @@ class AuthServiceImpl(
 
         refreshTokenService.validate(userId, refreshToken)
 
-        val user = userRepository.findById(userId)
-            .orElseThrow { UserNotFoundException() }
+        val user = userRepository.findByIdOrNull(userId) ?: throw UserNotFoundException() 
 
         val newAccessToken = tokenProvider.generateAccessToken(user.id!!, user.getRole())
         val newRefreshToken = tokenProvider.generateRefreshToken(user.id!!)

--- a/user-service/src/main/kotlin/com/hoppingmall/user/service/AdminCommandServiceImpl.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/service/AdminCommandServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.user.service
 
+import org.springframework.data.repository.findByIdOrNull
 import com.hoppingmall.user.domain.Seller
 import com.hoppingmall.user.domain.repository.SellerRepository
 import com.hoppingmall.user.dto.request.SellerApprovalRequest
@@ -23,5 +24,5 @@ class AdminCommandServiceImpl(
     }
 
     private fun findSellerById(sellerId: Long): Seller =
-        sellerRepository.findById(sellerId).orElseThrow { SellerNotFoundException() }
+        sellerRepository.findByIdOrNull(sellerId) ?: throw SellerNotFoundException() 
 }


### PR DESCRIPTION
Closes #385

### 📌 작업 개요
Java 스타일 `findById().orElseThrow()`를 Kotlin 관용 표현 `findByIdOrNull() ?: throw`로 전환했습니다.

---

### ✅ 주요 변경 사항

- `order-service` (8개 파일)
  - `OrderCommandServiceImpl`, `OrderQueryServiceImpl`, `RefundCommandServiceImpl`, `RefundQueryServiceImpl`
  - `ShippingCommandServiceImpl`, `ShippingQueryServiceImpl`, `CartItemCommandServiceImpl`

- `payment-service` (3개 파일)
  - `CouponCommandServiceImpl`, `PaymentQueryServiceImpl`, `PointPolicyServiceImpl`

- `product-service` (3개 파일)
  - `ProductCommandServiceImpl`, `BulkImportService`, `WishlistCommandServiceImpl`

- `user-service` (2개 파일)
  - `AuthServiceImpl`, `AdminCommandServiceImpl`

- `settlement-service` (2개 파일)
  - `SettlementCommandServiceImpl`, `SettlementQueryServiceImpl`

- `notification-service` (1개 파일)
  - `NotificationCommandServiceImpl`

---

### 🧪 테스트

- 6개 서비스 전체 jacocoTestVerification 통과

---

### 📎 관련 이슈
- #385
