### PR TITLE
feat: HotKeyDetector 멀티 인스턴스 동시 탐지 지원

### DIFF
--- a/hoppingmall-cache/build.gradle.kts
+++ b/hoppingmall-cache/build.gradle.kts
@@ -32,8 +32,8 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-cache")
 	implementation("com.github.ben-manes.caffeine:caffeine")
 	implementation("io.micrometer:micrometer-core")
-	compileOnly("org.springframework.boot:spring-boot-starter-data-redis")
-	compileOnly("org.redisson:redisson-spring-boot-starter:4.3.0")
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+	implementation("org.redisson:redisson-spring-boot-starter:4.3.0")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/HotKeyDetector.kt
+++ b/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/HotKeyDetector.kt
@@ -1,45 +1,8 @@
 package com.hoppingmall.cache
 
 import java.io.Closeable
-import java.time.Duration
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.LongAdder
 
-open class HotKeyDetector(
-    private val threshold: Long,
-    windowDuration: Duration
-) : Closeable {
-
-    private val counts = ConcurrentHashMap<String, LongAdder>()
-    private val hotKeys: MutableSet<String> = ConcurrentHashMap.newKeySet()
-    private val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { r ->
-        Thread(r, "hotkey-detector").apply { isDaemon = true }
-    }
-
-    init {
-        val windowMs = windowDuration.toMillis()
-        scheduler.scheduleAtFixedRate(::reset, windowMs, windowMs, TimeUnit.MILLISECONDS)
-    }
-
-    open fun recordAccess(key: String) {
-        val adder = counts.computeIfAbsent(key) { LongAdder() }
-        adder.increment()
-        if (adder.sum() >= threshold) {
-            hotKeys.add(key)
-        }
-    }
-
-    open fun isHot(key: String): Boolean = hotKeys.contains(key)
-
-    private fun reset() {
-        counts.clear()
-        hotKeys.clear()
-    }
-
-    override fun close() {
-        scheduler.shutdown()
-    }
+interface HotKeyDetector : Closeable {
+    fun recordAccess(key: String)
+    fun isHot(key: String): Boolean
 }

--- a/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/HotKeyDetectorRegistry.kt
+++ b/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/HotKeyDetectorRegistry.kt
@@ -1,20 +1,47 @@
 package com.hoppingmall.cache
 
+import org.redisson.api.RedissonClient
 import java.io.Closeable
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
 
 class HotKeyDetectorRegistry(
-    policies: Collection<CachePolicy>
+    policies: Collection<CachePolicy>,
+    private val detectorType: String = "local",
+    private val redissonClient: RedissonClient? = null
 ) : Closeable {
+
+    private val scheduler: ScheduledExecutorService = run {
+        val activePolicies = policies.count { it.dynamicHotKeyEnabled }
+        val threadCount = minOf(activePolicies, 4).coerceAtLeast(1)
+        Executors.newScheduledThreadPool(threadCount) { r ->
+            Thread(r, "hotkey-detector").apply { isDaemon = true }
+        }
+    }
 
     private val detectors: Map<String, HotKeyDetector> =
         policies.filter { it.dynamicHotKeyEnabled }
             .associate { policy ->
-                policy.cacheName to HotKeyDetector(policy.hotKeyThreshold, policy.hotKeyWindow)
+                policy.cacheName to createDetector(policy)
             }
+
+    private fun createDetector(policy: CachePolicy): HotKeyDetector {
+        if (detectorType == "redis" && redissonClient != null) {
+            return RedisHotKeyDetector(
+                cacheName = policy.cacheName,
+                threshold = policy.hotKeyThreshold,
+                windowMs = policy.hotKeyWindow.toMillis(),
+                redissonClient = redissonClient,
+                scheduler = scheduler
+            )
+        }
+        return LocalHotKeyDetector(policy.hotKeyThreshold, policy.hotKeyWindow, scheduler)
+    }
 
     fun getDetector(cacheName: String): HotKeyDetector? = detectors[cacheName]
 
     override fun close() {
         detectors.values.forEach { it.close() }
+        scheduler.shutdown()
     }
 }

--- a/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/LocalHotKeyDetector.kt
+++ b/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/LocalHotKeyDetector.kt
@@ -1,0 +1,40 @@
+package com.hoppingmall.cache
+
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.LongAdder
+
+class LocalHotKeyDetector(
+    private val threshold: Long,
+    windowDuration: Duration,
+    scheduler: ScheduledExecutorService
+) : HotKeyDetector {
+
+    private val counts = ConcurrentHashMap<String, LongAdder>()
+    private val hotKeys: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    init {
+        val windowMs = windowDuration.toMillis()
+        scheduler.scheduleWithFixedDelay(::reset, windowMs, windowMs, TimeUnit.MILLISECONDS)
+    }
+
+    override fun recordAccess(key: String) {
+        val adder = counts.computeIfAbsent(key) { LongAdder() }
+        adder.increment()
+        if (adder.sum() >= threshold) {
+            hotKeys.add(key)
+        }
+    }
+
+    override fun isHot(key: String): Boolean = hotKeys.contains(key)
+
+    private fun reset() {
+        counts.clear()
+        hotKeys.clear()
+    }
+
+    override fun close() {
+    }
+}

--- a/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/RedisHotKeyDetector.kt
+++ b/hoppingmall-cache/src/main/kotlin/com/hoppingmall/cache/RedisHotKeyDetector.kt
@@ -1,0 +1,98 @@
+package com.hoppingmall.cache
+
+import org.redisson.api.RScoredSortedSet
+import org.redisson.api.RedissonClient
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.LongAdder
+
+class RedisHotKeyDetector(
+    private val cacheName: String,
+    private val threshold: Long,
+    private val windowMs: Long,
+    private val redissonClient: RedissonClient,
+    scheduler: ScheduledExecutorService,
+    flushIntervalMs: Long = minOf(5000L, windowMs / 2)
+) : HotKeyDetector {
+
+    private val log = LoggerFactory.getLogger(RedisHotKeyDetector::class.java)
+
+    private val localCounts = ConcurrentHashMap<String, LongAdder>()
+    private val hotKeysSnapshot = AtomicReference<Set<String>>(emptySet())
+    private val lastFlushEpoch = AtomicLong(-1L)
+
+    init {
+        scheduler.scheduleWithFixedDelay(::flush, flushIntervalMs, flushIntervalMs, TimeUnit.MILLISECONDS)
+    }
+
+    override fun recordAccess(key: String) {
+        val adder = localCounts.computeIfAbsent(key) { LongAdder() }
+        adder.increment()
+    }
+
+    override fun isHot(key: String): Boolean = hotKeysSnapshot.get().contains(key)
+
+    internal fun flush() {
+        val currentEpoch = System.currentTimeMillis() / windowMs
+        val previousEpoch = currentEpoch - 1
+        val zsetKey = zsetKeyFor(currentEpoch)
+        val prevZsetKey = zsetKeyFor(previousEpoch)
+        val expireSeconds = (windowMs * 2) / 1000
+
+        val pendingCounts = drainLocalCounts()
+
+        val lastEpoch = lastFlushEpoch.getAndSet(currentEpoch)
+        if (lastEpoch != -1L && currentEpoch != lastEpoch) {
+            localCounts.clear()
+        }
+
+        try {
+            if (pendingCounts.isNotEmpty()) {
+                val batch = redissonClient.createBatch()
+                val asyncSet = batch.getScoredSortedSet<String>(zsetKey)
+                for ((key, count) in pendingCounts) {
+                    asyncSet.addScoreAsync(key, count.toDouble())
+                }
+                asyncSet.expireAsync(Duration.ofSeconds(expireSeconds))
+                batch.execute()
+            }
+
+            val currentHot = readHotKeysFrom(zsetKey)
+            val previousHot = readHotKeysFrom(prevZsetKey)
+            hotKeysSnapshot.set(currentHot.union(previousHot))
+        } catch (e: Exception) {
+            log.warn("Redis hot-key flush failed [cache={}]: {}", cacheName, e.message)
+        }
+    }
+
+    private fun readHotKeysFrom(zsetKey: String): Set<String> {
+        return try {
+            val scoredSet: RScoredSortedSet<String> = redissonClient.getScoredSortedSet(zsetKey)
+            scoredSet.valueRange(threshold.toDouble(), true, Double.MAX_VALUE, true).toSet()
+        } catch (e: Exception) {
+            log.warn("Redis hot-key snapshot read failed [cache={}, key={}]: {}", cacheName, zsetKey, e.message)
+            emptySet()
+        }
+    }
+
+    private fun drainLocalCounts(): Map<String, Long> {
+        val snapshot = mutableMapOf<String, Long>()
+        for ((key, adder) in localCounts.entries) {
+            val count = adder.sumThenReset()
+            if (count > 0) {
+                snapshot[key] = count
+            }
+        }
+        return snapshot
+    }
+
+    private fun zsetKeyFor(epoch: Long): String = "hotkey:$cacheName:counts:$epoch"
+
+    override fun close() {
+    }
+}

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/FakeHotKeyDetector.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/FakeHotKeyDetector.kt
@@ -1,11 +1,6 @@
 package com.hoppingmall.cache
 
-import java.time.Duration
-
-class FakeHotKeyDetector : HotKeyDetector(
-    threshold = Long.MAX_VALUE,
-    windowDuration = Duration.ofHours(1)
-) {
+class FakeHotKeyDetector : HotKeyDetector {
     var overrideIsHot: Boolean = false
     var recordCount: Int = 0
         private set
@@ -20,4 +15,6 @@ class FakeHotKeyDetector : HotKeyDetector(
         overrideIsHot = false
         recordCount = 0
     }
+
+    override fun close() {}
 }

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/HotKeyDetectorRegistryTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/HotKeyDetectorRegistryTest.kt
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.redisson.api.RedissonClient
 import java.time.Duration
 
 @DisplayName("HotKeyDetectorRegistry")
@@ -76,6 +78,31 @@ class HotKeyDetectorRegistryTest {
         val registry = HotKeyDetectorRegistry(emptyList())
 
         assertThat(registry.getDetector("any")).isNull()
+        registry.close()
+    }
+
+    @Test
+    fun redis_모드에서_RedissonClient가_주어지면_RedisHotKeyDetector를_생성한다() {
+        val mockRedisson: RedissonClient = mock()
+        val registry = HotKeyDetectorRegistry(
+            policies = listOf(policy("product", 5L)),
+            detectorType = "redis",
+            redissonClient = mockRedisson
+        )
+
+        assertThat(registry.getDetector("product")).isInstanceOf(RedisHotKeyDetector::class.java)
+        registry.close()
+    }
+
+    @Test
+    fun redis_모드에서_RedissonClient가_null이면_LocalHotKeyDetector로_폴백한다() {
+        val registry = HotKeyDetectorRegistry(
+            policies = listOf(policy("product", 5L)),
+            detectorType = "redis",
+            redissonClient = null
+        )
+
+        assertThat(registry.getDetector("product")).isInstanceOf(LocalHotKeyDetector::class.java)
         registry.close()
     }
 }

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/LocalHotKeyDetectorTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/LocalHotKeyDetectorTest.kt
@@ -1,7 +1,9 @@
 package com.hoppingmall.cache
 
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
@@ -9,14 +11,31 @@ import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 
-@DisplayName("HotKeyDetector")
+@DisplayName("LocalHotKeyDetector")
 @DisplayNameGeneration(ReplaceUnderscores::class)
-class HotKeyDetectorTest {
+class LocalHotKeyDetectorTest {
+
+    private lateinit var scheduler: ScheduledExecutorService
+
+    @BeforeEach
+    fun setUp() {
+        scheduler = Executors.newSingleThreadScheduledExecutor { r ->
+            Thread(r, "hotkey-detector-test").apply { isDaemon = true }
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        scheduler.shutdownNow()
+        scheduler.awaitTermination(2, TimeUnit.SECONDS)
+    }
 
     @Test
     fun 임계값_미만_접근은_핫키로_판별하지_않는다() {
-        val detector = HotKeyDetector(threshold = 5, windowDuration = Duration.ofMinutes(10))
+        val detector = LocalHotKeyDetector(threshold = 5, windowDuration = Duration.ofMinutes(10), scheduler = scheduler)
 
         repeat(4) { detector.recordAccess("key1") }
 
@@ -26,7 +45,7 @@ class HotKeyDetectorTest {
 
     @Test
     fun 임계값_이상_접근은_핫키로_승격한다() {
-        val detector = HotKeyDetector(threshold = 5, windowDuration = Duration.ofMinutes(10))
+        val detector = LocalHotKeyDetector(threshold = 5, windowDuration = Duration.ofMinutes(10), scheduler = scheduler)
 
         repeat(5) { detector.recordAccess("key1") }
 
@@ -36,7 +55,7 @@ class HotKeyDetectorTest {
 
     @Test
     fun 키별로_독립적으로_추적한다() {
-        val detector = HotKeyDetector(threshold = 3, windowDuration = Duration.ofMinutes(10))
+        val detector = LocalHotKeyDetector(threshold = 3, windowDuration = Duration.ofMinutes(10), scheduler = scheduler)
 
         repeat(3) { detector.recordAccess("hot-key") }
         repeat(2) { detector.recordAccess("cold-key") }
@@ -48,7 +67,7 @@ class HotKeyDetectorTest {
 
     @Test
     fun 동시_접근_시_정확하게_카운팅한다() {
-        val detector = HotKeyDetector(threshold = 100, windowDuration = Duration.ofMinutes(10))
+        val detector = LocalHotKeyDetector(threshold = 100, windowDuration = Duration.ofMinutes(10), scheduler = scheduler)
         val threadCount = 10
         val accessPerThread = 10
         val latch = CountDownLatch(threadCount)
@@ -73,7 +92,7 @@ class HotKeyDetectorTest {
 
     @Test
     fun 윈도우_리셋_후_핫키가_강등된다() {
-        val detector = HotKeyDetector(threshold = 3, windowDuration = Duration.ofMillis(100))
+        val detector = LocalHotKeyDetector(threshold = 3, windowDuration = Duration.ofMillis(100), scheduler = scheduler)
 
         repeat(3) { detector.recordAccess("key1") }
         assertTrue(detector.isHot("key1"))
@@ -86,7 +105,7 @@ class HotKeyDetectorTest {
 
     @Test
     fun 존재하지_않는_키는_핫키가_아니다() {
-        val detector = HotKeyDetector(threshold = 5, windowDuration = Duration.ofMinutes(10))
+        val detector = LocalHotKeyDetector(threshold = 5, windowDuration = Duration.ofMinutes(10), scheduler = scheduler)
 
         assertFalse(detector.isHot("nonexistent"))
         detector.close()

--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/RedisHotKeyDetectorTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/RedisHotKeyDetectorTest.kt
@@ -1,0 +1,197 @@
+package com.hoppingmall.cache
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.redisson.api.RBatch
+import org.redisson.api.RScoredSortedSet
+import org.redisson.api.RScoredSortedSetAsync
+import org.redisson.api.RedissonClient
+import java.time.Duration
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+@DisplayName("RedisHotKeyDetector")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class RedisHotKeyDetectorTest {
+
+    private lateinit var scheduler: ScheduledExecutorService
+
+    @BeforeEach
+    fun setUp() {
+        scheduler = Executors.newSingleThreadScheduledExecutor { r ->
+            Thread(r, "redis-hotkey-test").apply { isDaemon = true }
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        scheduler.shutdownNow()
+        scheduler.awaitTermination(2, TimeUnit.SECONDS)
+    }
+
+    private fun newDetector(
+        threshold: Long = 50,
+        windowMs: Long = 60_000L,
+        flushIntervalMs: Long = Duration.ofHours(1).toMillis(),
+        redissonClient: RedissonClient
+    ): RedisHotKeyDetector {
+        return RedisHotKeyDetector(
+            cacheName = "product",
+            threshold = threshold,
+            windowMs = windowMs,
+            redissonClient = redissonClient,
+            scheduler = scheduler,
+            flushIntervalMs = flushIntervalMs
+        )
+    }
+
+    @Test
+    fun recordAccess_호출_시_동기_Redis_호출이_발생하지_않는다() {
+        val redisson: RedissonClient = mock()
+        val detector = newDetector(redissonClient = redisson)
+
+        repeat(1000) { detector.recordAccess("key1") }
+
+        verifyNoInteractions(redisson)
+        detector.close()
+    }
+
+    @Test
+    fun 단일_인스턴스에서_임계값_이상_접근_후_플러시_사이클_후_핫키를_판별한다() {
+        val redisson: RedissonClient = mock()
+        val batch: RBatch = mock()
+        val asyncSet: RScoredSortedSetAsync<String> = mock()
+        val readSet: RScoredSortedSet<String> = mock()
+        whenever(redisson.createBatch()).thenReturn(batch)
+        whenever(batch.getScoredSortedSet<String>(any<String>())).thenReturn(asyncSet)
+        whenever(redisson.getScoredSortedSet<String>(any<String>())).thenReturn(readSet)
+        whenever(readSet.valueRange(50.0, true, Double.MAX_VALUE, true))
+            .thenReturn(setOf("key1"))
+            .thenReturn(emptySet())
+
+        val detector = newDetector(threshold = 50, redissonClient = redisson)
+        repeat(50) { detector.recordAccess("key1") }
+        detector.flush()
+
+        assertThat(detector.isHot("key1")).isTrue()
+        detector.close()
+    }
+
+    @Test
+    fun Redis_장애_시_예외가_전파되지_않고_로컬_스냅샷으로_폴백한다() {
+        val redisson: RedissonClient = mock()
+        whenever(redisson.createBatch()).thenThrow(RuntimeException("redis down"))
+        whenever(redisson.getScoredSortedSet<String>(any<String>())).thenThrow(RuntimeException("redis down"))
+
+        val detector = newDetector(redissonClient = redisson)
+        repeat(50) { detector.recordAccess("key1") }
+        detector.flush()
+
+        assertThat(detector.isHot("key1")).isFalse()
+        detector.close()
+    }
+
+    @Test
+    fun flush_시_누적된_카운트를_Redis_ZSet에_addScoreAsync로_반영한다() {
+        val redisson: RedissonClient = mock()
+        val batch: RBatch = mock()
+        val asyncSet: RScoredSortedSetAsync<String> = mock()
+        val readSet: RScoredSortedSet<String> = mock()
+        whenever(redisson.createBatch()).thenReturn(batch)
+        whenever(batch.getScoredSortedSet<String>(any<String>())).thenReturn(asyncSet)
+        whenever(redisson.getScoredSortedSet<String>(any<String>())).thenReturn(readSet)
+        whenever(readSet.valueRange(any(), any(), any(), any())).thenReturn(emptySet())
+
+        val detector = newDetector(threshold = 50, redissonClient = redisson)
+        repeat(10) { detector.recordAccess("key1") }
+        detector.flush()
+
+        val keyCaptor = argumentCaptor<String>()
+        val scoreCaptor = argumentCaptor<Double>()
+        verify(asyncSet, atLeastOnce()).addScoreAsync(keyCaptor.capture(), scoreCaptor.capture())
+        assertThat(keyCaptor.firstValue).isEqualTo("key1")
+        assertThat(scoreCaptor.firstValue).isEqualTo(10.0)
+        verify(asyncSet).expireAsync(any<Duration>())
+        verify(batch).execute()
+        detector.close()
+    }
+
+    @Test
+    fun flush_시_현재_및_이전_에포크_ZSet의_핫키를_합집합으로_읽는다() {
+        val redisson: RedissonClient = mock()
+        val readSet: RScoredSortedSet<String> = mock()
+        whenever(redisson.getScoredSortedSet<String>(any<String>())).thenReturn(readSet)
+        whenever(readSet.valueRange(any(), any(), any(), any()))
+            .thenReturn(setOf("currentKey"))
+            .thenReturn(setOf("previousKey"))
+
+        val detector = newDetector(threshold = 50, redissonClient = redisson)
+        detector.flush()
+
+        assertThat(detector.isHot("currentKey")).isTrue()
+        assertThat(detector.isHot("previousKey")).isTrue()
+        detector.close()
+    }
+
+    @Test
+    fun pendingCounts가_비어있으면_Redis_batch를_생성하지_않는다() {
+        val redisson: RedissonClient = mock()
+        val readSet: RScoredSortedSet<String> = mock()
+        whenever(redisson.getScoredSortedSet<String>(any<String>())).thenReturn(readSet)
+        whenever(readSet.valueRange(any(), any(), any(), any())).thenReturn(emptySet())
+
+        val detector = newDetector(redissonClient = redisson)
+        detector.flush()
+
+        verify(redisson, never()).createBatch()
+        detector.close()
+    }
+
+    @Test
+    fun 두_인스턴스_시뮬레이션에서_각_25회_recordAccess_후_플러시_시_동일_핫키를_판별한다() {
+        val redisson: RedissonClient = mock()
+        val batch: RBatch = mock()
+        val asyncSet: RScoredSortedSetAsync<String> = mock()
+        val readSet: RScoredSortedSet<String> = mock()
+        whenever(redisson.createBatch()).thenReturn(batch)
+        whenever(batch.getScoredSortedSet<String>(any<String>())).thenReturn(asyncSet)
+        whenever(redisson.getScoredSortedSet<String>(any<String>())).thenReturn(readSet)
+        whenever(readSet.valueRange(50.0, true, Double.MAX_VALUE, true)).thenReturn(setOf("hotKey"))
+
+        val instanceA = newDetector(threshold = 50, redissonClient = redisson)
+        val instanceB = newDetector(threshold = 50, redissonClient = redisson)
+        repeat(25) { instanceA.recordAccess("hotKey") }
+        repeat(25) { instanceB.recordAccess("hotKey") }
+        instanceA.flush()
+        instanceB.flush()
+
+        assertThat(instanceA.isHot("hotKey")).isTrue()
+        assertThat(instanceB.isHot("hotKey")).isTrue()
+        instanceA.close()
+        instanceB.close()
+    }
+
+    @Test
+    fun close는_no_op이며_스케줄러는_레지스트리가_관리한다() {
+        val redisson: RedissonClient = mock()
+        val detector = newDetector(redissonClient = redisson)
+
+        detector.close()
+
+        assertThat(scheduler.isShutdown).isFalse()
+    }
+}

--- a/notification-service/src/main/kotlin/com/hoppingmall/notification/config/CacheConfig.kt
+++ b/notification-service/src/main/kotlin/com/hoppingmall/notification/config/CacheConfig.kt
@@ -7,6 +7,8 @@ import com.hoppingmall.cache.RedissonLockProvider
 import com.hoppingmall.cache.TwoLevelCacheManager
 import io.micrometer.core.instrument.MeterRegistry
 import org.redisson.api.RedissonClient
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
@@ -32,8 +34,16 @@ class CacheConfig {
     )
 
     @Bean
-    fun hotKeyDetectorRegistry(cachePolicies: Map<String, CachePolicy>): HotKeyDetectorRegistry {
-        return HotKeyDetectorRegistry(cachePolicies.values)
+    fun hotKeyDetectorRegistry(
+        cachePolicies: Map<String, CachePolicy>,
+        @Value("\${cache.hot-key.detector-type:local}") detectorType: String,
+        redissonClient: ObjectProvider<RedissonClient>
+    ): HotKeyDetectorRegistry {
+        return HotKeyDetectorRegistry(
+            policies = cachePolicies.values,
+            detectorType = detectorType,
+            redissonClient = redissonClient.ifAvailable
+        )
     }
 
     @Bean

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/CacheConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/CacheConfig.kt
@@ -7,6 +7,8 @@ import com.hoppingmall.cache.RedissonLockProvider
 import com.hoppingmall.cache.TwoLevelCacheManager
 import io.micrometer.core.instrument.MeterRegistry
 import org.redisson.api.RedissonClient
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
@@ -50,8 +52,16 @@ class CacheConfig {
     )
 
     @Bean
-    fun hotKeyDetectorRegistry(cachePolicies: Map<String, CachePolicy>): HotKeyDetectorRegistry {
-        return HotKeyDetectorRegistry(cachePolicies.values)
+    fun hotKeyDetectorRegistry(
+        cachePolicies: Map<String, CachePolicy>,
+        @Value("\${cache.hot-key.detector-type:local}") detectorType: String,
+        redissonClient: ObjectProvider<RedissonClient>
+    ): HotKeyDetectorRegistry {
+        return HotKeyDetectorRegistry(
+            policies = cachePolicies.values,
+            detectorType = detectorType,
+            redissonClient = redissonClient.ifAvailable
+        )
     }
 
     @Bean

--- a/product-service/src/main/kotlin/com/hoppingmall/product/config/CacheConfig.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/config/CacheConfig.kt
@@ -7,6 +7,7 @@ import com.hoppingmall.cache.RedissonLockProvider
 import com.hoppingmall.cache.TwoLevelCacheManager
 import io.micrometer.core.instrument.MeterRegistry
 import org.redisson.api.RedissonClient
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
@@ -63,8 +64,16 @@ class CacheConfig {
     )
 
     @Bean
-    fun hotKeyDetectorRegistry(cachePolicies: Map<String, CachePolicy>): HotKeyDetectorRegistry {
-        return HotKeyDetectorRegistry(cachePolicies.values)
+    fun hotKeyDetectorRegistry(
+        cachePolicies: Map<String, CachePolicy>,
+        @Value("\${cache.hot-key.detector-type:local}") detectorType: String,
+        redissonClient: ObjectProvider<RedissonClient>
+    ): HotKeyDetectorRegistry {
+        return HotKeyDetectorRegistry(
+            policies = cachePolicies.values,
+            detectorType = detectorType,
+            redissonClient = redissonClient.ifAvailable
+        )
     }
 
     @Bean


### PR DESCRIPTION
Closes #449

### 📌 작업 개요
멀티 인스턴스 환경에서 모든 노드가 동일한 Hot 판정을 공유하도록 Redis 기반 탐지기를 추가하고, `cache.hot-key.detector-type=local|redis` 설정값으로 전환할 수 있도록 구현했습니다. 기본값을 `local`로 유지하여 기존 단일 인스턴스 배포는 동작 변경이 없으며, `RedissonClient` 빈 부재 시 자동 `LocalHotKeyDetector` 폴백을 보장합니다.

`recordAccess`는 `LongAdder.increment`만 수행해 hot-path latency 영향이 0이고, 5초 주기 `ZINCRBY` 일괄 flush로 인스턴스 간 카운터를 합산합니다. 윈도우별 ZSet 키 회전(`hotkey:{cache}:counts:{epoch}`) + 2×windowMs TTL로 별도 reset 스케줄러 없이 자동 만료되며, 현재+이전 epoch ZSet 합집합 읽기로 클럭 스큐를 보정합니다. Redisson 예외는 catch + WARN 로그 후 이전 스냅샷을 유지하여 Redis 장애가 캐시 계층 가용성을 깨지 않습니다.

---

### ✅ 주요 변경 사항

- `hoppingmall-cache.cache`
  - `HotKeyDetector`: 기존 클래스를 `interface : Closeable`로 추출 (`recordAccess`, `isHot`)
  - `LocalHotKeyDetector`: 기존 in-process 구현 분리, `scheduleWithFixedDelay` + 공유 `ScheduledExecutorService` 주입, `close()`는 no-op
  - `RedisHotKeyDetector`: 신규. `LongAdder` 누적 + 주기적 ZINCRBY flush + dual-epoch 합집합 읽기 + Redisson 예외 graceful degradation. 단일 인스턴스 단독 임계치 도달 시 즉시 hot 판정하지 않음(캐시 비일관성 방지)
  - `HotKeyDetectorRegistry`: `detectorType`/`redissonClient` 파라미터 분기, 공유 `ScheduledExecutorService` 한 개만 생성 (`min(activePolicies,4).coerceAtLeast(1)` 스레드)
  - `FakeHotKeyDetector`: 인터페이스 직접 구현으로 변경하여 phantom daemon scheduler 제거 (테스트 인스턴스마다 누수되던 1시간짜리 ScheduledExecutorService 제거)

- `hoppingmall-cache.build`
  - `build.gradle.kts`: Redisson + spring-data-redis 의존성을 `compileOnly`에서 `implementation`으로 승격 (`RedisHotKeyDetector`가 production source에서 Redisson API 직접 참조)

- `product/payment/notification.config.CacheConfig`
  - `hotKeyDetectorRegistry` 빈에 `@Value("${cache.hot-key.detector-type:local}")` + `ObjectProvider<RedissonClient>` 주입

---

### 🧪 테스트

- `LocalHotKeyDetectorTest` (이름변경, 6/6 통과): 기존 6개 케이스 그대로 통과 → 단일 인스턴스 동작 회귀 검증
- `RedisHotKeyDetectorTest` (신규, 8/8 통과)
  - `recordAccess_호출_시_동기_Redis_호출이_발생하지_않는다` — 1000회 호출 시 `RedissonClient` 상호작용 0회 검증
  - `단일_인스턴스에서_임계값_이상_접근_후_플러시_사이클_후_핫키를_판별한다`
  - `Redis_장애_시_예외가_전파되지_않고_로컬_스냅샷으로_폴백한다`
  - `flush_시_누적된_카운트를_Redis_ZSet에_addScoreAsync로_반영한다` — `addScoreAsync` + `expireAsync` + `batch.execute()` 호출 검증
  - `flush_시_현재_및_이전_에포크_ZSet의_핫키를_합집합으로_읽는다`
  - `pendingCounts가_비어있으면_Redis_batch를_생성하지_않는다`
  - `두_인스턴스_시뮬레이션에서_각_25회_recordAccess_후_플러시_시_동일_핫키를_판별한다`
  - `close는_no_op이며_스케줄러는_레지스트리가_관리한다`
- `HotKeyDetectorRegistryTest` (8/8 통과): 기존 6개 + 신규 2개 (`redis_모드에서_RedissonClient가_주어지면_RedisHotKeyDetector를_생성한다`, `redis_모드에서_RedissonClient가_null이면_LocalHotKeyDetector로_폴백한다`)
- `./gradlew :hoppingmall-cache:test` — BUILD SUCCESSFUL
- `./gradlew :hoppingmall-cache:jacocoTestVerification` — CLASS LINE 80% 이상 통과
- `product-service` / `payment-service` / `notification-service` `compileKotlin` — BUILD SUCCESSFUL

---

### 📎 관련 이슈
- #449
