### PR TITLE
perf: approveRefund 중복 Refund 조회 제거

### DIFF
--- a/order-service/src/main/kotlin/com/hoppingmall/order/refund/service/RefundCommandServiceImpl.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/refund/service/RefundCommandServiceImpl.kt
@@ -134,12 +134,11 @@ class RefundCommandServiceImpl(
     }
 
     override fun approveRefund(refundId: Long, approverId: Long): RefundResponse {
-        val payment = paymentQueryPort.findById(
-            (refundRepository.findByIdOrNull(refundId) ?: throw RefundNotFoundException()).paymentId
-        ) ?: throw RefundPaymentNotFoundException()
+        val paymentId = (refundRepository.findByIdOrNull(refundId) ?: throw RefundNotFoundException()).paymentId
+        val payment = paymentQueryPort.findById(paymentId) ?: throw RefundPaymentNotFoundException()
 
         return transactionTemplate.execute { _ ->
-            val refund = refundRepository.findByIdOrNull(refundId) ?: throw RefundNotFoundException() 
+            val refund = refundRepository.findByIdOrNull(refundId) ?: throw RefundNotFoundException()
 
             if (refund.sellerId != approverId) {
                 throw RefundAccessDeniedException()

--- a/order-service/src/test/kotlin/com/hoppingmall/order/refund/service/RefundCommandServiceImplTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/refund/service/RefundCommandServiceImplTest.kt
@@ -248,6 +248,16 @@ class RefundCommandServiceImplTest {
     }
 
     @Test
+    fun 환불_승인_시_결제정보가_없으면_예외가_발생한다() {
+        val refund = createRefund()
+        whenever(refundRepository.findById(1L)).thenReturn(Optional.of(refund))
+        whenever(paymentQueryPort.findById(20L)).thenReturn(null)
+
+        assertThatThrownBy { service.approveRefund(1L, 5L) }
+            .isInstanceOf(RefundPaymentNotFoundException::class.java)
+    }
+
+    @Test
     fun 환불_승인_시_트랜잭션_내부_조회_실패하면_예외가_발생한다() {
         val refund = createRefund()
 


### PR DESCRIPTION
Closes #406

### 📌 작업 개요
- `RefundCommandServiceImpl.approveRefund()`에서 동일 Refund 엔티티를 2회 조회하던 것을 개선
- 트랜잭션 밖에서 paymentId 추출 후 재사용하여 불필요한 DB 조회 1회 제거

---
### ✅ 주요 변경 사항
- 트랜잭션 밖 첫 번째 조회에서 `paymentId`를 변수로 추출
- 추출한 `paymentId`로 `paymentQueryPort.findById()` 호출
- 트랜잭션 내부에서는 JPA dirty checking을 위한 managed entity 조회만 유지

---
### 🧪 테스트
- 기존 단위 테스트 전체 통과 확인
- `RefundCommandServiceImplTest` 내 approveRefund 관련 테스트 케이스 정상 동작

---
### 📎 관련 이슈
- #406
