### PR TITLE
fix: 분산 락 leaseTime 무한 설정 수정

### DIFF
--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/internal/DistributedLockExecutor.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/internal/DistributedLockExecutor.kt
@@ -14,6 +14,10 @@ class DistributedLockExecutor(
     private val transactionManager: PlatformTransactionManager
 ) {
 
+    companion object {
+        private const val LEASE_TIME_MS = 30_000L
+    }
+
     private fun newTransactionTemplate(): TransactionTemplate {
         return TransactionTemplate(transactionManager).apply {
             propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
@@ -26,7 +30,7 @@ class DistributedLockExecutor(
         action: () -> T
     ): T {
         val lock = redissonClient.getLock(key)
-        val acquired = lock.tryLock(waitTime.toMillis(), -1, TimeUnit.MILLISECONDS)
+        val acquired = lock.tryLock(waitTime.toMillis(), LEASE_TIME_MS, TimeUnit.MILLISECONDS)
         if (!acquired) {
             throw DistributedLockException()
         }
@@ -46,7 +50,7 @@ class DistributedLockExecutor(
         action: () -> Unit
     ) {
         val lock = redissonClient.getLock(key)
-        val acquired = lock.tryLock(waitTime.toMillis(), -1, TimeUnit.MILLISECONDS)
+        val acquired = lock.tryLock(waitTime.toMillis(), LEASE_TIME_MS, TimeUnit.MILLISECONDS)
         if (!acquired) {
             throw DistributedLockException()
         }

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/internal/DistributedLockExecutorTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/internal/DistributedLockExecutorTest.kt
@@ -49,7 +49,7 @@ class DistributedLockExecutorTest {
     fun 락_획득_성공_시_트랜잭션_내에서_액션을_실행한다() {
         stubTransaction()
         whenever(redissonClient.getLock("test-key")).thenReturn(rLock)
-        whenever(rLock.tryLock(3000L, -1, TimeUnit.MILLISECONDS)).thenReturn(true)
+        whenever(rLock.tryLock(3000L, 30_000L, TimeUnit.MILLISECONDS)).thenReturn(true)
         whenever(rLock.isHeldByCurrentThread).thenReturn(true)
 
         val result = lockExecutor.withLock("test-key") { "success" }
@@ -62,7 +62,7 @@ class DistributedLockExecutorTest {
     @Test
     fun 락_획득_실패_시_예외를_던진다() {
         whenever(redissonClient.getLock("test-key")).thenReturn(rLock)
-        whenever(rLock.tryLock(3000L, -1, TimeUnit.MILLISECONDS)).thenReturn(false)
+        whenever(rLock.tryLock(3000L, 30_000L, TimeUnit.MILLISECONDS)).thenReturn(false)
 
         assertThatThrownBy { lockExecutor.withLock("test-key") { "should-not-run" } }
             .isInstanceOf(DistributedLockException::class.java)
@@ -72,7 +72,7 @@ class DistributedLockExecutorTest {
     fun 액션_예외_발생_시_롤백_후_락을_해제한다() {
         stubTransaction()
         whenever(redissonClient.getLock("test-key")).thenReturn(rLock)
-        whenever(rLock.tryLock(3000L, -1, TimeUnit.MILLISECONDS)).thenReturn(true)
+        whenever(rLock.tryLock(3000L, 30_000L, TimeUnit.MILLISECONDS)).thenReturn(true)
         whenever(rLock.isHeldByCurrentThread).thenReturn(true)
 
         assertThatThrownBy {
@@ -87,7 +87,7 @@ class DistributedLockExecutorTest {
     fun withLockVoid는_반환값_없이_실행한다() {
         stubTransaction()
         whenever(redissonClient.getLock("void-key")).thenReturn(rLock)
-        whenever(rLock.tryLock(3000L, -1, TimeUnit.MILLISECONDS)).thenReturn(true)
+        whenever(rLock.tryLock(3000L, 30_000L, TimeUnit.MILLISECONDS)).thenReturn(true)
         whenever(rLock.isHeldByCurrentThread).thenReturn(true)
 
         var executed = false
@@ -104,12 +104,12 @@ class DistributedLockExecutorTest {
         stubTransaction()
         val waitTime = Duration.ofSeconds(5)
         whenever(redissonClient.getLock("custom-key")).thenReturn(rLock)
-        whenever(rLock.tryLock(5000L, -1, TimeUnit.MILLISECONDS)).thenReturn(true)
+        whenever(rLock.tryLock(5000L, 30_000L, TimeUnit.MILLISECONDS)).thenReturn(true)
         whenever(rLock.isHeldByCurrentThread).thenReturn(true)
 
         val result = lockExecutor.withLock("custom-key", waitTime) { 42 }
 
         assertThat(result).isEqualTo(42)
-        verify(rLock).tryLock(5000L, -1, TimeUnit.MILLISECONDS)
+        verify(rLock).tryLock(5000L, 30_000L, TimeUnit.MILLISECONDS)
     }
 }


### PR DESCRIPTION
Closes #389

### 📌 작업 개요

`DistributedLockExecutor`의 `leaseTime=-1`(무한)을 30초로 변경하여, JVM 크래시 시 Redis 락이 영원히 해제되지 않는 분산 데드락을 방지합니다.

---

### ✅ 주요 변경 사항

- `payment.internal`
  - `DistributedLockExecutor`: `LEASE_TIME_MS = 30_000L` 상수 추출, `tryLock` 호출 시 leaseTime을 -1에서 30초로 변경

---

### 🧪 테스트

- `DistributedLockExecutorTest`: 5개 테스트 통과 (mock stubbing 값 동기화)

---

### 📎 관련 이슈
- #389
