### PR TITLE
perf: RefundEventLog completedSteps LAZY 로딩 전환

### DIFF
--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/refund/domain/RefundEventLog.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/refund/domain/RefundEventLog.kt
@@ -18,7 +18,7 @@ class RefundEventLog(
     @Column(nullable = false)
     val orderId: Long,
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "refund_event_log_steps", joinColumns = [JoinColumn(name = "refund_event_log_id")])
     @Column(name = "step")
     val completedSteps: MutableSet<String> = mutableSetOf()

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/refund/domain/repository/RefundEventLogRepository.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/refund/domain/repository/RefundEventLogRepository.kt
@@ -2,10 +2,13 @@ package com.hoppingmall.payment.refund.domain.repository
 
 import com.hoppingmall.payment.refund.domain.RefundEventLog
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
 interface RefundEventLogRepository : JpaRepository<RefundEventLog, Long> {
     fun existsByEventId(eventId: String): Boolean
-    fun findByEventId(eventId: String): RefundEventLog?
+
+    @Query("SELECT r FROM RefundEventLog r LEFT JOIN FETCH r.completedSteps WHERE r.eventId = :eventId")
+    fun findByEventIdWithSteps(eventId: String): RefundEventLog?
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/refund/service/RefundCompletionConsumer.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/refund/service/RefundCompletionConsumer.kt
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 
 @Service
@@ -65,9 +66,10 @@ class RefundCompletionConsumer(
         )
     }
 
+    @Transactional
     fun processRefundCompletion(event: RefundCompletedEvent) {
         try {
-            val existingLog = refundEventLogRepository.findByEventId(event.eventId)
+            val existingLog = refundEventLogRepository.findByEventIdWithSteps(event.eventId)
             if (existingLog != null && existingLog.completedSteps.size >= 6) {
                 logger.info("이미 완료된 환불 이벤트: ${event.eventId}")
                 return
@@ -97,7 +99,7 @@ class RefundCompletionConsumer(
                 )
             )
         } catch (e: DataIntegrityViolationException) {
-            refundEventLogRepository.findByEventId(event.eventId)
+            refundEventLogRepository.findByEventIdWithSteps(event.eventId)
                 ?: throw e
         }
     }

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/refund/service/RefundCompletionConsumerTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/refund/service/RefundCompletionConsumerTest.kt
@@ -107,7 +107,7 @@ class RefundCompletionConsumerTest {
         val event = fullRefundEvent()
         val eventLog = newEventLog()
 
-        whenever(refundEventLogRepository.findByEventId(event.eventId)).thenReturn(null)
+        whenever(refundEventLogRepository.findByEventIdWithSteps(event.eventId)).thenReturn(null)
         whenever(refundEventLogRepository.save(any<RefundEventLog>())).thenReturn(eventLog)
         whenever(orderCommandPort.cancelOrder(event.orderId)).thenReturn(true)
 
@@ -126,7 +126,7 @@ class RefundCompletionConsumerTest {
         val event = partialRefundEvent()
         val eventLog = newEventLog(event.eventId)
 
-        whenever(refundEventLogRepository.findByEventId(event.eventId)).thenReturn(null)
+        whenever(refundEventLogRepository.findByEventIdWithSteps(event.eventId)).thenReturn(null)
         whenever(refundEventLogRepository.save(any<RefundEventLog>())).thenReturn(eventLog)
 
         consumer.processRefundCompletion(event)
@@ -142,7 +142,7 @@ class RefundCompletionConsumerTest {
         val event = fullRefundEvent()
         val completedLog = completedEventLog()
 
-        whenever(refundEventLogRepository.findByEventId(event.eventId)).thenReturn(completedLog)
+        whenever(refundEventLogRepository.findByEventIdWithSteps(event.eventId)).thenReturn(completedLog)
 
         consumer.processRefundCompletion(event)
 
@@ -160,7 +160,7 @@ class RefundCompletionConsumerTest {
         partialLog.markStepCompleted(RefundEventLog.COUPON_RESTORED)
         partialLog.markStepCompleted(RefundEventLog.POINTS_REFUNDED)
 
-        whenever(refundEventLogRepository.findByEventId(event.eventId)).thenReturn(partialLog)
+        whenever(refundEventLogRepository.findByEventIdWithSteps(event.eventId)).thenReturn(partialLog)
         whenever(orderCommandPort.cancelOrder(event.orderId)).thenReturn(true)
 
         consumer.processRefundCompletion(event)


### PR DESCRIPTION
Closes #402

### 📌 작업 개요
RefundEventLog.completedSteps의 fetch 전략을 EAGER에서 LAZY로 전환하여
멱등성 체크 시 불필요한 컬렉션 로딩을 제거합니다.

---

### ✅ 주요 변경 사항

- `payment.refund.domain`
  - `RefundEventLog`: completedSteps fetch type EAGER → LAZY 전환
- `payment.refund.domain.repository`
  - `RefundEventLogRepository`: `findByEventIdWithSteps()` JOIN FETCH 쿼리 추가, 기존 `findByEventId()` 제거
- `payment.refund.service`
  - `RefundCompletionConsumer`: `@Transactional` 추가 및 `findByEventIdWithSteps()` 사용으로 전환

---

### 🧪 테스트

- payment-service 전체 테스트 통과 확인 (Kafka E2E 제외 - Docker 환경 미설정)

---

### 📎 관련 이슈
- #402
