### PR TITLE
feat: Coupon Redis-DB 정합성 스윕 스케줄러 추가

### DIFF
--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/domain/repository/UserCouponRepository.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/domain/repository/UserCouponRepository.kt
@@ -5,6 +5,8 @@ import com.hoppingmall.payment.coupon.enum.UserCouponStatus
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -19,4 +21,7 @@ interface UserCouponRepository : JpaRepository<UserCoupon, Long> {
     fun findByUserId(userId: Long, pageable: Pageable): Slice<UserCoupon>
 
     fun findByOrderId(orderId: Long): UserCoupon?
+
+    @Query("SELECT uc.userId FROM UserCoupon uc WHERE uc.couponId = :couponId")
+    fun findUserIdsByCouponId(@Param("couponId") couponId: Long): List<Long>
 }

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/infrastructure/CouponStockReconciliationScheduler.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/infrastructure/CouponStockReconciliationScheduler.kt
@@ -1,0 +1,61 @@
+package com.hoppingmall.payment.coupon.infrastructure
+
+import com.hoppingmall.payment.coupon.domain.repository.CouponRepository
+import com.hoppingmall.payment.coupon.domain.repository.UserCouponRepository
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(name = ["coupon.reconciliation.enabled"], havingValue = "true")
+class CouponStockReconciliationScheduler(
+    private val couponRepository: CouponRepository,
+    private val userCouponRepository: UserCouponRepository,
+    private val couponStockRedisRepository: CouponStockRedisRepository
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(fixedDelayString = "\${coupon.reconciliation.interval-ms:600000}")
+    fun reconcile() {
+        val activeCoupons = couponRepository.findAllActive()
+        if (activeCoupons.isEmpty()) return
+
+        var totalGhosts = 0
+        activeCoupons.forEach { coupon ->
+            val couponId = coupon.id ?: return@forEach
+            totalGhosts += reconcileCoupon(couponId)
+        }
+
+        if (totalGhosts > 0) {
+            log.warn("Coupon Redis 정합성 스윕 완료: 총 고스트 {} 건 보정", totalGhosts)
+        }
+    }
+
+    private fun reconcileCoupon(couponId: Long): Int {
+        val redisIssuedUserIds = runCatching { couponStockRedisRepository.getIssuedUserIds(couponId) }
+            .getOrElse { e ->
+                log.error("Redis issued set 조회 실패: couponId={}", couponId, e)
+                return 0
+            }
+        if (redisIssuedUserIds.isEmpty()) return 0
+
+        val dbIssuedUserIds = userCouponRepository.findUserIdsByCouponId(couponId).toSet()
+        val ghostUserIds = redisIssuedUserIds - dbIssuedUserIds
+        if (ghostUserIds.isEmpty()) return 0
+
+        log.warn("Coupon Redis 고스트 예약 발견: couponId={}, count={}", couponId, ghostUserIds.size)
+
+        var restored = 0
+        ghostUserIds.forEach { userId ->
+            try {
+                couponStockRedisRepository.restoreStock(couponId, userId)
+                restored++
+            } catch (e: Exception) {
+                log.error("Redis 고스트 복원 실패: couponId={}, userId={}", couponId, userId, e)
+            }
+        }
+        return restored
+    }
+}

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/infrastructure/CouponStockRedisRepository.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/infrastructure/CouponStockRedisRepository.kt
@@ -51,6 +51,11 @@ class CouponStockRedisRepository(
         redissonClient.keys.delete(stockKey(couponId), issuedKey(couponId))
     }
 
