### PR TITLE
feat: 엔드포인트별 차등 처리율 제한 구현

### DIFF
--- a/api-gateway/src/main/kotlin/com/hoppingmall/gateway/config/RateLimitConfig.kt
+++ b/api-gateway/src/main/kotlin/com/hoppingmall/gateway/config/RateLimitConfig.kt
@@ -1,28 +1,23 @@
 package com.hoppingmall.gateway.config
 
-import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver
-import org.springframework.cloud.gateway.filter.ratelimit.RedisRateLimiter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import reactor.core.publisher.Mono
+import java.time.Duration
 
 @Configuration
 class RateLimitConfig {
 
     @Bean
-    fun userKeyResolver(): KeyResolver {
-        return KeyResolver { exchange ->
-            val userId = exchange.request.headers.getFirst("x-user-id")
-            if (userId != null) {
-                Mono.just("user:$userId")
-            } else {
-                Mono.just("ip:${exchange.request.remoteAddress?.address?.hostAddress ?: "anonymous"}")
-            }
-        }
-    }
-
-    @Bean
-    fun redisRateLimiter(): RedisRateLimiter {
-        return RedisRateLimiter(50, 100, 1)
-    }
+    fun rateLimitPolicies(): List<RateLimitPolicy> = listOf(
+        RateLimitPolicy("login", "/api/v1/users/login", "POST", RateLimitKeyType.IP, 5, Duration.ofMinutes(1)),
+        RateLimitPolicy("signup", "/api/v1/users/signup", "POST", RateLimitKeyType.IP, 3, Duration.ofMinutes(1)),
+        RateLimitPolicy("refresh", "/api/v1/auth/refresh", "POST", RateLimitKeyType.USER_ID, 10, Duration.ofMinutes(1)),
+        RateLimitPolicy("coupon-issue", "/api/v1/coupons/*/issue", "POST", RateLimitKeyType.USER_ID, 5, Duration.ofMinutes(1)),
+        RateLimitPolicy("search", "/api/v1/products/search", "GET", RateLimitKeyType.USER_ID, 60, Duration.ofMinutes(1)),
+        RateLimitPolicy("upload", "/api/v1/products/images/upload", "POST", RateLimitKeyType.USER_ID, 20, Duration.ofMinutes(1)),
+        RateLimitPolicy("create-order", "/api/v1/orders", "POST", RateLimitKeyType.USER_ID, 5, Duration.ofMinutes(1)),
+        RateLimitPolicy("create-payment", "/api/v1/payments", "POST", RateLimitKeyType.USER_ID, 10, Duration.ofMinutes(1)),
+        RateLimitPolicy("create-refund", "/api/v1/refunds", "POST", RateLimitKeyType.USER_ID, 5, Duration.ofMinutes(1)),
+        RateLimitPolicy("create-review", "/api/v1/reviews", "POST", RateLimitKeyType.USER_ID, 5, Duration.ofMinutes(1))
+    )
 }

--- a/api-gateway/src/main/kotlin/com/hoppingmall/gateway/config/RateLimitPolicy.kt
+++ b/api-gateway/src/main/kotlin/com/hoppingmall/gateway/config/RateLimitPolicy.kt
@@ -1,0 +1,16 @@
+package com.hoppingmall.gateway.config
+
+import java.time.Duration
+
+enum class RateLimitKeyType {
+    IP, USER_ID
+}
+
+data class RateLimitPolicy(
+    val id: String,
+    val pathPattern: String,
+    val httpMethod: String? = null,
+    val keyType: RateLimitKeyType,
+    val maxRequests: Long,
+    val window: Duration
+)

--- a/api-gateway/src/main/kotlin/com/hoppingmall/gateway/filter/RateLimitGlobalFilter.kt
+++ b/api-gateway/src/main/kotlin/com/hoppingmall/gateway/filter/RateLimitGlobalFilter.kt
@@ -1,44 +1,109 @@
 package com.hoppingmall.gateway.filter
 
+import com.hoppingmall.gateway.config.RateLimitKeyType
+import com.hoppingmall.gateway.config.RateLimitPolicy
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.cloud.gateway.filter.GatewayFilterChain
 import org.springframework.cloud.gateway.filter.GlobalFilter
