### PR TITLE
feat: DLQ 메시지 MinIO 아카이빙 시스템 추가

### DIFF
--- a/hoppingmall-dlq/build.gradle.kts
+++ b/hoppingmall-dlq/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 	compileOnly("org.springframework.kafka:spring-kafka")
 	compileOnly("io.micrometer:micrometer-core")
 	compileOnly("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
+	implementation("software.amazon.awssdk:s3:2.31.9")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("io.micrometer:micrometer-core")

--- a/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/archival/DLQArchivalProperties.kt
+++ b/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/archival/DLQArchivalProperties.kt
@@ -1,0 +1,15 @@
+package com.hoppingmall.dlq.archival
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "dlq.archival")
+data class DLQArchivalProperties(
+    val enabled: Boolean = false,
+    val bucket: String = "dlq-archive",
+    val endpoint: String = "http://localhost:9000",
+    val accessKey: String = "minioadmin",
+    val secretKey: String = "minioadmin",
+    val region: String = "us-east-1",
+    val retentionDays: Long = 90,
+    val batchSize: Int = 100
+)

--- a/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/archival/DLQArchivalScheduler.kt
+++ b/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/archival/DLQArchivalScheduler.kt
@@ -1,0 +1,61 @@
+package com.hoppingmall.dlq.archival
+
+import com.hoppingmall.dlq.domain.DLQStatus
+import com.hoppingmall.dlq.domain.repository.DLQMessageRepository
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.data.domain.PageRequest
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.TimeUnit
+
+@Component
+@ConditionalOnProperty(name = ["dlq.archival.enabled"], havingValue = "true")
+class DLQArchivalScheduler(
+    private val dlqMessageRepository: DLQMessageRepository,
+    private val dlqArchivalService: DLQArchivalService,
+    private val dlqArchivalProperties: DLQArchivalProperties
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(fixedDelay = 60_000)
+    @Transactional
+    fun archiveFailedMessages() {
+        val pageable = PageRequest.of(0, dlqArchivalProperties.batchSize)
+        val unarchivedMessages = dlqMessageRepository.findUnarchivedByStatus(DLQStatus.FAILED, pageable)
+
+        if (unarchivedMessages.isEmpty) return
+
+        log.info("DLQ FAILED 메시지 아카이빙 시작: {} 건", unarchivedMessages.content.size)
+
+        var successCount = 0
+        unarchivedMessages.content.forEach { message ->
+            if (dlqArchivalService.archive(message)) {
+                message.markAsArchived()
+                dlqMessageRepository.save(message)
+                successCount++
+            }
+        }
+
+        log.info("DLQ FAILED 메시지 아카이빙 완료: 성공={}/{}", successCount, unarchivedMessages.content.size)
+    }
+
+    @Scheduled(fixedDelay = 3_600_000)
+    @Transactional
+    fun purgeArchivedMessages() {
+        val retentionMillis = TimeUnit.DAYS.toMillis(dlqArchivalProperties.retentionDays)
+        val cutoffTimestamp = System.currentTimeMillis() - retentionMillis
+
+        val archivedFailedMessages = dlqMessageRepository.findArchivedMessagesBefore(
+            DLQStatus.FAILED, cutoffTimestamp
+        )
+
+        if (archivedFailedMessages.isEmpty()) return
+
+        dlqMessageRepository.deleteAll(archivedFailedMessages)
+        log.info("아카이빙 완료된 FAILED DLQ 메시지 퍼지: {} 건 (보존기간 {} 일 초과)",
+            archivedFailedMessages.size, dlqArchivalProperties.retentionDays)
+    }
+}

--- a/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/archival/DLQArchivalService.kt
+++ b/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/archival/DLQArchivalService.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.dlq.archival
+
+import com.hoppingmall.dlq.domain.DLQMessage
+
+interface DLQArchivalService {
+    fun archive(dlqMessage: DLQMessage): Boolean
+    fun archiveBatch(dlqMessages: List<DLQMessage>): Int
+}

