### PR TITLE
fix: 쿠폰 보상 메트릭 빈 등록 조건 제거

### DIFF
--- a/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/metrics/CouponCompensationMetrics.kt
+++ b/payment-service/src/main/kotlin/com/hoppingmall/payment/coupon/metrics/CouponCompensationMetrics.kt
@@ -2,11 +2,9 @@ package com.hoppingmall.payment.coupon.metrics
 
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.stereotype.Component
 
 @Component
-@ConditionalOnBean(MeterRegistry::class)
 class CouponCompensationMetrics(
     meterRegistry: MeterRegistry
 ) {


### PR DESCRIPTION
Closes #455

### 📌 작업 개요
`CouponCompensationMetrics`의 `@ConditionalOnBean(MeterRegistry)`를 제거하여,
컨텍스트 초기화 순서와 무관하게 보상 메트릭 빈이 항상 등록되도록 했습니다.

---

### ✅ 주요 변경 사항

- `payment.coupon.metrics`
  - `CouponCompensationMetrics`: `@ConditionalOnBean(MeterRegistry)` 및 관련 import 제거

---

### 🧪 테스트

- payment-service 전체 테스트 통과 (컨텍스트 로딩 영향 없음 확인)

---

### 📎 관련 이슈
- #455
