### PR TITLE
feat: cache-disabled 프로파일 NoOp 캐시 매니저 추가

### DIFF
--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/CacheConfig.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/CacheConfig.kt
@@ -7,10 +7,12 @@ import com.hoppingmall.cache.RedissonLockProvider
 import com.hoppingmall.cache.TwoLevelCacheManager
 import io.micrometer.core.instrument.MeterRegistry
 import org.redisson.api.RedissonClient
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
 import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
@@ -18,16 +20,19 @@ import java.time.Duration
 
 @Configuration
 @EnableCaching
-@Profile("!test")
+@Profile("!test & !cache-disabled")
 class CacheConfig {
 
     @Bean
-    fun cachePolicies(): Map<String, CachePolicy> = mapOf(
+    fun cachePolicies(
+        @Value("\${cache.product.l1-ttl-seconds:600}") productL1TtlSec: Long,
+        @Value("\${cache.product.l2-ttl-seconds:1800}") productL2TtlSec: Long
+    ): Map<String, CachePolicy> = mapOf(
         "product" to CachePolicy(
             cacheName = "product",
             l1MaxSize = 500,
-            l1Ttl = Duration.ofMinutes(10),
-            l2Ttl = Duration.ofMinutes(30),
+            l1Ttl = Duration.ofSeconds(productL1TtlSec),
+            l2Ttl = Duration.ofSeconds(productL2TtlSec),
             hotKeyThreshold = 50,
             hotKeyWindow = Duration.ofSeconds(60)
         ),
@@ -76,6 +81,7 @@ class CacheConfig {
     }
 
     @Bean
+    @Primary
     fun cacheManager(
         redisCacheManager: RedisCacheManager,
         cachePolicies: Map<String, CachePolicy>,

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/NoOpCacheConfig.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/NoOpCacheConfig.kt
@@ -1,0 +1,19 @@
+package com.hoppingmall.product.config
+
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.support.NoOpCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+
+@Configuration
+@EnableCaching
+@Profile("cache-disabled")
+class NoOpCacheConfig {
+
+    @Bean
+    @Primary
+    fun cacheManager(): CacheManager = NoOpCacheManager()
+}


### PR DESCRIPTION
Closes #423

### 📌 작업 개요
캐시 비활성화 baseline 측정용 `cache-disabled` 프로파일과 `NoOpCacheManager` 빈을 도입했습니다.
기존 `CacheConfig` 는 동일 프로파일에서 비활성화되며, product 캐시 TTL 은 외부 프로퍼티로 분리해 부하 테스트 시 조정 가능하도록 했습니다.

---

### ✅ 주요 변경 사항

- `product.config`
  - `NoOpCacheConfig`: `cache-disabled` 프로파일 활성 시 `NoOpCacheManager` 를 `@Primary` 빈으로 등록
  - `CacheConfig`: `@Profile("!test & !cache-disabled")` 가드 추가, `cacheManager` 에 `@Primary` 명시
  - `cache.product.l1-ttl-seconds` (default 600) / `cache.product.l2-ttl-seconds` (default 1800) 프로퍼티화

---

### 🧪 테스트

- `./gradlew test --tests "*CacheConfig*"` 통과
- 기본값 유지로 기존 동작 영향 없음

---

### 📎 관련 이슈
- #423
