### PR TITLE
fix: Coupon Redis 재고 보상을 트랜잭션 동기화 훅으로 일원화

### DIFF
--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/service/CouponCommandServiceImpl.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/service/CouponCommandServiceImpl.kt
@@ -19,6 +19,8 @@ import org.springframework.cache.annotation.Caching
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.math.BigDecimal
 
 @Service
@@ -95,39 +97,44 @@ class CouponCommandServiceImpl(
             is CouponReserveResult.Success -> {}
         }
 
+        registerStockRestoreOnRollback(couponId, userId)
+
         val coupon = couponRepository.findActiveById(couponId)
-            ?: run {
-                couponStockRedisRepository.restoreStock(couponId, userId)
-                throw CouponNotFoundException()
-            }
+            ?: throw CouponNotFoundException()
 
         if (coupon.isExpired() || !coupon.isValid()) {
-            couponStockRedisRepository.restoreStock(couponId, userId)
             throw CouponExpiredException()
         }
 
-        var restored = false
-        try {
-            val updated = couponRepository.incrementIssuedQuantity(couponId)
-            if (updated == 0) {
-                couponStockRedisRepository.restoreStock(couponId, userId)
-                restored = true
-                throw CouponExhaustedException()
-            }
-            val userCoupon = UserCoupon.create(userId = userId, couponId = couponId)
-            val savedUserCoupon = userCouponRepository.save(userCoupon)
-            log.info("쿠폰 발급: userId={}, couponId={}", userId, couponId)
-            return UserCouponResponse.from(savedUserCoupon, coupon)
-        } catch (e: Exception) {
-            if (!restored) {
-                try {
-                    couponStockRedisRepository.restoreStock(couponId, userId)
-                } catch (re: Exception) {
-                    log.error("Redis 재고 복원 실패: couponId={}, userId={}", couponId, userId, re)
+        val updated = couponRepository.incrementIssuedQuantity(couponId)
+        if (updated == 0) {
+            throw CouponExhaustedException()
+        }
+
+        val userCoupon = UserCoupon.create(userId = userId, couponId = couponId)
+        val savedUserCoupon = userCouponRepository.save(userCoupon)
+        log.info("쿠폰 발급: userId={}, couponId={}", userId, couponId)
+        return UserCouponResponse.from(savedUserCoupon, coupon)
+    }
+
+    private fun registerStockRestoreOnRollback(couponId: Long, userId: Long) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            log.warn("트랜잭션 동기화 비활성 — Redis 재고 보상 훅 미등록: couponId={}, userId={}", couponId, userId)
+            return
+        }
+        TransactionSynchronizationManager.registerSynchronization(
+            object : TransactionSynchronization {
+                override fun afterCompletion(status: Int) {
+                    if (status != TransactionSynchronization.STATUS_ROLLED_BACK) return
+                    try {
+                        couponStockRedisRepository.restoreStock(couponId, userId)
+                        log.info("Redis 재고 복원 (tx rollback): couponId={}, userId={}", couponId, userId)
+                    } catch (e: Exception) {
+                        log.error("Redis 재고 복원 실패 (tx rollback): couponId={}, userId={}", couponId, userId, e)
+                    }
                 }
             }
-            throw e
-        }
+        )
     }
 
     override fun useCoupon(userId: Long, couponId: Long, orderAmount: BigDecimal, orderId: Long): BigDecimal {

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/coupon/service/CouponCommandServiceImplTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/coupon/service/CouponCommandServiceImplTest.kt
@@ -21,8 +21,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito.mockStatic
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.*
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.util.Optional
@@ -156,7 +159,7 @@ class CouponCommandServiceImplTest {
     }
 
     @Test
-    fun 쿠폰_발급_시_DB_저장_실패하면_Redis_재고를_복원한다() {
+    fun 쿠폰_발급_시_DB_저장_실패하면_예외를_던진다() {
         val coupon = createCoupon(id = 1L)
         whenever(couponStockRedisRepository.tryReserve(1L, 10L)).thenReturn(CouponReserveResult.Success)
         whenever(couponRepository.findActiveById(1L)).thenReturn(coupon)
@@ -165,12 +168,10 @@ class CouponCommandServiceImplTest {
 
         assertThatThrownBy { service.issueCoupon(10L, 1L) }
             .isInstanceOf(RuntimeException::class.java)
-
-        verify(couponStockRedisRepository).restoreStock(1L, 10L)
     }
 
     @Test
-    fun 쿠폰_발급_시_DB_재고_소진이면_Redis_복원_후_예외를_던진다() {
+    fun 쿠폰_발급_시_DB_재고_소진이면_예외를_던진다() {
         val coupon = createCoupon(id = 1L)
         whenever(couponStockRedisRepository.tryReserve(1L, 10L)).thenReturn(CouponReserveResult.Success)
         whenever(couponRepository.findActiveById(1L)).thenReturn(coupon)
@@ -178,20 +179,16 @@ class CouponCommandServiceImplTest {
 
         assertThatThrownBy { service.issueCoupon(10L, 1L) }
             .isInstanceOf(CouponExhaustedException::class.java)
-
-        verify(couponStockRedisRepository).restoreStock(1L, 10L)
     }
 
     @Test
-    fun 쿠폰_발급_시_만료된_쿠폰이면_Redis_복원_후_예외를_던진다() {
+    fun 쿠폰_발급_시_만료된_쿠폰이면_예외를_던진다() {
         val expiredCoupon = createCoupon(id = 1L, validTo = LocalDateTime.now().minusDays(1))
         whenever(couponStockRedisRepository.tryReserve(1L, 10L)).thenReturn(CouponReserveResult.Success)
         whenever(couponRepository.findActiveById(1L)).thenReturn(expiredCoupon)
 
         assertThatThrownBy { service.issueCoupon(10L, 1L) }
             .isInstanceOf(CouponExpiredException::class.java)
-
-        verify(couponStockRedisRepository).restoreStock(1L, 10L)
     }
 
     @Test
@@ -208,14 +205,95 @@ class CouponCommandServiceImplTest {
     }
 
     @Test
-    fun 쿠폰_발급_시_Redis_성공_후_쿠폰_조회_실패하면_Redis_복원_후_예외를_던진다() {
+    fun 쿠폰_발급_시_Redis_성공_후_쿠폰_조회_실패하면_예외를_던진다() {
         whenever(couponStockRedisRepository.tryReserve(1L, 10L)).thenReturn(CouponReserveResult.Success)
         whenever(couponRepository.findActiveById(1L)).thenReturn(null)
 
         assertThatThrownBy { service.issueCoupon(10L, 1L) }
             .isInstanceOf(CouponNotFoundException::class.java)
+    }
+
+    @Test
+    fun 쿠폰_발급_후_트랜잭션_롤백_시_Redis_재고가_복원된다() {
+        val coupon = createCoupon(id = 1L)
+        whenever(couponStockRedisRepository.tryReserve(1L, 10L)).thenReturn(CouponReserveResult.Success)
+        whenever(couponRepository.findActiveById(1L)).thenReturn(coupon)
+        whenever(couponRepository.incrementIssuedQuantity(1L)).thenReturn(0)
+
+        mockStatic(TransactionSynchronizationManager::class.java).use { mocked ->
+            mocked.`when`<Boolean> { TransactionSynchronizationManager.isSynchronizationActive() }.thenReturn(true)
+            val captor = argumentCaptor<TransactionSynchronization>()
+
+            assertThatThrownBy { service.issueCoupon(10L, 1L) }
+                .isInstanceOf(CouponExhaustedException::class.java)
+
+            mocked.verify { TransactionSynchronizationManager.registerSynchronization(captor.capture()) }
+            captor.firstValue.afterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK)
+        }
 
         verify(couponStockRedisRepository).restoreStock(1L, 10L)
+    }
+
+    @Test
+    fun 롤백_훅에서_Redis_복원이_실패해도_삼킨다() {
+        val coupon = createCoupon(id = 1L)
+        whenever(couponStockRedisRepository.tryReserve(1L, 10L)).thenReturn(CouponReserveResult.Success)
+        whenever(couponRepository.findActiveById(1L)).thenReturn(coupon)
+        whenever(couponRepository.incrementIssuedQuantity(1L)).thenReturn(0)
+        whenever(couponStockRedisRepository.restoreStock(1L, 10L)).thenThrow(RuntimeException("Redis down"))
+
+        mockStatic(TransactionSynchronizationManager::class.java).use { mocked ->
+            mocked.`when`<Boolean> { TransactionSynchronizationManager.isSynchronizationActive() }.thenReturn(true)
+            val captor = argumentCaptor<TransactionSynchronization>()
+
+            assertThatThrownBy { service.issueCoupon(10L, 1L) }
+                .isInstanceOf(CouponExhaustedException::class.java)
+
+            mocked.verify { TransactionSynchronizationManager.registerSynchronization(captor.capture()) }
+            captor.firstValue.afterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK)
+        }
+    }
+
+    @Test
+    fun 트랜잭션_커밋_시에는_Redis_재고가_복원되지_않는다() {
+        val coupon = createCoupon(id = 1L)
+        val userCoupon = createUserCoupon(id = 1L, userId = 10L, couponId = 1L)
+        whenever(couponStockRedisRepository.tryReserve(1L, 10L)).thenReturn(CouponReserveResult.Success)
+        whenever(couponRepository.findActiveById(1L)).thenReturn(coupon)
+        whenever(couponRepository.incrementIssuedQuantity(1L)).thenReturn(1)
+        whenever(userCouponRepository.save(any<UserCoupon>())).thenReturn(userCoupon)
+
+        mockStatic(TransactionSynchronizationManager::class.java).use { mocked ->
+            mocked.`when`<Boolean> { TransactionSynchronizationManager.isSynchronizationActive() }.thenReturn(true)
+            val captor = argumentCaptor<TransactionSynchronization>()
+
+            service.issueCoupon(10L, 1L)
+
+            mocked.verify { TransactionSynchronizationManager.registerSynchronization(captor.capture()) }
+            captor.firstValue.afterCompletion(TransactionSynchronization.STATUS_COMMITTED)
+        }
+
+        verify(couponStockRedisRepository, never()).restoreStock(any(), any())
+    }
+
+    @Test
+    fun 트랜잭션_동기화_비활성_시_훅_등록을_건너뛴다() {
+        val coupon = createCoupon(id = 1L)
+        whenever(couponStockRedisRepository.tryReserve(1L, 10L)).thenReturn(CouponReserveResult.Success)
+        whenever(couponRepository.findActiveById(1L)).thenReturn(coupon)
+        whenever(couponRepository.incrementIssuedQuantity(1L)).thenReturn(0)
+
+        mockStatic(TransactionSynchronizationManager::class.java).use { mocked ->
+            mocked.`when`<Boolean> { TransactionSynchronizationManager.isSynchronizationActive() }.thenReturn(false)
+
+            assertThatThrownBy { service.issueCoupon(10L, 1L) }
+                .isInstanceOf(CouponExhaustedException::class.java)
+
+            mocked.verify(
+                { TransactionSynchronizationManager.registerSynchronization(any()) },
+                org.mockito.kotlin.never()
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #441

### 📌 작업 개요
PR #432 후속: Coupon 발급 흐름의 Redis 재고 보상을 `TransactionSynchronization.afterCompletion(STATUS_ROLLED_BACK)` 훅으로 일원화합니다.
기존에는 in-method `try/catch` 와 분기마다 `restoreStock` 을 호출했지만, `@Transactional` 커밋 단계에서 발생하는 DB 오류는 catch 블록이 보지 못해 Redis 재고가 잘못 감소된 채로 남는 edge case 가 있었습니다.

---

### ✅ 주요 변경 사항

- `payment.coupon.service.CouponCommandServiceImpl`
  - `issueCoupon`: Redis `tryReserve` 성공 직후 `registerStockRestoreOnRollback(couponId, userId)` 호출
  - 분기별 명시적 `restoreStock` 호출 모두 제거 (예외만 정상적으로 throw)
  - `registerStockRestoreOnRollback`:
    - `TransactionSynchronizationManager.isSynchronizationActive()` 가 false 면 경고 로그 후 스킵
    - 등록된 훅은 `STATUS_ROLLED_BACK` 일 때만 `restoreStock` 실행 (커밋 시 no-op)
    - 훅 내 Redis 실패는 `error` 로그로 흡수 (메인 트랜잭션 영향 없음)

---

### 🧪 테스트

- `CouponCommandServiceImplTest`
  - 기존 4 개 테스트의 inline `verify(restoreStock)` 제거 (이름도 "복원 후 예외" → "예외" 로 정정)
  - 신규: 롤백 훅 발화 시 `restoreStock` 호출 검증 (mockStatic 으로 `TransactionSynchronizationManager` 가짜 활성)
  - 신규: 커밋 훅 발화 시 `restoreStock` 미호출 검증
  - 신규: 동기화 비활성 시 `registerSynchronization` 스킵 검증
  - 신규: 훅 내 `restoreStock` 실패 시 예외 흡수 검증
- `./gradlew jacocoTestVerification` 통과

---

### 📎 관련 이슈
- #441
