### PR TITLE
feat: Saga 보상 자동 회복 메트릭 및 카오스 부하 테스트 환경 추가

### DIFF
--- a/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TwoLevelCacheStampedeTest.kt
+++ b/hoppingmall-cache/src/test/kotlin/com/hoppingmall/cache/TwoLevelCacheStampedeTest.kt
@@ -1,0 +1,442 @@
+package com.hoppingmall.cache
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.cache.Cache
+import java.io.PrintWriter
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.time.Duration
+import java.util.concurrent.Callable
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+@DisplayName("TwoLevelCache Stampede Collapse 검증")
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class TwoLevelCacheStampedeTest {
+
+    private val redisCache: Cache = mock()
+    private val lockProvider = FakeLockProvider()
+    private lateinit var meterRegistry: SimpleMeterRegistry
+
+    private val nonHotPolicy = CachePolicy(
+        cacheName = "category",
+        l1MaxSize = 100,
+        l1Ttl = Duration.ofSeconds(30),
+        l2Ttl = Duration.ofMinutes(5),
+        jitterPercent = 10
+    )
+
+    private val shortTtlPolicy = CachePolicy(
+        cacheName = "category-short",
+        l1MaxSize = 100,
+        l1Ttl = Duration.ofMillis(100),
+        l2Ttl = Duration.ofMillis(200),
+        jitterPercent = 0
+    )
+
+    private val hotKeyPolicy = CachePolicy(
+        cacheName = "product",
+        l1MaxSize = 100,
+        l1Ttl = Duration.ofSeconds(10),
+        l2Ttl = Duration.ofMinutes(10),
+        jitterPercent = 10,
+        hotKeyThreshold = 5L,
+        hotKeyShardCount = 4
+    )
+
+    @BeforeEach
+    fun setUp() {
+        lockProvider.reset()
+        meterRegistry = SimpleMeterRegistry()
+        whenever(redisCache.get(org.mockito.kotlin.any())).thenReturn(null)
+    }
+
+    private fun createNonHotCache(policy: CachePolicy = nonHotPolicy): TwoLevelCache {
+        val caffeine = Caffeine.newBuilder()
+            .maximumSize(policy.l1MaxSize)
+            .expireAfterWrite(policy.l1Ttl)
+            .build<Any, Any>()
+        return TwoLevelCache(
+            policy.cacheName, caffeine, redisCache, policy,
+            lockProvider, meterRegistry = meterRegistry
+        )
+    }
+
+    private fun collapsedCount(cacheName: String): Double =
+        meterRegistry.counter("cache.singleflight.collapsed", "cache", cacheName).count()
+
+    private fun missCount(cacheName: String): Double =
+        meterRegistry.counter("cache.miss", "cache", cacheName).count()
+
+    @Test
+    @DisplayName("[1-1] cold start 100 스레드 동시 요청 → loader 1회 호출 + collapsed=99")
+    fun cold_start_single_flight_collapse() {
+        val cache = createNonHotCache()
+        val key = 1001L
+        val threadCount = 100
+        val loaderCount = AtomicInteger(0)
+        val barrier = CyclicBarrier(threadCount)
+        val latch = CountDownLatch(threadCount)
+        val executor = Executors.newFixedThreadPool(threadCount)
+        val gate = CountDownLatch(1)
+        val results = ConcurrentLinkedQueue<Any?>()
+        val expected = "loaded-value-1001"
+
+        val startedNanos = System.nanoTime()
+
+        repeat(threadCount) {
+            executor.submit {
+                try {
+                    barrier.await()
+                    val v = cache.get(key, Callable<String> {
+                        loaderCount.incrementAndGet()
+                        gate.await()
+                        expected
+                    })
+                    results.add(v)
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        Thread.sleep(150)
+        gate.countDown()
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "all threads finished")
+        executor.shutdown()
+
+        val elapsedMs = (System.nanoTime() - startedNanos) / 1_000_000
+
+        assertEquals(1, loaderCount.get(), "loader 호출은 정확히 1회 (collapse)")
+        assertEquals(threadCount, results.size, "100 스레드 모두 결과 수신")
+        assertEquals(setOf<Any?>(expected), results.toSet(), "전부 동일 결과")
+        assertEquals(99.0, collapsedCount("category"), 0.0001, "collapsed = N-1 = 99")
+
+        recordMetric(
+            "1-1 cold start collapse",
+            mapOf(
+                "threads" to threadCount,
+                "loader_calls" to loaderCount.get(),
+                "collapsed_total" to collapsedCount("category"),
+                "miss_total" to missCount("category"),
+                "results_received" to results.size,
+                "elapsed_ms" to elapsedMs
+            )
+        )
+    }
+
+    @Test
+    @DisplayName("[TTL] L1 만료 직후 100 스레드 동시 요청 → loader 1회 호출")
+    fun ttl_expired_window_single_flight_collapse() {
+        val cache = createNonHotCache(shortTtlPolicy)
+        val key = 2002L
+        val threadCount = 100
+
+        cache.put(key, "stale-prewarm")
+        Thread.sleep(250)
+
+        val loaderCount = AtomicInteger(0)
+        val barrier = CyclicBarrier(threadCount)
+        val latch = CountDownLatch(threadCount)
+        val executor = Executors.newFixedThreadPool(threadCount)
+        val gate = CountDownLatch(1)
+        val results = ConcurrentLinkedQueue<Any?>()
+        val expected = "loaded-after-ttl"
+
+        repeat(threadCount) {
+            executor.submit {
+                try {
+                    barrier.await()
+                    val v = cache.get(key, Callable<String> {
+                        loaderCount.incrementAndGet()
+                        gate.await()
+                        expected
+                    })
+                    results.add(v)
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        Thread.sleep(150)
+        gate.countDown()
+        assertTrue(latch.await(10, TimeUnit.SECONDS))
+        executor.shutdown()
+
+        assertEquals(1, loaderCount.get(), "TTL 만료 직후에도 loader는 1회")
+        assertEquals(setOf<Any?>(expected), results.toSet())
+        assertEquals(99.0, collapsedCount("category-short"), 0.0001)
+
+        recordMetric(
+            "TTL expired stampede window",
+            mapOf(
+                "threads" to threadCount,
+                "l1_ttl_ms" to shortTtlPolicy.l1Ttl.toMillis(),
+                "loader_calls" to loaderCount.get(),
+                "collapsed_total" to collapsedCount("category-short")
+            )
+        )
+    }
+
+    @Test
+    @DisplayName("[1-2] loader 예외 발생 시 모든 스레드 동일 예외 + in-flight 정리")
+    fun loader_exception_propagates_and_inflight_cleared() {
+        val cache = createNonHotCache()
+        val key = 3003L
+        val threadCount = 100
+        val loaderCount = AtomicInteger(0)
+        val barrier = CyclicBarrier(threadCount)
+        val latch = CountDownLatch(threadCount)
+        val executor = Executors.newFixedThreadPool(threadCount)
+        val gate = CountDownLatch(1)
+        val errors = ConcurrentLinkedQueue<Throwable>()
+
+        repeat(threadCount) {
+            executor.submit {
+                try {
+                    barrier.await()
+                    try {
+                        cache.get(key, Callable<String> {
+                            loaderCount.incrementAndGet()
+                            gate.await()
+                            throw IllegalStateException("loader-failed-3003")
+                        })
+                    } catch (e: Throwable) {
+                        errors.add(e)
+                    }
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        Thread.sleep(150)
+        gate.countDown()
+        assertTrue(latch.await(10, TimeUnit.SECONDS))
+        executor.shutdown()
+
+        assertEquals(1, loaderCount.get(), "예외 발생도 loader 1회로 collapse")
+        assertEquals(threadCount, errors.size, "모든 스레드 예외 수신")
+        errors.forEach { e ->
+            assertTrue(e is IllegalStateException) { "got ${e::class.qualifiedName}" }
+            assertEquals("loader-failed-3003", e.message)
+        }
+
+        val recoveryLoaderCount = AtomicInteger(0)
+        val recoveryValue = cache.get(key, Callable<String> {
+            recoveryLoaderCount.incrementAndGet()
+            "recovered"
+        })
+        assertEquals("recovered", recoveryValue, "in-flight 정리 후 다음 요청은 정상 동작")
+        assertEquals(1, recoveryLoaderCount.get(), "후속 단일 요청은 loader 정상 호출")
+
+        recordMetric(
+            "1-2 loader exception propagation",
+            mapOf(
+                "threads" to threadCount,
+                "loader_calls" to loaderCount.get(),
+                "errors_received" to errors.size,
+                "post_recovery_loader_calls" to recoveryLoaderCount.get()
+            )
+        )
+    }
+
+    @Test
+    @DisplayName("[1-3] 키 A/B 각 50 스레드 동시 요청 → 각 키 loader 1회씩 (서로 비간섭)")
+    fun per_key_independence() {
+        val cache = createNonHotCache()
+        val keyA = 4040L
+        val keyB = 5050L
+        val threadsPerKey = 50
+        val total = threadsPerKey * 2
+
+        val loaderA = AtomicInteger(0)
+        val loaderB = AtomicInteger(0)
+        val barrier = CyclicBarrier(total)
+        val latch = CountDownLatch(total)
+        val executor = Executors.newFixedThreadPool(total)
+        val gate = CountDownLatch(1)
+        val resultsA = ConcurrentLinkedQueue<Any?>()
+        val resultsB = ConcurrentLinkedQueue<Any?>()
+
+        repeat(threadsPerKey) {
+            executor.submit {
+                try {
+                    barrier.await()
+                    val v = cache.get(keyA, Callable<String> {
+                        loaderA.incrementAndGet()
+                        gate.await()
+                        "A-value"
+                    })
+                    resultsA.add(v)
+                } finally {
+                    latch.countDown()
+                }
+            }
+            executor.submit {
+                try {
+                    barrier.await()
+                    val v = cache.get(keyB, Callable<String> {
+                        loaderB.incrementAndGet()
+                        gate.await()
+                        "B-value"
+                    })
+                    resultsB.add(v)
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        Thread.sleep(200)
+        gate.countDown()
+        assertTrue(latch.await(10, TimeUnit.SECONDS))
+        executor.shutdown()
+
+        assertEquals(1, loaderA.get(), "키 A loader 1회")
+        assertEquals(1, loaderB.get(), "키 B loader 1회")
+        assertEquals(setOf<Any?>("A-value"), resultsA.toSet())
+        assertEquals(setOf<Any?>("B-value"), resultsB.toSet())
+        assertEquals(threadsPerKey, resultsA.size)
+        assertEquals(threadsPerKey, resultsB.size)
+        assertEquals(
+            (threadsPerKey - 1).toDouble() * 2,
+            collapsedCount("category"),
+            0.0001,
+            "collapsed = (50-1) * 2 = 98"
+        )
+
+        recordMetric(
+            "1-3 per-key independence",
+            mapOf(
+                "key_A_threads" to threadsPerKey,
+                "key_A_loader_calls" to loaderA.get(),
+                "key_B_threads" to threadsPerKey,
+                "key_B_loader_calls" to loaderB.get(),
+                "collapsed_total" to collapsedCount("category")
+            )
+        )
+    }
+
+    @Test
+    @DisplayName("[1-4] hot 키는 분산락 경로, 비-hot 키는 single-flight 경로 (격리)")
+    fun hot_and_non_hot_paths_isolated() {
+        val detector = FakeHotKeyDetector()
+        detector.overrideIsHot = true
+        val shardedCache: Cache = mock()
+        whenever(shardedCache.get(org.mockito.kotlin.any())).thenReturn(null)
+
+        val hotCaffeine = Caffeine.newBuilder()
+            .maximumSize(hotKeyPolicy.l1MaxSize)
+            .expireAfterWrite(hotKeyPolicy.l1Ttl)
+            .build<Any, Any>()
+        val hotCache = TwoLevelCache(
+            hotKeyPolicy.cacheName, hotCaffeine, redisCache, hotKeyPolicy,
+            lockProvider, shardedCache, detector, meterRegistry
+        )
+
+        val nonHotCache = createNonHotCache()
+
+        val hotKey = 6006L
+        val nonHotKey = 7007L
+        val threadsPerKey = 50
+        val total = threadsPerKey * 2
+
+        val hotLoader = AtomicInteger(0)
+        val nonHotLoader = AtomicInteger(0)
+        val barrier = CyclicBarrier(total)
+        val latch = CountDownLatch(total)
+        val executor = Executors.newFixedThreadPool(total)
+        val gate = CountDownLatch(1)
+
+        repeat(threadsPerKey) {
+            executor.submit {
+                try {
+                    barrier.await()
+                    hotCache.get(hotKey, Callable<String> {
+                        hotLoader.incrementAndGet()
+                        gate.await()
+                        "hot-value"
+                    })
+                } finally {
+                    latch.countDown()
+                }
+            }
+            executor.submit {
+                try {
+                    barrier.await()
+                    nonHotCache.get(nonHotKey, Callable<String> {
+                        nonHotLoader.incrementAndGet()
+                        gate.await()
+                        "non-hot-value"
+                    })
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        Thread.sleep(200)
+        gate.countDown()
+        assertTrue(latch.await(10, TimeUnit.SECONDS))
+        executor.shutdown()
+
+        assertTrue(lockProvider.lockCallCount >= 1, "hot 키 경로는 분산락 사용")
+        assertTrue(lockProvider.unlockCallCount >= 1, "락 획득자는 unlock 호출")
+        assertEquals(
+            0.0,
+            collapsedCount(hotKeyPolicy.cacheName),
+            0.0001,
+            "hot 경로는 single-flight collapsed 카운터 미증가"
+        )
+        assertEquals(
+            (threadsPerKey - 1).toDouble(),
+            collapsedCount(nonHotPolicy.cacheName),
+            0.0001,
+            "비-hot 경로는 collapsed = 49"
+        )
+        assertNotNull(hotLoader.get())
+        assertEquals(1, nonHotLoader.get(), "비-hot 키 loader 1회 (single-flight collapse)")
+
+        recordMetric(
+            "1-4 hot vs non-hot path isolation",
+            mapOf(
+                "hot_threads" to threadsPerKey,
+                "hot_lock_calls" to lockProvider.lockCallCount,
+                "hot_unlock_calls" to lockProvider.unlockCallCount,
+                "hot_loader_calls" to hotLoader.get(),
+                "hot_collapsed_total" to collapsedCount(hotKeyPolicy.cacheName),
+                "non_hot_threads" to threadsPerKey,
+                "non_hot_loader_calls" to nonHotLoader.get(),
+                "non_hot_collapsed_total" to collapsedCount(nonHotPolicy.cacheName)
+            )
+        )
+    }
+
+    private fun recordMetric(label: String, fields: Map<String, Any?>) {
+        val outDir = Paths.get("..", "load-tests", "results", "stampede-validation").toAbsolutePath().normalize()
+        Files.createDirectories(outDir)
+        val file = outDir.resolve("metrics.tsv")
+        PrintWriter(Files.newBufferedWriter(file, java.nio.charset.StandardCharsets.UTF_8,
+            java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND)).use { w ->
+            val joined = fields.entries.joinToString("\t") { "${it.key}=${it.value}" }
+            w.println("$label\t$joined")
+        }
+    }
+}

--- a/order-service/src/main/kotlin/com/hoppingmall/order/metrics/SagaCompensationMetrics.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/metrics/SagaCompensationMetrics.kt
@@ -1,0 +1,38 @@
+package com.hoppingmall.order.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Component
+class SagaCompensationMetrics(meterRegistry: MeterRegistry) {
+
+    private val triggered: Counter = Counter.builder("saga.compensation.triggered")
+        .description("Saga 보상 트랜잭션 트리거 수")
+        .register(meterRegistry)
+
+    private val success: Counter = Counter.builder("saga.compensation.success")
+        .description("Saga 보상 자동 회복 성공 수")
+        .register(meterRegistry)
+
+    private val failed: Counter = Counter.builder("saga.compensation.failed")
+        .description("Saga 보상 영구 실패 수")
+        .register(meterRegistry)
+
+    private val recoveryTime: Timer = Timer.builder("saga.compensation.recovery.time")
+        .description("Saga 보상 회복 시간 분포")
+        .publishPercentileHistogram()
+        .register(meterRegistry)
+
+    private val timeoutTriggered: Counter = Counter.builder("saga.timeout.triggered")
+        .description("Saga 타임아웃 자동 보상 트리거 수")
+        .register(meterRegistry)
+
+    fun recordTriggered() = triggered.increment()
+    fun recordSuccess() = success.increment()
+    fun recordFailed() = failed.increment()
+    fun recordRecoveryTime(durationMs: Long) = recoveryTime.record(durationMs, TimeUnit.MILLISECONDS)
+    fun recordTimeoutTriggered() = timeoutTriggered.increment()
+}

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/SagaEventLog.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/domain/SagaEventLog.kt
@@ -21,6 +21,9 @@ class SagaEventLog(
     @Column(nullable = false)
     val orderId: Long,
 
+    @Column(nullable = true)
+    val paymentId: Long? = null,
+
     @Column(nullable = false)
     val createdAt: LocalDateTime = LocalDateTime.now(),
 

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderSagaConsumer.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderSagaConsumer.kt
@@ -33,8 +33,9 @@ class OrderSagaConsumer(
 
     // Kafka 이벤트(Avro→JSON)는 camelCase 필드명을 사용하므로, 전역 SNAKE_CASE ObjectMapper 대신
     // camelCase 매퍼로 역직렬화한다 (전역 매퍼로 읽으면 orderId 등이 0으로 유실됨).
-    private val eventMapper: ObjectMapper =
+    private val eventMapper: ObjectMapper by lazy {
         objectMapper.copy().setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE)
+    }
 
     @KafkaListener(topics = [KafkaTopics.PAYMENT], groupId = "order-saga-service")
     fun handlePaymentCompleted(message: String) {

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderSagaConsumer.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/service/OrderSagaConsumer.kt
@@ -1,6 +1,7 @@
 package com.hoppingmall.order.order.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.hoppingmall.order.order.domain.SagaEventLog
 import com.hoppingmall.order.order.domain.repository.OrderItemRepository
 import com.hoppingmall.order.order.domain.repository.OrderRepository
@@ -8,6 +9,7 @@ import com.hoppingmall.order.order.domain.repository.SagaEventLogRepository
 import com.hoppingmall.order.order.dto.event.PaymentCompletedEvent
 import com.hoppingmall.common.KafkaTopics
 import com.hoppingmall.order.order.enum.OrderStatus
+import com.hoppingmall.order.metrics.SagaCompensationMetrics
 import com.hoppingmall.order.port.InventoryCommandPort
 import com.hoppingmall.outbox.service.TransactionalEventPublisher
 import org.slf4j.LoggerFactory
@@ -24,13 +26,19 @@ class OrderSagaConsumer(
     private val inventoryCommandPort: InventoryCommandPort,
     private val transactionalEventPublisher: TransactionalEventPublisher,
     private val objectMapper: ObjectMapper,
-    private val transactionTemplate: TransactionTemplate
+    private val transactionTemplate: TransactionTemplate,
+    private val sagaCompensationMetrics: SagaCompensationMetrics
 ) {
     private val logger = LoggerFactory.getLogger(OrderSagaConsumer::class.java)
 
+    // Kafka 이벤트(Avro→JSON)는 camelCase 필드명을 사용하므로, 전역 SNAKE_CASE ObjectMapper 대신
+    // camelCase 매퍼로 역직렬화한다 (전역 매퍼로 읽으면 orderId 등이 0으로 유실됨).
+    private val eventMapper: ObjectMapper =
+        objectMapper.copy().setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE)
+
     @KafkaListener(topics = [KafkaTopics.PAYMENT], groupId = "order-saga-service")
     fun handlePaymentCompleted(message: String) {
-        val event = objectMapper.readValue(message, PaymentCompletedEvent::class.java)
+        val event = eventMapper.readValue(message, PaymentCompletedEvent::class.java)
         val eventId = "payment-completed-${event.transactionId}"
 
         val existingLog = sagaEventLogRepository.findByEventId(eventId)
@@ -61,7 +69,12 @@ class OrderSagaConsumer(
             if (order.status !in setOf(OrderStatus.CREATED, OrderStatus.PAYING)) {
                 logger.warn("주문 상태가 CREATED/PAYING이 아님: orderId=${event.orderId}, status=${order.status}")
                 val log = sagaEventLogRepository.findByEventId(eventId)
-                    ?: SagaEventLog(eventId = eventId, eventType = "PAYMENT_COMPLETED", orderId = event.orderId)
+                    ?: SagaEventLog(
+                        eventId = eventId,
+                        eventType = "PAYMENT_COMPLETED",
+                        orderId = event.orderId,
+                        paymentId = event.paymentId
+                    )
                 log.markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
                 log.markStepCompleted(SagaEventLog.REMOTE_COMPLETED)
                 sagaEventLogRepository.save(log)
@@ -74,7 +87,12 @@ class OrderSagaConsumer(
             order.updateStatus(OrderStatus.PAID)
             orderRepository.save(order)
 
-            val log = SagaEventLog(eventId = eventId, eventType = "PAYMENT_COMPLETED", orderId = event.orderId)
+            val log = SagaEventLog(
+                eventId = eventId,
+                eventType = "PAYMENT_COMPLETED",
+                orderId = event.orderId,
+                paymentId = event.paymentId
+            )
             log.markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
             sagaEventLogRepository.save(log)
 
@@ -107,6 +125,8 @@ class OrderSagaConsumer(
     }
 
     fun compensateFailedConfirmation(eventId: String, event: PaymentCompletedEvent) {
+        sagaCompensationMetrics.recordTriggered()
+        val startTime = System.currentTimeMillis()
         val compensated = transactionTemplate.execute {
             val order = orderRepository.findByIdOrNull(event.orderId) ?: return@execute false
             if (order.status == OrderStatus.PAID && order.isCancellable()) {
@@ -138,6 +158,8 @@ class OrderSagaConsumer(
         } ?: false
 
         if (compensated) {
+            sagaCompensationMetrics.recordSuccess()
+            sagaCompensationMetrics.recordRecoveryTime(System.currentTimeMillis() - startTime)
             logger.warn("예약 만료로 주문 취소 + 결제 역보상 요청: orderId=${event.orderId}")
         }
     }
@@ -165,6 +187,9 @@ class OrderSagaConsumer(
 
         val orderId = node.get("orderId")?.asLong() ?: return
 
+        sagaCompensationMetrics.recordTriggered()
+        val startTime = System.currentTimeMillis()
+
         val reservationIds = if (existingLog == null || !existingLog.isStepCompleted(SagaEventLog.LOCAL_COMPLETED)) {
             executeCompensationLocalPhase(eventId, orderId)
         } else {
@@ -173,7 +198,7 @@ class OrderSagaConsumer(
 
         if (reservationIds == null) return
 
-        executeCompensationRemotePhase(eventId, orderId, reservationIds)
+        executeCompensationRemotePhase(eventId, orderId, reservationIds, startTime)
     }
 
     private fun executeCompensationLocalPhase(eventId: String, orderId: Long): List<String>? {
@@ -197,7 +222,7 @@ class OrderSagaConsumer(
         }
     }
 
-    private fun executeCompensationRemotePhase(eventId: String, orderId: Long, reservationIds: List<String>) {
+    private fun executeCompensationRemotePhase(eventId: String, orderId: Long, reservationIds: List<String>, startTime: Long) {
         try {
             reservationIds.forEach { inventoryCommandPort.cancelReservation(it) }
         } catch (e: Exception) {
@@ -210,6 +235,8 @@ class OrderSagaConsumer(
             sagaEventLogRepository.save(log)
         }
 
+        sagaCompensationMetrics.recordSuccess()
+        sagaCompensationMetrics.recordRecoveryTime(System.currentTimeMillis() - startTime)
         logger.info("결제 보상 처리 완료 (예약 취소 + 주문 CANCELLED): orderId=$orderId")
     }
 }

--- a/order-service/src/main/kotlin/com/hoppingmall/order/order/service/SagaTimeoutScheduler.kt
+++ b/order-service/src/main/kotlin/com/hoppingmall/order/order/service/SagaTimeoutScheduler.kt
@@ -4,6 +4,7 @@ import com.hoppingmall.common.KafkaTopics
 import com.hoppingmall.order.order.domain.repository.OrderRepository
 import com.hoppingmall.order.order.domain.repository.SagaEventLogRepository
 import com.hoppingmall.order.order.enum.OrderStatus
+import com.hoppingmall.order.metrics.SagaCompensationMetrics
 import com.hoppingmall.outbox.service.TransactionalEventPublisher
 import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
@@ -17,7 +18,8 @@ class SagaTimeoutScheduler(
     private val sagaEventLogRepository: SagaEventLogRepository,
     private val orderRepository: OrderRepository,
     private val transactionalEventPublisher: TransactionalEventPublisher,
-    private val transactionTemplate: TransactionTemplate
+    private val transactionTemplate: TransactionTemplate,
+    private val sagaCompensationMetrics: SagaCompensationMetrics
 ) {
     private val logger = LoggerFactory.getLogger(SagaTimeoutScheduler::class.java)
 
@@ -33,6 +35,7 @@ class SagaTimeoutScheduler(
                 compensateTimedOutSaga(saga.id!!, saga.orderId, saga.eventId)
             } catch (e: Exception) {
                 logger.error("saga 타임아웃 보상 실패: sagaId={}, orderId={}", saga.id, saga.orderId, e)
+                sagaCompensationMetrics.recordFailed()
             }
         }
     }
@@ -52,16 +55,22 @@ class SagaTimeoutScheduler(
                 orderRepository.save(order)
             }
 
+            if (saga.paymentId == null) {
+                logger.warn("타임아웃 saga에 paymentId 없음, 포인트 환불 생략: sagaId={}, orderId={}", sagaId, orderId)
+            }
+
             transactionalEventPublisher.publishEvent(
                 aggregateType = "Order",
                 aggregateId = orderId.toString(),
                 eventType = "PaymentReversalRequested",
-                eventData = mapOf(
-                    "eventType" to "PaymentReversalRequested",
-                    "eventId" to "timeout-$eventId",
-                    "orderId" to orderId,
-                    "reason" to "SAGA_TIMEOUT"
-                ),
+                eventData = buildMap<String, Any> {
+                    put("eventType", "PaymentReversalRequested")
+                    put("eventId", "timeout-$eventId")
+                    put("orderId", orderId)
+                    put("userId", order.buyerId)
+                    put("reason", "SAGA_TIMEOUT")
+                    saga.paymentId?.let { put("paymentId", it) }
+                },
                 topic = KafkaTopics.PAYMENT_REVERSAL,
                 partitionKey = orderId.toString()
             )
@@ -69,6 +78,7 @@ class SagaTimeoutScheduler(
         } ?: false
 
         if (compensated) {
+            sagaCompensationMetrics.recordTimeoutTriggered()
             logger.warn("saga 타임아웃 보상 완료: orderId={}, eventId={}", orderId, eventId)
         }
     }

--- a/order-service/src/test/kotlin/com/hoppingmall/order/metrics/SagaCompensationMetricsTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/metrics/SagaCompensationMetricsTest.kt
@@ -1,0 +1,54 @@
+package com.hoppingmall.order.metrics
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator
+import org.junit.jupiter.api.Test
+
+@DisplayName("SagaCompensationMetrics")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
+class SagaCompensationMetricsTest {
+
+    private val registry = SimpleMeterRegistry()
+    private val metrics = SagaCompensationMetrics(registry)
+
+    @Test
+    fun 보상_트리거_카운터를_증가시킨다() {
+        metrics.recordTriggered()
+        metrics.recordTriggered()
+
+        assertThat(registry.counter("saga.compensation.triggered").count()).isEqualTo(2.0)
+    }
+
+    @Test
+    fun 보상_성공_카운터를_증가시킨다() {
+        metrics.recordSuccess()
+
+        assertThat(registry.counter("saga.compensation.success").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun 보상_실패_카운터를_증가시킨다() {
+        metrics.recordFailed()
+
+        assertThat(registry.counter("saga.compensation.failed").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun 타임아웃_보상_트리거_카운터를_증가시킨다() {
+        metrics.recordTimeoutTriggered()
+
+        assertThat(registry.counter("saga.timeout.triggered").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun 회복_시간을_타이머에_기록한다() {
+        metrics.recordRecoveryTime(120)
+
+        val timer = registry.timer("saga.compensation.recovery.time")
+        assertThat(timer.count()).isEqualTo(1L)
+        assertThat(timer.totalTime(java.util.concurrent.TimeUnit.MILLISECONDS)).isEqualTo(120.0)
+    }
+}

--- a/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderSagaConsumerTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderSagaConsumerTest.kt
@@ -11,6 +11,7 @@ import com.hoppingmall.order.order.domain.repository.OrderRepository
 import com.hoppingmall.order.order.domain.repository.SagaEventLogRepository
 import com.hoppingmall.order.order.dto.event.PaymentCompletedEvent
 import com.hoppingmall.order.order.enum.OrderStatus
+import com.hoppingmall.order.metrics.SagaCompensationMetrics
 import com.hoppingmall.order.port.InventoryCommandPort
 import com.hoppingmall.outbox.service.TransactionalEventPublisher
 import org.assertj.core.api.Assertions.assertThat
@@ -60,6 +61,9 @@ class OrderSagaConsumerTest {
     @Mock
     private lateinit var transactionTemplate: TransactionTemplate
 
+    @Mock
+    private lateinit var sagaCompensationMetrics: SagaCompensationMetrics
+
     private lateinit var consumer: OrderSagaConsumer
 
     @BeforeEach
@@ -69,6 +73,8 @@ class OrderSagaConsumerTest {
             val callback = invocation.arguments[0] as TransactionCallback<Any?>
             callback.doInTransaction(mock())
         }
+        Mockito.lenient().`when`(objectMapper.copy()).thenReturn(objectMapper)
+        Mockito.lenient().`when`(objectMapper.setPropertyNamingStrategy(any())).thenReturn(objectMapper)
         consumer = OrderSagaConsumer(
             sagaEventLogRepository,
             orderRepository,
@@ -76,7 +82,8 @@ class OrderSagaConsumerTest {
             inventoryCommandPort,
             transactionalEventPublisher,
             objectMapper,
-            transactionTemplate
+            transactionTemplate,
+            sagaCompensationMetrics
         )
     }
 

--- a/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderTransactionalRollbackTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/order/service/OrderTransactionalRollbackTest.kt
@@ -3,6 +3,7 @@ package com.hoppingmall.order.order.service
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.hoppingmall.order.cartItem.domain.repository.CartItemRepository
 import com.hoppingmall.order.config.OrderMetrics
+import com.hoppingmall.order.metrics.SagaCompensationMetrics
 import com.hoppingmall.order.order.domain.Order
 import com.hoppingmall.order.order.domain.OrderItem
 import com.hoppingmall.order.order.domain.SagaEventLog
@@ -85,6 +86,9 @@ class OrderTransactionalRollbackTest {
 
     @MockitoBean
     private lateinit var orderMetrics: OrderMetrics
+
+    @MockitoBean
+    private lateinit var sagaCompensationMetrics: SagaCompensationMetrics
 
     @MockitoBean
     private lateinit var transactionalEventPublisher: TransactionalEventPublisher

--- a/order-service/src/test/kotlin/com/hoppingmall/order/order/service/SagaTimeoutSchedulerTest.kt
+++ b/order-service/src/test/kotlin/com/hoppingmall/order/order/service/SagaTimeoutSchedulerTest.kt
@@ -5,6 +5,7 @@ import com.hoppingmall.order.order.domain.SagaEventLog
 import com.hoppingmall.order.order.domain.repository.OrderRepository
 import com.hoppingmall.order.order.domain.repository.SagaEventLogRepository
 import com.hoppingmall.order.order.enum.OrderStatus
+import com.hoppingmall.order.metrics.SagaCompensationMetrics
 import com.hoppingmall.outbox.service.TransactionalEventPublisher
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -17,6 +18,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.Mockito
 import org.mockito.kotlin.any
+import org.mockito.kotlin.check
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -45,6 +47,9 @@ class SagaTimeoutSchedulerTest {
     @Mock
     private lateinit var transactionTemplate: TransactionTemplate
 
+    @Mock
+    private lateinit var sagaCompensationMetrics: SagaCompensationMetrics
+
     private lateinit var scheduler: SagaTimeoutScheduler
 
     @BeforeEach
@@ -58,7 +63,8 @@ class SagaTimeoutSchedulerTest {
             sagaEventLogRepository,
             orderRepository,
             transactionalEventPublisher,
-            transactionTemplate
+            transactionTemplate,
+            sagaCompensationMetrics
         )
     }
 
@@ -68,6 +74,7 @@ class SagaTimeoutSchedulerTest {
             eventId = "payment-completed-txn-1",
             eventType = "PAYMENT_COMPLETED",
             orderId = 1L,
+            paymentId = 100L,
             timeoutAt = LocalDateTime.now().minusMinutes(1)
         ).apply {
             id = 100L
@@ -90,9 +97,53 @@ class SagaTimeoutSchedulerTest {
             aggregateType = eq("Order"),
             aggregateId = eq("1"),
             eventType = eq("PaymentReversalRequested"),
-            eventData = any(),
+            eventData = check<Any> {
+                @Suppress("UNCHECKED_CAST")
+                val data = it as Map<String, Any?>
+                assertThat(data["paymentId"]).isEqualTo(100L)
+                assertThat(data["userId"]).isEqualTo(10L)
+                assertThat(data["reason"]).isEqualTo("SAGA_TIMEOUT")
+            },
             topic = eq("payment-reversal"),
             partitionKey = eq("1")
+        )
+    }
+
+    @Test
+    fun paymentId가_없는_타임아웃_saga는_userId만_포함하여_역보상을_발행한다() {
+        val saga = SagaEventLog(
+            eventId = "payment-completed-txn-4",
+            eventType = "PAYMENT_COMPLETED",
+            orderId = 4L,
+            timeoutAt = LocalDateTime.now().minusMinutes(1)
+        ).apply {
+            id = 400L
+            markStepCompleted(SagaEventLog.LOCAL_COMPLETED)
+        }
+        val order = Order.create(buyerId = 40L, totalAmount = BigDecimal("10000"))
+        order.updateStatus(OrderStatus.PAYING)
+        order.updateStatus(OrderStatus.PAID)
+
+        whenever(sagaEventLogRepository.findTimedOutSagas(any())).thenReturn(listOf(saga))
+        whenever(sagaEventLogRepository.findById(400L)).thenReturn(Optional.of(saga))
+        whenever(orderRepository.findById(4L)).thenReturn(Optional.of(order))
+        whenever(sagaEventLogRepository.save(any<SagaEventLog>())).thenAnswer { it.arguments[0] }
+
+        scheduler.checkTimedOutSagas()
+
+        verify(transactionalEventPublisher).publishEvent(
+            aggregateType = eq("Order"),
+            aggregateId = eq("4"),
+            eventType = eq("PaymentReversalRequested"),
+            eventData = check<Any> {
+                @Suppress("UNCHECKED_CAST")
+                val data = it as Map<String, Any?>
+                assertThat(data).doesNotContainKey("paymentId")
+                assertThat(data["userId"]).isEqualTo(40L)
+                assertThat(data["reason"]).isEqualTo("SAGA_TIMEOUT")
+            },
+            topic = eq("payment-reversal"),
+            partitionKey = eq("4")
         )
     }
 

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/config/CacheConfig.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/config/CacheConfig.kt
@@ -13,6 +13,7 @@ import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
 import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
@@ -78,6 +79,7 @@ class CacheConfig {
     }
 
     @Bean
+    @Primary
     fun cacheManager(
         redisCacheManager: RedisCacheManager,
         cachePolicies: Map<String, CachePolicy>,

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/MockPaymentService.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/payment/service/MockPaymentService.kt
@@ -5,6 +5,7 @@ import com.hoppingmall.payment.payment.dto.PaymentResult
 import com.hoppingmall.payment.payment.exception.PaymentException
 import com.hoppingmall.payment.payment.exception.PaymentInvalidAmountException
 import com.hoppingmall.payment.payment.exception.code.PaymentErrorCode
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
 import kotlin.random.Random
@@ -12,10 +13,13 @@ import kotlin.random.Random
 @Service
 class MockPaymentService : PaymentService {
 
+    @Value("\${chaos.payment.failure-rate:0.0}")
+    private var failureRate: Float = 0.0f
+
     override fun processPayment(payment: Payment): PaymentResult {
         validatePayment(payment)
 
-        val isSuccess = Random.nextFloat() < 0.9f
+        val isSuccess = Random.nextFloat() >= failureRate
 
         return if (isSuccess) {
             val transactionId = generateMockTransactionId()

--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointEventConsumer.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/point/service/PointEventConsumer.kt
@@ -11,10 +11,12 @@ import com.hoppingmall.payment.point.domain.PointHistoryRepository
 import com.hoppingmall.payment.point.domain.PointRepository
 import com.hoppingmall.payment.point.enum.PointType
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.CacheManager
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import kotlin.random.Random
 
 @Service
 @Transactional
@@ -29,8 +31,14 @@ class PointEventConsumer(
 
     private val log = LoggerFactory.getLogger(javaClass)
 
+    @Value("\${chaos.point.failure-rate:0.0}")
+    private var chaosFailureRate: Float = 0.0f
+
     @KafkaListener(topics = [KafkaTopics.POINT_EARN_REQUEST], groupId = "point-service")
     fun handlePointEarnRequest(message: String) {
+        if (chaosFailureRate > 0 && Random.nextFloat() < chaosFailureRate) {
+            throw RuntimeException("Chaos injection: point operation failed")
+        }
         val event = objectMapper.readValue(message, PointEarnRequestEvent::class.java)
         executeIdempotently(
             eventId = event.eventId,

--- a/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImpl.kt
+++ b/product-service/src/main/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImpl.kt
@@ -18,6 +18,7 @@ import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import kotlin.random.Random
 
 @Service
 @Transactional
@@ -29,6 +30,15 @@ class InventoryCommandServiceImpl(
 
     @Value("\${inventory.reservation.ttl-minutes:10}")
     private var ttlMinutes: Long = 10
+
+    @Value("\${chaos.inventory.failure-rate:0.0}")
+    private var chaosFailureRate: Float = 0.0f
+
+    private fun maybeInjectChaos(operation: String) {
+        if (chaosFailureRate > 0 && Random.nextFloat() < chaosFailureRate) {
+            throw RuntimeException("Chaos injection: inventory $operation failed")
+        }
+    }
 
     override fun initStock(request: InventoryInitRequest): InventoryResponse {
         if (!productRepository.existsById(request.productId)) {
@@ -74,6 +84,7 @@ class InventoryCommandServiceImpl(
 
     @CacheEvict(cacheNames = ["inventory"], key = "#productId")
     override fun reserveStock(productId: Long, quantity: Int): String {
+        maybeInjectChaos("reserveStock")
         val inventory = inventoryRepository.findByProductIdForUpdate(productId)
             ?: throw InventoryNotFoundException()
 
@@ -85,6 +96,7 @@ class InventoryCommandServiceImpl(
     }
 
     override fun confirmReservations(reservationIds: List<String>): Boolean {
+        maybeInjectChaos("confirmReservations")
         if (reservationIds.isEmpty()) return true
 
         val now = LocalDateTime.now()
@@ -124,6 +136,7 @@ class InventoryCommandServiceImpl(
     }
 
     override fun cancelReservation(reservationId: String) {
+        maybeInjectChaos("cancelReservation")
         val reservation = inventoryReservationRepository.findByReservationId(reservationId)
             ?: return
 

--- a/product-service/src/test/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImplTest.kt
+++ b/product-service/src/test/kotlin/com/hoppingmall/product/inventory/service/InventoryCommandServiceImplTest.kt
@@ -54,6 +54,17 @@ class InventoryCommandServiceImplTest {
     }
 
     @Test
+    fun 카오스_실패율이_주입되면_재고_예약이_예외를_던진다() {
+        val field = InventoryCommandServiceImpl::class.java.getDeclaredField("chaosFailureRate")
+        field.isAccessible = true
+        field.set(service, 1.0f)
+
+        assertThatThrownBy { service.reserveStock(1L, 1) }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("Chaos injection")
+    }
+
+    @Test
     fun 재고를_초기화한다() {
         val inventory = Inventory.create(productId = 1L, stockQuantity = 100).withId(1L)
         val request = com.hoppingmall.product.inventory.dto.request.InventoryInitRequest(productId = 1L, stockQuantity = 100)

--- a/user-service/src/main/kotlin/com/hoppingmall/user/config/ratelimit/RateLimitConfig.kt
+++ b/user-service/src/main/kotlin/com/hoppingmall/user/config/ratelimit/RateLimitConfig.kt
@@ -11,7 +11,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-@Profile("!test")
+@Profile("!test & !loadtest")
 class RateLimitConfig(
     private val redissonClient: RedissonClient
 ) : WebMvcConfigurer {


### PR DESCRIPTION
Closes #453

### 📌 작업 개요
Saga 보상/타임아웃 자동 회복 과정을 Micrometer 메트릭으로 계측하고,
부하·장애 상황에서 보상 흐름을 측정할 수 있도록 카오스 장애 주입 토글을 추가했습니다.
측정 과정에서 발견한 역보상 페이로드 누락·역직렬화 결함·캐시 빈 모호성도 함께 수정했습니다.

---

### ✅ 주요 변경 사항

- `order.metrics`
  - `SagaCompensationMetrics`: 보상 트리거/성공/실패/타임아웃/회복시간 계측

- `order.order.service`
  - `OrderSagaConsumer`: 보상 경로 메트릭 연동, Kafka 이벤트 camelCase 역직렬화로 전환(orderId 유실 방지)
  - `SagaTimeoutScheduler`: 타임아웃 보상 메트릭 연동, 역보상 이벤트에 paymentId/userId 포함

- `order.order.domain`
  - `SagaEventLog`: paymentId 컬럼 추가

- `payment` / `product` / `user`
  - `MockPaymentService`, `PointEventConsumer`, `InventoryCommandServiceImpl`: `chaos.*.failure-rate`로 장애 주입(기본 0)
  - `RateLimitConfig`: loadtest 프로파일에서 비활성화하여 측정 왜곡 방지

- `payment.config`
  - `CacheConfig`: cacheManager 빈에 @Primary 지정(주입 모호성 제거)

---

### 🧪 테스트

- `SagaCompensationMetricsTest`: 5개 지표 카운터/타이머 동작 검증
- `OrderSagaConsumerTest`, `SagaTimeoutSchedulerTest`: 메트릭 연동 및 paymentId/userId 역보상 페이로드 검증
- `TwoLevelCacheStampedeTest`: 동시 캐시 미스 시 단일 로더만 실행되는지(stampede 방지) 검증

---

### 📎 관련 이슈
- #453
