### PR TITLE
fix: grpc 프로파일에서 PaymentCommandPort 빈 누락 수정

### DIFF
--- a/order-service/src/main/kotlin/com/hoppingmall/order/port/HttpPaymentCommandAdapter.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/port/HttpPaymentCommandAdapter.kt
@@ -5,13 +5,11 @@ import io.github.resilience4j.retry.annotation.Retry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
-import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
 import java.time.Duration
 
 @Component
-@Profile("!grpc")
 class HttpPaymentCommandAdapter(
     @Value("\${services.payment-service.url:http://localhost:8085}") private val paymentServiceUrl: String,
     restTemplateBuilder: RestTemplateBuilder


### PR DESCRIPTION
Closes #433

### 📌 작업 개요
`grpc` Spring 프로파일 활성 시 `PaymentCommandPort` 빈이 비어 컨텍스트 로딩이 실패하는 회귀를 수정합니다.
`HttpPaymentCommandAdapter` 의 `@Profile("!grpc")` 가드를 제거해 모든 프로파일에서 빈이 등록되도록 합니다.

---

### ✅ 주요 변경 사항

- `order.port.HttpPaymentCommandAdapter`
  - `@Profile("!grpc")` 어노테이션 + `Profile` import 제거
- 동일 패키지 `HttpPaymentQueryAdapter` / `HttpProductQueryAdapter` 는 대응 gRPC 어댑터(`GrpcPaymentQueryAdapter`, `GrpcProductQueryAdapter`)가 있어 그대로 유지

---

### 🧪 테스트

- `./gradlew jacocoTestVerification` 통과
- `OrderCommandServiceImpl` → `PaymentCommandPort` 의존성 그래프 변화 없음 (단일 구현체)

---

### 📎 관련 이슈
- #433
