### PR TITLE
perf: flushHourlySnapshot findAllActive() 페이징 처리

### DIFF
--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductStatisticsRepository.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/domain/repository/ProductStatisticsRepository.kt
@@ -56,4 +56,7 @@ interface ProductStatisticsRepository : JpaRepository<ProductStatistics, Long> {
 
     @Query("SELECT ps FROM ProductStatistics ps WHERE ps.todaySalesQuantity > 0 OR ps.todayRefundQuantity > 0")
     fun findAllActive(): List<ProductStatistics>
+
+    @Query("SELECT ps FROM ProductStatistics ps WHERE ps.todaySalesQuantity > 0 OR ps.todayRefundQuantity > 0")
+    fun findAllActive(pageable: Pageable): Slice<ProductStatistics>
 }

--- a/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImpl.kt
@@ -107,36 +107,47 @@ class ProductStatisticsCommandServiceImpl(
         logger.info("일별 통계 스냅샷 완료: ${totalProcessed}건")
     }
 
-    @Transactional
     override fun flushHourlySnapshot() {
         val now = java.time.LocalDateTime.now()
         val today = now.toLocalDate()
         val currentHour = now.hour
-        val activeStats = productStatisticsRepository.findAllActive()
-        if (activeStats.isEmpty()) {
-            logger.info("시간별 통계 스냅샷 완료: 0건 (${currentHour}시)")
-            return
-        }
+        var page = 0
+        var totalProcessed = 0
 
-        val productIds = activeStats.map { it.productId }
-        val existingHourlyMap = productHourlyStatisticsRepository
-            .findByStatisticsDateAndHourAndProductIdIn(today, currentHour, productIds)
-            .associateBy { it.productId }
-
-        val hourlyToSave = mutableListOf<ProductHourlyStatistics>()
-        for (stats in activeStats) {
-            val hourly = existingHourlyMap[stats.productId] ?: ProductHourlyStatistics.create(
-                productId = stats.productId,
-                statisticsDate = today,
-                hour = currentHour
+        while (true) {
+            val slice = productStatisticsRepository.findAllActive(
+                PageRequest.of(page, BATCH_SIZE, Sort.by("id"))
             )
-            hourly.updateFromStatistics(stats)
-            hourlyToSave.add(hourly)
+            if (slice.isEmpty) break
+
+            val chunk = slice.content
+            transactionTemplate.executeWithoutResult {
+                val productIds = chunk.map { it.productId }
+
+                val existingHourlyMap = productHourlyStatisticsRepository
+                    .findByStatisticsDateAndHourAndProductIdIn(today, currentHour, productIds)
+                    .associateBy { it.productId }
+
+                val hourlyToSave = mutableListOf<ProductHourlyStatistics>()
+                for (stats in chunk) {
+                    val hourly = existingHourlyMap[stats.productId] ?: ProductHourlyStatistics.create(
+                        productId = stats.productId,
+                        statisticsDate = today,
+                        hour = currentHour
+                    )
+                    hourly.updateFromStatistics(stats)
+                    hourlyToSave.add(hourly)
+                }
+
+                productHourlyStatisticsRepository.saveAll(hourlyToSave)
+            }
+
+            totalProcessed += chunk.size
+            if (!slice.hasNext()) break
+            page++
         }
 
-        productHourlyStatisticsRepository.saveAll(hourlyToSave)
-
-        logger.info("시간별 통계 스냅샷 완료: ${hourlyToSave.size}건 (${currentHour}시)")
+        logger.info("시간별 통계 스냅샷 완료: ${totalProcessed}건 (${currentHour}시)")
     }
 
     private fun toSalesAmountMap(rows: List<Array<Any>>): Map<Long, BigDecimal> {

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImplTest.kt
@@ -29,6 +29,7 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.SliceImpl
+import org.springframework.data.domain.Sort
 import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.support.TransactionTemplate
 import java.math.BigDecimal
@@ -271,5 +272,31 @@ class ProductStatisticsCommandServiceImplTest {
         service.flushHourlySnapshot()
 
         assertThat(hourly.hourlySalesQuantity).isEqualTo(10)
+    }
+
+    @Test
+    fun 다수_페이지의_시간별_스냅샷을_배치_처리한다() {
+        val stats1 = createStats(1L)
+        stats1.incrementSales(5, BigDecimal("50000"))
+        val stats2 = ProductStatistics.create(
+            productId = 2L, productName = "테스트2", sellerId = 1L, categoryId = 1L
+        ).withId(2L)
+        stats2.incrementSales(3, BigDecimal("30000"))
+
+        val slice0 = SliceImpl(listOf(stats1), PageRequest.of(0, 1, Sort.by("id")), true)
+        val slice1 = SliceImpl(listOf(stats2), PageRequest.of(1, 1, Sort.by("id")), false)
+
+        whenever(productStatisticsRepository.findAllActive(any<Pageable>()))
+            .thenReturn(slice0)
+            .thenReturn(slice1)
+        whenever(productHourlyStatisticsRepository.findByStatisticsDateAndHourAndProductIdIn(any(), any<Int>(), any()))
+            .thenReturn(emptyList())
+        whenever(productHourlyStatisticsRepository.saveAll(any<List<ProductHourlyStatistics>>()))
+            .thenAnswer { it.arguments[0] }
+
+        service.flushHourlySnapshot()
+
+        verify(productHourlyStatisticsRepository, org.mockito.kotlin.times(2))
+            .saveAll(any<List<ProductHourlyStatistics>>())
     }
 }

--- a/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/product/service/ProductStatisticsCommandServiceImplTest.kt
@@ -28,6 +28,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.SliceImpl
 import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.support.TransactionTemplate
 import java.math.BigDecimal
@@ -229,7 +230,8 @@ class ProductStatisticsCommandServiceImplTest {
         val stats = createStats()
         stats.incrementSales(10, BigDecimal("100000"))
 
-        whenever(productStatisticsRepository.findAllActive()).thenReturn(listOf(stats))
+        whenever(productStatisticsRepository.findAllActive(any<Pageable>()))
+            .thenReturn(SliceImpl(listOf(stats)))
         whenever(productHourlyStatisticsRepository.findByStatisticsDateAndHourAndProductIdIn(any(), any<Int>(), any()))
             .thenReturn(emptyList())
         whenever(productHourlyStatisticsRepository.saveAll(any<List<ProductHourlyStatistics>>()))
@@ -242,7 +244,8 @@ class ProductStatisticsCommandServiceImplTest {
 
     @Test
     fun 오늘_활동이_없는_통계는_시간별_스냅샷에서_건너뛴다() {
-        whenever(productStatisticsRepository.findAllActive()).thenReturn(emptyList())
+        whenever(productStatisticsRepository.findAllActive(any<Pageable>()))
+            .thenReturn(SliceImpl(emptyList()))
 
         service.flushHourlySnapshot()
 
@@ -258,7 +261,8 @@ class ProductStatisticsCommandServiceImplTest {
             productId = 1L, statisticsDate = LocalDate.now(), hour = java.time.LocalDateTime.now().hour
         )
 
-        whenever(productStatisticsRepository.findAllActive()).thenReturn(listOf(stats))
+        whenever(productStatisticsRepository.findAllActive(any<Pageable>()))
+            .thenReturn(SliceImpl(listOf(stats)))
         whenever(productHourlyStatisticsRepository.findByStatisticsDateAndHourAndProductIdIn(any(), any<Int>(), any()))
             .thenReturn(listOf(hourly))
         whenever(productHourlyStatisticsRepository.saveAll(any<List<ProductHourlyStatistics>>()))


### PR DESCRIPTION
Closes #409

### 📌 작업 개요
flushHourlySnapshot()에서 findAllActive()로 전체 활성 통계를 한 번에 메모리에 로드하던 방식을
PageRequest 기반 배치 처리로 전환하여 OOM 위험을 제거합니다.
flushDailySnapshot()에 이미 적용된 동일한 페이징 패턴을 사용합니다.

---

### ✅ 주요 변경 사항

- `product.domain.repository`
  - `ProductStatisticsRepository`: Pageable 파라미터를 받는 findAllActive(Pageable) 메서드 추가 (Slice 반환)

- `product.service`
  - `ProductStatisticsCommandServiceImpl`: flushHourlySnapshot()을 PageRequest.of(page, BATCH_SIZE, Sort.by("id")) 기반 배치 루프로 전환

- `product.service (test)`
  - `ProductStatisticsCommandServiceImplTest`: 시간별 스냅샷 테스트를 SliceImpl 기반 페이징 mock으로 변경

---

### 📎 관련 이슈
- #409
