### PR TITLE
refactor: IdempotencyService Optional → Kotlin nullable 전환

### DIFF
--- a/hoppingmall-idempotency/src/main/kotlin/com/hoppingmall/idempotency/IdempotencyRecordRepository.kt
+++ b/hoppingmall-idempotency/src/main/kotlin/com/hoppingmall/idempotency/IdempotencyRecordRepository.kt
@@ -4,10 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import java.time.LocalDateTime
-import java.util.Optional
 
 interface IdempotencyRecordRepository : JpaRepository<IdempotencyRecord, Long> {
-    fun findByIdempotencyKey(idempotencyKey: String): Optional<IdempotencyRecord>
+    fun findByIdempotencyKey(idempotencyKey: String): IdempotencyRecord?
 
     @Modifying
     @Query("DELETE FROM IdempotencyRecord r WHERE r.expiresAt < :now")

--- a/hoppingmall-idempotency/src/main/kotlin/com/hoppingmall/idempotency/IdempotencyService.kt
+++ b/hoppingmall-idempotency/src/main/kotlin/com/hoppingmall/idempotency/IdempotencyService.kt
@@ -17,8 +17,7 @@ class IdempotencyService(
     @Transactional(readOnly = true)
     fun findByKey(key: String): IdempotencyRecord? =
         idempotencyRecordRepository.findByIdempotencyKey(key)
-            .filter { it.expiresAt.isAfter(LocalDateTime.now()) }
-            .orElse(null)
+            ?.takeIf { it.expiresAt.isAfter(LocalDateTime.now()) }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun save(

--- a/hoppingmall-idempotency/src/test/kotlin/com/hoppingmall/idempotency/IdempotencyServiceTest.kt
+++ b/hoppingmall-idempotency/src/test/kotlin/com/hoppingmall/idempotency/IdempotencyServiceTest.kt
@@ -16,7 +16,6 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.LocalDateTime
-import java.util.Optional
 
 @DisplayName("IdempotencyService")
 @DisplayNameGeneration(ReplaceUnderscores::class)
@@ -44,7 +43,7 @@ class IdempotencyServiceTest {
                 expiresAt = LocalDateTime.now().plusHours(1)
             )
             whenever(idempotencyRecordRepository.findByIdempotencyKey("test-key"))
-                .thenReturn(Optional.of(record))
+                .thenReturn(record)
 
             val result = idempotencyService.findByKey("test-key")
 
@@ -62,7 +61,7 @@ class IdempotencyServiceTest {
                 expiresAt = LocalDateTime.now().minusHours(1)
             )
             whenever(idempotencyRecordRepository.findByIdempotencyKey("test-key"))
-                .thenReturn(Optional.of(expiredRecord))
+                .thenReturn(expiredRecord)
 
             val result = idempotencyService.findByKey("test-key")
 
@@ -72,7 +71,7 @@ class IdempotencyServiceTest {
         @Test
         fun 키가_존재하지_않으면_null을_반환한다() {
             whenever(idempotencyRecordRepository.findByIdempotencyKey("missing-key"))
-                .thenReturn(Optional.empty())
+                .thenReturn(null)
 
             val result = idempotencyService.findByKey("missing-key")
 

--- a/order-service/src/test/kotlin/com/hoppingmall/order/idempotency/IdempotencyServiceTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/idempotency/IdempotencyServiceTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
 import java.time.LocalDateTime
-import java.util.Optional
 
 @DisplayName("IdempotencyService")
 @DisplayNameGeneration(ReplaceUnderscores::class)
@@ -38,7 +37,7 @@ class IdempotencyServiceTest {
             )
 
             whenever(idempotencyRecordRepository.findByIdempotencyKey(key))
-                .thenReturn(Optional.of(record))
+                .thenReturn(record)
 
             val result = idempotencyService.findByKey(key)
 
@@ -61,7 +60,7 @@ class IdempotencyServiceTest {
             )
 
             whenever(idempotencyRecordRepository.findByIdempotencyKey(key))
-                .thenReturn(Optional.of(record))
+                .thenReturn(record)
 
             val result = idempotencyService.findByKey(key)
 
@@ -73,7 +72,7 @@ class IdempotencyServiceTest {
             val key = "nonexistent-key"
 
             whenever(idempotencyRecordRepository.findByIdempotencyKey(key))
-                .thenReturn(Optional.empty())
+                .thenReturn(null)
 
             val result = idempotencyService.findByKey(key)
 


### PR DESCRIPTION
Closes #413

### 📌 작업 개요
IdempotencyRecordRepository의 반환 타입을 Java Optional에서 Kotlin nullable로 전환하고,
IdempotencyService에서 Optional 체인을 Kotlin idiomatic 패턴으로 변경합니다.

---

### ✅ 주요 변경 사항

- `idempotency`
  - `IdempotencyRecordRepository`: `findByIdempotencyKey()` 반환 타입 `Optional<IdempotencyRecord>` → `IdempotencyRecord?`
  - `IdempotencyService`: `.filter().orElse(null)` → `?.takeIf {}`

- `idempotency (test)`
  - `IdempotencyServiceTest` (idempotency, order-service): `Optional.of()`/`Optional.empty()` → 직접 값/null

---

### 🧪 테스트

- `IdempotencyServiceTest` (hoppingmall-idempotency): 전체 통과
- `IdempotencyServiceTest` (order-service): 전체 통과

---

### 📎 관련 이슈
- #413
