### PR TITLE
refactor: InventoryCommandServiceImpl LocalDateTime.now() 단일 캡처

### DIFF
--- a/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImpl.kt
@@ -87,11 +87,12 @@ class InventoryCommandServiceImpl(
     override fun confirmReservations(reservationIds: List<String>): Boolean {
         if (reservationIds.isEmpty()) return true
 
+        val now = LocalDateTime.now()
         val updatedCount = inventoryReservationRepository.batchUpdateStatusByCas(
             reservationIds = reservationIds,
             expectedStatus = ReservationStatus.RESERVED,
             targetStatus = ReservationStatus.CONFIRMED,
-            updatedAt = LocalDateTime.now()
+            updatedAt = now
         )
 
         if (updatedCount != reservationIds.size) {
@@ -107,7 +108,7 @@ class InventoryCommandServiceImpl(
                     reservationIds = reservationIds,
                     expectedStatus = ReservationStatus.CONFIRMED,
                     targetStatus = ReservationStatus.CANCELLED,
-                    updatedAt = LocalDateTime.now()
+                    updatedAt = now
                 )
                 reservationIds.mapNotNull { rsvId -> inventoryReservationRepository.findByReservationId(rsvId) }
                     .filter { it.status == ReservationStatus.CANCELLED }


### PR DESCRIPTION
Closes #407

### 📌 작업 개요
`InventoryCommandServiceImpl.confirmReservations()` 메서드 내에서 `LocalDateTime.now()`를 두 번 호출하여
동일 트랜잭션 내 타임스탬프가 미세하게 달라질 수 있는 문제를 수정했습니다.
메서드 시작 시 한 번 캡처한 값을 재사용하도록 변경하여 일관성을 확보합니다.

---

### ✅ 주요 변경 사항

- `inventory.service.InventoryCommandServiceImpl`
  - `confirmReservations()`: `val now = LocalDateTime.now()` 단일 캡처 후 재사용

---

### 📎 관련 이슈
- #407