--- a/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/archival/MinIOConfig.kt
+++ b/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/archival/MinIOConfig.kt
@@ -1,0 +1,62 @@
+package com.hoppingmall.dlq.archival
+
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException
+import java.net.URI
+
+@Configuration
+@ConditionalOnProperty(name = ["dlq.archival.enabled"], havingValue = "true")
+@EnableConfigurationProperties(DLQArchivalProperties::class)
+class MinIOConfig(
+    private val properties: DLQArchivalProperties
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Bean
+    fun s3Client(): S3Client {
+        val client = S3Client.builder()
+            .endpointOverride(URI(properties.endpoint))
+            .region(Region.of(properties.region))
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(properties.accessKey, properties.secretKey)
+                )
+            )
+            .forcePathStyle(true)
+            .build()
+
+        ensureBucketExists(client)
+        return client
+    }
+
+    private fun ensureBucketExists(client: S3Client) {
+        try {
+            client.headBucket(
+                HeadBucketRequest.builder()
+                    .bucket(properties.bucket)
+                    .build()
+            )
+            log.info("DLQ 아카이브 버킷 확인: {}", properties.bucket)
+        } catch (e: NoSuchBucketException) {
+            client.createBucket(
+                CreateBucketRequest.builder()
+                    .bucket(properties.bucket)
+                    .build()
+            )
+            log.info("DLQ 아카이브 버킷 생성: {}", properties.bucket)
+        } catch (e: Exception) {
+            log.warn("DLQ 아카이브 버킷 확인 실패 (서비스 시작은 계속): {}", e.message)
+        }
+    }
+}

--- a/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/archival/MinIODLQArchivalService.kt
+++ b/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/archival/MinIODLQArchivalService.kt
@@ -1,0 +1,92 @@
+package com.hoppingmall.dlq.archival
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.hoppingmall.dlq.domain.DLQMessage
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.stereotype.Component
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@Component
+@ConditionalOnBean(S3Client::class)
+class MinIODLQArchivalService(
+    private val s3Client: S3Client,
+    private val dlqArchivalProperties: DLQArchivalProperties
+) : DLQArchivalService {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    private val objectMapper = ObjectMapper().apply {
+        registerModule(JavaTimeModule())
+        disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    }
+
+    override fun archive(dlqMessage: DLQMessage): Boolean {
+        return try {
+            val key = buildObjectKey(dlqMessage)
+            val json = serializeToJson(dlqMessage)
+
+            s3Client.putObject(
+                PutObjectRequest.builder()
+                    .bucket(dlqArchivalProperties.bucket)
+                    .key(key)
+                    .contentType("application/json")
+                    .build(),
+                RequestBody.fromString(json)
+            )
+
+            log.info("DLQ 메시지 아카이빙 완료: id={}, key={}", dlqMessage.id, key)
+            true
+        } catch (e: Exception) {
+            log.error("DLQ 메시지 아카이빙 실패: id={}, error={}", dlqMessage.id, e.message, e)
+            false
+        }
+    }
+
+    override fun archiveBatch(dlqMessages: List<DLQMessage>): Int {
+        var successCount = 0
+        dlqMessages.forEach { message ->
+            if (archive(message)) {
+                successCount++
+            }
+        }
+        return successCount
+    }
+
+    private fun buildObjectKey(dlqMessage: DLQMessage): String {
+        val timestamp = Instant.ofEpochMilli(dlqMessage.errorTimestamp)
+            .atZone(ZoneId.systemDefault())
+        val datePath = timestamp.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"))
+        return "dlq-archive/${dlqMessage.originalTopic}/$datePath/${dlqMessage.id}.json"
+    }
+
+    private fun serializeToJson(dlqMessage: DLQMessage): String {
+        val archiveData = mapOf(
+            "id" to dlqMessage.id,
+            "originalTopic" to dlqMessage.originalTopic,
+            "originalPartition" to dlqMessage.originalPartition,
+            "originalOffset" to dlqMessage.originalOffset,
+            "originalKey" to dlqMessage.originalKey,
+            "originalValue" to dlqMessage.originalValue,
+            "exceptionMessage" to dlqMessage.exceptionMessage,
+            "errorTimestamp" to dlqMessage.errorTimestamp,
+            "status" to dlqMessage.status.name,
+            "retryCount" to dlqMessage.retryCount,
+            "lastRetryAt" to dlqMessage.lastRetryAt,
+            "processedAt" to dlqMessage.processedAt,
+            "notes" to dlqMessage.notes,
+            "nextRetryAt" to dlqMessage.nextRetryAt,
+            "createdAt" to dlqMessage.createdAt.toString(),
+            "updatedAt" to dlqMessage.updatedAt?.toString(),
+            "archivedAt" to System.currentTimeMillis()
+        )
+        return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(archiveData)
+    }
+}

