### PR TITLE
fix: KafkaDLQMessagePublisherTest send mock 누락 수정

### DIFF
--- a/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/publisher/KafkaDLQMessagePublisherTest.kt
+++ b/hoppingmall-dlq/src/test/kotlin/com/hoppingmall/dlq/publisher/KafkaDLQMessagePublisherTest.kt
@@ -10,7 +10,10 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.SendResult
+import java.util.concurrent.CompletableFuture
 
 @DisplayName("KafkaDLQMessagePublisher")
 @DisplayNameGeneration(ReplaceUnderscores::class)
@@ -23,11 +26,15 @@ class KafkaDLQMessagePublisherTest {
     @InjectMocks
     private lateinit var kafkaDLQMessagePublisher: KafkaDLQMessagePublisher
 
+    private fun completedSendResult(): CompletableFuture<SendResult<String, Any>> =
+        CompletableFuture.completedFuture(null)
+
     @Test
     fun 메시지를_Kafka로_발행하고_true를_반환한다() {
         val topic = "test-topic"
         val key = "test-key"
         val value = """{"orderId": 1}"""
+        whenever(kafkaTemplate.send(topic, key, value)).thenReturn(completedSendResult())
 
         val result = kafkaDLQMessagePublisher.publish(topic, key, value)
 
@@ -39,6 +46,7 @@ class KafkaDLQMessagePublisherTest {
     fun value가_null이어도_발행하고_true를_반환한다() {
         val topic = "test-topic"
         val key = "test-key"
+        whenever(kafkaTemplate.send(topic, key, null)).thenReturn(completedSendResult())
 
         val result = kafkaDLQMessagePublisher.publish(topic, key, null)
 


### PR DESCRIPTION
Closes #443

### 📌 작업 개요
develop 기준으로 사전 존재하던 `KafkaDLQMessagePublisherTest` 2 건의 실패를 해소합니다.
PR #418 비동기/블로킹 패턴 수정 시 `kafkaTemplate.send(...).get(5, TimeUnit.SECONDS)` 로 동기화한 뒤 테스트 mock 이 따라가지 못해 NPE 발생 → catch 블록이 false 반환 → assertion 실패.

---

### ✅ 주요 변경 사항

- `KafkaDLQMessagePublisherTest`
  - `whenever(kafkaTemplate.send(...))` 에 `CompletableFuture.completedFuture(null)` 반환 stub 추가
  - 2 개 테스트 모두 send 호출 시 정상 future 반환 → `.get(...)` 대기 통과 → `true` 반환
  - 헬퍼 함수 `completedSendResult()` 로 중복 제거

---

### 🧪 테스트

- `./gradlew test --tests "*KafkaDLQMessagePublisherTest*"` 통과
- `./gradlew test` 전체 통과 확인

---

### 📎 관련 이슈
- #443
