### PR TITLE
perf: api-gateway Lettuce 커넥션 풀 설정 추가

### DIFF
--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
 
 	implementation("org.springframework.cloud:spring-cloud-starter-gateway")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
+	implementation("org.apache.commons:commons-pool2")
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 
 	implementation("io.jsonwebtoken:jjwt-api:0.11.5")

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -25,6 +25,12 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+      lettuce:
+        pool:
+          max-active: 32
+          max-idle: 16
+          min-idle: 8
+          max-wait: 2000ms
 
   cloud:
     gateway:


### PR DESCRIPTION
Closes #405

### 📌 작업 개요
api-gateway의 Redis Lettuce 커넥션 풀 설정을 추가하여,
동시 요청 증가 시 Redis 커넥션 병목을 방지합니다.

---

### ✅ 주요 변경 사항

- `api-gateway/build.gradle.kts`
  - `commons-pool2` 의존성 추가 (Lettuce 풀링 활성화에 필요)

- `api-gateway/src/main/resources/application.yml`
  - `spring.data.redis.lettuce.pool` 설정 추가 (max-active: 32, max-idle: 16, min-idle: 8, max-wait: 2000ms)

---

### 📎 관련 이슈
- #405
