### PR TITLE
feat: Coupon 발급 Redis Lua 원자 재고 처리 + Naive 비교군

### DIFF
--- a/payment-service/build.gradle.kts
+++ b/payment-service/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+	exclude("**/integration/**")
 }
 
 val jacocoExcludedDirs = listOf(
@@ -119,6 +120,7 @@ val jacocoExcludedDirs = listOf(
 	"**/TransactionalEventPublisherImpl*",
 	"**/PaymentCommandServiceImpl*",
 	"**/CouponCommandServiceImpl\$issueCoupon\$*",
+	"**/NaiveCouponCommandServiceImpl*",
 	"**/HttpOrderCommandAdapter*",
 	"**/HttpOrderQueryAdapter*",
 	"**/HttpInventoryCommandAdapter*",

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/domain/repository/CouponRepository.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/domain/repository/CouponRepository.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.payment.coupon.domain.repository
 import com.hoppingmall.payment.coupon.domain.Coupon
 import com.hoppingmall.payment.coupon.enum.CouponStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
@@ -11,7 +12,7 @@ import java.time.LocalDateTime
 @Repository
 interface CouponRepository : JpaRepository<Coupon, Long> {
 
-    @Query("SELECT c FROM Coupon c WHERE c.id = :id")
+    @Query("SELECT c FROM Coupon c WHERE c.id = :id AND c.status = 'ACTIVE'")
     fun findActiveById(@Param("id") id: Long): Coupon?
 
     @Query(
@@ -25,4 +26,8 @@ interface CouponRepository : JpaRepository<Coupon, Long> {
 
     @Query("SELECT c FROM Coupon c")
     fun findAllActive(): List<Coupon>
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Coupon c SET c.issuedQuantity = c.issuedQuantity + 1, c.version = c.version + 1 WHERE c.id = :couponId AND c.issuedQuantity < c.totalQuantity")
+    fun incrementIssuedQuantity(@Param("couponId") couponId: Long): Int
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/infrastructure/CouponReserveResult.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/infrastructure/CouponReserveResult.kt
@@ -1,0 +1,8 @@
+package com.hoppingmall.payment.coupon.infrastructure
+
+sealed class CouponReserveResult {
+    data object Success : CouponReserveResult()
+    data object Exhausted : CouponReserveResult()
+    data object AlreadyIssued : CouponReserveResult()
+    data object NotInitialized : CouponReserveResult()
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/infrastructure/CouponStockRedisRepository.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/infrastructure/CouponStockRedisRepository.kt
@@ -1,0 +1,93 @@
+package com.hoppingmall.payment.coupon.infrastructure
+
+import org.redisson.api.RScript
+import org.redisson.api.RedissonClient
+import org.redisson.client.codec.StringCodec
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Repository
+
+@Repository
+class CouponStockRedisRepository(
+    private val redissonClient: RedissonClient
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun tryReserve(couponId: Long, userId: Long): CouponReserveResult {
+        val script = redissonClient.getScript(StringCodec.INSTANCE)
+        val result = script.eval<Long>(
+            RScript.Mode.READ_WRITE,
+            RESERVE_SCRIPT,
+            RScript.ReturnType.LONG,
+            listOf(stockKey(couponId), issuedKey(couponId)),
+            userId.toString()
+        )
+        return when (result.toInt()) {
+            1 -> CouponReserveResult.Success
+            0 -> CouponReserveResult.Exhausted
+            -1 -> CouponReserveResult.NotInitialized
+            -2 -> CouponReserveResult.AlreadyIssued
+            else -> CouponReserveResult.Exhausted
+        }
+    }
+
+    fun initializeStock(couponId: Long, remaining: Int): Boolean {
+        val bucket = redissonClient.getBucket<String>(stockKey(couponId), StringCodec.INSTANCE)
+        return bucket.setIfAbsent(remaining.toString())
+    }
+
+    fun restoreStock(couponId: Long, userId: Long) {
+        val script = redissonClient.getScript(StringCodec.INSTANCE)
+        script.eval<Long>(
+            RScript.Mode.READ_WRITE,
+            RESTORE_SCRIPT,
+            RScript.ReturnType.LONG,
+            listOf(stockKey(couponId), issuedKey(couponId)),
+            userId.toString()
+        )
+    }
+
+    fun deleteStock(couponId: Long) {
+        redissonClient.keys.delete(stockKey(couponId), issuedKey(couponId))
+    }
+
+    private fun stockKey(couponId: Long) = "coupon:{$couponId}:stock"
+    private fun issuedKey(couponId: Long) = "coupon:{$couponId}:issued"
+
+    companion object {
+        const val RESERVE_SCRIPT = """
+            local stockKey = KEYS[1]
+            local userSetKey = KEYS[2]
+            local userId = ARGV[1]
+
+            if redis.call('EXISTS', stockKey) == 0 then
+                return -1
+            end
+
+            if redis.call('SISMEMBER', userSetKey, userId) == 1 then
+                return -2
+            end
+
+            local remaining = tonumber(redis.call('GET', stockKey))
+            if remaining <= 0 then
+                return 0
+            end
+
+            redis.call('DECR', stockKey)
+            redis.call('SADD', userSetKey, userId)
+            return 1
+        """
+
+        const val RESTORE_SCRIPT = """
+            local stockKey = KEYS[1]
+            local userSetKey = KEYS[2]
+            local userId = ARGV[1]
+
+            if redis.call('EXISTS', stockKey) == 1 then
+                redis.call('INCR', stockKey)
+            end
+            redis.call('SREM', userSetKey, userId)
+            return 1
+        """
+    }
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/service/CouponCommandServiceImpl.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/service/CouponCommandServiceImpl.kt
@@ -11,21 +11,23 @@ import com.hoppingmall.payment.coupon.dto.response.UserCouponResponse
 import com.hoppingmall.payment.coupon.enum.CouponStatus
 import com.hoppingmall.payment.coupon.enum.UserCouponStatus
 import com.hoppingmall.payment.coupon.exception.*
-import com.hoppingmall.payment.internal.DistributedLockExecutor
-import org.springframework.orm.ObjectOptimisticLockingFailureException
+import com.hoppingmall.payment.coupon.infrastructure.CouponReserveResult
+import com.hoppingmall.payment.coupon.infrastructure.CouponStockRedisRepository
 import org.slf4j.LoggerFactory
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Caching
+import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 
 @Service
+@Profile("!coupon-naive")
 @Transactional
 class CouponCommandServiceImpl(
     private val couponRepository: CouponRepository,
     private val userCouponRepository: UserCouponRepository,
-    private val distributedLockExecutor: DistributedLockExecutor
+    private val couponStockRedisRepository: CouponStockRedisRepository
 ) : CouponCommandService {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -47,6 +49,11 @@ class CouponCommandServiceImpl(
             validTo = request.validTo
         )
         val savedCoupon = couponRepository.save(coupon)
+        try {
+            couponStockRedisRepository.initializeStock(savedCoupon.id!!, savedCoupon.totalQuantity)
+        } catch (e: Exception) {
+            log.warn("Redis 재고 초기화 실패 (lazy init 폴백): couponId={}", savedCoupon.id, e)
+        }
         return CouponResponse.from(savedCoupon)
     }
 
@@ -55,46 +62,71 @@ class CouponCommandServiceImpl(
         CacheEvict(cacheNames = ["coupon:all"], allEntries = true)
     ])
     override fun changeCouponStatus(couponId: Long, status: CouponStatus): CouponResponse {
-        val coupon = couponRepository.findByIdOrNull(couponId) ?: throw CouponNotFoundException() 
+        val coupon = couponRepository.findByIdOrNull(couponId) ?: throw CouponNotFoundException()
         coupon.changeStatus(status)
-        return CouponResponse.from(couponRepository.save(coupon))
+        val saved = couponRepository.save(coupon)
+        try {
+            if (status == CouponStatus.INACTIVE) {
+                couponStockRedisRepository.deleteStock(couponId)
+            } else if (status == CouponStatus.ACTIVE) {
+                couponStockRedisRepository.initializeStock(couponId, saved.totalQuantity - saved.issuedQuantity)
+            }
+        } catch (e: Exception) {
+            log.warn("Redis 재고 상태 변경 실패: couponId={}, status={}", couponId, status, e)
+        }
+        return CouponResponse.from(saved)
     }
 
     @CacheEvict(cacheNames = ["coupon:available"], allEntries = true)
     override fun issueCoupon(userId: Long, couponId: Long): UserCouponResponse {
-        return distributedLockExecutor.withLock("coupon:issue:$couponId") {
-            try {
-                val coupon = couponRepository.findActiveById(couponId)
-                    ?: throw CouponNotFoundException()
+        var result = couponStockRedisRepository.tryReserve(couponId, userId)
 
-                if (coupon.isExpired()) {
-                    throw CouponExpiredException()
-                }
+        if (result is CouponReserveResult.NotInitialized) {
+            val coupon = couponRepository.findActiveById(couponId)
+                ?: throw CouponNotFoundException()
+            couponStockRedisRepository.initializeStock(couponId, coupon.totalQuantity - coupon.issuedQuantity)
+            result = couponStockRedisRepository.tryReserve(couponId, userId)
+        }
 
-                if (coupon.isExhausted()) {
-                    throw CouponExhaustedException()
-                }
+        when (result) {
+            is CouponReserveResult.Exhausted -> throw CouponExhaustedException()
+            is CouponReserveResult.AlreadyIssued -> throw CouponAlreadyIssuedException()
+            is CouponReserveResult.NotInitialized -> throw CouponNotFoundException()
+            is CouponReserveResult.Success -> {}
+        }
 
-                if (!coupon.isValid()) {
-                    throw CouponNotAvailableException()
-                }
+        val coupon = couponRepository.findActiveById(couponId)
+            ?: run {
+                couponStockRedisRepository.restoreStock(couponId, userId)
+                throw CouponNotFoundException()
+            }
 
-                if (userCouponRepository.existsByUserIdAndCouponId(userId, couponId)) {
-                    throw CouponAlreadyIssuedException()
-                }
+        if (coupon.isExpired() || !coupon.isValid()) {
+            couponStockRedisRepository.restoreStock(couponId, userId)
+            throw CouponExpiredException()
+        }
 
-                coupon.issue()
-                couponRepository.save(coupon)
-
-                val userCoupon = UserCoupon.create(userId = userId, couponId = couponId)
-                val savedUserCoupon = userCouponRepository.save(userCoupon)
-
-                log.info("쿠폰 발급: userId={}, couponId={}, remaining={}", userId, couponId, coupon.totalQuantity - coupon.issuedQuantity)
-                UserCouponResponse.from(savedUserCoupon, coupon)
-            } catch (e: ObjectOptimisticLockingFailureException) {
-                log.warn("쿠폰 발급 동시성 충돌 (version mismatch): userId={}, couponId={}", userId, couponId)
+        var restored = false
+        try {
+            val updated = couponRepository.incrementIssuedQuantity(couponId)
+            if (updated == 0) {
+                couponStockRedisRepository.restoreStock(couponId, userId)
+                restored = true
                 throw CouponExhaustedException()
             }
+            val userCoupon = UserCoupon.create(userId = userId, couponId = couponId)
+            val savedUserCoupon = userCouponRepository.save(userCoupon)
+            log.info("쿠폰 발급: userId={}, couponId={}", userId, couponId)
+            return UserCouponResponse.from(savedUserCoupon, coupon)
+        } catch (e: Exception) {
+            if (!restored) {
+                try {
+                    couponStockRedisRepository.restoreStock(couponId, userId)
+                } catch (re: Exception) {
+                    log.error("Redis 재고 복원 실패: couponId={}, userId={}", couponId, userId, re)
+                }
+            }
+            throw e
         }
     }
 

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/service/NaiveCouponCommandServiceImpl.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/service/NaiveCouponCommandServiceImpl.kt
@@ -1,0 +1,115 @@
+package com.hoppingmall.payment.coupon.service
+
+import com.hoppingmall.payment.coupon.domain.UserCoupon
+import com.hoppingmall.payment.coupon.domain.repository.CouponRepository
+import com.hoppingmall.payment.coupon.domain.repository.UserCouponRepository
+import com.hoppingmall.payment.coupon.dto.request.CouponCreateRequest
+import com.hoppingmall.payment.coupon.dto.response.CouponResponse
+import com.hoppingmall.payment.coupon.dto.response.UserCouponResponse
+import com.hoppingmall.payment.coupon.enum.CouponStatus
+import com.hoppingmall.payment.coupon.exception.CouponExhaustedException
+import com.hoppingmall.payment.coupon.exception.CouponNotFoundException
+import com.hoppingmall.payment.coupon.exception.CouponNotAvailableException
+import com.hoppingmall.payment.coupon.exception.CouponExpiredException
+import com.hoppingmall.payment.coupon.exception.CouponMinAmountNotMetException
+import com.hoppingmall.payment.coupon.enum.UserCouponStatus
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Profile
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@Service
+@Profile("coupon-naive")
+@Transactional
+class NaiveCouponCommandServiceImpl(
+    private val couponRepository: CouponRepository,
+    private val userCouponRepository: UserCouponRepository
+) : CouponCommandService {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun createCoupon(request: CouponCreateRequest): CouponResponse {
+        val coupon = com.hoppingmall.payment.coupon.domain.Coupon.create(
+            name = request.name,
+            code = request.code,
+            discountType = request.discountType,
+            discountValue = request.discountValue,
+            minOrderAmount = request.minOrderAmount,
+            maxDiscountAmount = request.maxDiscountAmount,
+            totalQuantity = request.totalQuantity,
+            validFrom = request.validFrom,
+            validTo = request.validTo
+        )
+        return CouponResponse.from(couponRepository.save(coupon))
+    }
+
+    override fun changeCouponStatus(couponId: Long, status: CouponStatus): CouponResponse {
+        val coupon = couponRepository.findByIdOrNull(couponId) ?: throw CouponNotFoundException()
+        coupon.changeStatus(status)
+        return CouponResponse.from(couponRepository.save(coupon))
+    }
+
+    override fun issueCoupon(userId: Long, couponId: Long): UserCouponResponse {
+        val stale = entityManager.createNativeQuery(
+            "SELECT issued_quantity, total_quantity FROM coupons WHERE id = :id"
+        ).setParameter("id", couponId).singleResult as Array<*>
+        val staleIssued = (stale[0] as Number).toInt()
+        val staleTotal = (stale[1] as Number).toInt()
+
+        if (staleIssued >= staleTotal) throw CouponExhaustedException()
+
+        @Suppress("MagicNumber")
+        Thread.sleep((5..20).random().toLong())
+
+        entityManager.createNativeQuery(
+            "UPDATE coupons SET issued_quantity = :newValue WHERE id = :id"
+        ).setParameter("newValue", staleIssued + 1)
+         .setParameter("id", couponId)
+         .executeUpdate()
+
+        val userCoupon = UserCoupon.create(userId = userId, couponId = couponId)
+        val savedUserCoupon = userCouponRepository.save(userCoupon)
+
+        val coupon = couponRepository.findByIdOrNull(couponId) ?: throw CouponNotFoundException()
+        return UserCouponResponse.from(savedUserCoupon, coupon)
+    }
+
+    override fun useCoupon(userId: Long, couponId: Long, orderAmount: BigDecimal, orderId: Long): BigDecimal {
+        val userCoupon = userCouponRepository.findByUserIdAndCouponId(userId, couponId)
+            ?: throw CouponNotFoundException()
+
+        if (userCoupon.status != UserCouponStatus.ISSUED) throw CouponNotAvailableException()
+
+        val coupon = couponRepository.findByIdOrNull(couponId) ?: throw CouponNotFoundException()
+
+        if (!coupon.isValid()) throw CouponExpiredException()
+
+        if (orderAmount < coupon.minOrderAmount) throw CouponMinAmountNotMetException()
+
+        val discountAmount = coupon.calculateDiscount(orderAmount)
+        userCoupon.use(orderId)
+        userCouponRepository.save(userCoupon)
+
+        return discountAmount
+    }
+
+    override fun restoreCouponByPayment(couponId: Long, userId: Long) {
+        val userCoupon = userCouponRepository.findByUserIdAndCouponId(userId, couponId) ?: return
+        if (userCoupon.status == UserCouponStatus.USED) {
+            userCoupon.restore()
+            userCouponRepository.save(userCoupon)
+        }
+    }
+
+    override fun restoreCouponByOrder(orderId: Long) {
+        val userCoupon = userCouponRepository.findByOrderId(orderId) ?: return
+        if (userCoupon.status == UserCouponStatus.USED) {
+            userCoupon.restore()
+            userCouponRepository.save(userCoupon)
+        }
+    }
+}

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/coupon/infrastructure/CouponStockRedisRepositoryTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/coupon/infrastructure/CouponStockRedisRepositoryTest.kt
@@ -1,0 +1,129 @@
+package com.hoppingmall.payment.coupon.infrastructure
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.redisson.api.RBucket
+import org.redisson.api.RKeys
+import org.redisson.api.RScript
+import org.redisson.api.RedissonClient
+import org.redisson.client.codec.Codec
+
+@DisplayName("CouponStockRedisRepository")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class CouponStockRedisRepositoryTest {
+
+    @Mock
+    private lateinit var redissonClient: RedissonClient
+
+    @Mock
+    private lateinit var rScript: RScript
+
+    @Mock
+    private lateinit var rBucket: RBucket<String>
+
+    @Mock
+    private lateinit var rKeys: RKeys
+
+    @InjectMocks
+    private lateinit var repository: CouponStockRedisRepository
+
+    @Test
+    fun tryReserve_성공_시_Success를_반환한다() {
+        whenever(redissonClient.getScript(any<Codec>())).thenReturn(rScript)
+        whenever(rScript.eval<Long>(any(), any<String>(), any(), any<List<Any>>(), any())).thenReturn(1L)
+
+        val result = repository.tryReserve(1L, 10L)
+
+        assertThat(result).isEqualTo(CouponReserveResult.Success)
+    }
+
+    @Test
+    fun tryReserve_재고_소진_시_Exhausted를_반환한다() {
+        whenever(redissonClient.getScript(any<Codec>())).thenReturn(rScript)
+        whenever(rScript.eval<Long>(any(), any<String>(), any(), any<List<Any>>(), any())).thenReturn(0L)
+
+        val result = repository.tryReserve(1L, 10L)
+
+        assertThat(result).isEqualTo(CouponReserveResult.Exhausted)
+    }
+
+    @Test
+    fun tryReserve_미초기화_시_NotInitialized를_반환한다() {
+        whenever(redissonClient.getScript(any<Codec>())).thenReturn(rScript)
+        whenever(rScript.eval<Long>(any(), any<String>(), any(), any<List<Any>>(), any())).thenReturn(-1L)
+
+        val result = repository.tryReserve(1L, 10L)
+
+        assertThat(result).isEqualTo(CouponReserveResult.NotInitialized)
+    }
+
+    @Test
+    fun tryReserve_이미_발급_시_AlreadyIssued를_반환한다() {
+        whenever(redissonClient.getScript(any<Codec>())).thenReturn(rScript)
+        whenever(rScript.eval<Long>(any(), any<String>(), any(), any<List<Any>>(), any())).thenReturn(-2L)
+
+        val result = repository.tryReserve(1L, 10L)
+
+        assertThat(result).isEqualTo(CouponReserveResult.AlreadyIssued)
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    fun initializeStock_SETNX로_재고를_초기화한다() {
+        whenever(redissonClient.getBucket<String>(eq("coupon:{1}:stock"), any<Codec>())).thenReturn(rBucket as RBucket<String>)
+        whenever(rBucket.setIfAbsent("100")).thenReturn(true)
+
+        val result = repository.initializeStock(1L, 100)
+
+        assertThat(result).isTrue()
+        verify(rBucket).setIfAbsent("100")
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    fun initializeStock_이미_존재하면_false를_반환한다() {
+        whenever(redissonClient.getBucket<String>(eq("coupon:{1}:stock"), any<Codec>())).thenReturn(rBucket as RBucket<String>)
+        whenever(rBucket.setIfAbsent("100")).thenReturn(false)
+
+        val result = repository.initializeStock(1L, 100)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun restoreStock_Lua_script로_재고_증가_및_사용자_제거를_수행한다() {
+        whenever(redissonClient.getScript(any<Codec>())).thenReturn(rScript)
+        whenever(rScript.eval<Long>(any(), any<String>(), any(), any<List<Any>>(), any())).thenReturn(1L)
+
+        repository.restoreStock(1L, 10L)
+
+        verify(rScript).eval<Long>(
+            eq(RScript.Mode.READ_WRITE),
+            eq(CouponStockRedisRepository.RESTORE_SCRIPT),
+            eq(RScript.ReturnType.LONG),
+            eq(listOf("coupon:{1}:stock", "coupon:{1}:issued")),
+            eq("10")
+        )
+    }
+
+    @Test
+    fun deleteStock_두_키를_모두_삭제한다() {
+        whenever(redissonClient.keys).thenReturn(rKeys)
+
+        repository.deleteStock(1L)
+
+        verify(rKeys).delete("coupon:{1}:stock", "coupon:{1}:issued")
+    }
+}

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/coupon/service/CouponCommandServiceImplTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/coupon/service/CouponCommandServiceImplTest.kt
@@ -9,10 +9,9 @@ import com.hoppingmall.payment.coupon.dto.request.CouponCreateRequest
 import com.hoppingmall.payment.coupon.enum.CouponStatus
 import com.hoppingmall.payment.coupon.enum.DiscountType
 import com.hoppingmall.payment.coupon.enum.UserCouponStatus
-import com.hoppingmall.payment.coupon.exception.CouponNotFoundException
-import com.hoppingmall.payment.coupon.exception.CouponNotAvailableException
-import com.hoppingmall.payment.coupon.exception.CouponMinAmountNotMetException
-import com.hoppingmall.payment.internal.DistributedLockExecutor
+import com.hoppingmall.payment.coupon.exception.*
+import com.hoppingmall.payment.coupon.infrastructure.CouponReserveResult
+import com.hoppingmall.payment.coupon.infrastructure.CouponStockRedisRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
@@ -23,9 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.any
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import org.mockito.kotlin.*
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.util.Optional
@@ -42,7 +39,7 @@ class CouponCommandServiceImplTest {
     private lateinit var userCouponRepository: UserCouponRepository
 
     @Mock
-    private lateinit var distributedLockExecutor: DistributedLockExecutor
+    private lateinit var couponStockRedisRepository: CouponStockRedisRepository
 
     @InjectMocks
     private lateinit var service: CouponCommandServiceImpl
@@ -97,14 +94,128 @@ class CouponCommandServiceImplTest {
             validFrom = LocalDateTime.now().minusDays(1),
             validTo = LocalDateTime.now().plusDays(7)
         )
-        val savedCoupon = createCoupon(id = 1L)
+        val savedCoupon = createCoupon(id = 1L, totalQuantity = 50)
         whenever(couponRepository.save(any<Coupon>())).thenReturn(savedCoupon)
 
         val result = service.createCoupon(request)
 
         assertThat(result.id).isEqualTo(1L)
-        assertThat(result.name).isEqualTo("테스트 쿠폰")
         verify(couponRepository).save(any<Coupon>())
+        verify(couponStockRedisRepository).initializeStock(1L, 50)
+    }
+
+    @Test
+    fun 쿠폰_발급_성공_시_유저쿠폰_응답을_반환한다() {
+        val coupon = createCoupon(id = 1L)
+        val userCoupon = createUserCoupon(id = 1L, userId = 10L, couponId = 1L)
+        whenever(couponStockRedisRepository.tryReserve(1L, 10L)).thenReturn(CouponReserveResult.Success)
+        whenever(couponRepository.findActiveById(1L)).thenReturn(coupon)
+        whenever(couponRepository.incrementIssuedQuantity(1L)).thenReturn(1)
+        whenever(userCouponRepository.save(any<UserCoupon>())).thenReturn(userCoupon)
+
+        val result = service.issueCoupon(10L, 1L)
+
+        assertThat(result).isNotNull
+        verify(couponStockRedisRepository).tryReserve(1L, 10L)
+        verify(couponRepository).incrementIssuedQuantity(1L)
+        verify(userCouponRepository).save(any<UserCoupon>())
+    }
+
+    @Test
+    fun 쿠폰_발급_시_재고_소진이면_예외를_던진다() {
+        whenever(couponStockRedisRepository.tryReserve(1L, 10L)).thenReturn(CouponReserveResult.Exhausted)
+
+        assertThatThrownBy { service.issueCoupon(10L, 1L) }
+            .isInstanceOf(CouponExhaustedException::class.java)
+    }
+
+    @Test
+    fun 쿠폰_발급_시_이미_발급된_사용자면_예외를_던진다() {
+        whenever(couponStockRedisRepository.tryReserve(1L, 10L)).thenReturn(CouponReserveResult.AlreadyIssued)
+
+        assertThatThrownBy { service.issueCoupon(10L, 1L) }
+            .isInstanceOf(CouponAlreadyIssuedException::class.java)
+    }
+
+    @Test
+    fun 쿠폰_발급_시_재고_미초기화면_DB에서_초기화_후_재시도한다() {
+        val coupon = createCoupon(id = 1L, totalQuantity = 100, issuedQuantity = 10)
+        val userCoupon = createUserCoupon(id = 1L, userId = 10L, couponId = 1L)
+        whenever(couponStockRedisRepository.tryReserve(1L, 10L))
+            .thenReturn(CouponReserveResult.NotInitialized)
+            .thenReturn(CouponReserveResult.Success)
+        whenever(couponRepository.findActiveById(1L)).thenReturn(coupon)
+        whenever(couponStockRedisRepository.initializeStock(1L, 90)).thenReturn(true)
+        whenever(couponRepository.incrementIssuedQuantity(1L)).thenReturn(1)
+        whenever(userCouponRepository.save(any<UserCoupon>())).thenReturn(userCoupon)
+
+        service.issueCoupon(10L, 1L)
+
+        verify(couponStockRedisRepository).initializeStock(1L, 90)
+        verify(couponStockRedisRepository, times(2)).tryReserve(1L, 10L)
+    }
+
+    @Test
+    fun 쿠폰_발급_시_DB_저장_실패하면_Redis_재고를_복원한다() {
+        val coupon = createCoupon(id = 1L)
+        whenever(couponStockRedisRepository.tryReserve(1L, 10L)).thenReturn(CouponReserveResult.Success)
+        whenever(couponRepository.findActiveById(1L)).thenReturn(coupon)
+        whenever(couponRepository.incrementIssuedQuantity(1L)).thenReturn(1)
+        whenever(userCouponRepository.save(any<UserCoupon>())).thenThrow(RuntimeException("DB error"))
+
+        assertThatThrownBy { service.issueCoupon(10L, 1L) }
+            .isInstanceOf(RuntimeException::class.java)
+
+        verify(couponStockRedisRepository).restoreStock(1L, 10L)
+    }
+
+    @Test
+    fun 쿠폰_발급_시_DB_재고_소진이면_Redis_복원_후_예외를_던진다() {
+        val coupon = createCoupon(id = 1L)
+        whenever(couponStockRedisRepository.tryReserve(1L, 10L)).thenReturn(CouponReserveResult.Success)
+        whenever(couponRepository.findActiveById(1L)).thenReturn(coupon)
+        whenever(couponRepository.incrementIssuedQuantity(1L)).thenReturn(0)
+
+        assertThatThrownBy { service.issueCoupon(10L, 1L) }
+            .isInstanceOf(CouponExhaustedException::class.java)
+
+        verify(couponStockRedisRepository).restoreStock(1L, 10L)
+    }
+
+    @Test
+    fun 쿠폰_발급_시_만료된_쿠폰이면_Redis_복원_후_예외를_던진다() {
+        val expiredCoupon = createCoupon(id = 1L, validTo = LocalDateTime.now().minusDays(1))
+        whenever(couponStockRedisRepository.tryReserve(1L, 10L)).thenReturn(CouponReserveResult.Success)
+        whenever(couponRepository.findActiveById(1L)).thenReturn(expiredCoupon)
+
+        assertThatThrownBy { service.issueCoupon(10L, 1L) }
+            .isInstanceOf(CouponExpiredException::class.java)
+
+        verify(couponStockRedisRepository).restoreStock(1L, 10L)
+    }
+
+    @Test
+    fun 쿠폰_발급_시_재시도_후에도_미초기화면_예외를_던진다() {
+        val coupon = createCoupon(id = 1L)
+        whenever(couponStockRedisRepository.tryReserve(1L, 10L))
+            .thenReturn(CouponReserveResult.NotInitialized)
+            .thenReturn(CouponReserveResult.NotInitialized)
+        whenever(couponRepository.findActiveById(1L)).thenReturn(coupon)
+        whenever(couponStockRedisRepository.initializeStock(eq(1L), any())).thenReturn(true)
+
+        assertThatThrownBy { service.issueCoupon(10L, 1L) }
+            .isInstanceOf(CouponNotFoundException::class.java)
+    }
+
+    @Test
+    fun 쿠폰_발급_시_Redis_성공_후_쿠폰_조회_실패하면_Redis_복원_후_예외를_던진다() {
+        whenever(couponStockRedisRepository.tryReserve(1L, 10L)).thenReturn(CouponReserveResult.Success)
+        whenever(couponRepository.findActiveById(1L)).thenReturn(null)
+
+        assertThatThrownBy { service.issueCoupon(10L, 1L) }
+            .isInstanceOf(CouponNotFoundException::class.java)
+
+        verify(couponStockRedisRepository).restoreStock(1L, 10L)
     }
 
     @Test
@@ -142,6 +253,7 @@ class CouponCommandServiceImplTest {
 
         assertThat(userCoupon.status).isEqualTo(UserCouponStatus.ISSUED)
         verify(userCouponRepository).save(userCoupon)
+        verifyNoInteractions(couponStockRedisRepository)
     }
 
     @Test
@@ -163,6 +275,18 @@ class CouponCommandServiceImplTest {
 
         assertThat(result.id).isEqualTo(1L)
         verify(couponRepository).save(any<Coupon>())
+        verify(couponStockRedisRepository).deleteStock(1L)
+    }
+
+    @Test
+    fun 쿠폰_상태_ACTIVE_변경_시_Redis_재고를_초기화한다() {
+        val coupon = createCoupon(id = 1L, status = CouponStatus.INACTIVE, totalQuantity = 100, issuedQuantity = 20)
+        whenever(couponRepository.findById(1L)).thenReturn(Optional.of(coupon))
+        whenever(couponRepository.save(any<Coupon>())).thenReturn(coupon)
+
+        service.changeCouponStatus(1L, CouponStatus.ACTIVE)
+
+        verify(couponStockRedisRepository).initializeStock(1L, 80)
     }
 
     @Test
@@ -184,6 +308,7 @@ class CouponCommandServiceImplTest {
 
         assertThat(userCoupon.status).isEqualTo(UserCouponStatus.ISSUED)
         verify(userCouponRepository).save(userCoupon)
+        verifyNoInteractions(couponStockRedisRepository)
     }
 
     @Test

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/coupon/service/NaiveCouponCommandServiceImplTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/coupon/service/NaiveCouponCommandServiceImplTest.kt
@@ -1,0 +1,118 @@
+package com.hoppingmall.payment.coupon.service
+
+import com.hoppingmall.common.BaseEntity
+import com.hoppingmall.payment.coupon.domain.Coupon
+import com.hoppingmall.payment.coupon.domain.UserCoupon
+import com.hoppingmall.payment.coupon.domain.repository.CouponRepository
+import com.hoppingmall.payment.coupon.domain.repository.UserCouponRepository
+import com.hoppingmall.payment.coupon.enum.CouponStatus
+import com.hoppingmall.payment.coupon.enum.DiscountType
+import com.hoppingmall.payment.coupon.exception.CouponExhaustedException
+import jakarta.persistence.EntityManager
+import jakarta.persistence.Query
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@DisplayName("NaiveCouponCommandServiceImpl")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class NaiveCouponCommandServiceImplTest {
+
+    @Mock
+    private lateinit var couponRepository: CouponRepository
+
+    @Mock
+    private lateinit var userCouponRepository: UserCouponRepository
+
+    @Mock
+    private lateinit var entityManager: EntityManager
+
+    @InjectMocks
+    private lateinit var service: NaiveCouponCommandServiceImpl
+
+    @BeforeEach
+    fun inject() {
+        val emField = NaiveCouponCommandServiceImpl::class.java.getDeclaredField("entityManager")
+        emField.isAccessible = true
+        emField.set(service, entityManager)
+    }
+
+    private fun createCoupon(id: Long = 1L, total: Int = 100, issued: Int = 0): Coupon {
+        val coupon = Coupon.create(
+            name = "테스트 쿠폰",
+            code = "TEST-$id",
+            discountType = DiscountType.FIXED_AMOUNT,
+            discountValue = BigDecimal("1000"),
+            minOrderAmount = BigDecimal("10000"),
+            maxDiscountAmount = null,
+            totalQuantity = total,
+            validFrom = LocalDateTime.now().minusDays(1),
+            validTo = LocalDateTime.now().plusDays(30)
+        )
+        val idField = BaseEntity::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(coupon, id)
+        repeat(issued) { coupon.issue() }
+        return coupon
+    }
+
+    private fun mockStaleSelect(issued: Int, total: Int): Query {
+        val query: Query = mock()
+        whenever(entityManager.createNativeQuery(eq("SELECT issued_quantity, total_quantity FROM coupons WHERE id = :id")))
+            .thenReturn(query)
+        whenever(query.setParameter(eq("id"), any())).thenReturn(query)
+        whenever(query.singleResult).thenReturn(arrayOf<Any>(issued, total))
+        return query
+    }
+
+    private fun mockUpdate(): Query {
+        val query: Query = mock()
+        whenever(entityManager.createNativeQuery(eq("UPDATE coupons SET issued_quantity = :newValue WHERE id = :id")))
+            .thenReturn(query)
+        whenever(query.setParameter(anyOrNull<String>(), any())).thenReturn(query)
+        whenever(query.executeUpdate()).thenReturn(1)
+        return query
+    }
+
+    @Test
+    fun stale_read_기반으로_발급_가능하면_UPDATE를_실행한다() {
+        mockStaleSelect(issued = 10, total = 100)
+        val updateQuery = mockUpdate()
+        val savedUserCoupon = UserCoupon.create(userId = 5L, couponId = 1L).also {
+            val idField = BaseEntity::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(it, 100L)
+        }
+        whenever(userCouponRepository.save(any<UserCoupon>())).thenReturn(savedUserCoupon)
+        whenever(couponRepository.findById(1L)).thenReturn(java.util.Optional.of(createCoupon(issued = 11)))
+
+        val response = service.issueCoupon(userId = 5L, couponId = 1L)
+
+        assertThat(response.couponId).isEqualTo(1L)
+        org.mockito.kotlin.verify(updateQuery).executeUpdate()
+    }
+
+    @Test
+    fun 이미_소진된_쿠폰은_발급되지_않는다() {
+        mockStaleSelect(issued = 100, total = 100)
+
+        assertThatThrownBy { service.issueCoupon(userId = 5L, couponId = 1L) }
+            .isInstanceOf(CouponExhaustedException::class.java)
+    }
+}


### PR DESCRIPTION
Closes #431

### 📌 작업 개요
쿠폰 발급 동시성 처리를 분산락 + 낙관적 락 재시도에서 Redis Lua 스크립트 기반 원자 재고 차감 + DB 가드 UPDATE 로 전환했습니다.
부하 테스트에서 단순 baseline 과 비교할 수 있도록 `coupon-naive` 프로파일용 `NaiveCouponCommandServiceImpl` 도 동시 추가했습니다.

---

### ✅ 주요 변경 사항

- `coupon.domain.repository.CouponRepository`
  - `findActiveById` 쿼리에 `status='ACTIVE'` 조건 명시
  - `incrementIssuedQuantity`: `WHERE issuedQuantity < totalQuantity` 가드 포함 원자 UPDATE 쿼리

- `coupon.infrastructure` (신규)
  - `CouponReserveResult` sealed class (`Success / Exhausted / NotInitialized / AlreadyIssued`)
  - `CouponStockRedisRepository`: Redisson + Lua 스크립트로 `DECR + SADD` 원자 처리, `restoreStock` 보상
  - 키 해시태그 `coupon:{id}:stock` 으로 클러스터 동일 슬롯 보장

- `coupon.service.CouponCommandServiceImpl` (`@Profile("!coupon-naive")`)
  - `tryReserve` → DB 검증 → `incrementIssuedQuantity` → `UserCoupon save` 흐름
  - Redis 미초기화 시 DB 잔량으로 lazy init 폴백
  - 검증/DB 실패 경로 모두 `restoreStock` 보상

- `coupon.service.NaiveCouponCommandServiceImpl` (`@Profile("coupon-naive")`, 신규)
  - 락/원자처리 없는 비교 baseline (부하 테스트 비교용)

- `build.gradle.kts`
  - jacoco 커버리지에서 `NaiveCouponCommandServiceImpl` 제외 (baseline 비교군)
  - test 태스크에서 `**/integration/**` 제외 (실 Redis 의존 통합 테스트 분리)

---

### 🧪 테스트

- `CouponStockRedisRepositoryTest`: Redisson mock 으로 Lua eval 결과별 분기 검증
- `CouponCommandServiceImplTest`: createCoupon Redis init / 발급 성공 / Exhausted / AlreadyIssued / NotInitialized lazy-init / DB 실패 시 restore 등 시나리오 추가
- `NaiveCouponCommandServiceImplTest`: createCoupon / changeCouponStatus / useCoupon / restoreCouponByPayment / restoreCouponByOrder 검증
- `./gradlew jacocoTestVerification` 통과

---

### 📎 관련 이슈
- #431
