### PR TITLE
fix: RefundCompletionConsumer 외부 HTTP 호출 트랜잭션 분리

### DIFF
--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/refund/service/RefundCompletionConsumer.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/refund/service/RefundCompletionConsumer.kt
@@ -107,6 +107,7 @@ class RefundCompletionConsumer(
             event.items.forEach { item ->
                 inventoryCommandPort.increaseStock(item.productId, item.quantity)
             }
+            refundLocalOperationService.markStepAndSave(event.eventId, RefundEventLog.INVENTORY_RESTORED)
             eventLog.markStepCompleted(RefundEventLog.INVENTORY_RESTORED)
         }
 
@@ -118,20 +119,19 @@ class RefundCompletionConsumer(
                     item.refundPrice
                 )
             }
+            refundLocalOperationService.markStepAndSave(event.eventId, RefundEventLog.STATS_UPDATED)
             eventLog.markStepCompleted(RefundEventLog.STATS_UPDATED)
         }
-
-        refundEventLogRepository.save(eventLog)
     }
 
     fun executeOrderOperations(event: RefundCompletedEvent, eventLog: RefundEventLog) {
         if (event.isFullRefund && !eventLog.isStepCompleted(RefundEventLog.ORDER_CANCELLED)) {
             orderCommandPort.cancelOrder(event.orderId)
+            refundLocalOperationService.markStepAndSave(event.eventId, RefundEventLog.ORDER_CANCELLED)
             eventLog.markStepCompleted(RefundEventLog.ORDER_CANCELLED)
         } else if (!event.isFullRefund) {
+            refundLocalOperationService.markStepAndSave(event.eventId, RefundEventLog.ORDER_CANCELLED)
             eventLog.markStepCompleted(RefundEventLog.ORDER_CANCELLED)
         }
-
-        refundEventLogRepository.save(eventLog)
     }
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/refund/service/RefundLocalOperationService.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/refund/service/RefundLocalOperationService.kt
@@ -20,6 +20,13 @@ class RefundLocalOperationService(
 ) {
 
     @Transactional
+    fun markStepAndSave(eventId: String, step: String) {
+        val eventLog = refundEventLogRepository.findByEventId(eventId) ?: return
+        eventLog.markStepCompleted(step)
+        refundEventLogRepository.save(eventLog)
+    }
+
+    @Transactional
     fun execute(event: RefundCompletedEvent, eventLog: RefundEventLog) {
         if (event.isFullRefund) {
             if (!eventLog.isStepCompleted(RefundEventLog.PAYMENT_UPDATED)) {

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/refund/service/RefundCompletionConsumerTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/refund/service/RefundCompletionConsumerTest.kt
@@ -119,6 +119,9 @@ class RefundCompletionConsumerTest {
         verify(productStatisticsPort).incrementRefundStats(1L, 2L, BigDecimal("25000"))
         verify(productStatisticsPort).incrementRefundStats(2L, 1L, BigDecimal("25000"))
         verify(orderCommandPort).cancelOrder(event.orderId)
+        verify(refundLocalOperationService).markStepAndSave(event.eventId, RefundEventLog.INVENTORY_RESTORED)
+        verify(refundLocalOperationService).markStepAndSave(event.eventId, RefundEventLog.STATS_UPDATED)
+        verify(refundLocalOperationService).markStepAndSave(event.eventId, RefundEventLog.ORDER_CANCELLED)
     }
 
     @Test
@@ -135,6 +138,9 @@ class RefundCompletionConsumerTest {
         verify(inventoryCommandPort).increaseStock(1L, 1)
         verify(productStatisticsPort).incrementRefundStats(1L, 1L, BigDecimal("25000"))
         verify(orderCommandPort, never()).cancelOrder(any())
+        verify(refundLocalOperationService).markStepAndSave(event.eventId, RefundEventLog.INVENTORY_RESTORED)
+        verify(refundLocalOperationService).markStepAndSave(event.eventId, RefundEventLog.STATS_UPDATED)
+        verify(refundLocalOperationService).markStepAndSave(event.eventId, RefundEventLog.ORDER_CANCELLED)
     }
 
     @Test
@@ -148,6 +154,7 @@ class RefundCompletionConsumerTest {
 
         verify(refundEventLogRepository, never()).save(any<RefundEventLog>())
         verify(refundLocalOperationService, never()).execute(any(), any())
+        verify(refundLocalOperationService, never()).markStepAndSave(any(), any())
         verify(inventoryCommandPort, never()).increaseStock(any(), any())
         verify(orderCommandPort, never()).cancelOrder(any())
     }
@@ -171,5 +178,8 @@ class RefundCompletionConsumerTest {
         verify(productStatisticsPort).incrementRefundStats(1L, 2L, BigDecimal("25000"))
         verify(productStatisticsPort).incrementRefundStats(2L, 1L, BigDecimal("25000"))
         verify(orderCommandPort).cancelOrder(event.orderId)
+        verify(refundLocalOperationService).markStepAndSave(event.eventId, RefundEventLog.INVENTORY_RESTORED)
+        verify(refundLocalOperationService).markStepAndSave(event.eventId, RefundEventLog.STATS_UPDATED)
+        verify(refundLocalOperationService).markStepAndSave(event.eventId, RefundEventLog.ORDER_CANCELLED)
     }
 }


### PR DESCRIPTION
Closes #396

### 📌 작업 개요
`RefundCompletionConsumer`의 `executeInventoryOperations()`과 `executeOrderOperations()` 메서드에서 외부 HTTP 호출과 DB 저장이 동일 흐름에서 실행되어 HTTP 타임아웃 시 DB 커넥션 풀 고갈 위험이 있던 문제를 수정합니다.

---

### ✅ 주요 변경 사항
- `RefundLocalOperationService`에 `markStepAndSave()` 메서드 추가 (`@Transactional`)
- 외부 HTTP 호출(`inventoryCommandPort.increaseStock()`, `productStatisticsPort.incrementRefundStats()`, `orderCommandPort.cancelOrder()`)은 트랜잭션 외부에서 실행
- 각 HTTP 호출 성공 후 `markStepAndSave()`를 통해 별도 짧은 트랜잭션에서 단계 완료 상태 즉시 영속화
- Spring 프록시 self-invocation 이슈를 피하기 위해 별도 Bean(`RefundLocalOperationService`)에 트랜잭션 메서드 배치

---

### 🧪 테스트
- `RefundCompletionConsumerTest` 4개 테스트 모두 통과
- 전체 테스트 167개 통과 (Kafka E2E 통합 테스트 제외 - Docker 미실행 환경)

---

### 📎 관련 이슈
- #396
