### PR TITLE
chore: Codecov patch 커버리지 90%로 상향

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,7 @@ coverage:
         threshold: 5%
     patch:
       default:
-        target: 80%
+        target: 90%
         threshold: 1%
 
 flags:


### PR DESCRIPTION
Closes #439

### 📌 작업 개요
PR 단위 신규 코드 커버리지 기준을 80% → 90% 로 상향해 테스트 작성 디시플린을 강화합니다.

---

### ✅ 주요 변경 사항

- `.codecov.yml`
  - `coverage.status.patch.default.target` 80% → 90%
  - project 전체 기준 80% 는 그대로 유지
  - threshold 1% 유지

---

### 🧪 테스트

- yml 구문 변경 없음
- 본 PR 부터 patch 커버리지 90% 미만이면 codecov 체크 실패

---

### 📎 관련 이슈
- #439
