### PR TITLE
fix: CartItem.totalPrice 컬럼 precision 확대

### DIFF
--- a/order-service/src/main/kotlin/com/hoppingmall/order/cartItem/domain/CartItem.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/cartItem/domain/CartItem.kt
@@ -34,7 +34,7 @@ class CartItem private constructor(
     @Column
     var quantity: Int,
 
-    @Column(precision = 10, scale = 2)
+    @Column(precision = 19, scale = 2)
     var totalPrice: BigDecimal,
 ): BaseEntity() {
 


### PR DESCRIPTION
Closes #435

### 📌 작업 개요
`CartItem.totalPrice` 컬럼 precision 을 10 에서 19 로 확대해 누적 금액 잘림 가능성을 제거합니다.

---

### ✅ 주요 변경 사항

- `order.cartItem.domain.CartItem`
  - `totalPrice` `@Column(precision=10, scale=2)` → `@Column(precision=19, scale=2)`
  - `unitPrice` 는 단일 상품 가격이라 기존 10 자리 유지

---

### 🧪 테스트

- `./gradlew jacocoTestVerification` 통과
- DDL: `ddl-auto=update` 환경에서 자동 반영. 운영 DB 는 별도 ALTER 문 필요할 수 있음.

---

### 📎 관련 이슈
- #435
