### PR TITLE
fix: PointDomainService gap lock 데드락 수정

### DIFF
--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointDomainService.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointDomainService.kt
@@ -17,7 +17,13 @@ class PointDomainService(
 
     @Transactional
     fun findOrCreatePoint(userId: Long): Point {
-        pointRepository.findByUserIdForUpdate(userId)?.let { return it }
+        ensurePointExists(userId)
+        return pointRepository.findByUserIdForUpdate(userId)
+            ?: throw IllegalStateException("포인트 생성 실패: 사용자 $userId")
+    }
+
+    private fun ensurePointExists(userId: Long) {
+        if (pointRepository.findByUserId(userId) != null) return
 
         val newTx = TransactionTemplate(txManager).apply {
             propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
@@ -28,8 +34,5 @@ class PointDomainService(
             } catch (_: DataIntegrityViolationException) {
             }
         }
-
-        return pointRepository.findByUserIdForUpdate(userId)
-            ?: throw IllegalStateException("포인트 생성 실패: 사용자 $userId")
     }
 }

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/point/service/PointDomainServiceTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/point/service/PointDomainServiceTest.kt
@@ -41,6 +41,7 @@ class PointDomainServiceTest {
     @Test
     fun 기존_포인트가_있으면_조회하여_반환한다() {
         val existing = Point(userId = 1L, balance = BigDecimal("1000"))
+        whenever(pointRepository.findByUserId(1L)).thenReturn(existing)
         whenever(pointRepository.findByUserIdForUpdate(1L)).thenReturn(existing)
 
         val result = pointDomainService.findOrCreatePoint(1L)
@@ -56,9 +57,8 @@ class PointDomainServiceTest {
         val idField = BaseEntity::class.java.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(newPoint, 1L)
-        whenever(pointRepository.findByUserIdForUpdate(1L))
-            .thenReturn(null)
-            .thenReturn(newPoint)
+        whenever(pointRepository.findByUserId(1L)).thenReturn(null)
+        whenever(pointRepository.findByUserIdForUpdate(1L)).thenReturn(newPoint)
         whenever(txManager.getTransaction(any())).thenReturn(mock())
         doAnswer { newPoint }.whenever(pointRepository).save(any())
 
@@ -74,9 +74,8 @@ class PointDomainServiceTest {
         val idField = BaseEntity::class.java.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(existing, 1L)
-        whenever(pointRepository.findByUserIdForUpdate(1L))
-            .thenReturn(null)
-            .thenReturn(existing)
+        whenever(pointRepository.findByUserId(1L)).thenReturn(null)
+        whenever(pointRepository.findByUserIdForUpdate(1L)).thenReturn(existing)
         whenever(txManager.getTransaction(any())).thenReturn(mock())
         doThrow(DataIntegrityViolationException("duplicate")).whenever(pointRepository).save(any())
 
@@ -87,9 +86,8 @@ class PointDomainServiceTest {
 
     @Test
     fun 동시_생성_충돌_후에도_조회_실패하면_예외가_발생한다() {
-        whenever(pointRepository.findByUserIdForUpdate(1L))
-            .thenReturn(null)
-            .thenReturn(null)
+        whenever(pointRepository.findByUserId(1L)).thenReturn(null)
+        whenever(pointRepository.findByUserIdForUpdate(1L)).thenReturn(null)
         whenever(txManager.getTransaction(any())).thenReturn(mock())
         doThrow(DataIntegrityViolationException("duplicate")).whenever(pointRepository).save(any())
 


### PR DESCRIPTION
Closes #393

### 📌 작업 개요
PointDomainService.findOrCreatePoint()에서 MySQL REPEATABLE_READ 환경에서 발생 가능한
gap lock 데드락을 수정했습니다. 존재 확인과 잠금 획득을 분리하여 안전한 동시성 처리를 보장합니다.

---

### ✅ 주요 변경 사항

- `payment.point.service`
  - `PointDomainService`: findByUserIdForUpdate() 대신 findByUserId()로 존재 확인 분리, ensurePointExists() 메서드 추출

- `payment.point.service (test)`
  - `PointDomainServiceTest`: 변경된 호출 순서에 맞게 mock 설정 수정

---

### 🧪 테스트

- `PointDomainServiceTest`: 기존 포인트 조회, 신규 생성, 동시 생성 충돌, 생성 실패 4개 케이스 통과
- `PointCommandServiceImplTest`: 기존 테스트 통과 확인

---

### 📎 관련 이슈
- #393
