### PR TITLE
feat: CircuitBreaker 운영 제어 API 추가 (loadtest 한정)

### DIFF
--- a/order-service/src/main/kotlin/com/hoppingmall/order/config/SecurityConfig.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/config/SecurityConfig.kt
@@ -20,4 +20,10 @@ class SecurityConfig(
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         return configureBase(http).build()
     }
+
+    override fun configureServiceEndpoints(
+        auth: org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry
+    ) {
+        auth.requestMatchers("/ops/**").permitAll()
+    }
 }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/ops/CircuitBreakerAdminController.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/ops/CircuitBreakerAdminController.kt
@@ -1,0 +1,58 @@
+package com.hoppingmall.order.ops
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/ops/circuitbreakers")
+@Profile("loadtest")
+class CircuitBreakerAdminController(
+    private val registry: CircuitBreakerRegistry
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @PostMapping("/{name}/reset")
+    fun reset(@PathVariable name: String): Map<String, Any> {
+        val cb = registry.circuitBreaker(name)
+        val before = cb.state.name
+        cb.reset()
+        log.info("CircuitBreaker reset: name={}, before={}, after={}", name, before, cb.state.name)
+        return mapOf("name" to name, "before" to before, "after" to cb.state.name)
+    }
+
+    @PostMapping("/reset-all")
+    fun resetAll(): List<Map<String, Any>> {
+        return registry.allCircuitBreakers.map {
+            val before = it.state.name
+            it.reset()
+            log.info("CircuitBreaker reset: name={}, before={}, after={}", it.name, before, it.state.name)
+            mapOf<String, Any>("name" to it.name, "before" to before, "after" to it.state.name)
+        }
+    }
+
+    @PostMapping("/disable-all")
+    fun disableAll(): List<Map<String, Any>> {
+        return registry.allCircuitBreakers.map {
+            val before = it.state.name
+            it.transitionToDisabledState()
+            log.info("CircuitBreaker disabled: name={}, before={}, after={}", it.name, before, it.state.name)
+            mapOf<String, Any>("name" to it.name, "before" to before, "after" to it.state.name)
+        }
+    }
+
+    @PostMapping("/enable-all")
+    fun enableAll(): List<Map<String, Any>> {
+        return registry.allCircuitBreakers.map {
+            val before = it.state.name
+            it.transitionToClosedState()
+            log.info("CircuitBreaker enabled: name={}, before={}, after={}", it.name, before, it.state.name)
+            mapOf<String, Any>("name" to it.name, "before" to before, "after" to it.state.name)
+        }
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/ops/CircuitBreakerAdminControllerTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/ops/CircuitBreakerAdminControllerTest.kt
@@ -1,0 +1,67 @@
+package com.hoppingmall.order.ops
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+
+@DisplayName("CircuitBreakerAdminController")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class CircuitBreakerAdminControllerTest {
+
+    private fun newController(): Pair<CircuitBreakerAdminController, CircuitBreakerRegistry> {
+        val registry = CircuitBreakerRegistry.ofDefaults()
+        registry.circuitBreaker("product-query")
+        registry.circuitBreaker("payment-query")
+        return CircuitBreakerAdminController(registry) to registry
+    }
+
+    @Test
+    fun disable_all_은_모든_CB를_DISABLED_상태로_전환한다() {
+        val (controller, registry) = newController()
+
+        val result = controller.disableAll()
+
+        assertThat(result).hasSize(2)
+        assertThat(registry.allCircuitBreakers.map { it.state })
+            .containsOnly(CircuitBreaker.State.DISABLED)
+    }
+
+    @Test
+    fun enable_all_은_DISABLED_상태의_CB를_CLOSED로_복원한다() {
+        val (controller, registry) = newController()
+        registry.allCircuitBreakers.forEach { it.transitionToDisabledState() }
+
+        val result = controller.enableAll()
+
+        assertThat(result).hasSize(2)
+        assertThat(registry.allCircuitBreakers.map { it.state })
+            .containsOnly(CircuitBreaker.State.CLOSED)
+    }
+
+    @Test
+    fun reset_all_은_모든_CB를_CLOSED로_리셋한다() {
+        val (controller, registry) = newController()
+        registry.allCircuitBreakers.forEach { it.transitionToOpenState() }
+
+        val result = controller.resetAll()
+
+        assertThat(result).hasSize(2)
+        assertThat(registry.allCircuitBreakers.map { it.state })
+            .containsOnly(CircuitBreaker.State.CLOSED)
+    }
+
+    @Test
+    fun reset_단일_CB는_이름으로_지정해서_리셋한다() {
+        val (controller, registry) = newController()
+        registry.circuitBreaker("product-query").transitionToOpenState()
+
+        val result = controller.reset("product-query")
+
+        assertThat(result["name"]).isEqualTo("product-query")
+        assertThat(registry.circuitBreaker("product-query").state).isEqualTo(CircuitBreaker.State.CLOSED)
+    }
+}


### PR DESCRIPTION
Closes #429

### 📌 작업 개요
부하 테스트 시나리오에서 Resilience4j CircuitBreaker 상태를 외부에서 수동 제어할 수 있는 운영 API 를 추가했습니다.
`loadtest` Spring 프로파일에서만 빈이 등록되며, `/ops/**` 경로는 SecurityConfig 에서 permitAll 로 열어두어 인증 부하 없이 호출할 수 있도록 했습니다.

---

### ✅ 주요 변경 사항

- `order.ops.CircuitBreakerAdminController` (신규, `@Profile("loadtest")`)
  - `POST /ops/circuitbreakers/{name}/reset`
  - `POST /ops/circuitbreakers/reset-all`
  - `POST /ops/circuitbreakers/disable-all`
  - `POST /ops/circuitbreakers/enable-all`
  - 응답: `{ name, before, after }` 형태로 상태 전환 검증

- `order.config.SecurityConfig`
  - `configureServiceEndpoints` 오버라이드로 `/ops/**` permitAll 추가 (loadtest 프로파일 미활성 시 컨트롤러 자체가 없어 이중 안전)

---

### 🧪 테스트

- `CircuitBreakerAdminControllerTest`: Resilience4j Registry 실인스턴스로 reset / reset-all / disable-all / enable-all 4 엔드포인트 상태 전이 검증
- `./gradlew jacocoTestVerification` 통과

---

### 📎 관련 이슈
- #429
