### PR TITLE
perf: 위시리스트 조회 JPQL LEFT JOIN 단일 쿼리 최적화

### DIFF
--- a/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/domain/repository/WishlistRepository.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/domain/repository/WishlistRepository.kt
@@ -1,13 +1,24 @@
 package com.hoppingmall.product.wishlist.domain.repository
 
 import com.hoppingmall.product.wishlist.domain.Wishlist
+import com.hoppingmall.product.wishlist.dto.response.WishlistResponse
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
 interface WishlistRepository : JpaRepository<Wishlist, Long> {
-    fun findByBuyerId(buyerId: Long, pageable: Pageable): Slice<Wishlist>
+
+    @Query("""
+        SELECT new com.hoppingmall.product.wishlist.dto.response.WishlistResponse(
+            w.id, w.productId, p.name, p.price, p.status, w.createdAt
+        )
+        FROM Wishlist w LEFT JOIN Product p ON w.productId = p.id
+        WHERE w.buyerId = :buyerId
+    """)
+    fun findByBuyerIdWithProduct(buyerId: Long, pageable: Pageable): Slice<WishlistResponse>
+
     fun existsByBuyerIdAndProductId(buyerId: Long, productId: Long): Boolean
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/service/WishlistQueryServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/service/WishlistQueryServiceImpl.kt
@@ -1,6 +1,5 @@
 package com.hoppingmall.product.wishlist.service
 
-import com.hoppingmall.product.product.domain.repository.ProductRepository
 import com.hoppingmall.product.wishlist.domain.repository.WishlistRepository
 import com.hoppingmall.product.wishlist.dto.response.WishlistResponse
 import org.springframework.data.domain.Pageable
@@ -11,16 +10,11 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(readOnly = true)
 class WishlistQueryServiceImpl(
-    private val wishlistRepository: WishlistRepository,
-    private val productRepository: ProductRepository
+    private val wishlistRepository: WishlistRepository
 ) : WishlistQueryService {
 
     override fun getWishlists(buyerId: Long, pageable: Pageable): Slice<WishlistResponse> {
-        val wishlists = wishlistRepository.findByBuyerId(buyerId, pageable)
-        val productIds = wishlists.content.map { it.productId }
-        val productMap = productRepository.findAllById(productIds).associateBy { it.id!! }
-
-        return wishlists.map { WishlistResponse.from(it, productMap[it.productId]) }
+        return wishlistRepository.findByBuyerIdWithProduct(buyerId, pageable)
     }
 
     override fun isWishlisted(buyerId: Long, productId: Long): Boolean {

--- a/product-service/src/test/kotlin/com/hoppingmall/product/wishlist/service/WishlistQueryServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/wishlist/service/WishlistQueryServiceImplTest.kt
@@ -1,11 +1,8 @@
 package com.hoppingmall.product.wishlist.service
 
 import com.hoppingmall.product.common.enums.ProductStatus
-import com.hoppingmall.product.product.domain.Product
-import com.hoppingmall.product.product.domain.repository.ProductRepository
-import com.hoppingmall.product.support.withId
-import com.hoppingmall.product.wishlist.domain.Wishlist
 import com.hoppingmall.product.wishlist.domain.repository.WishlistRepository
+import com.hoppingmall.product.wishlist.dto.response.WishlistResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
@@ -19,6 +16,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.SliceImpl
 import java.math.BigDecimal
+import java.time.LocalDateTime
 
 @DisplayName("WishlistQueryServiceImpl")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
@@ -28,32 +26,46 @@ class WishlistQueryServiceImplTest {
     @Mock
     private lateinit var wishlistRepository: WishlistRepository
 
-    @Mock
-    private lateinit var productRepository: ProductRepository
-
     @InjectMocks
     private lateinit var service: WishlistQueryServiceImpl
 
     @Test
     fun 위시리스트를_조회하면_상품_정보가_포함된다() {
         val pageable = PageRequest.of(0, 20)
-        val wishlist = Wishlist.create(buyerId = 1L, productId = 10L).withId(1L)
-        val product = Product.create(
-            sellerId = 2L, categoryId = 1L, name = "테스트 상품",
-            description = "설명", price = BigDecimal("10000"),
-            status = ProductStatus.AVAILABLE
-        ).withId(10L)
+        val response = WishlistResponse(
+            id = 1L, productId = 10L,
+            productName = "테스트 상품", productPrice = BigDecimal("10000"),
+            productStatus = ProductStatus.AVAILABLE, createdAt = LocalDateTime.now()
+        )
 
-        whenever(wishlistRepository.findByBuyerId(1L, pageable))
-            .thenReturn(SliceImpl(listOf(wishlist), pageable, false))
-        whenever(productRepository.findAllById(listOf(10L)))
-            .thenReturn(listOf(product))
+        whenever(wishlistRepository.findByBuyerIdWithProduct(1L, pageable))
+            .thenReturn(SliceImpl(listOf(response), pageable, false))
 
         val result = service.getWishlists(1L, pageable)
 
         assertThat(result.content).hasSize(1)
         assertThat(result.content[0].productName).isEqualTo("테스트 상품")
         assertThat(result.content[0].productPrice).isEqualByComparingTo(BigDecimal("10000"))
+    }
+
+    @Test
+    fun 위시리스트를_조회하면_삭제된_상품은_null로_반환된다() {
+        val pageable = PageRequest.of(0, 20)
+        val response = WishlistResponse(
+            id = 1L, productId = 10L,
+            productName = null, productPrice = null,
+            productStatus = null, createdAt = LocalDateTime.now()
+        )
+
+        whenever(wishlistRepository.findByBuyerIdWithProduct(1L, pageable))
+            .thenReturn(SliceImpl(listOf(response), pageable, false))
+
+        val result = service.getWishlists(1L, pageable)
+
+        assertThat(result.content).hasSize(1)
+        assertThat(result.content[0].productName).isNull()
+        assertThat(result.content[0].productPrice).isNull()
+        assertThat(result.content[0].productStatus).isNull()
     }
 
     @Test


### PR DESCRIPTION
Closes #387

### 📌 작업 개요

위시리스트 목록 조회 시 2개의 쿼리(위시리스트 조회 + 상품 배치 조회)를 JPQL LEFT JOIN 단일 쿼리로 통합하여 성능을 개선했습니다.
기존 `findAllById()`가 `@SQLRestriction`을 우회하여 soft-delete된 상품이 누출될 수 있는 문제도 함께 해결됩니다.

---

### ✅ 주요 변경 사항

- `wishlist.domain.repository`
  - `WishlistRepository`: `findByBuyerIdWithProduct()` JPQL LEFT JOIN 쿼리 추가, 미사용 `findByBuyerId()` 제거

- `wishlist.service`
  - `WishlistQueryServiceImpl`: 단일 쿼리 호출로 변경, `ProductRepository` 의존 제거

---

### 🧪 테스트

- `WishlistQueryServiceImplTest`: 상품 정보 포함 조회 및 삭제된 상품 null 반환 테스트
- `WishlistControllerTest`: 기존 테스트 통과 확인
- `./gradlew jacocoTestVerification` 통과

---

### 📎 관련 이슈
- #387
