### PR TITLE
feat: Saga 타임아웃 감지 및 자동 보상 스케줄러 추가

### DIFF
--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/SagaEventLog.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/SagaEventLog.kt
@@ -7,7 +7,8 @@ import java.time.LocalDateTime
 @Table(
     name = "saga_event_logs",
     indexes = [
-        Index(name = "idx_saga_event_id", columnList = "eventId", unique = true)
+        Index(name = "idx_saga_event_id", columnList = "eventId", unique = true),
+        Index(name = "idx_saga_timeout", columnList = "timedOut, timeoutAt")
     ]
 )
 class SagaEventLog(
@@ -23,6 +24,9 @@ class SagaEventLog(
     @Column(nullable = false)
     val createdAt: LocalDateTime = LocalDateTime.now(),
 
+    @Column(nullable = false)
+    val timeoutAt: LocalDateTime = LocalDateTime.now().plusMinutes(DEFAULT_TIMEOUT_MINUTES),
+
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "saga_event_log_steps", joinColumns = [JoinColumn(name = "saga_event_log_id")])
     @Column(name = "step")
@@ -32,6 +36,9 @@ class SagaEventLog(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
 
+    @Column(nullable = false)
+    var timedOut: Boolean = false
+
     fun markStepCompleted(step: String) {
         completedSteps.add(step)
     }
@@ -40,8 +47,17 @@ class SagaEventLog(
 
     fun isFullyCompleted(): Boolean = completedSteps.containsAll(setOf(LOCAL_COMPLETED, REMOTE_COMPLETED))
 
+    fun markAsTimedOut() {
+        this.timedOut = true
+        markStepCompleted(TIMED_OUT)
+    }
+
+    fun isTimedOut(): Boolean = timedOut
+
     companion object {
         const val LOCAL_COMPLETED = "LOCAL_COMPLETED"
         const val REMOTE_COMPLETED = "REMOTE_COMPLETED"
+        const val TIMED_OUT = "TIMED_OUT"
+        const val DEFAULT_TIMEOUT_MINUTES = 5L
     }
 }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/repository/SagaEventLogRepository.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/repository/SagaEventLogRepository.kt
@@ -2,8 +2,24 @@ package com.hoppingmall.order.order.domain.repository
 
 import com.hoppingmall.order.order.domain.SagaEventLog
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
 
 interface SagaEventLogRepository : JpaRepository<SagaEventLog, Long> {
     fun existsByEventId(eventId: String): Boolean
     fun findByEventId(eventId: String): SagaEventLog?
+
+    @Query(
+        """
+        SELECT s FROM SagaEventLog s
+        WHERE s.timedOut = false
+        AND s.timeoutAt < :now
+        AND NOT EXISTS (
+            SELECT 1 FROM s.completedSteps step WHERE step = 'REMOTE_COMPLETED'
+        )
+        ORDER BY s.timeoutAt ASC
+    """
+    )
+    fun findTimedOutSagas(@Param("now") now: LocalDateTime): List<SagaEventLog>
 }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/service/SagaTimeoutScheduler.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/service/SagaTimeoutScheduler.kt
@@ -1,0 +1,75 @@
+package com.hoppingmall.order.order.service
+
+import com.hoppingmall.common.KafkaTopics
+import com.hoppingmall.order.order.domain.repository.OrderRepository
+import com.hoppingmall.order.order.domain.repository.SagaEventLogRepository
+import com.hoppingmall.order.order.enum.OrderStatus
+import com.hoppingmall.outbox.service.TransactionalEventPublisher
+import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.LocalDateTime
+
+@Service
+class SagaTimeoutScheduler(
+    private val sagaEventLogRepository: SagaEventLogRepository,
+    private val orderRepository: OrderRepository,
+    private val transactionalEventPublisher: TransactionalEventPublisher,
+    private val transactionTemplate: TransactionTemplate
+) {
+    private val logger = LoggerFactory.getLogger(SagaTimeoutScheduler::class.java)
+
+    @Scheduled(fixedDelay = 60_000)
+    fun checkTimedOutSagas() {
+        val timedOutSagas = sagaEventLogRepository.findTimedOutSagas(LocalDateTime.now())
+        if (timedOutSagas.isEmpty()) return
+
+        logger.warn("타임아웃된 saga {} 건 감지", timedOutSagas.size)
+
+        timedOutSagas.forEach { saga ->
+            try {
+                compensateTimedOutSaga(saga.id!!, saga.orderId, saga.eventId)
+            } catch (e: Exception) {
+                logger.error("saga 타임아웃 보상 실패: sagaId={}, orderId={}", saga.id, saga.orderId, e)
+            }
+        }
+    }
+
+    private fun compensateTimedOutSaga(sagaId: Long, orderId: Long, eventId: String) {
+        val compensated = transactionTemplate.execute {
+            val saga = sagaEventLogRepository.findByIdOrNull(sagaId) ?: return@execute false
+            if (saga.isTimedOut() || saga.isFullyCompleted()) return@execute false
+
+            saga.markAsTimedOut()
+            sagaEventLogRepository.save(saga)
+
+            val order = orderRepository.findByIdOrNull(orderId) ?: return@execute false
+            if (order.status == OrderStatus.PAID && order.isCancellable()) {
+                order.updateStatus(OrderStatus.CANCEL_REQUESTED)
+                order.updateStatus(OrderStatus.CANCELLED)
+                orderRepository.save(order)
+            }
+
+            transactionalEventPublisher.publishEvent(
+                aggregateType = "Order",
+                aggregateId = orderId.toString(),
+                eventType = "PaymentReversalRequested",
+                eventData = mapOf(
+                    "eventType" to "PaymentReversalRequested",
+                    "eventId" to "timeout-$eventId",
+                    "orderId" to orderId,
+                    "reason" to "SAGA_TIMEOUT"
+                ),
+                topic = KafkaTopics.PAYMENT_REVERSAL,
+                partitionKey = orderId.toString()
+            )
+            true
+        } ?: false
+
+        if (compensated) {
+            logger.warn("saga 타임아웃 보상 완료: orderId={}, eventId={}", orderId, eventId)
+        }
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/order/domain/SagaEventLogTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/order/domain/SagaEventLogTest.kt
@@ -2,6 +2,7 @@ package com.hoppingmall.order.order.domain
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
+import java.time.LocalDateTime
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
@@ -96,5 +97,59 @@ class SagaEventLogTest {
     fun 상수_값이_올바르다() {
         assertThat(SagaEventLog.LOCAL_COMPLETED).isEqualTo("LOCAL_COMPLETED")
         assertThat(SagaEventLog.REMOTE_COMPLETED).isEqualTo("REMOTE_COMPLETED")
+        assertThat(SagaEventLog.TIMED_OUT).isEqualTo("TIMED_OUT")
+    }
+
+    @Test
+    fun 기본_timeoutAt은_생성_시점으로부터_5분_후이다() {
+        val before = LocalDateTime.now().plusMinutes(4)
+        val log = SagaEventLog(
+            eventId = "evt-timeout-1",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 1L
+        )
+        val after = LocalDateTime.now().plusMinutes(6)
+
+        assertThat(log.timeoutAt).isAfter(before)
+        assertThat(log.timeoutAt).isBefore(after)
+    }
+
+    @Test
+    fun markAsTimedOut_호출_시_timedOut이_true이고_TIMED_OUT_스텝이_추가된다() {
+        val log = SagaEventLog(
+            eventId = "evt-timeout-2",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 1L
+        )
+        log.markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
+
+        log.markAsTimedOut()
+
+        assertThat(log.isTimedOut()).isTrue()
+        assertThat(log.isStepCompleted(SagaEventLog.TIMED_OUT)).isTrue()
+    }
+
+    @Test
+    fun 생성_시_timedOut은_false이다() {
+        val log = SagaEventLog(
+            eventId = "evt-timeout-3",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 1L
+        )
+
+        assertThat(log.isTimedOut()).isFalse()
+    }
+
+    @Test
+    fun 커스텀_timeoutAt을_지정할_수_있다() {
+        val customTimeout = LocalDateTime.now().plusMinutes(10)
+        val log = SagaEventLog(
+            eventId = "evt-timeout-4",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 1L,
+            timeoutAt = customTimeout
+        )
+
+        assertThat(log.timeoutAt).isEqualTo(customTimeout)
     }
 }

--- a/order-service/src/test/kotlin/com/hoppingmall/order/order/service/SagaTimeoutSchedulerTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/order/service/SagaTimeoutSchedulerTest.kt
@@ -1,0 +1,156 @@
+package com.hoppingmall.order.order.service
+
+import com.hoppingmall.order.order.domain.Order
+import com.hoppingmall.order.order.domain.SagaEventLog
+import com.hoppingmall.order.order.domain.repository.OrderRepository
+import com.hoppingmall.order.order.domain.repository.SagaEventLogRepository
+import com.hoppingmall.order.order.enum.OrderStatus
+import com.hoppingmall.outbox.service.TransactionalEventPublisher
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.Optional
+
+@DisplayName("SagaTimeoutScheduler")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class SagaTimeoutSchedulerTest {
+
+    @Mock
+    private lateinit var sagaEventLogRepository: SagaEventLogRepository
+
+    @Mock
+    private lateinit var orderRepository: OrderRepository
+
+    @Mock
+    private lateinit var transactionalEventPublisher: TransactionalEventPublisher
+
+    @Mock
+    private lateinit var transactionTemplate: TransactionTemplate
+
+    private lateinit var scheduler: SagaTimeoutScheduler
+
+    @BeforeEach
+    fun setUp() {
+        Mockito.lenient().`when`(transactionTemplate.execute(any<TransactionCallback<Any>>())).thenAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            val callback = invocation.arguments[0] as TransactionCallback<Any?>
+            callback.doInTransaction(mock())
+        }
+        scheduler = SagaTimeoutScheduler(
+            sagaEventLogRepository,
+            orderRepository,
+            transactionalEventPublisher,
+            transactionTemplate
+        )
+    }
+
+    @Test
+    fun 타임아웃된_saga를_감지하여_보상_트랜잭션을_트리거한다() {
+        val saga = SagaEventLog(
+            eventId = "payment-completed-txn-1",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 1L,
+            timeoutAt = LocalDateTime.now().minusMinutes(1)
+        ).apply {
+            id = 100L
+            markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
+        }
+        val order = Order.create(buyerId = 10L, totalAmount = BigDecimal("50000"))
+        order.updateStatus(OrderStatus.PAYING)
+        order.updateStatus(OrderStatus.PAID)
+
+        whenever(sagaEventLogRepository.findTimedOutSagas(any())).thenReturn(listOf(saga))
+        whenever(sagaEventLogRepository.findById(100L)).thenReturn(Optional.of(saga))
+        whenever(orderRepository.findById(1L)).thenReturn(Optional.of(order))
+        whenever(sagaEventLogRepository.save(any<SagaEventLog>())).thenAnswer { it.arguments[0] }
+
+        scheduler.checkTimedOutSagas()
+
+        assertThat(saga.isTimedOut()).isTrue()
+        assertThat(order.status).isEqualTo(OrderStatus.CANCELLED)
+        verify(transactionalEventPublisher).publishEvent(
+            aggregateType = eq("Order"),
+            aggregateId = eq("1"),
+            eventType = eq("PaymentReversalRequested"),
+            eventData = any(),
+            topic = eq("payment-reversal"),
+            partitionKey = eq("1")
+        )
+    }
+
+    @Test
+    fun 타임아웃된_saga가_없으면_아무것도_하지_않는다() {
+        whenever(sagaEventLogRepository.findTimedOutSagas(any())).thenReturn(emptyList())
+
+        scheduler.checkTimedOutSagas()
+
+        verify(sagaEventLogRepository, never()).findById(any())
+        verify(transactionalEventPublisher, never()).publishEvent(
+            any(), any(), any(), any(), any(), any()
+        )
+    }
+
+    @Test
+    fun 이미_타임아웃_처리된_saga는_중복_보상하지_않는다() {
+        val saga = SagaEventLog(
+            eventId = "payment-completed-txn-2",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 2L,
+            timeoutAt = LocalDateTime.now().minusMinutes(1)
+        ).apply {
+            id = 200L
+            markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
+            markAsTimedOut()
+        }
+
+        whenever(sagaEventLogRepository.findTimedOutSagas(any())).thenReturn(listOf(saga))
+        whenever(sagaEventLogRepository.findById(200L)).thenReturn(Optional.of(saga))
+
+        scheduler.checkTimedOutSagas()
+
+        verify(transactionalEventPublisher, never()).publishEvent(
+            any(), any(), any(), any(), any(), any()
+        )
+    }
+
+    @Test
+    fun 이미_완료된_saga는_보상하지_않는다() {
+        val saga = SagaEventLog(
+            eventId = "payment-completed-txn-3",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 3L,
+            timeoutAt = LocalDateTime.now().minusMinutes(1)
+        ).apply {
+            id = 300L
+            markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
+            markStepCompleted(SagaEventLog.REMOTE_COMPLETED)
+        }
+
+        whenever(sagaEventLogRepository.findTimedOutSagas(any())).thenReturn(listOf(saga))
+        whenever(sagaEventLogRepository.findById(300L)).thenReturn(Optional.of(saga))
+
+        scheduler.checkTimedOutSagas()
+
+        verify(transactionalEventPublisher, never()).publishEvent(
+            any(), any(), any(), any(), any(), any()
+        )
+    }
+}


### PR DESCRIPTION
Closes #427

### 📌 작업 개요
결제 saga 가 타임아웃 (기본 5분) 까지 REMOTE_COMPLETED 되지 않으면 자동으로 보상 처리하는 스케줄러를 추가했습니다.
보상 시 주문 상태를 CANCELLED 로 전이하고 `PaymentReversalRequested` 이벤트를 outbox 로 발행해 결제 역전을 트리거합니다.

---

### ✅ 주요 변경 사항

- `order.domain.SagaEventLog`
  - `timeoutAt` (기본 `createdAt + 5분`), `timedOut` 플래그, `markAsTimedOut()` / `isTimedOut()` 추가
  - `TIMED_OUT` 스텝 상수 + `DEFAULT_TIMEOUT_MINUTES` 추가
  - `(timedOut, timeoutAt)` 복합 인덱스로 조회 최적화

- `order.domain.repository.SagaEventLogRepository`
  - `findTimedOutSagas(now)`: `timedOut=false` 이면서 `timeoutAt<now` 이고 `REMOTE_COMPLETED` 미완료 항목 조회

- `order.order.service.SagaTimeoutScheduler` (신규)
  - 60s `@Scheduled` 주기로 감지, 항목별 `TransactionTemplate.execute` 로 트랜잭션 격리
  - `markAsTimedOut` → 주문 CANCEL_REQUESTED → CANCELLED 전이 → `PaymentReversalRequested` outbox 이벤트 발행
  - 이미 `timedOut` / `fullyCompleted` 인 saga 는 멱등 no-op

---

### 🧪 테스트

- `SagaEventLogTest`: 기본 timeoutAt, markAsTimedOut, 커스텀 timeout 검증
- `SagaTimeoutSchedulerTest`: 정상 보상, 멱등 no-op, 보상 실패 시 다음 항목 진행 시나리오
- `./gradlew jacocoTestVerification` 통과

---

### 📎 관련 이슈
- #427