+    fun getIssuedUserIds(couponId: Long): Set<Long> {
+        val set = redissonClient.getSet<String>(issuedKey(couponId), StringCodec.INSTANCE)
+        return set.readAll().mapNotNullTo(mutableSetOf()) { it.toLongOrNull() }
+    }
+
     private fun stockKey(couponId: Long) = "coupon:{$couponId}:stock"
     private fun issuedKey(couponId: Long) = "coupon:{$couponId}:issued"
 

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/coupon/infrastructure/CouponStockReconciliationSchedulerTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/coupon/infrastructure/CouponStockReconciliationSchedulerTest.kt
@@ -1,0 +1,125 @@
+package com.hoppingmall.payment.coupon.infrastructure
+
+import com.hoppingmall.payment.coupon.domain.Coupon
+import com.hoppingmall.payment.coupon.domain.repository.CouponRepository
+import com.hoppingmall.payment.coupon.domain.repository.UserCouponRepository
+import com.hoppingmall.payment.coupon.enum.CouponStatus
+import com.hoppingmall.payment.coupon.enum.DiscountType
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.test.util.ReflectionTestUtils
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@DisplayName("CouponStockReconciliationScheduler")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+@ExtendWith(MockitoExtension::class)
+class CouponStockReconciliationSchedulerTest {
+
+    @Mock
+    private lateinit var couponRepository: CouponRepository
+
+    @Mock
+    private lateinit var userCouponRepository: UserCouponRepository
+
+    @Mock
+    private lateinit var couponStockRedisRepository: CouponStockRedisRepository
+
+    @InjectMocks
+    private lateinit var scheduler: CouponStockReconciliationScheduler
+
+    private fun createCoupon(id: Long): Coupon {
+        val coupon = Coupon.create(
+            name = "쿠폰",
+            code = "C$id",
+            discountType = DiscountType.FIXED_AMOUNT,
+            discountValue = BigDecimal("1000"),
+            minOrderAmount = BigDecimal("10000"),
+            maxDiscountAmount = BigDecimal("1000"),
+            totalQuantity = 100,
+            validFrom = LocalDateTime.now().minusDays(1),
+            validTo = LocalDateTime.now().plusDays(7)
+        )
+        coupon.changeStatus(CouponStatus.ACTIVE)
+        ReflectionTestUtils.setField(coupon, "id", id)
+        return coupon
+    }
+
+    @Test
+    fun ACTIVE_쿠폰이_없으면_아무것도_하지_않는다() {
+        whenever(couponRepository.findAllActive()).thenReturn(emptyList())
+
+        scheduler.reconcile()
+
+        verify(couponStockRedisRepository, never()).getIssuedUserIds(org.mockito.kotlin.any())
+    }
+
+    @Test
+    fun Redis_set이_비어있으면_DB_조회를_건너뛴다() {
+        whenever(couponRepository.findAllActive()).thenReturn(listOf(createCoupon(1L)))
+        whenever(couponStockRedisRepository.getIssuedUserIds(1L)).thenReturn(emptySet())
+
+        scheduler.reconcile()
+
+        verify(userCouponRepository, never()).findUserIdsByCouponId(org.mockito.kotlin.any())
+        verify(couponStockRedisRepository, never()).restoreStock(org.mockito.kotlin.any(), org.mockito.kotlin.any())
+    }
+
+    @Test
+    fun 고스트가_없으면_복원하지_않는다() {
+        whenever(couponRepository.findAllActive()).thenReturn(listOf(createCoupon(1L)))
+        whenever(couponStockRedisRepository.getIssuedUserIds(1L)).thenReturn(setOf(10L, 20L))
+        whenever(userCouponRepository.findUserIdsByCouponId(1L)).thenReturn(listOf(10L, 20L))
+
+        scheduler.reconcile()
+
+        verify(couponStockRedisRepository, never()).restoreStock(org.mockito.kotlin.any(), org.mockito.kotlin.any())
+    }
+
+    @Test
+    fun 고스트_사용자만_restoreStock으로_보정한다() {
+        whenever(couponRepository.findAllActive()).thenReturn(listOf(createCoupon(1L)))
+        whenever(couponStockRedisRepository.getIssuedUserIds(1L)).thenReturn(setOf(10L, 20L, 30L))
+        whenever(userCouponRepository.findUserIdsByCouponId(1L)).thenReturn(listOf(10L))
+
+        scheduler.reconcile()
+
+        verify(couponStockRedisRepository).restoreStock(eq(1L), eq(20L))
+        verify(couponStockRedisRepository).restoreStock(eq(1L), eq(30L))
+        verify(couponStockRedisRepository, never()).restoreStock(eq(1L), eq(10L))
+    }
+
+    @Test
+    fun Redis_조회_실패_시_해당_쿠폰을_건너뛴다() {
+        whenever(couponRepository.findAllActive()).thenReturn(listOf(createCoupon(1L), createCoupon(2L)))
+        whenever(couponStockRedisRepository.getIssuedUserIds(1L)).thenThrow(RuntimeException("Redis down"))
+        whenever(couponStockRedisRepository.getIssuedUserIds(2L)).thenReturn(setOf(10L))
+        whenever(userCouponRepository.findUserIdsByCouponId(2L)).thenReturn(emptyList())
+
+        scheduler.reconcile()
+
+        verify(couponStockRedisRepository).restoreStock(eq(2L), eq(10L))
+    }
+
+    @Test
+    fun 복원_실패해도_다음_고스트를_계속_처리한다() {
+        whenever(couponRepository.findAllActive()).thenReturn(listOf(createCoupon(1L)))
+        whenever(couponStockRedisRepository.getIssuedUserIds(1L)).thenReturn(setOf(10L, 20L))
+        whenever(userCouponRepository.findUserIdsByCouponId(1L)).thenReturn(emptyList())
+        whenever(couponStockRedisRepository.restoreStock(eq(1L), eq(10L))).thenThrow(RuntimeException("partial fail"))
+
+        scheduler.reconcile()
+
+        verify(couponStockRedisRepository).restoreStock(eq(1L), eq(20L))
+    }
+}

