### PR TITLE
perf: SettlementSnapshotService findAll() 페이징 처리

### DIFF
--- a/settlement-service/src/main/kotlin/com/hoppingmall/settlement/service/SettlementSnapshotService.kt
+++ b/settlement-service/src/main/kotlin/com/hoppingmall/settlement/service/SettlementSnapshotService.kt
@@ -4,6 +4,8 @@ import com.hoppingmall.settlement.domain.SettlementSummary
 import com.hoppingmall.settlement.domain.repository.SettlementRepository
 import com.hoppingmall.settlement.domain.repository.SettlementSummaryRepository
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,34 +18,50 @@ class SettlementSnapshotService(
 
     private val log = LoggerFactory.getLogger(javaClass)
 
+    companion object {
+        private const val BATCH_SIZE = 200
+    }
+
     @Scheduled(cron = "0 0 3 * * *")
     @Transactional
     fun createSnapshot() {
         log.info("Settlement snapshot job started")
 
-        val settlements = settlementRepository.findAll()
-        val summaryMap = settlementSummaryRepository
-            .findBySettlementIdIn(settlements.map { it.id!! })
-            .associateBy { it.settlementId }
+        var totalCreated = 0
+        var totalUpdated = 0
+        var page = 0
 
-        val newSummaries = mutableListOf<SettlementSummary>()
+        do {
+            val pageable = PageRequest.of(page, BATCH_SIZE, Sort.by("id"))
+            val settlementPage = settlementRepository.findAll(pageable)
+            val settlements = settlementPage.content
 
-        settlements.forEach { settlement ->
-            val existing = summaryMap[settlement.id!!]
-            if (existing != null) {
-                existing.updateFrom(settlement)
-            } else {
-                newSummaries.add(SettlementSummary.from(settlement))
+            if (settlements.isEmpty()) break
+
+            val summaryMap = settlementSummaryRepository
+                .findBySettlementIdIn(settlements.map { it.id!! })
+                .associateBy { it.settlementId }
+
+            val newSummaries = mutableListOf<SettlementSummary>()
+
+            settlements.forEach { settlement ->
+                val existing = summaryMap[settlement.id!!]
+                if (existing != null) {
+                    existing.updateFrom(settlement)
+                } else {
+                    newSummaries.add(SettlementSummary.from(settlement))
+                }
             }
-        }
 
-        if (newSummaries.isNotEmpty()) {
-            settlementSummaryRepository.saveAll(newSummaries)
-        }
+            if (newSummaries.isNotEmpty()) {
+                settlementSummaryRepository.saveAll(newSummaries)
+            }
 
-        val created = newSummaries.size
-        val updated = settlements.size - created
+            totalCreated += newSummaries.size
+            totalUpdated += settlements.size - newSummaries.size
+            page++
+        } while (settlementPage.hasNext())
 
-        log.info("Settlement snapshot job completed: created=$created, updated=$updated")
+        log.info("Settlement snapshot job completed: created=$totalCreated, updated=$totalUpdated")
     }
 }

--- a/settlement-service/src/test/kotlin/com/hoppingmall/settlement/service/SettlementSnapshotServiceTest.kt
+++ b/settlement-service/src/test/kotlin/com/hoppingmall/settlement/service/SettlementSnapshotServiceTest.kt
@@ -16,6 +16,10 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.test.util.ReflectionTestUtils
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -52,8 +56,10 @@ class SettlementSnapshotServiceTest {
     @Test
     fun 스냅샷_생성_시_신규_Summary를_생성한다() {
         val settlement = createSettlement(1L)
+        val pageable = PageRequest.of(0, 200, Sort.by("id"))
+        val page = PageImpl(listOf(settlement), pageable, 1)
 
-        whenever(settlementRepository.findAll()).thenReturn(listOf(settlement))
+        whenever(settlementRepository.findAll(any<Pageable>())).thenReturn(page)
         whenever(settlementSummaryRepository.findBySettlementIdIn(listOf(1L))).thenReturn(emptyList())
         whenever(settlementSummaryRepository.saveAll(any<List<SettlementSummary>>())).thenAnswer { it.arguments[0] }
 
@@ -66,8 +72,10 @@ class SettlementSnapshotServiceTest {
     fun 기존_Summary가_있으면_업데이트한다() {
         val settlement = createSettlement(1L)
         val existingSummary = SettlementSummary.from(settlement)
+        val pageable = PageRequest.of(0, 200, Sort.by("id"))
+        val page = PageImpl(listOf(settlement), pageable, 1)
 
-        whenever(settlementRepository.findAll()).thenReturn(listOf(settlement))
+        whenever(settlementRepository.findAll(any<Pageable>())).thenReturn(page)
         whenever(settlementSummaryRepository.findBySettlementIdIn(listOf(1L))).thenReturn(listOf(existingSummary))
 
         settlementSnapshotService.createSnapshot()


### PR DESCRIPTION
Closes #401

### 📌 작업 개요
SettlementSnapshotService.createSnapshot()에서 settlementRepository.findAll()을
PageRequest 기반 배치 처리로 전환하여 대량 데이터 환경에서의 메모리/트랜잭션 안정성을 확보합니다.

---

### ✅ 주요 변경 사항

- `settlement.service`
  - `SettlementSnapshotService`: findAll() → 페이지 단위 배치 처리로 전환

---

### 🧪 테스트

- settlement-service 전체 테스트 통과 확인

---

### 📎 관련 이슈
- #401
