### PR TITLE
config: Redisson 클러스터 노드 설정 명시

### DIFF
--- a/order-service/src/main/resources/application-docker.yml
+++ b/order-service/src/main/resources/application-docker.yml
@@ -23,6 +23,14 @@ spring:
           - redis-node-1:7001
           - redis-node-2:7002
           - redis-node-3:7003
+      redisson:
+        config: |
+          clusterServersConfig:
+            nodeAddresses:
+              - "redis://redis-node-1:7001"
+              - "redis://redis-node-2:7002"
+              - "redis://redis-node-3:7003"
+            scanInterval: 1000
 management:
   metrics:
     tags:

--- a/payment-service/src/main/resources/application-docker.yml
+++ b/payment-service/src/main/resources/application-docker.yml
@@ -23,6 +23,14 @@ spring:
           - redis-node-1:7001
           - redis-node-2:7002
           - redis-node-3:7003
+      redisson:
+        config: |
+          clusterServersConfig:
+            nodeAddresses:
+              - "redis://redis-node-1:7001"
+              - "redis://redis-node-2:7002"
+              - "redis://redis-node-3:7003"
+            scanInterval: 1000
 management:
   metrics:
     tags:

--- a/product-service/src/main/resources/application-docker.yml
+++ b/product-service/src/main/resources/application-docker.yml
@@ -25,6 +25,14 @@ spring:
           - redis-node-1:7001
           - redis-node-2:7002
           - redis-node-3:7003
+      redisson:
+        config: |
+          clusterServersConfig:
+            nodeAddresses:
+              - "redis://redis-node-1:7001"
+              - "redis://redis-node-2:7002"
+              - "redis://redis-node-3:7003"
+            scanInterval: 1000
 management:
   metrics:
     tags:

--- a/user-service/src/main/resources/application-docker.yml
+++ b/user-service/src/main/resources/application-docker.yml
@@ -29,6 +29,14 @@ spring:
           - redis-node-1:7001
           - redis-node-2:7002
           - redis-node-3:7003
+      redisson:
+        config: |
+          clusterServersConfig:
+            nodeAddresses:
+              - "redis://redis-node-1:7001"
+              - "redis://redis-node-2:7002"
+              - "redis://redis-node-3:7003"
+            scanInterval: 1000
 management:
   metrics:
     tags:


### PR DESCRIPTION
Closes #437

### 📌 작업 개요
order / payment / product / user 4 개 서비스의 docker 프로파일에 Redisson 클러스터 모드 설정을 명시 추가합니다.
Spring Data Redis 의 `cluster.nodes` 만 정의된 상태에서는 Redisson 자체가 클러스터 모드로 시작되지 않을 가능성이 있어 명시화합니다.

---

### ✅ 주요 변경 사항

- 4 개 서비스 `application-docker.yml`
  - `spring.data.redis.redisson.config` 블록 추가
  - `clusterServersConfig.nodeAddresses` 에 3 노드 지정
  - `scanInterval: 1000`

---

### 🧪 테스트

- yml 구문 검증
- 실제 클러스터 동작은 docker-compose 기동 후 health check 로 확인 필요 (별도 검증)

---

### 📎 관련 이슈
- #437