--- a/payment-service/src/test/kotlin/com/hoppingmall/payment/coupon/infrastructure/CouponStockRedisRepositoryTest.kt
+++ b/payment-service/src/test/kotlin/com/hoppingmall/payment/coupon/infrastructure/CouponStockRedisRepositoryTest.kt
@@ -16,6 +16,7 @@ import org.mockito.kotlin.whenever
 import org.redisson.api.RBucket
 import org.redisson.api.RKeys
 import org.redisson.api.RScript
+import org.redisson.api.RSet
 import org.redisson.api.RedissonClient
 import org.redisson.client.codec.Codec
 
@@ -125,5 +126,17 @@ class CouponStockRedisRepositoryTest {
         repository.deleteStock(1L)
 
         verify(rKeys).delete("coupon:{1}:stock", "coupon:{1}:issued")
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    fun getIssuedUserIds_set_멤버를_Long으로_파싱해서_반환한다() {
+        val rSet: RSet<String> = org.mockito.kotlin.mock()
+        whenever(redissonClient.getSet<String>(eq("coupon:{1}:issued"), any<Codec>())).thenReturn(rSet)
+        whenever(rSet.readAll()).thenReturn(setOf("10", "20", "abc"))
+
+        val result = repository.getIssuedUserIds(1L)
+
+        assertThat(result).containsExactlyInAnyOrder(10L, 20L)
     }
 }


### PR DESCRIPTION
Closes #447

### 📌 작업 개요
PR #432 / #442 후속: Coupon Redis 사용자 set 과 DB `user_coupons` 의 정합성을 주기적으로 검사하고 고스트 예약을 자동 보정하는 스케줄러를 추가합니다.
트랜잭션 동기화 훅(#442)이 처리하지 못한 극히 드문 케이스(예: Redis 다운으로 훅 내 catch 흡수) 의 잔여 고스트를 정리합니다.

---

### ✅ 주요 변경 사항

- `coupon.infrastructure.CouponStockRedisRepository`
  - `getIssuedUserIds(couponId)` 추가: SMEMBERS → Long 파싱

- `coupon.domain.repository.UserCouponRepository`
  - `findUserIdsByCouponId(couponId)` 추가: 특정 쿠폰을 보유한 사용자 ID 목록

- `coupon.infrastructure.CouponStockReconciliationScheduler` (신규)
  - `@ConditionalOnProperty(coupon.reconciliation.enabled=true)` 로 기본 비활성
  - `coupon.reconciliation.interval-ms` (기본 10분) 주기 실행
  - ACTIVE 쿠폰 순회 → Redis - DB = 고스트 → `restoreStock` 보정
  - 쿠폰별/사용자별 실패는 catch + error 로그로 격리, 다음 항목 계속 진행

---

### 🧪 테스트

- `CouponStockRedisRepositoryTest.getIssuedUserIds_set_멤버를_Long으로_파싱해서_반환한다`
- `CouponStockReconciliationSchedulerTest`
  - ACTIVE 쿠폰 없으면 no-op
  - Redis set 비어있으면 DB 조회 스킵
  - 고스트 없으면 복원 안 함
  - 고스트만 선별 복원
  - Redis 조회 실패 쿠폰 건너뛰고 다음 진행
  - 복원 실패해도 다음 고스트 처리
- `./gradlew jacocoTestVerification` 통과

---

### 📎 관련 이슈
- #447
