### PR TITLE
refactor: Kotlin idiomatic 코드 정리

### DIFF
--- a/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/ShardedRedisCache.kt
+++ b/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/ShardedRedisCache.kt
@@ -29,9 +29,8 @@ class ShardedRedisCache(
         return delegate.get(key, type)
     }
 
-    override fun <T : Any?> get(key: Any, valueLoader: Callable<T>): T? {
-        return delegate.get(key, valueLoader)
-    }
+    override fun <T : Any?> get(key: Any, valueLoader: Callable<T>): T? =
+        delegate.get(key, valueLoader)
 
     override fun put(key: Any, value: Any?) {
         delegate.put(key, value)

--- a/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/TwoLevelCacheManager.kt
+++ b/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/TwoLevelCacheManager.kt
@@ -89,7 +89,5 @@ class TwoLevelCacheManager(
         }
     }
 
-    override fun getCacheNames(): Collection<String> {
-        return redisCacheManager.cacheNames
-    }
+    override fun getCacheNames(): Collection<String> = redisCacheManager.cacheNames
 }

--- a/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/UserPrincipal.kt
+++ b/hoppingmall-common/src/main/kotlin/com/hoppingmall/common/UserPrincipal.kt
@@ -9,9 +9,8 @@ class UserPrincipal(
     private val role: String
 ) : UserDetails {
 
-    override fun getAuthorities(): Collection<GrantedAuthority> {
-        return listOf(SimpleGrantedAuthority("ROLE_$role"))
-    }
+    override fun getAuthorities(): Collection<GrantedAuthority> =
+        listOf(SimpleGrantedAuthority("ROLE_$role"))
 
     override fun getPassword(): String? = null
 
@@ -30,8 +29,6 @@ class UserPrincipal(
     fun getRole(): String = role
 
     companion object {
-        fun of(userId: Long, role: String): UserPrincipal {
-            return UserPrincipal(userId, role)
-        }
+        fun of(userId: Long, role: String): UserPrincipal = UserPrincipal(userId, role)
     }
 }

--- a/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/domain/DLQMessage.kt
+++ b/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/domain/DLQMessage.kt
@@ -74,9 +74,7 @@ class DLQMessage(
         this.notes = notes
     }
 
-    fun getMessageKey(): String {
-        return "${originalTopic}:${originalPartition}:${originalOffset}"
-    }
+    fun getMessageKey(): String = "${originalTopic}:${originalPartition}:${originalOffset}"
 
     fun scheduleNextRetry() {
         this.status = DLQStatus.PENDING

--- a/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/service/DLQCommandService.kt
+++ b/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/service/DLQCommandService.kt
@@ -8,6 +8,7 @@ import com.hoppingmall.dlq.metrics.DLQMetrics
 import com.hoppingmall.dlq.publisher.DLQMessagePublisher
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.concurrent.ConcurrentHashMap
@@ -81,7 +82,7 @@ class DLQCommandService(
         }
 
         return try {
-            val dlqMessage = dlqMessageRepository.findById(dlqMessageId).orElse(null)
+            val dlqMessage = dlqMessageRepository.findByIdOrNull(dlqMessageId)
             if (dlqMessage == null) {
                 logger.warn("DLQ 메시지를 찾을 수 없음: id={}", dlqMessageId)
                 return false
@@ -129,7 +130,7 @@ class DLQCommandService(
             dlqMetrics.recordDlqRetryFailed()
 
             try {
-                val dlqMessage = dlqMessageRepository.findById(dlqMessageId).orElse(null)
+                val dlqMessage = dlqMessageRepository.findByIdOrNull(dlqMessageId)
                 dlqMessage?.let {
                     if (it.retryCount >= MAX_RETRY_COUNT) {
                         it.markAsFailed("최대 재시도 후 실패: ${e.message}")

--- a/hoppingmall-idempotency/src/main/kotlin/com/hoppingmall/idempotency/IdempotencyService.kt
+++ b/hoppingmall-idempotency/src/main/kotlin/com/hoppingmall/idempotency/IdempotencyService.kt
@@ -15,11 +15,10 @@ class IdempotencyService(
     private val log = LoggerFactory.getLogger(javaClass)
 
     @Transactional(readOnly = true)
-    fun findByKey(key: String): IdempotencyRecord? {
-        return idempotencyRecordRepository.findByIdempotencyKey(key)
+    fun findByKey(key: String): IdempotencyRecord? =
+        idempotencyRecordRepository.findByIdempotencyKey(key)
             .filter { it.expiresAt.isAfter(LocalDateTime.now()) }
             .orElse(null)
-    }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun save(
@@ -29,8 +28,8 @@ class IdempotencyService(
         responseStatus: Int,
         responseBody: String,
         ttlHours: Long
-    ): IdempotencyRecord {
-        return idempotencyRecordRepository.save(
+    ): IdempotencyRecord =
+        idempotencyRecordRepository.save(
             IdempotencyRecord(
                 idempotencyKey = key,
                 httpMethod = httpMethod,
@@ -40,7 +39,6 @@ class IdempotencyService(
                 expiresAt = LocalDateTime.now().plusHours(ttlHours)
             )
         )
-    }
 
     @Scheduled(cron = "0 0 3 * * ?")
     @Transactional

--- a/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/scheduler/OutboxEventPublisher.kt
+++ b/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/scheduler/OutboxEventPublisher.kt
@@ -6,6 +6,7 @@ import com.hoppingmall.outbox.domain.OutboxStatus
 import com.hoppingmall.outbox.metrics.OutboxMetrics
 import com.hoppingmall.outbox.repository.OutboxEventRepository
 import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.support.SendResult
 import org.springframework.scheduling.annotation.Scheduled
@@ -63,7 +64,7 @@ class OutboxEventPublisher(
 
     fun publishEvent(eventId: Long) {
         val event = transactionTemplate.execute {
-            outboxEventRepository.findById(eventId).orElse(null)
+            outboxEventRepository.findByIdOrNull(eventId)
         } ?: return
 
         if (event.processed || event.status != OutboxStatus.RETRYING) {

--- a/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/service/OutboxEventService.kt
+++ b/hoppingmall-outbox/src/main/kotlin/com/hoppingmall/outbox/service/OutboxEventService.kt
@@ -31,9 +31,8 @@ class OutboxEventService(
         )
     }
 
-    fun getEventsByAggregateId(aggregateId: String, aggregateType: String): List<OutboxEvent> {
-        return outboxEventRepository.findByAggregateIdAndType(aggregateId, aggregateType)
-    }
+    fun getEventsByAggregateId(aggregateId: String, aggregateType: String): List<OutboxEvent> =
+        outboxEventRepository.findByAggregateIdAndType(aggregateId, aggregateType)
 
     fun getEventStats(): Map<String, Long> {
         return mapOf(

--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/service/SseEmitterRepository.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/service/SseEmitterRepository.kt
@@ -15,9 +15,8 @@ class SseEmitterRepository {
         return emitter
     }
 
-    fun findByUserId(userId: Long): List<SseEmitter> {
-        return emitters[userId]?.toList() ?: emptyList()
-    }
+    fun findByUserId(userId: Long): List<SseEmitter> =
+        emitters[userId]?.toList() ?: emptyList()
 
     fun remove(userId: Long, emitter: SseEmitter) {
         emitters.compute(userId) { _, list ->

--- a/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcOrderQueryService.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/grpc/GrpcOrderQueryService.kt
@@ -7,6 +7,7 @@ import com.hoppingmall.order.order.domain.repository.OrderItemRepository
 import com.hoppingmall.order.order.domain.repository.OrderRepository
 import com.hoppingmall.order.shipping.domain.repository.ShippingRepository
 import com.hoppingmall.order.shipping.enum.ShippingStatus
+import org.springframework.data.repository.findByIdOrNull
 
 @GrpcService
 class GrpcOrderQueryService(
@@ -34,7 +35,7 @@ class GrpcOrderQueryService(
     }
 
     override suspend fun isDelivered(request: DeliveredCheckRequest): DeliveredResponse {
-        val order = orderRepository.findById(request.orderId).orElse(null)
+        val order = orderRepository.findByIdOrNull(request.orderId)
         if (order == null || order.buyerId != request.buyerId) {
             return deliveredResponse { delivered = false }
         }
@@ -43,7 +44,7 @@ class GrpcOrderQueryService(
     }
 
     override suspend fun findOrderItemById(request: OrderItemIdRequest): OrderItemResponse {
-        val item = orderItemRepository.findById(request.orderItemId).orElse(null)
+        val item = orderItemRepository.findByIdOrNull(request.orderItemId)
             ?: throw StatusException(Status.NOT_FOUND.withDescription("OrderItem not found: ${request.orderItemId}"))
         return orderItemResponse {
             id = item.id!!

--- a/order-service/src/main/kotlin/com/hoppingmall/order/internal/InternalOrderController.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/internal/InternalOrderController.kt
@@ -6,6 +6,7 @@ import com.hoppingmall.order.refund.domain.repository.RefundRepository
 import com.hoppingmall.order.refund.enum.RefundStatus
 import com.hoppingmall.order.shipping.domain.repository.ShippingRepository
 import com.hoppingmall.order.shipping.enum.ShippingStatus
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.transaction.annotation.Transactional
@@ -41,7 +42,7 @@ class InternalOrderController(
 
     @GetMapping("/order-items/{orderItemId}")
     fun getOrderItem(@PathVariable orderItemId: Long): ResponseEntity<OrderItemResponse> {
-        val item = orderItemRepository.findById(orderItemId).orElse(null)
+        val item = orderItemRepository.findByIdOrNull(orderItemId)
             ?: return ResponseEntity.notFound().build()
         return ResponseEntity.ok(OrderItemResponse(
             id = item.id!!,
@@ -58,7 +59,7 @@ class InternalOrderController(
     @PostMapping("/orders/{orderId}/cancel")
     @Transactional
     fun cancelOrder(@PathVariable orderId: Long): ResponseEntity<Void> {
-        val order = orderRepository.findById(orderId).orElse(null)
+        val order = orderRepository.findByIdOrNull(orderId)
             ?: return ResponseEntity.notFound().build()
         if (order.isCancelled()) {
             return ResponseEntity.ok().build()
@@ -70,7 +71,7 @@ class InternalOrderController(
 
     @GetMapping("/orders/{orderId}/delivered")
     fun isDelivered(@PathVariable orderId: Long, @RequestParam buyerId: Long): ResponseEntity<Boolean> {
-        val order = orderRepository.findById(orderId).orElse(null)
+        val order = orderRepository.findByIdOrNull(orderId)
             ?: return ResponseEntity.ok(false)
         if (order.buyerId != buyerId) return ResponseEntity.ok(false)
         val shipping = shippingRepository.findByOrderId(orderId)

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/Order.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/Order.kt
@@ -41,12 +41,11 @@ class Order private constructor(
         fun create(
             buyerId: Long,
             totalAmount: BigDecimal
-        ): Order {
-            return Order(
+        ): Order =
+            Order(
                 buyerId = buyerId,
                 totalAmount = totalAmount
             )
-        }
     }
 
     fun updateStatus(newStatus: OrderStatus) {
@@ -62,7 +61,5 @@ class Order private constructor(
         return OrderStatus.CANCELLED in allowed || OrderStatus.CANCEL_REQUESTED in allowed
     }
 
-    fun isCancelled(): Boolean {
-        return this.status == OrderStatus.CANCELLED
-    }
+    fun isCancelled(): Boolean = status == OrderStatus.CANCELLED
 }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderCancellationResultConsumer.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderCancellationResultConsumer.kt
@@ -10,6 +10,7 @@ import com.hoppingmall.order.order.enum.OrderStatus
 import com.hoppingmall.order.port.InventoryCommandPort
 import com.hoppingmall.outbox.service.TransactionalEventPublisher
 import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
@@ -49,7 +50,7 @@ class OrderCancellationResultConsumer(
         }
 
         val cancelled = transactionTemplate.execute {
-            val order = orderRepository.findById(orderId).orElse(null)
+            val order = orderRepository.findByIdOrNull(orderId)
             if (order == null) {
                 logger.error("주문을 찾을 수 없음: orderId=$orderId")
                 return@execute false
@@ -93,7 +94,7 @@ class OrderCancellationResultConsumer(
                 eventData = mapOf(
                     "eventType" to "OrderCancellationNotificationRequested",
                     "eventId" to "notif-cancel-$eventId",
-                    "userId" to (orderRepository.findById(orderId).orElse(null)?.buyerId ?: 0L),
+                    "userId" to (orderRepository.findByIdOrNull(orderId)?.buyerId ?: 0L),
                     "type" to "PAYMENT_CANCELLED",
                     "title" to "주문이 취소되었습니다",
                     "content" to "주문번호 ${orderId}의 결제 취소가 완료되었습니다."
@@ -118,7 +119,7 @@ class OrderCancellationResultConsumer(
         }
 
         transactionTemplate.execute {
-            val order = orderRepository.findById(orderId).orElse(null)
+            val order = orderRepository.findByIdOrNull(orderId)
             if (order == null) {
                 logger.error("주문을 찾을 수 없음: orderId=$orderId")
                 return@execute

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderSagaConsumer.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderSagaConsumer.kt
@@ -11,6 +11,7 @@ import com.hoppingmall.order.order.enum.OrderStatus
 import com.hoppingmall.order.port.InventoryCommandPort
 import com.hoppingmall.outbox.service.TransactionalEventPublisher
 import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
@@ -51,7 +52,7 @@ class OrderSagaConsumer(
 
     private fun executeLocalPhase(event: PaymentCompletedEvent, eventId: String): List<String>? {
         return transactionTemplate.execute {
-            val order = orderRepository.findById(event.orderId).orElse(null)
+            val order = orderRepository.findByIdOrNull(event.orderId)
             if (order == null) {
                 logger.error("주문을 찾을 수 없음: orderId=${event.orderId}")
                 return@execute null
@@ -107,7 +108,7 @@ class OrderSagaConsumer(
 
     fun compensateFailedConfirmation(eventId: String, event: PaymentCompletedEvent) {
         val compensated = transactionTemplate.execute {
-            val order = orderRepository.findById(event.orderId).orElse(null) ?: return@execute false
+            val order = orderRepository.findByIdOrNull(event.orderId) ?: return@execute false
             if (order.status == OrderStatus.PAID && order.isCancellable()) {
                 order.updateStatus(OrderStatus.CANCEL_REQUESTED)
                 order.updateStatus(OrderStatus.CANCELLED)
@@ -177,7 +178,7 @@ class OrderSagaConsumer(
 
     private fun executeCompensationLocalPhase(eventId: String, orderId: Long): List<String>? {
         return transactionTemplate.execute {
-            val order = orderRepository.findById(orderId).orElse(null)
+            val order = orderRepository.findByIdOrNull(orderId)
             if (order == null) {
                 logger.error("주문을 찾을 수 없음: orderId=$orderId")
                 return@execute null

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/domain/Coupon.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/domain/Coupon.kt
@@ -61,8 +61,8 @@ class Coupon private constructor(
             totalQuantity: Int,
             validFrom: LocalDateTime,
             validTo: LocalDateTime
-        ): Coupon {
-            return Coupon(
+        ): Coupon =
+            Coupon(
                 name = name,
                 code = code,
                 discountType = discountType,
@@ -73,7 +73,6 @@ class Coupon private constructor(
                 validFrom = validFrom,
                 validTo = validTo
             )
-        }
     }
 
     fun calculateDiscount(orderAmount: BigDecimal): BigDecimal {
@@ -96,13 +95,9 @@ class Coupon private constructor(
             now.isBefore(validTo)
     }
 
-    fun isExpired(): Boolean {
-        return LocalDateTime.now().isAfter(validTo)
-    }
+    fun isExpired(): Boolean = LocalDateTime.now().isAfter(validTo)
 
-    fun isExhausted(): Boolean {
-        return issuedQuantity >= totalQuantity
-    }
+    fun isExhausted(): Boolean = issuedQuantity >= totalQuantity
 
     fun issue() {
         issuedQuantity++

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/GrpcPaymentQueryService.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/grpc/GrpcPaymentQueryService.kt
@@ -4,6 +4,7 @@ import com.hoppingmall.payment.payment.domain.repository.PaymentRepository
 import io.grpc.Status
 import io.grpc.StatusException
 import net.devh.boot.grpc.server.service.GrpcService
+import org.springframework.data.repository.findByIdOrNull
 
 @GrpcService
 class GrpcPaymentQueryService(
@@ -24,7 +25,7 @@ class GrpcPaymentQueryService(
     }
 
     override suspend fun findPaymentById(request: PaymentIdRequest): PaymentResponse {
-        val payment = paymentRepository.findById(request.paymentId).orElse(null)
+        val payment = paymentRepository.findByIdOrNull(request.paymentId)
             ?: throw StatusException(Status.NOT_FOUND.withDescription("Payment not found for id=${request.paymentId}"))
         return paymentResponse {
             id = payment.id!!

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/internal/DistributedLockExecutor.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/internal/DistributedLockExecutor.kt
@@ -18,11 +18,10 @@ class DistributedLockExecutor(
         private const val LEASE_TIME_MS = 30_000L
     }
 
-    private fun newTransactionTemplate(): TransactionTemplate {
-        return TransactionTemplate(transactionManager).apply {
+    private fun newTransactionTemplate(): TransactionTemplate =
+        TransactionTemplate(transactionManager).apply {
             propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
         }
-    }
 
     fun <T : Any> withLock(
         key: String,

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/internal/InternalPaymentController.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/internal/InternalPaymentController.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.payment.internal
 import com.hoppingmall.payment.payment.domain.repository.PaymentRepository
 import com.hoppingmall.payment.payment.dto.response.PaymentResponse
 import com.hoppingmall.payment.payment.service.PaymentCommandService
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.math.BigDecimal
@@ -23,7 +24,7 @@ class InternalPaymentController(
 
     @GetMapping("/{id}")
     fun getPaymentById(@PathVariable id: Long): ResponseEntity<PaymentInfoResponse> {
-        val payment = paymentRepository.findById(id).orElse(null)
+        val payment = paymentRepository.findByIdOrNull(id)
             ?: return ResponseEntity.notFound().build()
         return ResponseEntity.ok(toResponse(payment))
     }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/domain/Payment.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/domain/Payment.kt
@@ -61,8 +61,8 @@ class Payment private constructor(
             pointAmount: BigDecimal = BigDecimal.ZERO,
             couponId: Long? = null,
             couponDiscountAmount: BigDecimal = BigDecimal.ZERO
-        ): Payment {
-            return Payment(
+        ): Payment =
+            Payment(
                 orderId = orderId,
                 userId = userId,
                 amount = amount,
@@ -71,7 +71,6 @@ class Payment private constructor(
                 couponId = couponId,
                 couponDiscountAmount = couponDiscountAmount
             )
-        }
     }
 
     fun copy(): Payment {
@@ -103,11 +102,7 @@ class Payment private constructor(
         this.errorMessage = errorMessage
     }
 
-    fun isSuccess(): Boolean {
-        return status == PaymentStatus.SUCCESS
-    }
+    fun isSuccess(): Boolean = status == PaymentStatus.SUCCESS
 
-    fun isFailed(): Boolean {
-        return status == PaymentStatus.FAILED
-    }
+    fun isFailed(): Boolean = status == PaymentStatus.FAILED
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/MockPaymentService.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/MockPaymentService.kt
@@ -43,9 +43,8 @@ class MockPaymentService : PaymentService {
         }
     }
 
-    private fun generateMockTransactionId(): String {
-        return "MOCK_${System.currentTimeMillis()}_${Random.nextInt(1000, 9999)}"
-    }
+    private fun generateMockTransactionId(): String =
+        "MOCK_${System.currentTimeMillis()}_${Random.nextInt(1000, 9999)}"
 
     private fun getRandomErrorMessage(): String {
         val errors = listOf(

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/strategy/CompensationEventHandlerRegistry.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/strategy/CompensationEventHandlerRegistry.kt
@@ -8,7 +8,6 @@ class CompensationEventHandlerRegistry(
 ) {
     private val handlerList: List<CompensationEventHandler> = handlers
 
-    fun getHandler(eventType: String): CompensationEventHandler? {
-        return handlerList.find { it.supports(eventType) }
-    }
+    fun getHandler(eventType: String): CompensationEventHandler? =
+        handlerList.find { it.supports(eventType) }
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/strategy/PaymentMethodProcessorRegistry.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/strategy/PaymentMethodProcessorRegistry.kt
@@ -10,8 +10,7 @@ class PaymentMethodProcessorRegistry(
     private val processorMap: Map<PaymentMethod, PaymentMethodProcessor> =
         processors.associateBy { it.method }
 
-    fun getProcessor(method: PaymentMethod): PaymentMethodProcessor {
-        return processorMap[method]
+    fun getProcessor(method: PaymentMethod): PaymentMethodProcessor =
+        processorMap[method]
             ?: throw IllegalArgumentException("지원하지 않는 결제 수단: $method")
-    }
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/domain/PointPolicy.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/domain/PointPolicy.kt
@@ -42,13 +42,9 @@ data class PointPolicy(
         require(minUseAmount <= maxUseAmount) { "최소 사용 금액은 최대 사용 금액을 초과할 수 없습니다" }
     }
 
-    fun activate(): PointPolicy {
-        return this.copy(isActive = true)
-    }
+    fun activate(): PointPolicy = copy(isActive = true)
 
-    fun deactivate(): PointPolicy {
-        return this.copy(isActive = false)
-    }
+    fun deactivate(): PointPolicy = copy(isActive = false)
 
     fun update(
         policyName: String,
@@ -57,8 +53,8 @@ data class PointPolicy(
         minUseAmount: BigDecimal,
         maxUseAmount: BigDecimal,
         description: String?
-    ): PointPolicy {
-        return this.copy(
+    ): PointPolicy =
+        copy(
             policyName = policyName,
             earnRate = earnRate,
             maxEarnRate = maxEarnRate,
@@ -66,16 +62,14 @@ data class PointPolicy(
             maxUseAmount = maxUseAmount,
             description = description
         )
-    }
 
     fun calculateEarnPoints(purchaseAmount: BigDecimal): BigDecimal {
         require(purchaseAmount > BigDecimal.ZERO) { "구매 금액은 0보다 커야 합니다" }
         return purchaseAmount * earnRate
     }
 
-    fun canUsePoints(useAmount: BigDecimal): Boolean {
-        return useAmount >= minUseAmount && useAmount <= maxUseAmount
-    }
+    fun canUsePoints(useAmount: BigDecimal): Boolean =
+        useAmount >= minUseAmount && useAmount <= maxUseAmount
 
     companion object {
         fun create(
@@ -85,8 +79,8 @@ data class PointPolicy(
             minUseAmount: BigDecimal,
             maxUseAmount: BigDecimal,
             description: String? = null
-        ): PointPolicy {
-            return PointPolicy(
+        ): PointPolicy =
+            PointPolicy(
                 policyName = policyName,
                 earnRate = earnRate,
                 maxEarnRate = maxEarnRate,
@@ -95,6 +89,5 @@ data class PointPolicy(
                 isActive = false,
                 description = description
             )
-        }
     }
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/strategy/MembershipBasedRateStrategy.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/strategy/MembershipBasedRateStrategy.kt
@@ -9,7 +9,6 @@ class MembershipBasedRateStrategy(
     private val membershipQueryPort: MembershipQueryPort
 ) : PointEarnRateStrategy {
 
-    override fun getEarnRate(userId: Long): BigDecimal {
-        return membershipQueryPort.getPointEarningRate(userId)
-    }
+    override fun getEarnRate(userId: Long): BigDecimal =
+        membershipQueryPort.getPointEarningRate(userId)
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/refund/service/RefundLocalOperationService.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/refund/service/RefundLocalOperationService.kt
@@ -7,6 +7,7 @@ import com.hoppingmall.payment.point.service.PointCommandService
 import com.hoppingmall.payment.refund.domain.RefundEventLog
 import com.hoppingmall.payment.refund.domain.repository.RefundEventLogRepository
 import com.hoppingmall.payment.refund.dto.event.RefundCompletedEvent
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -22,7 +23,7 @@ class RefundLocalOperationService(
     fun execute(event: RefundCompletedEvent, eventLog: RefundEventLog) {
         if (event.isFullRefund) {
             if (!eventLog.isStepCompleted(RefundEventLog.PAYMENT_UPDATED)) {
-                val payment = paymentRepository.findById(event.paymentId).orElse(null)
+                val payment = paymentRepository.findByIdOrNull(event.paymentId)
                 if (payment != null) {
                     payment.updateStatus(PaymentStatus.REFUNDED)
                     paymentRepository.save(payment)

--- a/product-service/src/main/kotlin/com/hoppingmall/product/category/domain/Category.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/category/domain/Category.kt
@@ -25,13 +25,10 @@ class Category private constructor(
         this.name = name
     }
 
-    fun isRootCategory(): Boolean {
-        return parentCategoryId == null
-    }
+    fun isRootCategory(): Boolean = parentCategoryId == null
 
     companion object {
-        fun create(name: String, parentCategoryId: Long?, depth: Int): Category {
-            return Category(name = name, parentCategoryId = parentCategoryId, depth = depth)
-        }
+        fun create(name: String, parentCategoryId: Long?, depth: Int): Category =
+            Category(name = name, parentCategoryId = parentCategoryId, depth = depth)
     }
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/inventory/domain/Inventory.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/inventory/domain/Inventory.kt
@@ -26,13 +26,10 @@ class Inventory private constructor(
         stockQuantity += quantity
     }
 
-    fun hasStock(quantity: Int): Boolean {
-        return stockQuantity >= quantity
-    }
+    fun hasStock(quantity: Int): Boolean = stockQuantity >= quantity
 
     companion object {
-        fun create(productId: Long, stockQuantity: Int): Inventory {
-            return Inventory(productId = productId, stockQuantity = stockQuantity)
-        }
+        fun create(productId: Long, stockQuantity: Int): Inventory =
+            Inventory(productId = productId, stockQuantity = stockQuantity)
     }
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/Product.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/Product.kt
@@ -53,8 +53,6 @@ class Product private constructor(
             description: String,
             price: BigDecimal,
             status: ProductStatus
-        ): Product {
-            return Product(sellerId, categoryId, name, description, price, status)
-        }
+        ): Product = Product(sellerId, categoryId, name, description, price, status)
     }
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/ProductImage.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/ProductImage.kt
@@ -28,8 +28,6 @@ class ProductImage private constructor(
             productId: Long,
             imageUrl: String,
             sortOrder: Int = 0
-        ): ProductImage {
-            return ProductImage(productId, imageUrl, sortOrder)
-        }
+        ): ProductImage = ProductImage(productId, imageUrl, sortOrder)
     }
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImpl.kt
@@ -10,6 +10,7 @@ import com.hoppingmall.product.product.domain.repository.ProductStatisticsReposi
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
@@ -150,7 +151,7 @@ class ProductStatisticsCommandServiceImpl(
         val existing = productStatisticsRepository.findByProductId(productId)
         if (existing != null) return existing
 
-        val product = productRepository.findById(productId).orElse(null)
+        val product = productRepository.findByIdOrNull(productId)
             ?: throw IllegalArgumentException("상품을 찾을 수 없습니다: $productId")
 
         return productStatisticsRepository.save(

--- a/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/domain/Wishlist.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/domain/Wishlist.kt
@@ -19,8 +19,6 @@ class Wishlist private constructor(
     val productId: Long,
 ) : BaseEntity() {
     companion object {
-        fun create(buyerId: Long, productId: Long): Wishlist {
-            return Wishlist(buyerId, productId)
-        }
+        fun create(buyerId: Long, productId: Long): Wishlist = Wishlist(buyerId, productId)
     }
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/service/WishlistQueryServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/wishlist/service/WishlistQueryServiceImpl.kt
@@ -13,11 +13,9 @@ class WishlistQueryServiceImpl(
     private val wishlistRepository: WishlistRepository
 ) : WishlistQueryService {
 
-    override fun getWishlists(buyerId: Long, pageable: Pageable): Slice<WishlistResponse> {
-        return wishlistRepository.findByBuyerIdWithProduct(buyerId, pageable)
-    }
+    override fun getWishlists(buyerId: Long, pageable: Pageable): Slice<WishlistResponse> =
+        wishlistRepository.findByBuyerIdWithProduct(buyerId, pageable)
 
-    override fun isWishlisted(buyerId: Long, productId: Long): Boolean {
-        return wishlistRepository.existsByBuyerIdAndProductId(buyerId, productId)
-    }
+    override fun isWishlisted(buyerId: Long, productId: Long): Boolean =
+        wishlistRepository.existsByBuyerIdAndProductId(buyerId, productId)
 }

--- a/user-service/src/main/kotlin/com/hoppingmall/user/auth/TokenProviderImpl.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/auth/TokenProviderImpl.kt
@@ -55,13 +55,11 @@ class TokenProviderImpl(
         return true
     }
 
-    override fun getUserIdFromToken(token: String): Long {
-        return parseClaims(token).subject.toLong()
-    }
+    override fun getUserIdFromToken(token: String): Long =
+        parseClaims(token).subject.toLong()
 
-    override fun getUserRoleFromToken(token: String): Role {
-        return Role.valueOf(parseClaims(token)["role"] as String)
-    }
+    override fun getUserRoleFromToken(token: String): Role =
+        Role.valueOf(parseClaims(token)["role"] as String)
 
     override fun getUserPrincipal(token: String): UserPrincipal {
         val userId = getUserIdFromToken(token)

--- a/user-service/src/main/kotlin/com/hoppingmall/user/common/vo/Password.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/common/vo/Password.kt
@@ -14,7 +14,7 @@ data class Password(
 
     override fun toString(): String = maskingStrategy.mask()
 
-    fun isSameHashedValueWith(hashed: String): Boolean = this.value == hashed
+    fun isSameHashedValueWith(hashed: String): Boolean = value == hashed
 }
 
 fun interface PasswordMaskingStrategy {

--- a/user-service/src/main/kotlin/com/hoppingmall/user/common/vo/PasswordVerifier.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/common/vo/PasswordVerifier.kt
@@ -7,9 +7,8 @@ import org.springframework.stereotype.Component
 class PasswordVerifier(
     private val passwordEncoder: PasswordEncoder
 ) {
-    fun matches(raw: String, encoded: Password): Boolean {
-        return passwordEncoder.matches(raw, encoded.value)
-    }
+    fun matches(raw: String, encoded: Password): Boolean =
+        passwordEncoder.matches(raw, encoded.value)
 
     fun assertMatches(raw: String, encoded: Password) {
         if (!matches(raw, encoded)) {

--- a/user-service/src/main/kotlin/com/hoppingmall/user/domain/Buyer.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/domain/Buyer.kt
@@ -16,8 +16,6 @@ class Buyer private constructor(
 ) : BaseEntity() {
 
     companion object {
-        fun create(user: User): Buyer {
-            return Buyer(user.id!!)
-        }
+        fun create(user: User): Buyer = Buyer(user.id!!)
     }
 }

--- a/user-service/src/main/kotlin/com/hoppingmall/user/domain/Membership.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/domain/Membership.kt
@@ -20,9 +20,7 @@ class Membership(
 ) : BaseEntity() {
 
     companion object {
-        fun create(userId: Long): Membership {
-            return Membership(userId = userId)
-        }
+        fun create(userId: Long): Membership = Membership(userId = userId)
     }
 
     fun addPurchaseAmount(amount: BigDecimal) {

--- a/user-service/src/main/kotlin/com/hoppingmall/user/domain/Seller.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/domain/Seller.kt
@@ -29,12 +29,11 @@ class Seller private constructor(
         this.approvalStatus = ApprovalStatus.REJECTED
     }
 
-    fun getApprovalStatus(): ApprovalStatus = this.approvalStatus
+    fun getApprovalStatus(): ApprovalStatus = approvalStatus
 
     companion object {
-        fun create(user: User, businessNumber: String): Seller {
-            return Seller(user.id!!, businessNumber, ApprovalStatus.PENDING)
-        }
+        fun create(user: User, businessNumber: String): Seller =
+            Seller(user.id!!, businessNumber, ApprovalStatus.PENDING)
     }
 
     enum class ApprovalStatus {

--- a/user-service/src/main/kotlin/com/hoppingmall/user/domain/User.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/domain/User.kt
@@ -25,9 +25,8 @@ class User private constructor(
 ) : BaseEntity() {
 
     companion object {
-        fun create(email: Email, password: Password, name: String, role: Role = Role.BUYER): User {
-            return User(email, password, name, role)
-        }
+        fun create(email: Email, password: Password, name: String, role: Role = Role.BUYER): User =
+            User(email, password, name, role)
     }
 
     fun updatePassword(newPassword: Password) {

--- a/user-service/src/main/kotlin/com/hoppingmall/user/service/strategy/SellerApprovalCommandMapper.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/service/strategy/SellerApprovalCommandMapper.kt
@@ -14,7 +14,6 @@ class SellerApprovalCommandMapper(
         Seller.ApprovalStatus.REJECTED to reject,
     )
 
-    fun getCommand(status: Seller.ApprovalStatus): SellerApprovalCommand {
-        return commandMap[status] ?: throw SellerInvalidApprovalCommandException()
-    }
+    fun getCommand(status: Seller.ApprovalStatus): SellerApprovalCommand =
+        commandMap[status] ?: throw SellerInvalidApprovalCommandException()
 }


### PR DESCRIPTION
Closes #391

### 📌 작업 개요
Kotlin idiomatic 스타일로 코드 표현 방식을 정리했습니다.
동작 변경 없이 `findByIdOrNull()` 전환, expression body 전환, 불필요한 `this.` 제거를 적용했습니다.

---

### ✅ 주요 변경 사항

- `hoppingmall-dlq`, `hoppingmall-outbox`, `order-service`, `payment-service`, `product-service`
  - `findById().orElse(null)` → `findByIdOrNull()` 전환 (10개 파일)

- `hoppingmall-cache`, `hoppingmall-common`, `hoppingmall-dlq`, `hoppingmall-idempotency`, `hoppingmall-outbox`, `notification-service`, `order-service`, `payment-service`, `product-service`, `user-service`
  - 단일 return 함수 expression body 전환
  - companion factory expression body 전환
  - 불필요한 `this.` 참조 제거 (30개 파일)

---

### 🧪 테스트

- hoppingmall-common, hoppingmall-cache, hoppingmall-dlq, hoppingmall-idempotency, hoppingmall-outbox 테스트 통과
- order-service, product-service, user-service, notification-service 테스트 통과
- payment-service compileKotlin, compileTestKotlin 통과

---

### 📎 관련 이슈
- #391
