### PR TITLE
fix: OutboxMaintenanceSchedulerTest @Mock 누락 수정

### DIFF
--- a/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/scheduler/OutboxMaintenanceSchedulerTest.kt
+++ b/hoppingmall-outbox/src/test/kotlin/com/hoppingmall/outbox/scheduler/OutboxMaintenanceSchedulerTest.kt
@@ -17,6 +17,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.test.util.ReflectionTestUtils
 import java.time.LocalDateTime
 
@@ -30,6 +31,9 @@ class OutboxMaintenanceSchedulerTest {
 
     @Mock
     private lateinit var outboxEventPublisher: OutboxEventPublisher
+
+    @Mock
+    private lateinit var transactionManager: PlatformTransactionManager
 
     @InjectMocks
     private lateinit var outboxMaintenanceScheduler: OutboxMaintenanceScheduler


### PR DESCRIPTION
Closes #445

### 📌 작업 개요
develop 기준 사전 존재 실패였던 `OutboxMaintenanceSchedulerTest` 7건을 해소합니다.
이 실패가 CI `공유 모듈 테스트` 잡을 항상 fail 시켜 다른 PR(예: #444) 머지를 차단해왔습니다.

---

### ✅ 주요 변경 사항

- `OutboxMaintenanceSchedulerTest`
  - `@Mock private lateinit var transactionManager: PlatformTransactionManager` 추가
  - PR #418 에서 추가된 생성자 파라미터에 대응되는 mock 이 없어 null 주입 → Kotlin non-null intrinsic 에서 NPE → 7개 테스트 모두 ExceptionInInitializerError 였음

---

### 🧪 테스트

- `./gradlew test --tests "*OutboxMaintenanceScheduler*"` 7건 통과
- `./gradlew test` 전체 통과 확인

---

### 📎 관련 이슈
- #445
