### PR TITLE
feat: TwoLevelCache 비-hot 키 single-flight stampede 보호

### DIFF
--- a/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/TwoLevelCache.kt
+++ b/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/TwoLevelCache.kt
@@ -2,11 +2,17 @@ package com.hoppingmall.cache
 
 import com.github.benmanes.caffeine.cache.Cache
 import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.cache.support.AbstractValueAdaptingCache
 import java.time.Duration
 import java.util.concurrent.Callable
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 class TwoLevelCache(
     private val name: String,
@@ -32,12 +38,26 @@ class TwoLevelCache(
     private val l2FailureCounter = meterRegistry?.let {
         Counter.builder("cache.l2.failure").tag("cache", name).register(it)
     }
+    private val singleFlightCollapsedCounter = meterRegistry?.let {
+        Counter.builder("cache.singleflight.collapsed").tag("cache", name).register(it)
+    }
+
+    private val inFlightLoads = ConcurrentHashMap<Any, CompletableFuture<Any?>>()
+
+    init {
+        meterRegistry?.let {
+            Gauge.builder("cache.singleflight.inflight", inFlightLoads) { it.size.toDouble() }
+                .tag("cache", name)
+                .register(it)
+        }
+    }
 
     companion object {
         private const val LOCK_KEY_PREFIX = "lock:"
         private val LOCK_LEASE_TIME = Duration.ofSeconds(3)
         private const val LOCK_RETRY_INTERVAL_MS = 50L
         private const val LOCK_MAX_WAIT_MS = 500L
+        private const val SINGLE_FLIGHT_TIMEOUT_MS = 500L
     }
 
     override fun getName(): String = name
@@ -93,7 +113,7 @@ class TwoLevelCache(
         }
 
         missCounter?.increment()
-        return loadAndCache(key, valueLoader)
+        return loadWithSingleFlight(key, valueLoader)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -153,6 +173,38 @@ class TwoLevelCache(
         val loaded = valueLoader.call()
         put(key, loaded)
         return loaded
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : Any?> loadWithSingleFlight(key: Any, valueLoader: Callable<T>): T? {
+        val newFuture = CompletableFuture<Any?>()
+        val existing = inFlightLoads.putIfAbsent(key, newFuture)
+
+        if (existing != null) {
+            singleFlightCollapsedCounter?.increment()
+            return try {
+                existing.get(SINGLE_FLIGHT_TIMEOUT_MS, TimeUnit.MILLISECONDS) as T?
+            } catch (e: TimeoutException) {
+                log.warn("Single-flight 대기 초과 [cache={}, key={}], DB 로더 직접 호출", name, key)
+                loadAndCache(key, valueLoader)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+                loadAndCache(key, valueLoader)
+            } catch (e: ExecutionException) {
+                throw e.cause ?: e
+            }
+        }
+
+        return try {
+            val result = loadAndCache(key, valueLoader)
+            newFuture.complete(result)
+            result
+        } catch (e: Exception) {
+            newFuture.completeExceptionally(e)
+            throw e
+        } finally {
+            inFlightLoads.remove(key, newFuture)
+        }
     }
 
     override fun put(key: Any, value: Any?) {

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TwoLevelCacheSingleFlightTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TwoLevelCacheSingleFlightTest.kt
@@ -1,0 +1,401 @@
+package com.hoppingmall.cache
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.cache.Cache
+import java.time.Duration
+import java.util.concurrent.Callable
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+@DisplayName("TwoLevelCache single-flight")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class TwoLevelCacheSingleFlightTest {
+
+    private val redisCache: Cache = mock()
+    private val lockProvider = FakeLockProvider()
+    private lateinit var meterRegistry: SimpleMeterRegistry
+
+    private val normalPolicy = CachePolicy(
+        cacheName = "category",
+        l1MaxSize = 100,
+        l1Ttl = Duration.ofSeconds(30),
+        l2Ttl = Duration.ofMinutes(5),
+        jitterPercent = 10
+    )
+
+    private val hotKeyPolicy = CachePolicy(
+        cacheName = "product",
+        l1MaxSize = 100,
+        l1Ttl = Duration.ofSeconds(10),
+        l2Ttl = Duration.ofMinutes(10),
+        jitterPercent = 10,
+        hotKeyThreshold = 5L,
+        hotKeyShardCount = 4
+    )
+
+    @BeforeEach
+    fun setUp() {
+        lockProvider.reset()
+        meterRegistry = SimpleMeterRegistry()
+        whenever(redisCache.get(org.mockito.kotlin.any())).thenReturn(null)
+    }
+
+    private fun createNonHotCache(): TwoLevelCache {
+        val caffeineCache = Caffeine.newBuilder()
+            .maximumSize(normalPolicy.l1MaxSize)
+            .expireAfterWrite(normalPolicy.l1Ttl)
+            .build<Any, Any>()
+        return TwoLevelCache(
+            normalPolicy.cacheName, caffeineCache, redisCache, normalPolicy,
+            lockProvider, meterRegistry = meterRegistry
+        )
+    }
+
+    private fun collapsedCount(cacheName: String = "category"): Double =
+        meterRegistry.counter("cache.singleflight.collapsed", "cache", cacheName).count()
+
+    @Nested
+    @DisplayName("비-hot 키 동시 요청")
+    inner class NonHotConcurrency {
+
+        @Test
+        fun 동시_100_스레드_cache_miss_시_DB_로더는_1회만_호출된다() {
+            val cache = createNonHotCache()
+            val threadCount = 100
+            val loaderCount = AtomicInteger(0)
+            val barrier = CyclicBarrier(threadCount)
+            val latch = CountDownLatch(threadCount)
+            val executor = Executors.newFixedThreadPool(threadCount)
+            val gate = CountDownLatch(1)
+
+            val results = ConcurrentLinkedQueue<Any?>()
+
+            repeat(threadCount) {
+                executor.submit {
+                    try {
+                        barrier.await()
+                        val v = cache.get(1L, Callable<String> {
+                            loaderCount.incrementAndGet()
+                            gate.await()
+                            "loaded-value"
+                        })
+                        results.add(v)
+                    } finally {
+                        latch.countDown()
+                    }
+                }
+            }
+
+            Thread.sleep(150)
+            gate.countDown()
+            assertTrue(latch.await(10, TimeUnit.SECONDS), "all threads finished")
+            executor.shutdown()
+
+            assertEquals(1, loaderCount.get(), "loader 호출은 정확히 1회")
+            assertEquals(threadCount, results.size)
+            println("[VERIFY] 100 threads -> DB 1 call: loaderCount=${loaderCount.get()}")
+        }
+
+        @Test
+        fun 모든_스레드가_동일한_결과를_수신한다() {
+            val cache = createNonHotCache()
+            val threadCount = 100
+            val barrier = CyclicBarrier(threadCount)
+            val latch = CountDownLatch(threadCount)
+            val executor = Executors.newFixedThreadPool(threadCount)
+            val gate = CountDownLatch(1)
+            val expected = "single-result"
+            val results = ConcurrentLinkedQueue<Any?>()
+
+            repeat(threadCount) {
+                executor.submit {
+                    try {
+                        barrier.await()
+                        val v = cache.get(2L, Callable<String> {
+                            gate.await()
+                            expected
+                        })
+                        results.add(v)
+                    } finally {
+                        latch.countDown()
+                    }
+                }
+            }
+
+            Thread.sleep(150)
+            gate.countDown()
+            assertTrue(latch.await(10, TimeUnit.SECONDS))
+            executor.shutdown()
+
+            assertEquals(threadCount, results.size)
+            assertEquals(setOf<Any?>(expected), results.toSet())
+        }
+
+        @Test
+        fun collapsed_메트릭이_99_증가한다() {
+            val cache = createNonHotCache()
+            val threadCount = 100
+            val barrier = CyclicBarrier(threadCount)
+            val latch = CountDownLatch(threadCount)
+            val executor = Executors.newFixedThreadPool(threadCount)
+            val gate = CountDownLatch(1)
+
+            repeat(threadCount) {
+                executor.submit {
+                    try {
+                        barrier.await()
+                        cache.get(3L, Callable<String> {
+                            gate.await()
+                            "v"
+                        })
+                    } finally {
+                        latch.countDown()
+                    }
+                }
+            }
+
+            Thread.sleep(150)
+            gate.countDown()
+            assertTrue(latch.await(10, TimeUnit.SECONDS))
+            executor.shutdown()
+
+            assertEquals(99.0, collapsedCount(), 0.0001)
+        }
+    }
+
+    @Nested
+    @DisplayName("예외 전파")
+    inner class ExceptionPropagation {
+
+        @Test
+        fun DB_로더_예외_시_모든_대기_스레드가_동일_예외를_전파받는다() {
+            val cache = createNonHotCache()
+            val threadCount = 50
+            val barrier = CyclicBarrier(threadCount)
+            val latch = CountDownLatch(threadCount)
+            val executor = Executors.newFixedThreadPool(threadCount)
+            val gate = CountDownLatch(1)
+            val loaderCount = AtomicInteger(0)
+            val errors = ConcurrentLinkedQueue<Throwable>()
+
+            repeat(threadCount) {
+                executor.submit {
+                    try {
+                        barrier.await()
+                        try {
+                            cache.get(4L, Callable<String> {
+                                loaderCount.incrementAndGet()
+                                gate.await()
+                                throw IllegalStateException("loader-failed")
+                            })
+                        } catch (e: Throwable) {
+                            errors.add(e)
+                        }
+                    } finally {
+                        latch.countDown()
+                    }
+                }
+            }
+
+            Thread.sleep(150)
+            gate.countDown()
+            assertTrue(latch.await(10, TimeUnit.SECONDS))
+            executor.shutdown()
+
+            assertEquals(1, loaderCount.get())
+            assertEquals(threadCount, errors.size)
+            errors.forEach { e ->
+                assertTrue(e is IllegalStateException) { "got ${e::class.qualifiedName}" }
+                assertEquals("loader-failed", e.message)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("null 결과")
+    inner class NullResult {
+
+        @Test
+        fun DB_로더가_null을_반환하면_모든_스레드가_null을_수신한다() {
+            val cache = createNonHotCache()
+            val threadCount = 30
+            val barrier = CyclicBarrier(threadCount)
+            val latch = CountDownLatch(threadCount)
+            val executor = Executors.newFixedThreadPool(threadCount)
+            val gate = CountDownLatch(1)
+            val loaderCount = AtomicInteger(0)
+            val nullCount = AtomicInteger(0)
+
+            repeat(threadCount) {
+                executor.submit {
+                    try {
+                        barrier.await()
+                        val v = cache.get(5L, Callable<String?> {
+                            loaderCount.incrementAndGet()
+                            gate.await()
+                            null
+                        })
+                        if (v == null) nullCount.incrementAndGet()
+                    } finally {
+                        latch.countDown()
+                    }
+                }
+            }
+
+            Thread.sleep(150)
+            gate.countDown()
+            assertTrue(latch.await(10, TimeUnit.SECONDS))
+            executor.shutdown()
+
+            assertEquals(1, loaderCount.get())
+            assertEquals(threadCount, nullCount.get())
+        }
+    }
+
+    @Nested
+    @DisplayName("fail-open fallback")
+    inner class FailOpenFallback {
+
+        @Test
+        fun timeout_시_follower는_DB_로더를_직접_호출한다() {
+            val cache = createNonHotCache()
+            val loaderCount = AtomicInteger(0)
+            val creatorReady = CountDownLatch(1)
+            val creatorRelease = CountDownLatch(1)
+            val followerDone = CountDownLatch(1)
+            val executor = Executors.newFixedThreadPool(2)
+            val creatorResult = AtomicReference<Any?>()
+            val followerResult = AtomicReference<Any?>()
+
+            executor.submit {
+                creatorResult.set(cache.get(6L, Callable<String> {
+                    loaderCount.incrementAndGet()
+                    creatorReady.countDown()
+                    creatorRelease.await()
+                    "creator-value"
+                }))
+            }
+
+            assertTrue(creatorReady.await(2, TimeUnit.SECONDS))
+
+            executor.submit {
+                try {
+                    followerResult.set(cache.get(6L, Callable<String> {
+                        loaderCount.incrementAndGet()
+                        "follower-fallback-value"
+                    }))
+                } finally {
+                    followerDone.countDown()
+                }
+            }
+
+            assertTrue(followerDone.await(2, TimeUnit.SECONDS), "follower must time out within 500ms and fallback")
+
+            creatorRelease.countDown()
+            executor.shutdown()
+            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS))
+
+            assertEquals(2, loaderCount.get(), "creator + follower-fallback = 2 loader calls")
+            assertEquals(1.0, collapsedCount(), 0.0001)
+            assertNotNull(followerResult.get())
+            assertNotNull(creatorResult.get())
+        }
+
+        @Test
+        fun interrupt_시_follower는_DB_로더를_직접_호출한다() {
+            val cache = createNonHotCache()
+            val loaderCount = AtomicInteger(0)
+            val creatorReady = CountDownLatch(1)
+            val creatorRelease = CountDownLatch(1)
+            val followerStarted = CountDownLatch(1)
+            val followerDone = CountDownLatch(1)
+            val followerInterruptedFlag = AtomicBoolean(false)
+
+            val creatorThread = Thread {
+                cache.get(7L, Callable<String> {
+                    loaderCount.incrementAndGet()
+                    creatorReady.countDown()
+                    creatorRelease.await()
+                    "creator-value"
+                })
+            }
+            creatorThread.start()
+            assertTrue(creatorReady.await(2, TimeUnit.SECONDS))
+
+            val followerThread = Thread {
+                followerStarted.countDown()
+                try {
+                    cache.get(7L, Callable<String> {
+                        loaderCount.incrementAndGet()
+                        "follower-fallback"
+                    })
+                } finally {
+                    followerInterruptedFlag.set(Thread.currentThread().isInterrupted)
+                    followerDone.countDown()
+                }
+            }
+            followerThread.start()
+            assertTrue(followerStarted.await(2, TimeUnit.SECONDS))
+
+            Thread.sleep(50)
+            followerThread.interrupt()
+
+            assertTrue(followerDone.await(2, TimeUnit.SECONDS), "follower must finish after interrupt + fallback")
+
+            creatorRelease.countDown()
+            creatorThread.join(5_000)
+
+            assertEquals(2, loaderCount.get(), "creator + follower-fallback after interrupt = 2 loader calls")
+            assertTrue(followerInterruptedFlag.get(), "interrupt flag restored on follower thread")
+        }
+    }
+
+    @Nested
+    @DisplayName("hot 키 경로 비간섭")
+    inner class HotKeyNonInterference {
+
+        @Test
+        fun hot_키_요청은_loadWithLock을_사용하고_inFlightLoads에_등록되지_않는다() {
+            val fakeDetector = FakeHotKeyDetector()
+            fakeDetector.overrideIsHot = true
+            val shardedCache: Cache = mock()
+            whenever(shardedCache.get(8L)).thenReturn(null)
+            whenever(redisCache.get(8L)).thenReturn(null)
+
+            val caffeineCache = Caffeine.newBuilder()
+                .maximumSize(hotKeyPolicy.l1MaxSize)
+                .expireAfterWrite(hotKeyPolicy.l1Ttl)
+                .build<Any, Any>()
+
+            val cache = TwoLevelCache(
+                hotKeyPolicy.cacheName, caffeineCache, redisCache, hotKeyPolicy,
+                lockProvider, shardedCache, fakeDetector, meterRegistry
+            )
+
+            val v = cache.get(8L, Callable { "loaded" })
+
+            assertEquals("loaded", v)
+            assertEquals(1, lockProvider.lockCallCount, "hot 경로는 분산락 사용")
+            assertEquals(1, lockProvider.unlockCallCount)
+            assertEquals(0.0, collapsedCount("product"), 0.0001, "hot 경로는 collapsed 카운터 미증가")
+        }
+    }
+}


### PR DESCRIPTION
Closes #421

### 📌 작업 개요
TwoLevelCache 비-hot 키 cache miss 시 동일 JVM 내 다수 스레드가 모두 DB로 직행하던 thundering-herd를 1회 DB 호출로 collapse 하도록 in-process single-flight 보호를 추가했습니다. Redisson 분산락은 hot 키 전용으로 유지하고, 비-hot 키는 ConcurrentHashMap + CompletableFuture 기반 in-process 동기화로 충분히 방어합니다. `@Cacheable(sync=true)` 의도와 본 구현체 동작이 일치하도록 보강하였습니다.

---

### ✅ 주요 변경 사항

- `hoppingmall-cache.cache.TwoLevelCache`
  - `inFlightLoads: ConcurrentHashMap<Any, CompletableFuture<Any?>>` 필드 추가
  - `loadWithSingleFlight(key, valueLoader)` private 메서드 추가 — `putIfAbsent` + `complete/completeExceptionally` + `remove(key, future)` CAS 패턴
  - 비-hot miss 경로에서 `loadAndCache` 직접 호출 → `loadWithSingleFlight` 호출로 교체
  - timeout(`SINGLE_FLIGHT_TIMEOUT_MS=500ms`) / interrupt 시 fail-open: `loadAndCache` 직접 호출 + interrupt flag 복원
  - `ExecutionException` 시 cause 언래핑 후 재throw로 모든 대기 스레드에 동일 예외 전파
  - `cache.singleflight.collapsed` Counter (follower 카운트), `cache.singleflight.inflight` Gauge (in-flight 키 수) 메트릭 추가
  - `loadWithLock` / `waitForCacheOrFallback` / `loadAndCache` 본문 무변경 — hot 경로 영향 없음

---

### 🧪 테스트

- `TwoLevelCacheSingleFlightTest`
  - `NonHotConcurrency.동시_100_스레드_cache_miss_시_DB_로더는_1회만_호출된다` — `[VERIFY] 100 threads -> DB 1 call: loaderCount=1` 로그 출력
  - `NonHotConcurrency.모든_스레드가_동일한_결과를_수신한다`
  - `NonHotConcurrency.collapsed_메트릭이_99_증가한다`
  - `ExceptionPropagation.DB_로더_예외_시_모든_대기_스레드가_동일_예외를_전파받는다`
  - `NullResult.DB_로더가_null을_반환하면_모든_스레드가_null을_수신한다`
  - `FailOpenFallback.timeout_시_follower는_DB_로더를_직접_호출한다` — creator 700ms sleep, follower 500ms timeout 후 fallback (loader 호출 2회, collapsed 1)
  - `FailOpenFallback.interrupt_시_follower는_DB_로더를_직접_호출한다` — interrupt flag 복원 검증
  - `HotKeyNonInterference.hot_키_요청은_loadWithLock을_사용하고_inFlightLoads에_등록되지_않는다` — hot 경로 비간섭 회귀 방지

- 검증 명령
  - `./gradlew :hoppingmall-cache:test` — 90 tests, 0 failures
  - `./gradlew :hoppingmall-cache:jacocoTestVerification` — CLASS LINE 80% 통과

---

### 📎 관련 이슈
- #421
