### PR TITLE
perf: ProductStatistics 조회 DTO Projection 전환

### DIFF
--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductStatisticsRepository.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductStatisticsRepository.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.product.product.domain.repository
 
 import com.hoppingmall.product.product.domain.ProductStatistics
+import com.hoppingmall.product.product.dto.TopSellingProductDto
 import jakarta.persistence.LockModeType
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
@@ -51,8 +52,13 @@ interface ProductStatisticsRepository : JpaRepository<ProductStatistics, Long> {
     """)
     fun findSellerTodaySummary(@Param("sellerId") sellerId: Long): SellerTodaySummaryProjection
 
-    @Query("SELECT ps FROM ProductStatistics ps WHERE ps.sellerId = :sellerId ORDER BY ps.todaySalesAmount DESC LIMIT 1")
-    fun findTopSellingBySellerId(@Param("sellerId") sellerId: Long): ProductStatistics?
+    @Query("""
+        SELECT new com.hoppingmall.product.product.dto.TopSellingProductDto(
+            ps.productId, ps.productName
+        )
+        FROM ProductStatistics ps WHERE ps.sellerId = :sellerId ORDER BY ps.todaySalesAmount DESC LIMIT 1
+    """)
+    fun findTopSellingBySellerId(@Param("sellerId") sellerId: Long): TopSellingProductDto?
 
     @Query("SELECT ps FROM ProductStatistics ps WHERE ps.todaySalesQuantity > 0 OR ps.todayRefundQuantity > 0")
     fun findAllActive(): List<ProductStatistics>

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/dto/TopSellingProductDto.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/dto/TopSellingProductDto.kt
@@ -1,0 +1,6 @@
+package com.hoppingmall.product.product.dto
+
+data class TopSellingProductDto(
+    val productId: Long,
+    val productName: String
+)

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/SellerDashboardServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/SellerDashboardServiceImpl.kt
@@ -40,14 +40,14 @@ class SellerDashboardServiceImpl(
 
     override fun getTodaySummary(sellerId: Long): SellerTodaySummaryResponse {
         val summary = productStatisticsRepository.findSellerTodaySummary(sellerId)
-        val topSelling = productStatisticsRepository.findTopSellingBySellerId(sellerId)
+        val topSellingDto = productStatisticsRepository.findTopSellingBySellerId(sellerId)
         return SellerTodaySummaryResponse(
             totalProducts = summary.getTotalProducts(),
             todaySalesAmount = summary.getTodaySalesAmount(),
             todayOrderCount = summary.getTodayOrderCount(),
             todayRefundAmount = summary.getTodayRefundAmount(),
-            topSellingProductId = topSelling?.productId,
-            topSellingProductName = topSelling?.productName
+            topSellingProductId = topSellingDto?.productId,
+            topSellingProductName = topSellingDto?.productName
         )
     }
 

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/SellerDashboardServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/SellerDashboardServiceImplTest.kt
@@ -7,6 +7,7 @@ import com.hoppingmall.product.product.domain.repository.ProductDailyStatisticsR
 import com.hoppingmall.product.product.domain.repository.ProductHourlyStatisticsRepository
 import com.hoppingmall.product.product.domain.repository.ProductStatisticsRepository
 import com.hoppingmall.product.product.domain.repository.SellerTodaySummaryProjection
+import com.hoppingmall.product.product.dto.TopSellingProductDto
 import com.hoppingmall.product.product.exception.ProductException
 import com.hoppingmall.product.product.exception.ProductStatisticsNotFoundException
 import com.hoppingmall.product.support.withId
@@ -92,11 +93,11 @@ class SellerDashboardServiceImplTest {
 
     @Test
     fun 오늘_요약을_조회한다() {
-        val topSelling = createStats()
+        val topSellingDto = TopSellingProductDto(productId = 1L, productName = "테스트")
         val summary = mockSummaryProjection(5L, BigDecimal("500000"), 10L, BigDecimal("10000"))
 
         whenever(productStatisticsRepository.findSellerTodaySummary(1L)).thenReturn(summary)
-        whenever(productStatisticsRepository.findTopSellingBySellerId(1L)).thenReturn(topSelling)
+        whenever(productStatisticsRepository.findTopSellingBySellerId(1L)).thenReturn(topSellingDto)
 
         val result = service.getTodaySummary(1L)
 


### PR DESCRIPTION
Closes #395

### 📌 작업 개요
findTopSellingBySellerId() 쿼리가 전체 ProductStatistics 엔티티(25개 컬럼)를 로드하던 것을 JPQL constructor expression을 사용한 DTO Projection으로 전환하여 실제 사용하는 productId, productName 필드만 조회하도록 개선

---

### ✅ 주요 변경 사항

- `com.hoppingmall.product.product.dto`
  - `TopSellingProductDto`: productId, productName만 담는 경량 DTO 신규 추가

- `com.hoppingmall.product.product.domain.repository`
  - `ProductStatisticsRepository`: findTopSellingBySellerId() 반환 타입을 ProductStatistics에서 TopSellingProductDto로 변경, JPQL constructor expression 적용

- `com.hoppingmall.product.product.service`
  - `SellerDashboardServiceImpl`: getTodaySummary()에서 TopSellingProductDto 사용하도록 변경

- `com.hoppingmall.product.product.service (test)`
  - `SellerDashboardServiceImplTest`: TopSellingProductDto를 사용하도록 테스트 수정

---

### 🧪 테스트

- 전체 테스트 통과 (BUILD SUCCESSFUL)

---

### 📎 관련 이슈
- #395
