### PR TITLE
perf: notification-service default_batch_fetch_size 설정 추가

### DIFF
--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -1,0 +1,67 @@
+spring:
+  application:
+    name: notification-service
+  datasource:
+    url: jdbc:h2:mem:notification_db;DB_CLOSE_DELAY=-1;MODE=MYSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+        default_batch_fetch_size: 100
+  data:
+    redis:
+      redisson:
+        config: |
+          clusterServersConfig:
+            nodeAddresses:
+              - "redis://localhost:7001"
+              - "redis://localhost:7002"
+              - "redis://localhost:7003"
+            scanInterval: 1000
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: notification-service
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "*"
+
+server:
+  port: 8081
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,metrics,prometheus
+  metrics:
+    tags:
+      application: notification-service
+  tracing:
+    sampling:
+      probability: 0.0
+    enabled: false
+
+jwt:
+  secret: ${JWT_SECRET:default-docker-secret-key-for-development-only-32chars!}
+
+logging:
+  level:
+    root: INFO
+    com.hoppingmall: DEBUG
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html


### PR DESCRIPTION
Closes #399

### 📌 작업 개요
notification-service에 누락된 default_batch_fetch_size 설정을 추가하여
user-service, settlement-service와 동일한 JPA 배치 패칭 설정을 적용합니다.

---

### ✅ 주요 변경 사항

- `notification-service/src/main/resources/application.yml`
  - `spring.jpa.properties.hibernate.default_batch_fetch_size: 100` 추가

---

### 🧪 테스트

- notification-service 전체 테스트 통과 확인

---

### 📎 관련 이슈
- #399