-import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver
-import org.springframework.cloud.gateway.filter.ratelimit.RedisRateLimiter
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
+import org.springframework.util.AntPathMatcher
 import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
+import java.time.Duration
 
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE + 5)
 class RateLimitGlobalFilter(
-    private val keyResolver: KeyResolver,
-    private val redisRateLimiter: RedisRateLimiter
+    private val policies: List<RateLimitPolicy>,
+    private val redisTemplate: ReactiveStringRedisTemplate,
+    @Value("\${gateway.rate-limit.enabled:true}")
+    private val enabled: Boolean
 ) : GlobalFilter {
 
+    private val pathMatcher = AntPathMatcher()
+
+    companion object {
+        private val GLOBAL_FALLBACK = RateLimitPolicy(
+            id = "global",
+            pathPattern = "/**",
+            keyType = RateLimitKeyType.USER_ID,
+            maxRequests = 200,
+            window = Duration.ofMinutes(1)
+        )
+    }
+
     override fun filter(exchange: ServerWebExchange, chain: GatewayFilterChain): Mono<Void> {
+        if (!enabled) {
+            return chain.filter(exchange)
+        }
+
         val path = exchange.request.uri.path
 
         if (isExcluded(path)) {
             return chain.filter(exchange)
         }
 
-        return keyResolver.resolve(exchange).flatMap { key ->
-            redisRateLimiter.isAllowed("gateway", key).flatMap { response ->
-                if (response.isAllowed) {
-                    response.headers.forEach { (name, value) ->
-                        exchange.response.headers[name] = listOf(value)
-                    }
+        val method = exchange.request.method.name()
+        val policy = findPolicy(path, method) ?: GLOBAL_FALLBACK
+
+        return checkLimit(exchange, chain, policy)
+    }
+
+    private fun findPolicy(path: String, method: String?): RateLimitPolicy? {
+        return policies.find { policy ->
+            pathMatcher.match(policy.pathPattern, path) &&
+                (policy.httpMethod == null || policy.httpMethod == method)
+        }
+    }
+
+    private fun resolveKey(exchange: ServerWebExchange, keyType: RateLimitKeyType): String {
+        return when (keyType) {
+            RateLimitKeyType.USER_ID -> {
+                exchange.request.headers.getFirst("x-user-id")
+                    ?: exchange.request.remoteAddress?.address?.hostAddress
+                    ?: "anonymous"
+            }
+            RateLimitKeyType.IP -> {
+                exchange.request.remoteAddress?.address?.hostAddress ?: "anonymous"
+            }
+        }
+    }
+
+    private fun checkLimit(
+        exchange: ServerWebExchange,
+        chain: GatewayFilterChain,
+        policy: RateLimitPolicy
+    ): Mono<Void> {
+        val key = resolveKey(exchange, policy.keyType)
+        val windowSeconds = policy.window.seconds
+        val window = System.currentTimeMillis() / (windowSeconds * 1000)
+        val redisKey = "rl:${policy.id}:$key:$window"
+
+        return redisTemplate.opsForValue().increment(redisKey)
+            .flatMap { count ->
+                if (count == 1L) {
+                    redisTemplate.expire(redisKey, policy.window).thenReturn(count)
+                } else {
+                    Mono.just(count)
+                }
+            }
+            .flatMap { count ->
+                val remaining = (policy.maxRequests - count).coerceAtLeast(0)
+                exchange.response.headers.set("X-RateLimit-Limit", policy.maxRequests.toString())
+                exchange.response.headers.set("X-RateLimit-Remaining", remaining.toString())
+
+                if (count <= policy.maxRequests) {
                     chain.filter(exchange)
                 } else {
                     exchange.response.statusCode = HttpStatus.TOO_MANY_REQUESTS
-                    exchange.response.headers.set("Retry-After", "1")
+                    exchange.response.headers.set("Retry-After", windowSeconds.toString())
                     exchange.response.setComplete()
                 }
             }
-        }
     }
 
     private fun isExcluded(path: String): Boolean {
@@ -46,9 +111,6 @@ class RateLimitGlobalFilter(
             path.startsWith("/internal") ||
             path.startsWith("/swagger-ui") ||
             path.startsWith("/v3/api-docs") ||
-            path.startsWith("/webjars") ||
-            path == "/api/v1/users/signup" ||
-            path == "/api/v1/users/login" ||
-            path == "/api/v1/auth/refresh"
+            path.startsWith("/webjars")
     }
 }

--- a/api-gateway/src/test/kotlin/com/hoppingmall/gateway/filter/RateLimitGlobalFilterTest.kt
+++ b/api-gateway/src/test/kotlin/com/hoppingmall/gateway/filter/RateLimitGlobalFilterTest.kt
@@ -1,5 +1,7 @@
 package com.hoppingmall.gateway.filter
 
+import com.hoppingmall.gateway.config.RateLimitKeyType
+import com.hoppingmall.gateway.config.RateLimitPolicy
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
@@ -9,16 +11,19 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.cloud.gateway.filter.GatewayFilterChain
-import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver
-import org.springframework.cloud.gateway.filter.ratelimit.RateLimiter
-import org.springframework.cloud.gateway.filter.ratelimit.RedisRateLimiter
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import org.springframework.data.redis.core.ReactiveValueOperations
 import org.springframework.http.HttpStatus
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest
 import org.springframework.mock.web.server.MockServerWebExchange
 import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
+import java.time.Duration
 
 @DisplayName("RateLimitGlobalFilter")
 @DisplayNameGeneration(ReplaceUnderscores::class)
@@ -26,12 +31,18 @@ import reactor.core.publisher.Mono
 class RateLimitGlobalFilterTest {
 
     @Mock
-    private lateinit var keyResolver: KeyResolver
+    private lateinit var redisTemplate: ReactiveStringRedisTemplate
 
     @Mock
-    private lateinit var redisRateLimiter: RedisRateLimiter
+    private lateinit var valueOps: ReactiveValueOperations<String, String>
 
-    private fun buildFilter() = RateLimitGlobalFilter(keyResolver, redisRateLimiter)
+    private val policies = listOf(
+        RateLimitPolicy("login", "/api/v1/users/login", "POST", RateLimitKeyType.IP, 5, Duration.ofMinutes(1)),
+        RateLimitPolicy("signup", "/api/v1/users/signup", "POST", RateLimitKeyType.IP, 3, Duration.ofMinutes(1)),
+        RateLimitPolicy("create-order", "/api/v1/orders", "POST", RateLimitKeyType.USER_ID, 5, Duration.ofMinutes(1))
+    )
+
+    private fun buildFilter(enabled: Boolean = true) = RateLimitGlobalFilter(policies, redisTemplate, enabled)
 
     private fun chainCapturing(captured: MutableList<ServerWebExchange>): GatewayFilterChain =
         GatewayFilterChain { exchange ->
@@ -39,11 +50,13 @@ class RateLimitGlobalFilterTest {
             Mono.empty()
         }
 
-    private fun allowedResponse(): RateLimiter.Response =
-        RateLimiter.Response(true, mapOf("X-RateLimit-Remaining" to "49"))
-
-    private fun deniedResponse(): RateLimiter.Response =
-        RateLimiter.Response(false, emptyMap())
+    private fun mockRedisIncrement(count: Long) {
+        whenever(redisTemplate.opsForValue()).thenReturn(valueOps)
+        whenever(valueOps.increment(any())).thenReturn(Mono.just(count))
+        if (count == 1L) {
+            whenever(redisTemplate.expire(any(), any<Duration>())).thenReturn(Mono.just(true))
+        }
+    }
 
     @Test
     fun actuator_경로는_레이트_리밋을_건너뛴다() {
@@ -101,42 +114,8 @@ class RateLimitGlobalFilterTest {
     }
 
     @Test
-    fun 회원가입_경로는_레이트_리밋을_건너뛴다() {
-        val request = MockServerHttpRequest.post("/api/v1/users/signup").build()
-        val exchange = MockServerWebExchange.from(request)
-        val captured = mutableListOf<ServerWebExchange>()
-
-        buildFilter().filter(exchange, chainCapturing(captured)).block()
-
-        assertThat(captured).hasSize(1)
-    }
-
-    @Test
-    fun 로그인_경로는_레이트_리밋을_건너뛴다() {
-        val request = MockServerHttpRequest.post("/api/v1/users/login").build()
-        val exchange = MockServerWebExchange.from(request)
-        val captured = mutableListOf<ServerWebExchange>()
-
-        buildFilter().filter(exchange, chainCapturing(captured)).block()
-
-        assertThat(captured).hasSize(1)
-    }
-
-    @Test
-    fun 토큰_갱신_경로는_레이트_리밋을_건너뛴다() {
-        val request = MockServerHttpRequest.post("/api/v1/auth/refresh").build()
-        val exchange = MockServerWebExchange.from(request)
-        val captured = mutableListOf<ServerWebExchange>()
-
-        buildFilter().filter(exchange, chainCapturing(captured)).block()
-
-        assertThat(captured).hasSize(1)
-    }
-
-    @Test
     fun 허용된_요청이면_다음_필터로_전달한다() {
-        whenever(keyResolver.resolve(any())).thenReturn(Mono.just("user:1"))
-        whenever(redisRateLimiter.isAllowed(any(), any())).thenReturn(Mono.just(allowedResponse()))
+        mockRedisIncrement(1L)
 
         val request = MockServerHttpRequest.get("/api/v1/products").build()
         val exchange = MockServerWebExchange.from(request)
@@ -149,8 +128,7 @@ class RateLimitGlobalFilterTest {
 
     @Test
     fun 허용된_요청이면_레이트_리밋_헤더가_응답에_포함된다() {
-        whenever(keyResolver.resolve(any())).thenReturn(Mono.just("user:1"))
-        whenever(redisRateLimiter.isAllowed(any(), any())).thenReturn(Mono.just(allowedResponse()))
+        mockRedisIncrement(1L)
 
         val request = MockServerHttpRequest.get("/api/v1/products").build()
         val exchange = MockServerWebExchange.from(request)
@@ -158,13 +136,13 @@ class RateLimitGlobalFilterTest {
 
         buildFilter().filter(exchange, chainCapturing(captured)).block()
 
-        assertThat(captured[0].response.headers["X-RateLimit-Remaining"]).containsExactly("49")
+        assertThat(exchange.response.headers.getFirst("X-RateLimit-Limit")).isEqualTo("200")
+        assertThat(exchange.response.headers.getFirst("X-RateLimit-Remaining")).isEqualTo("199")
     }
 
     @Test
-    fun 허용_한도를_초과하면_429를_반환한다() {
-        whenever(keyResolver.resolve(any())).thenReturn(Mono.just("user:1"))
-        whenever(redisRateLimiter.isAllowed(any(), any())).thenReturn(Mono.just(deniedResponse()))
+    fun 글로벌_한도를_초과하면_429를_반환한다() {
+        mockRedisIncrement(201L)
 
         val request = MockServerHttpRequest.get("/api/v1/products").build()
         val exchange = MockServerWebExchange.from(request)
@@ -177,15 +155,125 @@ class RateLimitGlobalFilterTest {
     }
 
     @Test
-    fun 허용_한도를_초과하면_Retry_After_헤더가_1로_설정된다() {
-        whenever(keyResolver.resolve(any())).thenReturn(Mono.just("user:1"))
-        whenever(redisRateLimiter.isAllowed(any(), any())).thenReturn(Mono.just(deniedResponse()))
+    fun 한도_초과_시_Retry_After_헤더가_설정된다() {
+        mockRedisIncrement(201L)
 
-        val request = MockServerHttpRequest.get("/api/v1/orders").build()
+        val request = MockServerHttpRequest.get("/api/v1/products").build()
         val exchange = MockServerWebExchange.from(request)
 
         buildFilter().filter(exchange, chainCapturing(mutableListOf())).block()
 
-        assertThat(exchange.response.headers.getFirst("Retry-After")).isEqualTo("1")
+        assertThat(exchange.response.headers.getFirst("Retry-After")).isEqualTo("60")
+    }
+
+    @Test
+    fun 로그인_엔드포인트는_IP_기반_5회_제한이_적용된다() {
+        mockRedisIncrement(6L)
+
+        val request = MockServerHttpRequest.post("/api/v1/users/login").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(exchange.response.statusCode).isEqualTo(HttpStatus.TOO_MANY_REQUESTS)
+        assertThat(captured).isEmpty()
+    }
+
+    @Test
+    fun 로그인_엔드포인트_한도_내_요청은_통과한다() {
+        mockRedisIncrement(3L)
+
+        val request = MockServerHttpRequest.post("/api/v1/users/login").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured).hasSize(1)
+        assertThat(exchange.response.headers.getFirst("X-RateLimit-Limit")).isEqualTo("5")
+        assertThat(exchange.response.headers.getFirst("X-RateLimit-Remaining")).isEqualTo("2")
+    }
+
+    @Test
+    fun 회원가입_엔드포인트는_3회_제한이_적용된다() {
+        mockRedisIncrement(4L)
+
+        val request = MockServerHttpRequest.post("/api/v1/users/signup").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(exchange.response.statusCode).isEqualTo(HttpStatus.TOO_MANY_REQUESTS)
+        assertThat(captured).isEmpty()
+    }
+
+    @Test
+    fun 정책에_없는_GET_요청은_글로벌_폴백이_적용된다() {
+        mockRedisIncrement(50L)
+
+        val request = MockServerHttpRequest.get("/api/v1/notifications").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured).hasSize(1)
+        assertThat(exchange.response.headers.getFirst("X-RateLimit-Limit")).isEqualTo("200")
+    }
+
+    @Test
+    fun enabled가_false이면_모든_요청을_통과시킨다() {
+        val request = MockServerHttpRequest.get("/api/v1/products").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter(enabled = false).filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured).hasSize(1)
+        verify(redisTemplate, never()).opsForValue()
+    }
+
+    @Test
+    fun 첫_번째_요청이면_Redis_TTL을_설정한다() {
+        mockRedisIncrement(1L)
+
+        val request = MockServerHttpRequest.get("/api/v1/products").build()
+        val exchange = MockServerWebExchange.from(request)
+
+        buildFilter().filter(exchange, chainCapturing(mutableListOf())).block()
+
+        verify(redisTemplate).expire(any(), eq(Duration.ofMinutes(1)))
+    }
+
+    @Test
+    fun POST_주문_엔드포인트는_USER_ID_기반_5회_제한이_적용된다() {
+        mockRedisIncrement(6L)
+
+        val request = MockServerHttpRequest.post("/api/v1/orders")
+            .header("x-user-id", "42")
+            .build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(exchange.response.statusCode).isEqualTo(HttpStatus.TOO_MANY_REQUESTS)
+        assertThat(exchange.response.headers.getFirst("X-RateLimit-Limit")).isEqualTo("5")
+    }
+
+    @Test
+    fun GET_주문_엔드포인트는_글로벌_폴백이_적용된다() {
+        mockRedisIncrement(10L)
+
+        val request = MockServerHttpRequest.get("/api/v1/orders").build()
+        val exchange = MockServerWebExchange.from(request)
+        val captured = mutableListOf<ServerWebExchange>()
+
+        buildFilter().filter(exchange, chainCapturing(captured)).block()
+
+        assertThat(captured).hasSize(1)
+        assertThat(exchange.response.headers.getFirst("X-RateLimit-Limit")).isEqualTo("200")
     }
 }


### PR DESCRIPTION
Closes #417

### 📌 작업 개요
API Gateway에 엔드포인트별 차등 Rate Limiting 적용

---

### ✅ 주요 변경 사항

- `gateway/config`
  - `RateLimitPolicy`: 정책 데이터 클래스 추가
  - `RateLimitConfig`: 엔드포인트별 정책 정의

- `gateway/filter`
  - `RateLimitGlobalFilter`: Redis 고정 윈도우 카운터 기반으로 재구현, 글로벌 폴백 적용, 부하테스트 해제 지원

---

### 🧪 테스트

- `RateLimitGlobalFilterTest`: 정책별 제한, 글로벌 폴백, 비활성화 등 테스트
- api-gateway 전체 테스트 통과

---

### 📎 관련 이슈
- #417