--- a/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/archival/NoOpDLQArchivalService.kt
+++ b/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/archival/NoOpDLQArchivalService.kt
@@ -1,0 +1,25 @@
+package com.hoppingmall.dlq.archival
+
+import com.hoppingmall.dlq.domain.DLQMessage
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnMissingBean(MinIODLQArchivalService::class)
+class NoOpDLQArchivalService : DLQArchivalService {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun archive(dlqMessage: DLQMessage): Boolean {
+        log.warn("S3Client 미설정으로 DLQ 아카이빙 불가: topic={}, id={}", dlqMessage.originalTopic, dlqMessage.id)
+        return false
+    }
+
+    override fun archiveBatch(dlqMessages: List<DLQMessage>): Int {
+        if (dlqMessages.isNotEmpty()) {
+            log.warn("S3Client 미설정으로 DLQ 배치 아카이빙 불가: {} 건", dlqMessages.size)
+        }
+        return 0
+    }
+}

--- a/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/domain/DLQMessage.kt
+++ b/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/domain/DLQMessage.kt
@@ -52,7 +52,10 @@ class DLQMessage(
     var notes: String? = null,
 
     @Column(name = "next_retry_at")
-    var nextRetryAt: Long? = null
+    var nextRetryAt: Long? = null,
+
+    @Column(name = "archived_at")
+    var archivedAt: Long? = null
 
 ) : BaseEntity() {
 
@@ -72,6 +75,10 @@ class DLQMessage(
     fun markAsFailed(notes: String? = null) {
         this.status = DLQStatus.FAILED
         this.notes = notes
+    }
+
+    fun markAsArchived() {
+        this.archivedAt = System.currentTimeMillis()
     }
 
     fun getMessageKey(): String = "${originalTopic}:${originalPartition}:${originalOffset}"

--- a/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/domain/repository/DLQMessageRepository.kt
+++ b/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/domain/repository/DLQMessageRepository.kt
@@ -88,6 +88,28 @@ interface DLQMessageRepository : JpaRepository<DLQMessage, Long> {
         originalPartition: Int,
         originalOffset: Long
     ): Boolean
+
+    @Query("""
+        SELECT d FROM DLQMessage d
+        WHERE d.status = :status
+        AND d.archivedAt IS NULL
+        ORDER BY d.createdAt ASC
+    """)
+    fun findUnarchivedByStatus(
+        @Param("status") status: DLQStatus,
+        pageable: Pageable
+    ): Page<DLQMessage>
+
+    @Query("""
+        SELECT d FROM DLQMessage d
+        WHERE d.status = :status
+        AND d.archivedAt IS NOT NULL
+        AND d.archivedAt < :beforeTimestamp
+    """)
+    fun findArchivedMessagesBefore(
+        @Param("status") status: DLQStatus,
+        @Param("beforeTimestamp") beforeTimestamp: Long
+    ): List<DLQMessage>
 }
 
 interface DLQStatsProjection {

--- a/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/service/DLQCommandService.kt
+++ b/hoppingmall-dlq/src/main/kotlin/com/hoppingmall/dlq/service/DLQCommandService.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.dlq.service
 
+import com.hoppingmall.dlq.archival.DLQArchivalService
 import com.hoppingmall.dlq.domain.DLQMessage
 import com.hoppingmall.dlq.domain.DLQStatus
 import com.hoppingmall.dlq.domain.DeadLetterMessage
@@ -18,7 +19,8 @@ import java.util.concurrent.ConcurrentHashMap
 class DLQCommandService(
     private val dlqMessageRepository: DLQMessageRepository,
     private val dlqMessagePublisher: DLQMessagePublisher,
-    private val dlqMetrics: DLQMetrics
+    private val dlqMetrics: DLQMetrics,
+    private val dlqArchivalService: DLQArchivalService
 ) {
 
     private val logger = LoggerFactory.getLogger(DLQCommandService::class.java)
@@ -184,8 +186,12 @@ class DLQCommandService(
 
         val deleteCount = processedMessages.content.size.toLong()
         if (deleteCount > 0) {
+            val archivedCount = dlqArchivalService.archiveBatch(processedMessages.content)
+            if (archivedCount < processedMessages.content.size) {
+                logger.warn("일부 DLQ 메시지 아카이빙 실패: topic={}, 아카이빙={}/{}", topic, archivedCount, deleteCount)
+            }
             dlqMessageRepository.deleteAll(processedMessages.content)
-            logger.info("처리 완료된 DLQ 메시지 삭제: topic={}, count={}", topic, deleteCount)
+            logger.info("처리 완료된 DLQ 메시지 삭제: topic={}, count={}, archived={}", topic, deleteCount, archivedCount)
         }
 
         return deleteCount

--- a/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/archival/DLQArchivalSchedulerTest.kt
+++ b/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/archival/DLQArchivalSchedulerTest.kt
@@ -1,0 +1,135 @@
+package com.hoppingmall.dlq.archival
+
+import com.hoppingmall.dlq.domain.DLQMessage
+import com.hoppingmall.dlq.domain.DLQStatus
+import com.hoppingmall.dlq.domain.repository.DLQMessageRepository
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+
+@DisplayName("DLQArchivalScheduler")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class DLQArchivalSchedulerTest {
+
+    private val dlqMessageRepository: DLQMessageRepository = mock()
+    private val dlqArchivalService: DLQArchivalService = mock()
+    private val properties = DLQArchivalProperties(
+        enabled = true,
+        bucket = "test-bucket",
+        retentionDays = 90,
+        batchSize = 100
+    )
+    private val scheduler = DLQArchivalScheduler(dlqMessageRepository, dlqArchivalService, properties)
+
+    @Nested
+    @DisplayName("archiveFailedMessages")
+    inner class ArchiveFailedMessages {
+
+        @Test
+        fun FAILED_메시지를_아카이빙하고_archivedAt을_설정한다() {
+            val message1 = createDLQMessage(id = 1L, status = DLQStatus.FAILED)
+            val message2 = createDLQMessage(id = 2L, status = DLQStatus.FAILED)
+            val page = PageImpl(listOf(message1, message2))
+
+            whenever(dlqMessageRepository.findUnarchivedByStatus(eq(DLQStatus.FAILED), any()))
+                .thenReturn(page)
+            whenever(dlqArchivalService.archive(any())).thenReturn(true)
+
+            scheduler.archiveFailedMessages()
+
+            verify(dlqArchivalService).archive(message1)
+            verify(dlqArchivalService).archive(message2)
+            verify(dlqMessageRepository).save(message1)
+            verify(dlqMessageRepository).save(message2)
+            assertNotNull(message1.archivedAt)
+            assertNotNull(message2.archivedAt)
+        }
+
+        @Test
+        fun 아카이빙_대상이_없으면_아무_작업도_하지_않는다() {
+            whenever(dlqMessageRepository.findUnarchivedByStatus(eq(DLQStatus.FAILED), any()))
+                .thenReturn(Page.empty())
+
+            scheduler.archiveFailedMessages()
+
+            verify(dlqArchivalService, never()).archive(any())
+            verify(dlqMessageRepository, never()).save(any<DLQMessage>())
+        }
+
+        @Test
+        fun 아카이빙_실패한_메시지는_archivedAt을_설정하지_않는다() {
+            val message1 = createDLQMessage(id = 1L, status = DLQStatus.FAILED)
+            val message2 = createDLQMessage(id = 2L, status = DLQStatus.FAILED)
+            val page = PageImpl(listOf(message1, message2))
+
+            whenever(dlqMessageRepository.findUnarchivedByStatus(eq(DLQStatus.FAILED), any()))
+                .thenReturn(page)
+            whenever(dlqArchivalService.archive(message1)).thenReturn(true)
+            whenever(dlqArchivalService.archive(message2)).thenReturn(false)
+
+            scheduler.archiveFailedMessages()
+
+            verify(dlqMessageRepository).save(message1)
+            verify(dlqMessageRepository, never()).save(message2)
+            assertNotNull(message1.archivedAt)
+            assertNull(message2.archivedAt)
+        }
+    }
+
+    @Nested
+    @DisplayName("purgeArchivedMessages")
+    inner class PurgeArchivedMessages {
+
+        @Test
+        fun 보존기간_초과_아카이빙된_메시지를_퍼지한다() {
+            val oldMessage = createDLQMessage(id = 1L, status = DLQStatus.FAILED)
+            whenever(dlqMessageRepository.findArchivedMessagesBefore(eq(DLQStatus.FAILED), any()))
+                .thenReturn(listOf(oldMessage))
+
+            scheduler.purgeArchivedMessages()
+
+            verify(dlqMessageRepository).deleteAll(listOf(oldMessage))
+        }
+
+        @Test
+        fun 퍼지_대상이_없으면_deleteAll을_호출하지_않는다() {
+            whenever(dlqMessageRepository.findArchivedMessagesBefore(eq(DLQStatus.FAILED), any()))
+                .thenReturn(emptyList())
+
+            scheduler.purgeArchivedMessages()
+
+            verify(dlqMessageRepository, never()).deleteAll(any<List<DLQMessage>>())
+        }
+    }
+
+    private fun createDLQMessage(
+        id: Long? = 1L,
+        status: DLQStatus = DLQStatus.FAILED
+    ): DLQMessage {
+        val dlqMessage = DLQMessage(
+            originalTopic = "test-topic",
+            originalPartition = 0,
+            originalOffset = 1000L,
+            originalKey = "test-key",
+            originalValue = "test-value",
+            exceptionMessage = "Test exception",
+            errorTimestamp = System.currentTimeMillis()
+        ).apply {
+            this.status = status
+        }
+
+        id?.let {
+            val idField = DLQMessage::class.java.superclass.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(dlqMessage, it)
+        }
+
+        return dlqMessage
+    }
+}

--- a/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/archival/MinIODLQArchivalServiceTest.kt
+++ b/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/archival/MinIODLQArchivalServiceTest.kt
@@ -1,0 +1,192 @@
+package com.hoppingmall.dlq.archival
+
+import com.hoppingmall.dlq.domain.DLQMessage
+import com.hoppingmall.dlq.domain.DLQStatus
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.model.PutObjectResponse
+import software.amazon.awssdk.services.s3.model.S3Exception
+
+@DisplayName("MinIODLQArchivalService")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class MinIODLQArchivalServiceTest {
+
+    private val s3Client: S3Client = mock()
+    private val properties = DLQArchivalProperties(
+        enabled = true,
+        bucket = "test-bucket",
+        endpoint = "http://localhost:9000",
+        accessKey = "minioadmin",
+        secretKey = "minioadmin"
+    )
+    private val archivalService = MinIODLQArchivalService(s3Client, properties)
+
+    @Nested
+    @DisplayName("archive")
+    inner class Archive {
+
+        @Test
+        fun DLQ_메시지를_S3에_아카이빙한다() {
+            val dlqMessage = createDLQMessage(id = 1L, status = DLQStatus.FAILED)
+            whenever(s3Client.putObject(any<PutObjectRequest>(), any<RequestBody>()))
+                .thenReturn(PutObjectResponse.builder().build())
+
+            val result = archivalService.archive(dlqMessage)
+
+            assertTrue(result)
+            verify(s3Client).putObject(
+                argThat<PutObjectRequest> { bucket() == "test-bucket" && contentType() == "application/json" },
+                any<RequestBody>()
+            )
+        }
+
+        @Test
+        fun S3_오류_시_false를_반환한다() {
+            val dlqMessage = createDLQMessage(id = 1L, status = DLQStatus.FAILED)
+            whenever(s3Client.putObject(any<PutObjectRequest>(), any<RequestBody>()))
+                .thenThrow(S3Exception.builder().message("Connection refused").build())
+
+            val result = archivalService.archive(dlqMessage)
+
+            assertFalse(result)
+        }
+
+        @Test
+        fun originalValue가_null이어도_아카이빙에_성공한다() {
+            val dlqMessage = createDLQMessage(id = 1L, value = null, status = DLQStatus.FAILED)
+            whenever(s3Client.putObject(any<PutObjectRequest>(), any<RequestBody>()))
+                .thenReturn(PutObjectResponse.builder().build())
+
+            val result = archivalService.archive(dlqMessage)
+
+            assertTrue(result)
+        }
+
+        @Test
+        @Suppress("UNCHECKED_CAST")
+        fun 아카이빙된_JSON에_모든_필드가_포함된다() {
+            val dlqMessage = createDLQMessage(
+                id = 1L,
+                topic = "payment",
+                partition = 2,
+                offset = 500L,
+                key = "pay-key",
+                value = """{"orderId": 123}""",
+                exception = "TimeoutException",
+                status = DLQStatus.FAILED,
+                retryCount = 3
+            )
+
+            var capturedBody: String? = null
+            whenever(s3Client.putObject(any<PutObjectRequest>(), any<RequestBody>())).thenAnswer { invocation ->
+                val body = invocation.getArgument<RequestBody>(1)
+                capturedBody = body.contentStreamProvider().newStream().bufferedReader().readText()
+                PutObjectResponse.builder().build()
+            }
+
+            archivalService.archive(dlqMessage)
+
+            assertNotNull(capturedBody)
+            val parsed = ObjectMapper().readValue(capturedBody, Map::class.java) as Map<String, Any?>
+            assertEquals("payment", parsed["originalTopic"])
+            assertEquals(2, parsed["originalPartition"])
+            assertEquals(500, parsed["originalOffset"])
+            assertEquals("pay-key", parsed["originalKey"])
+            assertEquals("{\"orderId\": 123}", parsed["originalValue"])
+            assertEquals("TimeoutException", parsed["exceptionMessage"])
+            assertEquals("FAILED", parsed["status"])
+            assertEquals(3, parsed["retryCount"])
+            assertNotNull(parsed["createdAt"])
+            assertNotNull(parsed["archivedAt"])
+        }
+    }
+
+    @Nested
+    @DisplayName("archiveBatch")
+    inner class ArchiveBatch {
+
+        @Test
+        fun 여러_메시지를_배치로_아카이빙한다() {
+            val messages = listOf(
+                createDLQMessage(id = 1L),
+                createDLQMessage(id = 2L),
+                createDLQMessage(id = 3L)
+            )
+            whenever(s3Client.putObject(any<PutObjectRequest>(), any<RequestBody>()))
+                .thenReturn(PutObjectResponse.builder().build())
+
+            val result = archivalService.archiveBatch(messages)
+
+            assertEquals(3, result)
+            verify(s3Client, times(3)).putObject(any<PutObjectRequest>(), any<RequestBody>())
+        }
+
+        @Test
+        fun 일부_실패_시_성공_건수만_반환한다() {
+            val messages = listOf(
+                createDLQMessage(id = 1L),
+                createDLQMessage(id = 2L),
+                createDLQMessage(id = 3L)
+            )
+            whenever(s3Client.putObject(any<PutObjectRequest>(), any<RequestBody>()))
+                .thenReturn(PutObjectResponse.builder().build())
+                .thenThrow(S3Exception.builder().message("Error").build())
+                .thenReturn(PutObjectResponse.builder().build())
+
+            val result = archivalService.archiveBatch(messages)
+
+            assertEquals(2, result)
+        }
+
+        @Test
+        fun 빈_리스트는_0을_반환한다() {
+            val result = archivalService.archiveBatch(emptyList())
+
+            assertEquals(0, result)
+            verify(s3Client, never()).putObject(any<PutObjectRequest>(), any<RequestBody>())
+        }
+    }
+
+    private fun createDLQMessage(
+        id: Long? = 1L,
+        topic: String = "test-topic",
+        partition: Int = 0,
+        offset: Long = 1000L,
+        key: String? = "test-key",
+        value: String? = "test-value",
+        exception: String? = "Test exception",
+        timestamp: Long = System.currentTimeMillis(),
+        status: DLQStatus = DLQStatus.FAILED,
+        retryCount: Int = 0
+    ): DLQMessage {
+        val dlqMessage = DLQMessage(
+            originalTopic = topic,
+            originalPartition = partition,
+            originalOffset = offset,
+            originalKey = key,
+            originalValue = value,
+            exceptionMessage = exception,
+            errorTimestamp = timestamp
+        ).apply {
+            this.status = status
+            this.retryCount = retryCount
+        }
+
+        id?.let {
+            val idField = DLQMessage::class.java.superclass.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(dlqMessage, it)
+        }
+
+        return dlqMessage
+    }
+}

--- a/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/archival/NoOpDLQArchivalServiceTest.kt
+++ b/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/archival/NoOpDLQArchivalServiceTest.kt
@@ -1,0 +1,66 @@
+package com.hoppingmall.dlq.archival
+
+import com.hoppingmall.dlq.domain.DLQMessage
+import com.hoppingmall.dlq.domain.DLQStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("NoOpDLQArchivalService")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class NoOpDLQArchivalServiceTest {
+
+    private val archivalService = NoOpDLQArchivalService()
+
+    @Test
+    fun archive_호출하면_false를_반환한다() {
+        val dlqMessage = createDLQMessage()
+
+        val result = archivalService.archive(dlqMessage)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun archiveBatch_호출하면_0을_반환한다() {
+        val messages = listOf(createDLQMessage(), createDLQMessage())
+
+        val result = archivalService.archiveBatch(messages)
+
+        assertThat(result).isEqualTo(0)
+    }
+
+    @Test
+    fun archiveBatch_빈_리스트도_0을_반환한다() {
+        val result = archivalService.archiveBatch(emptyList())
+
+        assertThat(result).isEqualTo(0)
+    }
+
+    private fun createDLQMessage(
+        id: Long? = 1L,
+        status: DLQStatus = DLQStatus.FAILED
+    ): DLQMessage {
+        val dlqMessage = DLQMessage(
+            originalTopic = "test-topic",
+            originalPartition = 0,
+            originalOffset = 1000L,
+            originalKey = "test-key",
+            originalValue = "test-value",
+            exceptionMessage = "Test exception",
+            errorTimestamp = System.currentTimeMillis()
+        ).apply {
+            this.status = status
+        }
+
+        id?.let {
+            val idField = DLQMessage::class.java.superclass.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(dlqMessage, it)
+        }
+
+        return dlqMessage
+    }
+}

--- a/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/service/DLQCommandServiceTest.kt
+++ b/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/service/DLQCommandServiceTest.kt
@@ -1,5 +1,6 @@
 package com.hoppingmall.dlq.service
 
+import com.hoppingmall.dlq.archival.DLQArchivalService
 import com.hoppingmall.dlq.domain.DLQMessage
 import com.hoppingmall.dlq.domain.DLQStatus
 import com.hoppingmall.dlq.domain.DeadLetterMessage
@@ -24,7 +25,8 @@ class DLQCommandServiceTest {
     private val dlqMessageRepository: DLQMessageRepository = mock()
     private val dlqMessagePublisher: DLQMessagePublisher = mock()
     private val dlqMetrics: DLQMetrics = mock()
-    private val dlqCommandService = DLQCommandService(dlqMessageRepository, dlqMessagePublisher, dlqMetrics)
+    private val dlqArchivalService: DLQArchivalService = mock()
+    private val dlqCommandService = DLQCommandService(dlqMessageRepository, dlqMessagePublisher, dlqMetrics, dlqArchivalService)
 
     @Nested
     @DisplayName("saveDLQMessage")
@@ -333,7 +335,7 @@ class DLQCommandServiceTest {
     inner class ClearProcessedDLQMessages {
 
         @Test
-        fun 처리_완료된_DLQ_메시지들을_삭제한다() {
+        fun 처리_완료된_DLQ_메시지들을_아카이빙_후_삭제한다() {
             val topic = "payment"
             val processedMessage1 = createDLQMessage(topic = topic, status = DLQStatus.PROCESSED)
             val processedMessage2 = createDLQMessage(topic = topic, status = DLQStatus.PROCESSED)
@@ -342,10 +344,12 @@ class DLQCommandServiceTest {
             whenever(dlqMessageRepository.findByOriginalTopicAndStatusOrderByCreatedAtDesc(
                 eq(topic), eq(DLQStatus.PROCESSED), any()
             )).thenReturn(processedMessages)
+            whenever(dlqArchivalService.archiveBatch(any())).thenReturn(2)
 
             val deletedCount = dlqCommandService.clearProcessedDLQMessages(topic)
 
             assertEquals(2, deletedCount)
+            verify(dlqArchivalService).archiveBatch(processedMessages.content)
             verify(dlqMessageRepository).deleteAll(processedMessages.content)
         }
 


### PR DESCRIPTION
Closes #425

### 📌 작업 개요
처리 완료/실패 DLQ 메시지를 MinIO(S3 호환) 객체 스토리지로 아카이빙 후 보존기간이 지나면 DB 에서 정리하는 시스템을 추가했습니다.
운영 환경은 MinIO 구현체, `dlq.archival.enabled=false` 환경은 NoOp 구현체로 자동 분기되어 기존 동작에 영향을 주지 않습니다.

---

### ✅ 주요 변경 사항

- `dlq.domain`
  - `DLQMessage`: `archivedAt` 컬럼 + `markAsArchived()` 메서드 추가
  - `DLQMessageRepository`: `findUnarchivedByStatus`, `findArchivedMessagesBefore` 쿼리 추가

- `dlq.archival` (신규 패키지)
  - `DLQArchivalService` 인터페이스 + `MinIODLQArchivalService` / `NoOpDLQArchivalService` 구현체
  - `DLQArchivalScheduler`: 60s 주기 FAILED 아카이빙, 1h 주기 보존기간 만료 퍼지
  - `DLQArchivalProperties`: `dlq.archival.enabled/bucket/retentionDays/batchSize` 외부 프로퍼티
  - `MinIOConfig`: `dlq.archival.enabled=true` 일 때만 `S3Client` 빈 등록

- `dlq.service`
  - `DLQCommandService.clearProcessedDLQMessages`: 삭제 전 `archiveBatch` 호출, 부분 실패 시 경고 로깅

- `build.gradle.kts`
  - `software.amazon.awssdk:s3:2.31.9` 의존성 추가

---

### 🧪 테스트

- `DLQArchivalSchedulerTest`: 아카이빙/퍼지 시나리오 단위 테스트
- `MinIODLQArchivalServiceTest`: S3 PutObject mocking + 직렬화 검증
- `NoOpDLQArchivalServiceTest`: NoOp 분기 동작 검증
- `DLQCommandServiceTest`: 아카이빙 위탁 후 삭제 흐름 mock 검증
- `./gradlew test --tests "*Archival*" --tests "*DLQCommandServiceTest*" --tests "*DLQMessageTest*"` 통과
- 사전 존재 실패였던 `KafkaDLQMessagePublisherTest` 2건은 본 변경과 무관

---

### 📎 관련 이슈
- #425
